### PR TITLE
feat: add Shell Commands breakdown panel

### DIFF
--- a/src/bash-utils.ts
+++ b/src/bash-utils.ts
@@ -1,0 +1,57 @@
+import { basename } from 'path'
+
+const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool'])
+
+/**
+ * Strips quoted substrings from a command string before splitting on separators,
+ * so that separators inside quotes (e.g. "hello && world") are not treated as
+ * command boundaries.
+ */
+function stripQuotedStrings(command: string): string {
+  return command.replace(/"[^"]*"|'[^']*'/g, '""')
+}
+
+export function extractBashCommands(command: string): string[] {
+  if (!command || !command.trim()) return []
+
+  // Strip quoted content so separators inside quotes are ignored
+  const stripped = stripQuotedStrings(command)
+
+  // Find separator positions (start and end) in the stripped version
+  const separatorRegex = /\s*(?:&&|;|\|)\s*/g
+  const separators: Array<{ start: number; end: number }> = []
+  let match: RegExpExecArray | null
+
+  while ((match = separatorRegex.exec(stripped)) !== null) {
+    separators.push({ start: match.index, end: match.index + match[0].length })
+  }
+
+  // Build segment ranges from the original command
+  const ranges: Array<[number, number]> = []
+  let cursor = 0
+  for (const sep of separators) {
+    ranges.push([cursor, sep.start])
+    cursor = sep.end
+  }
+  ranges.push([cursor, command.length])
+
+  // Extract the first token from each segment
+  const commands: string[] = []
+  for (const [start, end] of ranges) {
+    const segment = command.slice(start, end).trim()
+    if (!segment) continue
+
+    const firstToken = segment.split(/\s+/)[0]
+    const base = basename(firstToken)
+
+    if (base && base !== 'cd') {
+      commands.push(base)
+    }
+  }
+
+  return commands
+}
+
+export function isBashTool(toolName: string): boolean {
+  return BASH_TOOLS.has(toolName)
+}

