### PR TITLE
feat: add 30-day rolling window period

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,10 @@ function getDateRange(period: string): { range: DateRange; label: string } {
       const start = new Date(now.getFullYear(), now.getMonth(), 1)
       return { range: { start, end }, label: `${now.toLocaleString('default', { month: 'long' })} ${now.getFullYear()}` }
     }
+    case '30days': {
+      const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30)
+      return { range: { start, end }, label: 'Last 30 Days' }
+    }
     case 'all': {
       return { range: { start: new Date(0), end }, label: 'All Time' }
     }
@@ -40,9 +44,10 @@ function getDateRange(period: string): { range: DateRange; label: string } {
   }
 }
 
-function toPeriod(s: string): 'today' | 'week' | 'month' {
+function toPeriod(s: string): 'today' | 'week' | 'month' | '30days' {
   if (s === 'today') return 'today'
   if (s === 'month') return 'month'
+  if (s === '30days') return '30days'
   return 'week'
 }
 
@@ -54,7 +59,7 @@ const program = new Command()
 program
   .command('report', { isDefault: true })
   .description('Interactive usage dashboard')
-  .option('-p, --period <period>', 'Starting period: today, week, month', 'week')
+  .option('-p, --period <period>', 'Starting period: today, week, month, 30days', 'week')
   .option('--provider <provider>', 'Filter by provider: all, claude, codex', 'all')
   .action(async (opts) => {
     await renderDashboard(toPeriod(opts.period), opts.provider)
@@ -161,7 +166,7 @@ program
     const periods: PeriodExport[] = [
       { label: 'Today', projects: await parseAllSessions(getDateRange('today').range, pf) },
       { label: '7 Days', projects: await parseAllSessions(getDateRange('week').range, pf) },
-      { label: '30 Days', projects: await parseAllSessions(getDateRange('month').range, pf) },
+      { label: '30 Days', projects: await parseAllSessions(getDateRange('30days').range, pf) },
     ]
 
     if (periods.every(p => p.projects.length === 0)) {

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -6,12 +6,13 @@ import { parseAllSessions } from './parser.js'
 import { loadPricing } from './models.js'
 import { providers } from './providers/index.js'
 
-type Period = 'today' | 'week' | 'month'
+type Period = 'today' | 'week' | 'month' | '30days'
 
-const PERIODS: Period[] = ['today', 'week', 'month']
+const PERIODS: Period[] = ['today', 'week', '30days', 'month']
 const PERIOD_LABELS: Record<Period, string> = {
   today: 'Today',
   week: '7 Days',
+  '30days': '30 Days',
   month: 'This Month',
 }
 
@@ -75,6 +76,7 @@ function getDateRange(period: Period): { start: Date; end: Date } {
   switch (period) {
     case 'today': return { start: new Date(now.getFullYear(), now.getMonth(), now.getDate()), end }
     case 'week': return { start: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7), end }
+    case '30days': return { start: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30), end }
     case 'month': return { start: new Date(now.getFullYear(), now.getMonth(), 1), end }
   }
 }
@@ -407,6 +409,8 @@ function StatusBar({ width, showProvider }: { width: number; showProvider?: bool
         <Text color={ORANGE} bold>2</Text>
         <Text dimColor> week   </Text>
         <Text color={ORANGE} bold>3</Text>
+        <Text dimColor> 30 days   </Text>
+        <Text color={ORANGE} bold>4</Text>
         <Text dimColor> month</Text>
         {showProvider && (
           <>
@@ -443,7 +447,7 @@ function DashboardContent({ projects, period }: { projects: ProjectSummary[]; pe
       <Overview projects={projects} label={PERIOD_LABELS[period]} width={dashWidth} />
 
       <Row wide={wide} width={dashWidth}>
-        <DailyActivity projects={projects} days={period === 'month' ? 31 : 14} pw={pw} bw={barWidth} />
+        <DailyActivity projects={projects} days={period === 'month' || period === '30days' ? 31 : 14} pw={pw} bw={barWidth} />
         <ProjectBreakdown projects={projects} pw={pw} bw={barWidth} />
       </Row>
 
@@ -532,7 +536,8 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider 
       switchPeriod(PERIODS[(idx + 1) % PERIODS.length])
     } else if (input === '1') switchPeriod('today')
     else if (input === '2') switchPeriod('week')
-    else if (input === '3') switchPeriod('month')
+    else if (input === '3') switchPeriod('30days')
+    else if (input === '4') switchPeriod('month')
   })
 
   if (loading) {
@@ -566,7 +571,7 @@ function StaticDashboard({ projects, period }: { projects: ProjectSummary[]; per
   )
 }
 
-export async function renderDashboard(period: Period = 'week', provider: string = 'all'): Promise<void> {
+export async function renderDashboard(period: 'today' | 'week' | 'month' | '30days' = 'week', provider: string = 'all'): Promise<void> {
   await loadPricing()
   const range = getDateRange(period)
   const projects = await parseAllSessions(range, provider)


### PR DESCRIPTION
## Summary
- Adds a new `30days` period showing a rolling 30-day window, distinct from `month` (calendar month starting on the 1st)
- Accessible via `codeburn report -p 30days`, keyboard shortcut `3` in the interactive dashboard, or arrow key cycling
- Fixes the export command which labeled a period "30 Days" but actually used calendar month data

## Changes
- `src/cli.ts`: new `30days` case in `getDateRange()`, updated `toPeriod()`, fixed export to use actual 30-day range
- `src/dashboard.tsx`: added `30days` to `Period` type, `PERIODS` array, labels, date range, keyboard shortcuts, and daily activity row count

## Test plan
- [ ] `codeburn report -p 30days` opens dashboard with 30-day data
- [ ] Arrow keys cycle through Today > 7 Days > 30 Days > This Month
- [ ] Pressing `3` switches to 30 Days, `4` switches to This Month
- [ ] `codeburn export` produces correct 30-day range data (not calendar month)