### PR TITLE
fix(menubar): invoke binary directly + correct currency subcommand (#32, #27)

### DIFF
--- a/src/menubar.ts
+++ b/src/menubar.ts
@@ -151,8 +151,12 @@ export function renderMenubarFormat(
   lines.push('---')
   const home = process.env.HOME ?? '~'
   const bin = getCodeburnBin()
-  lines.push(`Open Full Report | terminal=true shell=/bin/bash param1=-c param2="cd '${home}/codeburn' && npx tsx src/cli.ts report; echo ''; echo 'Press any key to close...'; read -n1"`)
-  lines.push(`Export CSV to Desktop | terminal=false shell=/bin/bash param1=-c param2="cd '${home}/codeburn' && npx tsx src/cli.ts export -o '${home}/Desktop/codeburn-report.csv' 2>/dev/null"`)
+  // Invoke the resolved `codeburn` binary directly. SwiftBar/xbar deliver
+  // each `paramN=` value as its own argv entry, so there's no shell
+  // quoting involved — and we don't ship the user to a `~/codeburn`
+  // checkout that only exists when running from a dev clone (#32).
+  lines.push(`Open Full Report | terminal=true shell=${bin} param1=report`)
+  lines.push(`Export CSV to Desktop | terminal=false shell=${bin} param1=export param2=-o param3=${home}/Desktop/codeburn-report.csv`)
 
   // Currency submenu -- common currencies as clickable items.
   // Clicking one runs 'codeburn config currency XXX' and refreshes the plugin.
@@ -179,10 +183,14 @@ export function renderMenubarFormat(
   lines.push(`Currency: ${activeCurrency} | size=14`)
   for (const { code, name } of currencies) {
     const check = code === activeCurrency ? ' *' : ''
-    const cmd = code === 'USD'
-      ? `${bin} config currency --reset`
-      : `${bin} config currency ${code}`
-    lines.push(`--${name} (${code})${check} | terminal=false refresh=true shell=/bin/bash param1=-c param2="${cmd}"`)
+    // The real CLI subcommand is `codeburn currency [code]` (with `--reset`
+    // for USD), not `codeburn config currency` — the latter doesn't exist
+    // and silently fails when SwiftBar runs it. Fixes #27.
+    if (code === 'USD') {
+      lines.push(`--${name} (${code})${check} | terminal=false refresh=true shell=${bin} param1=currency param2=--reset`)
+    } else {
+      lines.push(`--${name} (${code})${check} | terminal=false refresh=true shell=${bin} param1=currency param2=${code}`)
+    }
   }
 
   lines.push(`Refresh | refresh=true`)


### PR DESCRIPTION
## Summary

Closes #32 and #27.

The two action items at the bottom of the menubar plugin were built as:

\`\`\`
Open Full Report | terminal=true shell=/bin/bash param1=-c param2=\"cd '<HOME>/codeburn' && npx tsx src/cli.ts report; ...\"
Export CSV to Desktop | terminal=false shell=/bin/bash param1=-c param2=\"cd '<HOME>/codeburn' && npx tsx src/cli.ts export -o '<HOME>/Desktop/codeburn-report.csv' 2>/dev/null\"
\`\`\`

That breaks for npm-installed users in two ways:

1. **No \`~/codeburn\` checkout exists.** That path is only present on a dev clone — \`npm i -g codeburn\` doesn't ship a source tree.
2. **SwiftBar's \`param2=\` quoting eats the \`&&\`.** Only the \`cd\` half makes it into \`bash -c\`; the rest runs in the parent shell from \`$HOME\`, so the user sees \`Cannot find module '/Users/<u>/src/cli.ts'\` (the issue's exact symptom).

Fix: invoke the resolved \`\${bin}\` directly with discrete \`paramN=\` args. SwiftBar/xbar deliver each \`paramN=\` value as its own argv entry, so there's no shell quoting at all — and we no longer assume any checkout layout.

\`\`\`
Open Full Report | terminal=true shell=<bin> param1=report
Export CSV to Desktop | terminal=false shell=<bin> param1=export param2=-o param3=<HOME>/Desktop/codeburn-report.csv
\`\`\`

### Bonus: currency submenu (#27)

While here, the currency picker was emitting \`\${bin} config currency XXX\` — but the real subcommand in \`src/cli.ts\` is \`codeburn currency [code]\` (with \`--reset\` for USD). The \`config currency\` form silently fails on click. Fixed using the same direct-invoke pattern:

\`\`\`
--US Dollar (USD) * | terminal=false refresh=true shell=<bin> param1=currency param2=--reset
--British Pound (GBP) | terminal=false refresh=true shell=<bin> param1=currency param2=GBP
\`\`\`

### Test plan

- [x] \`npm run build\` — clean.
- [x] \`npm test -- --run\` — 28/28 pass.
- [x] Manually ran \`node ./dist/cli.js status --format menubar\` and inspected the rendered lines; matches the patterns above.

### AI-assisted disclosure

Drafted with Claude Code based on the diagnosis in #32 (the reporter had already pinpointed the param-quoting issue and proposed exactly this shape). I also verified the related #27 currency-subcommand mismatch in \`src/cli.ts\` and folded that fix in. I understand what the code does.