### PR TITLE
feat: add rolling 30-day window to menubar status

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,6 +127,7 @@ program
       const todayRange = getDateRange('today').range
       const todayData = buildPeriodData('Today', await parseAllSessions(todayRange, pf))
       const weekData = buildPeriodData('7 Days', await parseAllSessions(getDateRange('week').range, pf))
+      const thirtyDayData = buildPeriodData('30 Days', await parseAllSessions(getDateRange('30days').range, pf))
       const monthData = buildPeriodData('Month', await parseAllSessions(getDateRange('month').range, pf))
       const todayProviders: ProviderCost[] = []
       for (const p of await getAllProviders()) {
@@ -134,7 +135,7 @@ program
         const cost = data.reduce((s, proj) => s + proj.totalCostUSD, 0)
         if (cost > 0) todayProviders.push({ name: p.displayName, cost })
       }
-      console.log(renderMenubarFormat(todayData, weekData, monthData, todayProviders))
+      console.log(renderMenubarFormat(todayData, weekData, thirtyDayData, monthData, todayProviders))
       return
     }
 

--- a/src/menubar.ts
+++ b/src/menubar.ts
@@ -68,6 +68,7 @@ export type ProviderCost = {
 export function renderMenubarFormat(
   today: PeriodData,
   week: PeriodData,
+  thirtyDays: PeriodData,
   month: PeriodData,
   todayProviders?: ProviderCost[],
 ): string {
@@ -126,6 +127,24 @@ export function renderMenubarFormat(
   for (const model of week.models.slice(0, 5)) {
     if (model.name === '<synthetic>') continue
     const bar = miniBar(model.cost, weekMaxModel)
+    const name = model.name.padEnd(14)
+    lines.push(`--${bar}  ${name} ${formatCost(model.cost).padStart(8)}  ${String(model.calls).padStart(5)} calls | font=Menlo size=11`)
+  }
+
+  lines.push(`30 Days    ${formatCost(thirtyDays.cost)}    ${thirtyDays.calls.toLocaleString()} calls | size=14`)
+  const tdMaxCat = Math.max(...thirtyDays.categories.map(c => c.cost), 0.01)
+  const tdMaxModel = Math.max(...thirtyDays.models.filter(m => m.name !== '<synthetic>').map(m => m.cost), 0.01)
+  lines.push(`--Activity | size=12 color=#FF8C42`)
+  for (const cat of thirtyDays.categories.slice(0, 8)) {
+    const bar = miniBar(cat.cost, tdMaxCat)
+    const name = cat.name.padEnd(14)
+    lines.push(`--${bar}  ${name} ${formatCost(cat.cost).padStart(8)}  ${String(cat.turns).padStart(4)} turns | font=Menlo size=11`)
+  }
+  lines.push(`-----`)
+  lines.push(`--Models | size=12 color=#FF8C42`)
+  for (const model of thirtyDays.models.slice(0, 5)) {
+    if (model.name === '<synthetic>') continue
+    const bar = miniBar(model.cost, tdMaxModel)
     const name = model.name.padEnd(14)
     lines.push(`--${bar}  ${name} ${formatCost(model.cost).padStart(8)}  ${String(model.calls).padStart(5)} calls | font=Menlo size=11`)
   }


### PR DESCRIPTION
## Summary

Adds a rolling **30 Days** section to the SwiftBar/xbar menubar output, positioned between **7 Days** and **Month** to match the tab order in the interactive `codeburn report` view.

## Motivation

The `Month` section shows calendar-month-to-date data. Early in the month this is nearly empty and not very useful. The rolling 30-day window provides a consistent cost picture regardless of where you are in the month.

The 30-day date range logic already existed (used by `report --period 30days` and `export`) — this wires it into the `status --format menubar` renderer.

## Changes

- **`src/menubar.ts`**: Add `thirtyDays` parameter to `renderMenubarFormat()` and render a `30 Days` section with activity and model breakdowns before the existing `Month` section.
- **`src/cli.ts`**: Fetch 30-day data via the existing `getDateRange('30days')` and pass it to the renderer.

## Testing

- `npx vitest run` — all 28 tests pass
- `npx tsx src/cli.ts status --format menubar` — verified output shows Today, 7 Days, 30 Days, Month in correct order with accurate data
- `npx tsx src/cli.ts report` — confirmed tab order matches (Today, 7 Days, 30 Days, This Month)