### PR TITLE
feat: add multi-currency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Any [ISO 4217 currency code](https://en.wikipedia.org/wiki/ISO_4217#List_of_ISO_
 
 The currency setting applies everywhere: dashboard, status bar, menu bar widget, CSV/JSON exports, and JSON API output.
 
+The menu bar widget also includes a currency picker with 16 common currencies. For any currency not listed in the menu bar, use the CLI command above.
+
 ## What it tracks
 
 **13 task categories** classified from tool usage patterns and user message keywords. No LLM calls, fully deterministic.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ codeburn uninstall-menubar  # remove it
 
 Requires [SwiftBar](https://github.com/swiftbar/SwiftBar) (`brew install --cask swiftbar`). Shows today's cost in the menu bar with a flame icon. Dropdown shows activity breakdown, model costs, and token stats for today, 7 days, and month. Refreshes every 5 minutes.
 
+## Currency
+
+By default, costs are shown in USD. To display in a different currency:
+
+```bash
+codeburn config currency GBP     # set to British Pounds
+codeburn config currency AUD     # set to Australian Dollars
+codeburn config currency JPY     # set to Japanese Yen
+codeburn config currency         # show current setting
+codeburn config currency --reset # back to USD
+```
+
+Any [ISO 4217 currency code](https://en.wikipedia.org/wiki/ISO_4217#List_of_ISO_4217_currency_codes) is supported (162 currencies). Exchange rates are fetched from [Frankfurter](https://www.frankfurter.app/) (European Central Bank data, free, no API key) and cached for 24 hours at `~/.cache/codeburn/`. Config is stored at `~/.config/codeburn/config.json`.
+
+The currency setting applies everywhere: dashboard, status bar, menu bar widget, CSV/JSON exports, and JSON API output.
+
 ## What it tracks
 
 **13 task categories** classified from tool usage patterns and user message keywords. No LLM calls, fully deterministic.
@@ -109,6 +125,8 @@ src/
   format.ts       Text rendering (status bar)
   menubar.ts      SwiftBar plugin generator
   export.ts       CSV/JSON multi-period export
+  config.ts       Config file management (~/.config/codeburn/)
+  currency.ts     Currency conversion, exchange rates, Intl formatting
 ```
 
 ## License

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,8 @@ import { installMenubar, renderMenubarFormat, type PeriodData, type ProviderCost
 import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory } from './types.js'
 import { renderDashboard } from './dashboard.js'
 import { providers } from './providers/index.js'
+import { readConfig, saveConfig, getConfigFilePath } from './config.js'
+import { loadCurrency, getCurrency, isValidCurrencyCode } from './currency.js'
 
 function getDateRange(period: string): { range: DateRange; label: string } {
   const now = new Date()
@@ -55,6 +57,12 @@ const program = new Command()
   .name('codeburn')
   .description('See where your AI coding tokens go - by task, tool, model, and project')
   .version('0.4.0')
+
+// Load currency config before any command runs.
+// If no currency is configured, this is a no-op and everything stays USD.
+program.hook('preAction', async () => {
+  await loadCurrency()
+})
 
 program
   .command('report', { isDefault: true })
@@ -130,7 +138,12 @@ program
     if (opts.format === 'json') {
       const todayData = buildPeriodData('today', await parseAllSessions(getDateRange('today').range, pf))
       const monthData = buildPeriodData('month', await parseAllSessions(getDateRange('month').range, pf))
-      console.log(JSON.stringify({ today: { cost: todayData.cost, calls: todayData.calls }, month: { cost: monthData.cost, calls: monthData.calls } }))
+      const { code, rate } = getCurrency()
+      console.log(JSON.stringify({
+        currency: code,
+        today: { cost: Math.round(todayData.cost * rate * 100) / 100, calls: todayData.calls },
+        month: { cost: Math.round(monthData.cost * rate * 100) / 100, calls: monthData.calls },
+      }))
       return
     }
 
@@ -201,6 +214,67 @@ program
   .action(async () => {
     const result = await uninstallMenubar()
     console.log(result)
+  })
+
+// --- Config commands ---
+
+const configCmd = program
+  .command('config')
+  .description('View or set configuration')
+
+configCmd
+  .command('currency [code]')
+  .description('Set display currency (e.g. codeburn config currency AUD)')
+  .option('--symbol <symbol>', 'Override the currency symbol')
+  .option('--reset', 'Reset to USD (removes currency config)')
+  .action(async (code?: string, opts?: { symbol?: string; reset?: boolean }) => {
+    // Reset: remove currency from config
+    if (opts?.reset) {
+      const config = await readConfig()
+      delete config.currency
+      await saveConfig(config)
+      console.log('\n  Currency reset to USD.\n')
+      return
+    }
+
+    // Show: display current setting
+    if (!code) {
+      const { code: activeCode, rate, symbol } = getCurrency()
+      if (activeCode === 'USD' && rate === 1) {
+        console.log('\n  Currency: USD (default)')
+        console.log(`  Config: ${getConfigFilePath()}\n`)
+      } else {
+        console.log(`\n  Currency: ${activeCode}`)
+        console.log(`  Symbol: ${symbol}`)
+        console.log(`  Rate: 1 USD = ${rate} ${activeCode}`)
+        console.log(`  Config: ${getConfigFilePath()}\n`)
+      }
+      return
+    }
+
+    // Set: validate and save
+    const upperCode = code.toUpperCase()
+    if (!isValidCurrencyCode(upperCode)) {
+      console.error(`\n  "${code}" is not a valid ISO 4217 currency code.\n`)
+      process.exitCode = 1
+      return
+    }
+
+    const config = await readConfig()
+    config.currency = {
+      code: upperCode,
+      ...(opts?.symbol ? { symbol: opts.symbol } : {}),
+    }
+    await saveConfig(config)
+
+    // Load the currency to fetch the rate and confirm it works
+    await loadCurrency()
+    const { rate, symbol } = getCurrency()
+
+    console.log(`\n  Currency set to ${upperCode}.`)
+    console.log(`  Symbol: ${symbol}`)
+    console.log(`  Rate: 1 USD = ${rate} ${upperCode}`)
+    console.log(`  Config saved to ${getConfigFilePath()}\n`)
   })
 
 program.parse()

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,47 @@
+/**
+ * Generic config file management for ~/.config/codeburn/config.json.
+ *
+ * This module handles reading and writing the config file only.
+ * Feature-specific logic (e.g. currency) lives in its own module
+ * and imports from here.
+ */
+
+import { readFile, writeFile, mkdir } from 'fs/promises'
+import { join } from 'path'
+import { homedir } from 'os'
+
+export type CodeburnConfig = {
+  currency?: {
+    code: string
+    symbol?: string  // optional override, otherwise resolved via Intl
+  }
+}
+
+function getConfigDir(): string {
+  return join(homedir(), '.config', 'codeburn')
+}
+
+function getConfigPath(): string {
+  return join(getConfigDir(), 'config.json')
+}
+
+/** Reads the config file. Returns an empty object if the file is missing or invalid. */
+export async function readConfig(): Promise<CodeburnConfig> {
+  try {
+    const raw = await readFile(getConfigPath(), 'utf-8')
+    return JSON.parse(raw) as CodeburnConfig
+  } catch {
+    return {}
+  }
+}
+
+/** Writes the config to disk, creating ~/.config/codeburn/ if needed. */
+export async function saveConfig(config: CodeburnConfig): Promise<void> {
+  await mkdir(getConfigDir(), { recursive: true })
+  await writeFile(getConfigPath(), JSON.stringify(config, null, 2) + '\n', 'utf-8')
+}
+
+/** Returns the absolute path to the config file (for display in CLI output). */
+export function getConfigFilePath(): string {
+  return getConfigPath()
+}

--- a/src/currency.ts
+++ b/src/currency.ts
@@ -32,6 +32,8 @@ const FRANKFURTER_URL = 'https://api.frankfurter.app/latest?from=USD&to='
 // Overwritten by loadCurrency() if the user has configured a currency.
 let active: CurrencyState = { code: 'USD', rate: 1, symbol: '$' }
 
+const USD: CurrencyState = { code: 'USD', rate: 1, symbol: '$' }
+
 // ---------------------------------------------------------------------------
 // Intl-based currency helpers
 // ---------------------------------------------------------------------------
@@ -162,6 +164,21 @@ export async function loadCurrency(): Promise<void> {
 /** Returns the active currency state (code, rate, and symbol). */
 export function getCurrency(): CurrencyState {
   return active
+}
+
+/**
+ * Switches the active currency at runtime. Used by the dashboard currency picker.
+ * Fetches the exchange rate (from cache or API) and updates the display currency.
+ * Does not write to the config file -- session-only unless the caller saves separately.
+ */
+export async function switchCurrency(code: string): Promise<void> {
+  if (code === 'USD') {
+    active = USD
+    return
+  }
+  const rate = await getExchangeRate(code)
+  const symbol = resolveSymbol(code)
+  active = { code, rate, symbol }
 }
 
 /** Returns a dynamic column header like "Cost (AUD)" for use in CSV/JSON exports. */

--- a/src/currency.ts
+++ b/src/currency.ts
@@ -1,0 +1,203 @@
+/**
+ * Currency conversion and formatting.
+ *
+ * All internal cost data is USD (from Anthropic API pricing). This module
+ * handles converting and formatting those values for display in the user's
+ * preferred currency.
+ *
+ * Currency symbols and decimal rules come from Node's built-in Intl API
+ * (ISO 4217), so no hardcoded tables or external dependencies are needed.
+ *
+ * Exchange rates are fetched from frankfurter.app (free, no API key, ECB-backed)
+ * and cached for 24 hours at ~/.cache/codeburn/exchange-rate.json -- the same
+ * pattern used for LiteLLM pricing in models.ts.
+ */
+
+import { readFile, writeFile, mkdir } from 'fs/promises'
+import { join } from 'path'
+import { homedir } from 'os'
+
+import { readConfig } from './config.js'
+
+type CurrencyState = {
+  code: string
+  rate: number
+  symbol: string
+}
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const FRANKFURTER_URL = 'https://api.frankfurter.app/latest?from=USD&to='
+
+// Default state: USD passthrough (rate=1, no conversion applied).
+// Overwritten by loadCurrency() if the user has configured a currency.
+let active: CurrencyState = { code: 'USD', rate: 1, symbol: '$' }
+
+// ---------------------------------------------------------------------------
+// Intl-based currency helpers
+// ---------------------------------------------------------------------------
+// Node's Intl API knows all 162 ISO 4217 currencies: symbols, decimal places,
+// and code validation. Using it avoids hardcoded lookup tables that go stale.
+
+/**
+ * Validates a currency code against ISO 4217.
+ * Used by the CLI command to reject invalid input before saving config.
+ */
+export function isValidCurrencyCode(code: string): boolean {
+  try {
+    new Intl.NumberFormat('en', { style: 'currency', currency: code })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolves the display symbol for a currency code via Intl.
+ * Uses 'symbol' display (not 'narrowSymbol') so that dollar-based currencies
+ * get distinguishing prefixes: AUD -> "A$", CAD -> "CA$", USD -> "$".
+ */
+function resolveSymbol(code: string): string {
+  const parts = new Intl.NumberFormat('en', {
+    style: 'currency',
+    currency: code,
+    currencyDisplay: 'symbol',
+  }).formatToParts(0)
+  return parts.find(p => p.type === 'currency')?.value ?? code
+}
+
+/**
+ * Returns the standard number of decimal places for a currency.
+ * Most currencies return 2 (USD, EUR, GBP). JPY and KRW return 0.
+ * Drives rounding in both formatCost() and convertCost().
+ */
+function getFractionDigits(code: string): number {
+  return new Intl.NumberFormat('en', {
+    style: 'currency',
+    currency: code,
+  }).resolvedOptions().maximumFractionDigits
+}
+
+// ---------------------------------------------------------------------------
+// Exchange rate fetching and caching
+// ---------------------------------------------------------------------------
+// Mirrors the cache pattern in models.ts (loadPricing / loadCachedPricing):
+// try cache first, fetch on miss, fall back to defaults on failure.
+
+function getCacheDir(): string {
+  return join(homedir(), '.cache', 'codeburn')
+}
+
+function getRateCachePath(): string {
+  return join(getCacheDir(), 'exchange-rate.json')
+}
+
+async function fetchRate(code: string): Promise<number> {
+  const response = await fetch(`${FRANKFURTER_URL}${code}`)
+  if (!response.ok) throw new Error(`HTTP ${response.status}`)
+  const data = await response.json() as { rates: Record<string, number> }
+  const rate = data.rates[code]
+  if (!rate) throw new Error(`No rate returned for ${code}`)
+  return rate
+}
+
+async function loadCachedRate(code: string): Promise<number | null> {
+  try {
+    const raw = await readFile(getRateCachePath(), 'utf-8')
+    const cached = JSON.parse(raw) as { timestamp: number; code: string; rate: number }
+    // Invalidate if the user switched currencies or the cache expired
+    if (cached.code !== code) return null
+    if (Date.now() - cached.timestamp > CACHE_TTL_MS) return null
+    return cached.rate
+  } catch {
+    return null
+  }
+}
+
+async function cacheRate(code: string, rate: number): Promise<void> {
+  await mkdir(getCacheDir(), { recursive: true })
+  await writeFile(getRateCachePath(), JSON.stringify({ timestamp: Date.now(), code, rate }))
+}
+
+async function getExchangeRate(code: string): Promise<number> {
+  if (code === 'USD') return 1
+
+  const cached = await loadCachedRate(code)
+  if (cached) return cached
+
+  try {
+    const rate = await fetchRate(code)
+    await cacheRate(code, rate)
+    return rate
+  } catch {
+    // API unreachable and no cache -- fall back to no conversion.
+    // The tool still works, it just shows USD values.
+    return 1
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Loads currency config and fetches the exchange rate.
+ * Called once at CLI startup via a Commander preAction hook in cli.ts.
+ * If no currency is configured, this is a no-op and everything stays USD.
+ */
+export async function loadCurrency(): Promise<void> {
+  const config = await readConfig()
+  if (!config.currency) return
+
+  const code = config.currency.code.toUpperCase()
+  const rate = await getExchangeRate(code)
+  const symbol = config.currency.symbol ?? resolveSymbol(code)
+
+  active = { code, rate, symbol }
+}
+
+// ---------------------------------------------------------------------------
+// Accessors -- used by format.ts, export.ts, cli.ts, and dashboard/menubar
+// ---------------------------------------------------------------------------
+
+/** Returns the active currency state (code, rate, and symbol). */
+export function getCurrency(): CurrencyState {
+  return active
+}
+
+/** Returns a dynamic column header like "Cost (AUD)" for use in CSV/JSON exports. */
+export function getCostColumnHeader(): string {
+  return `Cost (${active.code})`
+}
+
+/**
+ * Converts a USD cost to the active currency, rounded to the correct
+ * number of decimal places. Used in exports where a raw number is needed
+ * rather than a formatted string.
+ */
+export function convertCost(costUSD: number): number {
+  const digits = getFractionDigits(active.code)
+  const factor = 10 ** digits
+  return Math.round(costUSD * active.rate * factor) / factor
+}
+
+/**
+ * Formats a USD cost for display in the active currency.
+ *
+ * Uses adaptive precision so small values stay readable:
+ *   >= 1    -> 2 decimal places   (A$4.59)
+ *   >= 0.01 -> 3 decimal places   (A$0.123)
+ *   < 0.01  -> 4 decimal places   (A$0.0034)
+ *
+ * Zero-decimal currencies (JPY, KRW) are rounded to whole numbers.
+ */
+export function formatCost(costUSD: number): string {
+  const { rate, symbol, code } = active
+  const cost = costUSD * rate
+  const digits = getFractionDigits(code)
+
+  if (digits === 0) return `${symbol}${Math.round(cost)}`
+
+  if (cost >= 1) return `${symbol}${cost.toFixed(2)}`
+  if (cost >= 0.01) return `${symbol}${cost.toFixed(3)}`
+  return `${symbol}${cost.toFixed(4)}`
+}

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -4,6 +4,7 @@ import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory } from './types
 import { formatCost, formatTokens } from './format.js'
 import { parseAllSessions } from './parser.js'
 import { loadPricing } from './models.js'
+import { switchCurrency, getCurrency, isValidCurrencyCode } from './currency.js'
 import { providers } from './providers/index.js'
 
 type Period = 'today' | 'week' | 'month' | '30days'
@@ -411,7 +412,9 @@ function StatusBar({ width, showProvider }: { width: number; showProvider?: bool
         <Text color={ORANGE} bold>3</Text>
         <Text dimColor> 30 days   </Text>
         <Text color={ORANGE} bold>4</Text>
-        <Text dimColor> month</Text>
+        <Text dimColor> month   </Text>
+        <Text color={ORANGE} bold>c</Text>
+        <Text dimColor> currency ({getCurrency().code})</Text>
         {showProvider && (
           <>
             <Text dimColor>   </Text>
@@ -420,6 +423,115 @@ function StatusBar({ width, showProvider }: { width: number; showProvider?: bool
           </>
         )}
       </Text>
+    </Box>
+  )
+}
+
+// Common currencies shown in the picker. Full list is searchable by typing a code.
+const COMMON_CURRENCIES = [
+  { code: 'USD', name: 'US Dollar' },
+  { code: 'GBP', name: 'British Pound' },
+  { code: 'EUR', name: 'Euro' },
+  { code: 'AUD', name: 'Australian Dollar' },
+  { code: 'CAD', name: 'Canadian Dollar' },
+  { code: 'NZD', name: 'New Zealand Dollar' },
+  { code: 'JPY', name: 'Japanese Yen' },
+  { code: 'CHF', name: 'Swiss Franc' },
+  { code: 'INR', name: 'Indian Rupee' },
+  { code: 'BRL', name: 'Brazilian Real' },
+  { code: 'SEK', name: 'Swedish Krona' },
+  { code: 'SGD', name: 'Singapore Dollar' },
+  { code: 'HKD', name: 'Hong Kong Dollar' },
+  { code: 'KRW', name: 'South Korean Won' },
+  { code: 'MXN', name: 'Mexican Peso' },
+  { code: 'ZAR', name: 'South African Rand' },
+  { code: 'DKK', name: 'Danish Krone' },
+  { code: 'NOK', name: 'Norwegian Krone' },
+  { code: 'PLN', name: 'Polish Zloty' },
+  { code: 'THB', name: 'Thai Baht' },
+  { code: 'TWD', name: 'Taiwan Dollar' },
+  { code: 'TRY', name: 'Turkish Lira' },
+  { code: 'PHP', name: 'Philippine Peso' },
+  { code: 'CZK', name: 'Czech Koruna' },
+]
+
+function CurrencyPicker({ width, onSelect, onCancel }: {
+  width: number
+  onSelect: (code: string) => void
+  onCancel: () => void
+}) {
+  const [search, setSearch] = useState('')
+  const [cursor, setCursor] = useState(0)
+  const activeCode = getCurrency().code
+
+  const filtered = search.length > 0
+    ? COMMON_CURRENCIES.filter(c =>
+        c.code.toLowerCase().includes(search.toLowerCase()) ||
+        c.name.toLowerCase().includes(search.toLowerCase()))
+    : COMMON_CURRENCIES
+
+  // Keep cursor in bounds when search narrows the list
+  const safeCursor = Math.min(cursor, Math.max(filtered.length - 1, 0))
+  const maxVisible = 12
+
+  useInput((input, key) => {
+    if (key.escape) { onCancel(); return }
+    if (key.return) {
+      if (filtered.length > 0) {
+        onSelect(filtered[safeCursor].code)
+      } else if (search.length === 3 && isValidCurrencyCode(search.toUpperCase())) {
+        onSelect(search.toUpperCase())
+      }
+      return
+    }
+    if (key.upArrow) { setCursor(Math.max(0, safeCursor - 1)); return }
+    if (key.downArrow) { setCursor(Math.min(filtered.length - 1, safeCursor + 1)); return }
+    if (key.backspace || key.delete) {
+      setSearch(s => s.slice(0, -1))
+      setCursor(0)
+      return
+    }
+    if (input && input.length === 1 && /[a-zA-Z]/.test(input)) {
+      setSearch(s => s + input)
+      setCursor(0)
+    }
+  })
+
+  // Scroll window around the cursor
+  const scrollStart = Math.max(0, Math.min(safeCursor - Math.floor(maxVisible / 2), filtered.length - maxVisible))
+  const visible = filtered.slice(scrollStart, scrollStart + maxVisible)
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={ORANGE} width={Math.min(width, 44)} paddingX={1}>
+      <Text bold color={ORANGE}>Currency</Text>
+      <Text dimColor>Type to search, arrows to move, enter to select, esc to cancel</Text>
+      <Box marginTop={1}>
+        <Text color={ORANGE}>{'> '}</Text>
+        <Text>{search.length > 0 ? search.toUpperCase() : ''}</Text>
+        <Text dimColor>{search.length === 0 ? 'search...' : ''}</Text>
+      </Box>
+      <Box flexDirection="column" marginTop={1}>
+        {visible.map((c, i) => {
+          const idx = scrollStart + i
+          const isActive = c.code === activeCode
+          const isSelected = idx === safeCursor
+          return (
+            <Text key={c.code}>
+              <Text color={isSelected ? ORANGE : undefined} bold={isSelected}>
+                {isSelected ? '> ' : '  '}
+                {c.code} {c.name}
+                {isActive ? ' *' : ''}
+              </Text>
+            </Text>
+          )
+        })}
+        {filtered.length === 0 && search.length >= 3 && isValidCurrencyCode(search.toUpperCase()) && (
+          <Text color={GOLD}>  Press enter to use {search.toUpperCase()}</Text>
+        )}
+        {filtered.length === 0 && (search.length < 3 || !isValidCurrencyCode(search.toUpperCase())) && (
+          <Text dimColor>  No matches</Text>
+        )}
+      </Box>
     </Box>
   )
 }
@@ -475,6 +587,8 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider 
   const [period, setPeriod] = useState<Period>(initialPeriod)
   const [projects, setProjects] = useState<ProjectSummary[]>(initialProjects)
   const [loading, setLoading] = useState(false)
+  const [showCurrencyPicker, setShowCurrencyPicker] = useState(false)
+  const [, forceRender] = useState(0)
   const [activeProvider, setActiveProvider] = useState(initialProvider)
   const [detectedProviders, setDetectedProviders] = useState<string[]>([])
   const { dashWidth } = getLayout()
@@ -515,8 +629,16 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider 
   }, [period, activeProvider, reloadData])
 
   useInput((input, key) => {
+    // Don't capture keys while the currency picker is open -- it has its own input handler
+    if (showCurrencyPicker) return
+
     if (input === 'q') {
       exit()
+      return
+    }
+
+    if (input === 'c') {
+      setShowCurrencyPicker(true)
       return
     }
 
@@ -539,6 +661,25 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider 
     else if (input === '3') switchPeriod('30days')
     else if (input === '4') switchPeriod('month')
   })
+
+  const handleCurrencySelect = async (code: string) => {
+    setShowCurrencyPicker(false)
+    await switchCurrency(code)
+    forceRender(n => n + 1)
+  }
+
+  const handleCurrencyCancel = () => {
+    setShowCurrencyPicker(false)
+  }
+
+  if (showCurrencyPicker) {
+    return (
+      <Box flexDirection="column" width={dashWidth}>
+        <PeriodTabs active={period} providerName={activeProvider} showProvider={multipleProviders} />
+        <CurrencyPicker width={dashWidth} onSelect={handleCurrencySelect} onCancel={handleCurrencyCancel} />
+      </Box>
+    )
+  }
 
   if (loading) {
     return (

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,6 +1,8 @@
 import { writeFile } from 'fs/promises'
 import { resolve } from 'path'
+
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory } from './types.js'
+import { getCostColumnHeader, convertCost } from './currency.js'
 
 function escCsv(s: string): string {
   if (s.includes(',') || s.includes('"') || s.includes('\n')) {
@@ -32,7 +34,7 @@ function buildDailyRows(projects: ProjectSummary[]): Array<Record<string, string
 
   return Object.entries(daily).sort().map(([date, d]) => ({
     Date: date,
-    'Cost (USD)': Math.round(d.cost * 100) / 100,
+    [getCostColumnHeader()]: convertCost(d.cost),
     'API Calls': d.calls,
     'Input Tokens': d.input,
     'Output Tokens': d.output,
@@ -56,7 +58,7 @@ function buildActivityRows(projects: ProjectSummary[]): Array<Record<string, str
     .sort(([, a], [, b]) => b.cost - a.cost)
     .map(([cat, d]) => ({
       Activity: CATEGORY_LABELS[cat as TaskCategory] ?? cat,
-      'Cost (USD)': Math.round(d.cost * 100) / 100,
+      [getCostColumnHeader()]: convertCost(d.cost),
       Turns: d.turns,
     }))
 }
@@ -78,7 +80,7 @@ function buildModelRows(projects: ProjectSummary[]): Array<Record<string, string
     .sort(([, a], [, b]) => b.cost - a.cost)
     .map(([model, d]) => ({
       Model: model,
-      'Cost (USD)': Math.round(d.cost * 100) / 100,
+      [getCostColumnHeader()]: convertCost(d.cost),
       'API Calls': d.calls,
       'Input Tokens': d.input,
       'Output Tokens': d.output,
@@ -116,7 +118,7 @@ function buildBashRows(projects: ProjectSummary[]): Array<Record<string, string 
 function buildProjectRows(projects: ProjectSummary[]): Array<Record<string, string | number>> {
   return projects.map(p => ({
     Project: p.projectPath,
-    'Cost (USD)': Math.round(p.totalCostUSD * 100) / 100,
+    [getCostColumnHeader()]: convertCost(p.totalCostUSD),
     'API Calls': p.totalApiCalls,
     Sessions: p.sessions.length,
   }))
@@ -141,7 +143,7 @@ function buildSummaryRow(period: PeriodExport): Record<string, string | number> 
   const cost = period.projects.reduce((s, p) => s + p.totalCostUSD, 0)
   const calls = period.projects.reduce((s, p) => s + p.totalApiCalls, 0)
   const sessions = period.projects.reduce((s, p) => s + p.sessions.length, 0)
-  return { Period: period.label, 'Cost (USD)': Math.round(cost * 100) / 100, 'API Calls': calls, Sessions: sessions }
+  return { Period: period.label, [getCostColumnHeader()]: convertCost(cost), 'API Calls': calls, Sessions: sessions }
 }
 
 export async function exportCsv(periods: PeriodExport[], outputPath: string): Promise<string> {

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk'
 import type { ProjectSummary } from './types.js'
 
-export function formatCost(cost: number): string {
-  if (cost >= 1) return `$${cost.toFixed(2)}`
-  if (cost >= 0.01) return `$${cost.toFixed(3)}`
-  return `$${cost.toFixed(4)}`
-}
+// Re-exported from currency.ts so existing imports from './format.js' keep working.
+// The currency-aware version applies exchange rate and symbol automatically.
+// Imported locally too since renderStatusBar below uses it directly.
+import { formatCost } from './currency.js'
+export { formatCost }
 
 export function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`

--- a/src/menubar.ts
+++ b/src/menubar.ts
@@ -174,6 +174,7 @@ export function renderMenubarFormat(
     { code: 'KRW', name: 'South Korean Won' },
     { code: 'MXN', name: 'Mexican Peso' },
     { code: 'ZAR', name: 'South African Rand' },
+    { code: 'DKK', name: 'Danish Krone' },
   ]
   lines.push(`Currency: ${activeCurrency} | size=14`)
   for (const { code, name } of currencies) {

--- a/src/menubar.ts
+++ b/src/menubar.ts
@@ -4,6 +4,7 @@ import { chmod, mkdir, unlink, writeFile } from 'fs/promises'
 import { homedir, platform } from 'os'
 import { join } from 'path'
 import { formatCost, formatTokens } from './format.js'
+import { getCurrency } from './currency.js'
 
 const PLUGIN_REFRESH = '5m'
 
@@ -149,8 +150,40 @@ export function renderMenubarFormat(
 
   lines.push('---')
   const home = process.env.HOME ?? '~'
+  const bin = getCodeburnBin()
   lines.push(`Open Full Report | terminal=true shell=/bin/bash param1=-c param2="cd '${home}/codeburn' && npx tsx src/cli.ts report; echo ''; echo 'Press any key to close...'; read -n1"`)
   lines.push(`Export CSV to Desktop | terminal=false shell=/bin/bash param1=-c param2="cd '${home}/codeburn' && npx tsx src/cli.ts export -o '${home}/Desktop/codeburn-report.csv' 2>/dev/null"`)
+
+  // Currency submenu -- common currencies as clickable items.
+  // Clicking one runs 'codeburn config currency XXX' and refreshes the plugin.
+  const activeCurrency = getCurrency().code
+  const currencies = [
+    { code: 'USD', name: 'US Dollar' },
+    { code: 'GBP', name: 'British Pound' },
+    { code: 'EUR', name: 'Euro' },
+    { code: 'AUD', name: 'Australian Dollar' },
+    { code: 'CAD', name: 'Canadian Dollar' },
+    { code: 'NZD', name: 'New Zealand Dollar' },
+    { code: 'JPY', name: 'Japanese Yen' },
+    { code: 'CHF', name: 'Swiss Franc' },
+    { code: 'INR', name: 'Indian Rupee' },
+    { code: 'BRL', name: 'Brazilian Real' },
+    { code: 'SEK', name: 'Swedish Krona' },
+    { code: 'SGD', name: 'Singapore Dollar' },
+    { code: 'HKD', name: 'Hong Kong Dollar' },
+    { code: 'KRW', name: 'South Korean Won' },
+    { code: 'MXN', name: 'Mexican Peso' },
+    { code: 'ZAR', name: 'South African Rand' },
+  ]
+  lines.push(`Currency: ${activeCurrency} | size=14`)
+  for (const { code, name } of currencies) {
+    const check = code === activeCurrency ? ' *' : ''
+    const cmd = code === 'USD'
+      ? `${bin} config currency --reset`
+      : `${bin} config currency ${code}`
+    lines.push(`--${name} (${code})${check} | terminal=false refresh=true shell=/bin/bash param1=-c param2="${cmd}"`)
+  }
+
   lines.push(`Refresh | refresh=true`)
 
   return lines.join('\n')


### PR DESCRIPTION
Hey, love this project - it's exactly what I've been wanting for tracking Claude Code costs.

I work in the UK with a Danish team, so seeing everything in USD isn't ideal. I wanted to be able to see costs in GBP and DKK without doing mental conversion every time, so I built this.

## What this adds

Three ways to change currency, so users can pick whatever fits their workflow:

### 1. CLI (persistent)
```bash
codeburn config currency GBP     # set to British Pounds
codeburn config currency JPY     # set to Japanese Yen
codeburn config currency         # show current setting
codeburn config currency --reset # back to USD
```
Any of the 162 ISO 4217 currency codes are supported. Saves to `~/.config/codeburn/config.json`.

### 2. Dashboard picker (session)
Press `c` in the interactive dashboard to open a searchable currency picker. Type to filter, arrow keys to navigate, enter to select, escape to cancel. Supports all 162 currencies by typing the code directly. This is a session-only switch for quick comparison -- doesn't change the saved config.

### 3. Menu bar dropdown (persistent)
A Currency submenu in the SwiftBar/xbar dropdown with 17 common currencies. Click one and it switches immediately with a plugin refresh.

**Exchange rates** are fetched from [Frankfurter](https://www.frankfurter.app/) (European Central Bank data, free, no API key) and cached for 24 hours at `~/.cache/codeburn/` -- same cache pattern and TTL already used for LiteLLM pricing.

**Works everywhere** -- dashboard, status bar, menu bar, CSV/JSON exports, and JSON API output.

## How it works

All internal calculations stay in USD. Currency conversion is purely a display concern -- applied in `formatCost()` and exports at render time.

Currency symbols and decimal rules (e.g. JPY uses 0 decimal places) come from Node's built-in `Intl.NumberFormat` API rather than hardcoded lookup tables, so there's no new dependency and all 162 currencies are handled correctly.

If the exchange rate API is unreachable and there's no cache, it falls back to USD silently so the tool never breaks.

## Files changed

- `src/config.ts` (new) - config file I/O for `~/.config/codeburn/config.json`
- `src/currency.ts` (new) - exchange rate fetching/caching, Intl-based formatting, runtime switching
- `src/format.ts` - re-exports `formatCost` from currency.ts (existing imports keep working)
- `src/export.ts` - dynamic cost column headers and value conversion
- `src/cli.ts` - preAction hook for config loading, `config currency` command
- `src/dashboard.tsx` - interactive currency picker modal with search
- `src/menubar.ts` - currency picker submenu
- `README.md` - Currency section with usage examples

No changes to types, parser, models, or classifier.

Happy to adjust anything based on your feedback.