### PR TITLE
fix: prevent CSV formula injection in exports

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -3,10 +3,11 @@ import { resolve } from 'path'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory } from './types.js'
 
 function escCsv(s: string): string {
-  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
-    return `"${s.replace(/"/g, '""')}"`
+  const sanitized = /^[=+\-@]/.test(s) ? `'${s}` : s
+  if (sanitized.includes(',') || sanitized.includes('"') || sanitized.includes('\n')) {
+    return `"${sanitized.replace(/"/g, '""')}"`
   }
-  return s
+  return sanitized
 }
 
 function buildDailyRows(projects: ProjectSummary[]): Array<Record<string, string | number>> {

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { exportCsv, type PeriodExport } from '../src/export.js'
+import type { ProjectSummary } from '../src/types.js'
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'export-test-'))
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+function makeProject(projectPath: string): ProjectSummary {
+  return {
+    project: projectPath,
+    projectPath,
+    sessions: [
+      {
+        sessionId: 'sess-001',
+        project: projectPath,
+        firstTimestamp: '2026-04-14T10:00:00Z',
+        lastTimestamp: '2026-04-14T10:01:00Z',
+        totalCostUSD: 1.23,
+        totalInputTokens: 100,
+        totalOutputTokens: 50,
+        totalCacheReadTokens: 0,
+        totalCacheWriteTokens: 0,
+        apiCalls: 1,
+        turns: [
+          {
+            userMessage: '=SUM(1,2)',
+            timestamp: '2026-04-14T10:00:00Z',
+            sessionId: 'sess-001',
+            category: 'coding',
+            retries: 0,
+            hasEdits: true,
+            assistantCalls: [
+              {
+                provider: 'claude',
+                model: '+danger-model',
+                usage: {
+                  inputTokens: 100,
+                  outputTokens: 50,
+                  cacheCreationInputTokens: 0,
+                  cacheReadInputTokens: 0,
+                  cachedInputTokens: 0,
+                  reasoningTokens: 0,
+                  webSearchRequests: 0,
+                },
+                costUSD: 1.23,
+                tools: ['Read'],
+                mcpTools: [],
+                hasAgentSpawn: false,
+                hasPlanMode: false,
+                speed: 'standard',
+                timestamp: '2026-04-14T10:00:00Z',
+                bashCommands: ['@malicious'],
+                deduplicationKey: 'dedup-1',
+              },
+            ],
+          },
+        ],
+        modelBreakdown: {
+          '+danger-model': {
+            calls: 1,
+            costUSD: 1.23,
+            tokens: {
+              inputTokens: 100,
+              outputTokens: 50,
+              cacheCreationInputTokens: 0,
+              cacheReadInputTokens: 0,
+              cachedInputTokens: 0,
+              reasoningTokens: 0,
+              webSearchRequests: 0,
+            },
+          },
+        },
+        toolBreakdown: {
+          Read: { calls: 1 },
+        },
+        mcpBreakdown: {},
+        bashBreakdown: {
+          '@malicious': { calls: 1 },
+        },
+        categoryBreakdown: {
+          coding: { turns: 1, costUSD: 1.23, retries: 0, editTurns: 1, oneShotTurns: 1 },
+          debugging: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+          feature: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+          refactoring: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+          testing: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+          exploration: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+          planning: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+          delegation: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+          git: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+          'build/deploy': { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+          conversation: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+          brainstorming: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+          general: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+        },
+      },
+    ],
+    totalCostUSD: 1.23,
+    totalApiCalls: 1,
+  }
+}
+
+describe('exportCsv', () => {
+  it('prefixes formula-like cells to prevent CSV injection', async () => {
+    const periods: PeriodExport[] = [
+      {
+        label: '30 Days',
+        projects: [makeProject('=cmd,calc')],
+      },
+    ]
+
+    const outputPath = join(tmpDir, 'report.csv')
+    await exportCsv(periods, outputPath)
+    const content = await readFile(outputPath, 'utf-8')
+
+    expect(content).toContain("\"'=cmd,calc\"")
+    expect(content).toContain("'+danger-model")
+    expect(content).toContain("'@malicious")
+  })
+})


### PR DESCRIPTION
## Summary

Prevent CSV formula injection in exported reports by prefixing formula-like cells with an apostrophe before CSV escaping.

This covers cells that begin with:
- `=`
- `+`
- `-`
- `@`

Without this, opening an exported CSV in spreadsheet software can treat attacker-controlled values as formulas.

## Changes

- update `escCsv()` in `src/export.ts` to neutralize formula-like cells
- add `tests/export.test.ts` regression coverage for dangerous exported values

## Why

`codeburn export` writes project names, model names, shell commands, and other transcript-derived strings into CSV output. Quoting alone does not reliably prevent spreadsheet formula execution. Prefixing these cells with `'` is the usual mitigation.

## Authorship note

Codex helped write the patch and draft this PR. I reviewed the changes and verified the final result locally.

## Verification

- `npm test -- --run`
- `npm run build`
- `npx tsx src/cli.ts report`
- `npx tsx src/cli.ts today`