--- a/src/bash-utils.ts
+++ b/src/bash-utils.ts
@@ -8,7 +8,7 @@ const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool'])
  * command boundaries.
  */
 function stripQuotedStrings(command: string): string {
-  return command.replace(/"[^"]*"|'[^']*'/g, '""')
+  return command.replace(/"[^"]*"|'[^']*'/g, match => ' '.repeat(match.length))
 }
 
 export function extractBashCommands(command: string): string[] {

--- a/src/bash-utils.ts
+++ b/src/bash-utils.ts
@@ -1,12 +1,5 @@
 import { basename } from 'path'
 
-const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool'])
-
-/**
- * Strips quoted substrings from a command string before splitting on separators,
- * so that separators inside quotes (e.g. "hello && world") are not treated as
- * command boundaries.
- */
 function stripQuotedStrings(command: string): string {
   return command.replace(/"[^"]*"|'[^']*'/g, match => ' '.repeat(match.length))
 }
@@ -14,10 +7,8 @@ function stripQuotedStrings(command: string): string {
 export function extractBashCommands(command: string): string[] {
   if (!command || !command.trim()) return []
 
-  // Strip quoted content so separators inside quotes are ignored
   const stripped = stripQuotedStrings(command)
 
-  // Find separator positions (start and end) in the stripped version
   const separatorRegex = /\s*(?:&&|;|\|)\s*/g
   const separators: Array<{ start: number; end: number }> = []
   let match: RegExpExecArray | null
@@ -26,7 +17,6 @@ export function extractBashCommands(command: string): string[] {
     separators.push({ start: match.index, end: match.index + match[0].length })
   }
 
-  // Build segment ranges from the original command
   const ranges: Array<[number, number]> = []
   let cursor = 0
   for (const sep of separators) {
@@ -35,7 +25,6 @@ export function extractBashCommands(command: string): string[] {
   }
   ranges.push([cursor, command.length])
 
-  // Extract the first token from each segment
   const commands: string[] = []
   for (const [start, end] of ranges) {
     const segment = command.slice(start, end).trim()
@@ -50,8 +39,4 @@ export function extractBashCommands(command: string): string[] {
   }
 
   return commands
-}
-
-export function isBashTool(toolName: string): boolean {
-  return BASH_TOOLS.has(toolName)
 }

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -13,7 +13,7 @@ const RESEARCH_KEYWORDS = /\b(research|investigate|look\s+into|find\s+out|check|
 
 const EDIT_TOOLS = new Set(['Edit', 'Write', 'FileEditTool', 'FileWriteTool', 'NotebookEdit'])
 const READ_TOOLS = new Set(['Read', 'Grep', 'Glob', 'FileReadTool', 'GrepTool', 'GlobTool'])
-const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool'])
+export const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool'])
 const TASK_TOOLS = new Set(['TaskCreate', 'TaskUpdate', 'TaskGet', 'TaskList', 'TaskOutput', 'TaskStop', 'TodoWrite'])
 const SEARCH_TOOLS = new Set(['WebSearch', 'WebFetch', 'ToolSearch'])
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -27,6 +27,7 @@ const PANEL_COLORS = {
   activity: '#F5C85B',
   tools: '#5BF5E0',
   mcp: '#F55BE0',
+  bash: '#F5A05B',
 }
 
 const CATEGORY_COLORS: Record<TaskCategory, string> = {
@@ -331,6 +332,36 @@ function McpBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; pw: nu
   )
 }
 
+function BashBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; pw: number; bw: number }) {
+  const bashTotals: Record<string, number> = {}
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      for (const [cmd, data] of Object.entries(session.bashBreakdown)) {
+        bashTotals[cmd] = (bashTotals[cmd] ?? 0) + data.calls
+      }
+    }
+  }
+  const sorted = Object.entries(bashTotals).sort(([, a], [, b]) => b - a)
+  if (sorted.length === 0) {
+    return <Panel title="Shell Commands" color={PANEL_COLORS.bash} width={pw}><Text dimColor>No shell commands</Text></Panel>
+  }
+  const maxCalls = sorted[0]?.[1] ?? 0
+  const nw = Math.max(6, pw - bw - 15)
+
+  return (
+    <Panel title="Shell Commands" color={PANEL_COLORS.bash} width={pw}>
+      <Text dimColor wrap="truncate-end">{''.padEnd(bw + 1 + nw)}{'calls'.padStart(7)}</Text>
+      {sorted.slice(0, 10).map(([cmd, calls]) => (
+        <Text key={cmd} wrap="truncate-end">
+          <HBar value={calls} max={maxCalls} width={bw} />
+          <Text> {fit(cmd, nw)}</Text>
+          <Text>{String(calls).padStart(7)}</Text>
+        </Text>
+      ))}
+    </Panel>
+  )
+}
+
 function PeriodTabs({ active }: { active: Period }) {
   return (
     <Box gap={1} paddingX={1}>
@@ -397,6 +428,10 @@ function DashboardContent({ projects, period }: { projects: ProjectSummary[]; pe
       <Row wide={wide} width={dashWidth}>
         <ToolBreakdown projects={projects} pw={pw} bw={barWidth} />
         <McpBreakdown projects={projects} pw={pw} bw={barWidth} />
+      </Row>
+
+      <Row wide={wide} width={dashWidth}>
+        <BashBreakdown projects={projects} pw={pw} bw={barWidth} />
       </Row>
     </Box>
   )

--- a/src/export.ts
+++ b/src/export.ts
@@ -99,6 +99,20 @@ function buildToolRows(projects: ProjectSummary[]): Array<Record<string, string 
     .map(([tool, calls]) => ({ Tool: tool, Calls: calls }))
 }
 
+function buildBashRows(projects: ProjectSummary[]): Array<Record<string, string | number>> {
+  const bashTotals: Record<string, number> = {}
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      for (const [cmd, d] of Object.entries(session.bashBreakdown)) {
+        bashTotals[cmd] = (bashTotals[cmd] ?? 0) + d.calls
+      }
+    }
+  }
+  return Object.entries(bashTotals)
+    .sort(([, a], [, b]) => b - a)
+    .map(([cmd, calls]) => ({ Command: cmd, Calls: calls }))
+}
+
 function buildProjectRows(projects: ProjectSummary[]): Array<Record<string, string | number>> {
   return projects.map(p => ({
     Project: p.projectPath,
@@ -158,6 +172,10 @@ export async function exportCsv(periods: PeriodExport[], outputPath: string): Pr
   parts.push(rowsToCsv(buildToolRows(allProjects)))
   parts.push('')
 
+  parts.push('# Shell Commands - All')
+  parts.push(rowsToCsv(buildBashRows(allProjects)))
+  parts.push('')
+
   parts.push('# Projects - All')
   parts.push(rowsToCsv(buildProjectRows(allProjects)))
   parts.push('')
@@ -185,6 +203,7 @@ export async function exportJson(periods: PeriodExport[], outputPath: string): P
     generated: new Date().toISOString(),
     periods: periodData,
     tools: buildToolRows(allProjects),
+    shellCommands: buildBashRows(allProjects),
     projects: buildProjectRows(allProjects),
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -16,6 +16,7 @@ import type {
   ToolUseBlock,
 } from './types.js'
 import { classifyTurn } from './classifier.js'
+import { extractBashCommands, isBashTool } from './bash-utils.js'
 
 function getClaudeDir(): string {
   return process.env['CLAUDE_CONFIG_DIR'] || join(homedir(), '.claude')
@@ -83,6 +84,15 @@ function extractCoreTools(tools: string[]): string[] {
   return tools.filter(t => !t.startsWith('mcp__'))
 }
 
+function extractBashCommandsFromContent(content: ContentBlock[]): string[] {
+  return content
+    .filter((b): b is ToolUseBlock => b.type === 'tool_use' && isBashTool((b as ToolUseBlock).name))
+    .flatMap(b => {
+      const command = (b.input as Record<string, unknown>)?.command
+      return typeof command === 'string' ? extractBashCommands(command) : []
+    })
+}
+
 function getUserMessageText(entry: JournalEntry): string {
   if (!entry.message || entry.message.role !== 'user') return ''
   const content = entry.message.content
@@ -127,6 +137,8 @@ function parseApiCall(entry: JournalEntry): ParsedApiCall | null {
     usage.speed ?? 'standard',
   )
 
+  const bashCmds = extractBashCommandsFromContent(msg.content ?? [])
+
   return {
     model: msg.model,
     usage: tokens,
@@ -137,6 +149,7 @@ function parseApiCall(entry: JournalEntry): ParsedApiCall | null {
     hasPlanMode: tools.includes('EnterPlanMode'),
     speed: usage.speed ?? 'standard',
     timestamp: entry.timestamp ?? '',
+    bashCommands: bashCmds,
   }
 }
 
@@ -193,6 +206,7 @@ function buildSessionSummary(
   const modelBreakdown: SessionSummary['modelBreakdown'] = {}
   const toolBreakdown: SessionSummary['toolBreakdown'] = {}
   const mcpBreakdown: SessionSummary['mcpBreakdown'] = {}
+  const bashBreakdown: SessionSummary['bashBreakdown'] = {}
   const categoryBreakdown: SessionSummary['categoryBreakdown'] = {} as SessionSummary['categoryBreakdown']
 
   let totalCost = 0
@@ -250,6 +264,10 @@ function buildSessionSummary(
         mcpBreakdown[server] = mcpBreakdown[server] ?? { calls: 0 }
         mcpBreakdown[server].calls++
       }
+      for (const cmd of call.bashCommands) {
+        bashBreakdown[cmd] = bashBreakdown[cmd] ?? { calls: 0 }
+        bashBreakdown[cmd].calls++
+      }
 
       if (!firstTs || call.timestamp < firstTs) firstTs = call.timestamp
       if (!lastTs || call.timestamp > lastTs) lastTs = call.timestamp
@@ -271,6 +289,7 @@ function buildSessionSummary(
     modelBreakdown,
     toolBreakdown,
     mcpBreakdown,
+    bashBreakdown,
     categoryBreakdown,
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -15,8 +15,8 @@ import type {
   TokenUsage,
   ToolUseBlock,
 } from './types.js'
-import { classifyTurn } from './classifier.js'
-import { extractBashCommands, isBashTool } from './bash-utils.js'
+import { classifyTurn, BASH_TOOLS } from './classifier.js'
+import { extractBashCommands } from './bash-utils.js'
 
 function getClaudeDir(): string {
   return process.env['CLAUDE_CONFIG_DIR'] || join(homedir(), '.claude')
@@ -86,7 +86,7 @@ function extractCoreTools(tools: string[]): string[] {
 
 function extractBashCommandsFromContent(content: ContentBlock[]): string[] {
   return content
-    .filter((b): b is ToolUseBlock => b.type === 'tool_use' && isBashTool((b as ToolUseBlock).name))
+    .filter((b): b is ToolUseBlock => b.type === 'tool_use' && BASH_TOOLS.has((b as ToolUseBlock).name))
     .flatMap(b => {
       const command = (b.input as Record<string, unknown>)?.command
       return typeof command === 'string' ? extractBashCommands(command) : []

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export type ParsedApiCall = {
   hasPlanMode: boolean
   speed: 'standard' | 'fast'
   timestamp: string
+  bashCommands: string[]
 }
 
 export type TaskCategory =
@@ -111,6 +112,7 @@ export type SessionSummary = {
   modelBreakdown: Record<string, { calls: number; costUSD: number; tokens: TokenUsage }>
   toolBreakdown: Record<string, { calls: number }>
   mcpBreakdown: Record<string, { calls: number }>
+  bashBreakdown: Record<string, { calls: number }>
   categoryBreakdown: Record<TaskCategory, { turns: number; costUSD: number; retries: number; editTurns: number; oneShotTurns: number }>
 }
 

--- a/tests/bash-commands.test.ts
+++ b/tests/bash-commands.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { extractBashCommands } from '../src/bash-utils.js'
+
+describe('extractBashCommands', () => {
+  it('extracts single command', () => {
+    expect(extractBashCommands('git status')).toEqual(['git'])
+  })
+
+  it('extracts chained commands with &&', () => {
+    expect(extractBashCommands('git add . && git commit -m "x"')).toEqual(['git', 'git'])
+  })
+
+  it('extracts chained commands with ;', () => {
+    expect(extractBashCommands('ls; pwd')).toEqual(['ls', 'pwd'])
+  })
+
+  it('extracts piped commands', () => {
+    expect(extractBashCommands('cat file | grep pattern')).toEqual(['cat', 'grep'])
+  })
+
+  it('filters out cd', () => {
+    expect(extractBashCommands('cd /path && git status')).toEqual(['git'])
+  })
+
+  it('returns empty for cd only', () => {
+    expect(extractBashCommands('cd /path')).toEqual([])
+  })
+
+  it('returns empty for empty string', () => {
+    expect(extractBashCommands('')).toEqual([])
+  })
+
+  it('returns empty for whitespace only', () => {
+    expect(extractBashCommands('   ')).toEqual([])
+  })
+
+  it('extracts basename from full path binary', () => {
+    expect(extractBashCommands('/usr/bin/git status')).toEqual(['git'])
+  })
+
+  it('handles mixed separators', () => {
+    expect(extractBashCommands('cd /x && npm install; npm run build | tee log')).toEqual(['npm', 'npm', 'tee'])
+  })
+
+  it('handles extra whitespace', () => {
+    expect(extractBashCommands('  git   status  ')).toEqual(['git'])
+  })
+
+  it('handles command with quotes containing separators', () => {
+    expect(extractBashCommands('echo "hello && world"')).toEqual(['echo'])
+  })
+})

--- a/tests/bash-commands.test.ts
+++ b/tests/bash-commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { extractBashCommands } from '../src/bash-utils.js'
+import { extractBashCommands, isBashTool } from '../src/bash-utils.js'
 
 describe('extractBashCommands', () => {
   it('extracts single command', () => {
@@ -49,4 +49,18 @@ describe('extractBashCommands', () => {
   it('handles command with quotes containing separators', () => {
     expect(extractBashCommands('echo "hello && world"')).toEqual(['echo'])
   })
+
+  it('handles quoted separators followed by real separator', () => {
+    expect(extractBashCommands('echo "hello && world" && git status')).toEqual(['echo', 'git'])
+  })
+
+  it('handles single-quoted separators', () => {
+    expect(extractBashCommands("echo 'hello && world'")).toEqual(['echo'])
+  })
+})
+
+describe('isBashTool', () => {
+  it('recognizes Bash', () => { expect(isBashTool('Bash')).toBe(true) })
+  it('recognizes BashTool', () => { expect(isBashTool('BashTool')).toBe(true) })
+  it('rejects unknown tools', () => { expect(isBashTool('Read')).toBe(false) })
 })

--- a/tests/bash-commands.test.ts
+++ b/tests/bash-commands.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { extractBashCommands, isBashTool } from '../src/bash-utils.js'
+import { extractBashCommands } from '../src/bash-utils.js'
+import { BASH_TOOLS } from '../src/classifier.js'
 
 describe('extractBashCommands', () => {
   it('extracts single command', () => {
@@ -59,8 +60,8 @@ describe('extractBashCommands', () => {
   })
 })
 
-describe('isBashTool', () => {
-  it('recognizes Bash', () => { expect(isBashTool('Bash')).toBe(true) })
-  it('recognizes BashTool', () => { expect(isBashTool('BashTool')).toBe(true) })
-  it('rejects unknown tools', () => { expect(isBashTool('Read')).toBe(false) })
+describe('BASH_TOOLS', () => {
+  it('recognizes Bash', () => { expect(BASH_TOOLS.has('Bash')).toBe(true) })
+  it('recognizes BashTool', () => { expect(BASH_TOOLS.has('BashTool')).toBe(true) })
+  it('rejects unknown tools', () => { expect(BASH_TOOLS.has('Read')).toBe(false) })
 })


### PR DESCRIPTION
## Summary

- Adds a new **Shell Commands** panel to the dashboard that extracts and groups actual CLI commands (`git`, `npm`, `docker`, `glab`, etc.) from Bash tool usage
- Parses compound commands (`&&`, `;`, `|`) and counts each command individually
- Filters out `cd` (noise) and handles quoted strings containing separators
- Adds shell commands section to CSV and JSON export
- Includes 17 unit tests (first test suite in the project)

## What it looks like

```
╭─ Shell Commands ──────────────────────────────╮
│                                        calls  │
│ ██████████ git                          164   │
│ ██████░░░░ head                         102   │
│ █████░░░░░ grep                          87   │
│ ████░░░░░░ glab                          64   │
│ ███░░░░░░░ echo                          55   │
│ ███░░░░░░░ ls                            45   │
│ ██░░░░░░░░ python3                       34   │
╰───────────────────────────────────────────────╯
```

## Files changed

| File | Change |
|---|---|
| `src/bash-utils.ts` | New: `extractBashCommands()` parser + `isBashTool()` helper |
| `src/types.ts` | Add `bashCommands` to `ParsedApiCall`, `bashBreakdown` to `SessionSummary` |
| `src/parser.ts` | Wire bash command extraction into parsing pipeline |
| `src/dashboard.tsx` | New `BashBreakdown` component, 4th row in dashboard |
| `src/export.ts` | Add `buildBashRows()`, new CSV/JSON section |
| `tests/bash-commands.test.ts` | 17 tests covering parsing edge cases |

## Test plan

- [x] 17 unit tests pass (`npx vitest run`)
- [x] Dashboard renders Shell Commands panel with real session data
- [x] CSV export contains `# Shell Commands - All` section
- [x] JSON export contains `shellCommands` array
- [x] `npm run build` succeeds, built version works
- [x] No type regressions (`npx tsc --noEmit`)