### PR TITLE
feat: add scrollable dashboard with sticky header and status bar

### DIFF
--- a/src/components/scroll-panel.tsx
+++ b/src/components/scroll-panel.tsx
@@ -1,0 +1,113 @@
+// from https://gist.github.com/janis-me/1a55a8747f12e1c4fc86ebe2d05a0a55
+
+import { Box, DOMElement, measureElement, useFocus, useInput } from 'ink';
+import { useEffect, useReducer, useRef } from 'react';
+
+interface ScrollPanelState {
+  innerHeight: number;
+  height: number;
+  scrollTop: number;
+}
+
+type ScrollPanelAction =
+  | { type: 'SET_INNER_HEIGHT'; innerHeight: number }
+  | { type: 'SET_HEIGHT'; height: number }
+  | { type: 'SCROLL_DOWN' }
+  | { type: 'SCROLL_UP' }
+  | { type: 'PAGE_DOWN' }
+  | { type: 'PAGE_UP' };
+
+const reducer = (state: ScrollPanelState, action: ScrollPanelAction) => {
+  switch (action.type) {
+    case 'SET_INNER_HEIGHT':
+      return {
+        ...state,
+        innerHeight: action.innerHeight,
+      };
+    case 'SET_HEIGHT':
+      return {
+        ...state,
+        height: action.height,
+      };
+
+    case 'SCROLL_DOWN':
+      return {
+        ...state,
+        scrollTop: Math.min(
+          state.innerHeight <= state.height ? 0 : state.innerHeight - state.height,
+          state.scrollTop + 1,
+        ),
+      };
+
+    case 'SCROLL_UP':
+      return {
+        ...state,
+        scrollTop: Math.max(0, state.scrollTop - 1),
+      };
+
+    case 'PAGE_DOWN':
+      return {
+        ...state,
+        scrollTop: Math.min(
+          state.innerHeight <= state.height ? 0 : state.innerHeight - state.height,
+          state.scrollTop + state.height,
+        ),
+      };
+
+    case 'PAGE_UP':
+      return {
+        ...state,
+        scrollTop: Math.max(0, state.scrollTop - state.height),
+      };
+
+    default:
+      return state;
+  }
+};
+
+export interface ScrollPanelProps extends React.PropsWithChildren {
+  height: number;
+}
+
+export function ScrollPanel({ height, children }: ScrollPanelProps) {
+  useFocus();
+  const [state, dispatch] = useReducer(reducer, {
+    height: height,
+    scrollTop: 0,
+    innerHeight: 0,
+  });
+
+  const innerRef = useRef<DOMElement>(null);
+
+  useEffect(() => {
+    dispatch({ type: 'SET_HEIGHT', height });
+  }, [height]);
+
+  useEffect(() => {
+    if (!innerRef.current) return;
+
+    const dimensions = measureElement(innerRef.current);
+
+    if (dimensions.height !== state.innerHeight) {
+      dispatch({
+        type: 'SET_INNER_HEIGHT',
+        innerHeight: dimensions.height,
+      });
+    }
+  });
+
+  useInput((_input, key) => {
+    if (key.downArrow) dispatch({ type: 'SCROLL_DOWN' });
+    if (key.upArrow) dispatch({ type: 'SCROLL_UP' });
+    if (key.pageDown) dispatch({ type: 'PAGE_DOWN' });
+    if (key.pageUp) dispatch({ type: 'PAGE_UP' });
+  });
+
+  return (
+    <Box height={height} flexDirection="column" overflow="hidden">
+      <Box ref={innerRef} flexShrink={0} flexDirection="column" marginTop={-state.scrollTop}>
+        {children}
+      </Box>
+    </Box>
+  );
+}

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -3,6 +3,7 @@ import { homedir } from 'os'
 import React, { useState, useCallback, useEffect } from 'react'
 import { render, Box, Text, useInput, useApp, useWindowSize } from 'ink'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory } from './types.js'
+import { ScrollPanel } from './components/scroll-panel'
 import { formatCost, formatTokens } from './format.js'
 import { parseAllSessions } from './parser.js'
 import { loadPricing } from './models.js'
@@ -112,7 +113,7 @@ function HBar({ value, max, width }: { value: number; max: number; width: number
 
 function Panel({ title, color, children, width }: { title: string; color: string; children: React.ReactNode; width: number }) {
   return (
-    <Box flexDirection="column" borderStyle="round" borderColor={color} paddingX={1} width={width} overflowX="hidden">
+    <Box flexDirection="column" borderStyle="round" borderColor={color} paddingX={1} width={width}>
       <Text bold color={color}>{title}</Text>
       {children}
     </Box>
@@ -415,12 +416,16 @@ function PeriodTabs({ active, providerName, showProvider }: {
 
 function StatusBar({ width, showProvider }: { width: number; showProvider?: boolean }) {
   return (
-    <Box borderStyle="round" borderColor={DIM} width={width} justifyContent="center" paddingX={1}>
+    <Box borderStyle="round" borderColor={DIM} width={width} flexDirection="column" alignItems="center" paddingX={1}>
       <Text>
-        <Text color={ORANGE} bold>{'<'}</Text><Text color={ORANGE}>{'>'}</Text>
-        <Text dimColor> switch   </Text>
+        <Text color={ORANGE} bold>{'←'}</Text><Text color={ORANGE}>{'→'}</Text>
+        <Text dimColor> switch  </Text>
+        <Text color={ORANGE} bold>{'↑ / PgUp'}</Text><Text color={ORANGE}>{'↓ / PgDn'}</Text>
+        <Text dimColor> scroll </Text>
         <Text color={ORANGE} bold>q</Text>
-        <Text dimColor> quit   </Text>
+        <Text dimColor> quit</Text>
+      </Text>
+      <Text>
         <Text color={ORANGE} bold>1</Text>
         <Text dimColor> today   </Text>
         <Text color={ORANGE} bold>2</Text>
@@ -446,9 +451,14 @@ function Row({ wide, width, children }: { wide: boolean; width: number; children
   return <>{children}</>
 }
 
-function DashboardContent({ projects, period, columns }: { projects: ProjectSummary[]; period: Period; columns?: number }) {
+const FIXED_ROWS = 10 // PeriodTabs(1) + Overview(5) + StatusBar(4)
+function DashboardContent({ projects, period, columns, scrollHeight }: {
+  projects: ProjectSummary[]
+  period: Period
+  columns?: number
+  scrollHeight?: number
+}) {
   const { dashWidth, wide, halfWidth, barWidth } = getLayout(columns)
-
   if (projects.length === 0) {
     return (
       <Panel title="CodeBurn" color={ORANGE} width={dashWidth}>
@@ -458,27 +468,35 @@ function DashboardContent({ projects, period, columns }: { projects: ProjectSumm
   }
 
   const pw = wide ? halfWidth : dashWidth
+  const content = (
+      <>
+        <Row wide={wide} width={dashWidth}>
+          <DailyActivity projects={projects} days={period === 'month' || period === '30days' ? 31 : 14} pw={pw} bw={barWidth} />
+          <ProjectBreakdown projects={projects} pw={pw} bw={barWidth} />
+        </Row>
+
+        <Row wide={wide} width={dashWidth}>
+          <ActivityBreakdown projects={projects} pw={pw} bw={barWidth} />
+          <ModelBreakdown projects={projects} pw={pw} bw={barWidth} />
+        </Row>
+
+        <Row wide={wide} width={dashWidth}>
+          <ToolBreakdown projects={projects} pw={pw} bw={barWidth} />
+          <BashBreakdown projects={projects} pw={pw} bw={barWidth} />
+        </Row>
+
+        <McpBreakdown projects={projects} pw={dashWidth} bw={barWidth} />
+      </>
+  )
 
   return (
     <Box flexDirection="column" width={dashWidth}>
       <Overview projects={projects} label={PERIOD_LABELS[period]} width={dashWidth} />
-
-      <Row wide={wide} width={dashWidth}>
-        <DailyActivity projects={projects} days={period === 'month' || period === '30days' ? 31 : 14} pw={pw} bw={barWidth} />
-        <ProjectBreakdown projects={projects} pw={pw} bw={barWidth} />
-      </Row>
-
-      <Row wide={wide} width={dashWidth}>
-        <ActivityBreakdown projects={projects} pw={pw} bw={barWidth} />
-        <ModelBreakdown projects={projects} pw={pw} bw={barWidth} />
-      </Row>
-
-      <Row wide={wide} width={dashWidth}>
-        <ToolBreakdown projects={projects} pw={pw} bw={barWidth} />
-        <BashBreakdown projects={projects} pw={pw} bw={barWidth} />
-      </Row>
-
-      <McpBreakdown projects={projects} pw={dashWidth} bw={barWidth} />
+      {scrollHeight != null ? (
+        <ScrollPanel height={scrollHeight}>{content}</ScrollPanel>
+      ) : (
+        content
+      )}
     </Box>
   )
 }
@@ -496,8 +514,10 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
   const [activeProvider, setActiveProvider] = useState(initialProvider)
   const [detectedProviders, setDetectedProviders] = useState<string[]>([])
   const { columns } = useWindowSize()
+  const totalRows = Math.max(process.stdout.rows, FIXED_ROWS)
   const { dashWidth } = getLayout(columns)
   const multipleProviders = detectedProviders.length > 1
+  const scrollHeight = totalRows - FIXED_ROWS
 
   useEffect(() => {
     let cancelled = false
@@ -567,7 +587,7 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
 
   if (loading) {
     return (
-      <Box flexDirection="column" width={dashWidth}>
+      <Box flexDirection="column" width={dashWidth} height={totalRows}>
         <PeriodTabs active={period} providerName={activeProvider} showProvider={multipleProviders} />
         <Panel title="CodeBurn" color={ORANGE} width={dashWidth}>
           <Text dimColor>Loading {PERIOD_LABELS[period]}...</Text>
@@ -578,9 +598,9 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
   }
 
   return (
-    <Box flexDirection="column" width={dashWidth}>
+    <Box flexDirection="column" width={dashWidth} height={totalRows}>
       <PeriodTabs active={period} providerName={activeProvider} showProvider={multipleProviders} />
-      <DashboardContent projects={projects} period={period} columns={columns} />
+      <DashboardContent projects={projects} period={period} columns={columns} scrollHeight={scrollHeight} />
       <StatusBar width={dashWidth} showProvider={multipleProviders} />
     </Box>
   )


### PR DESCRIPTION
  - Added ScrollPanel component (src/components/scroll-panel.tsx) - native Ink scrolling using overflow="hidden" + negative marginTop, no external dependencies (from https://gist.github.com/janis-me/1a55a8747f12e1c4fc86ebe2d05a0a55)                                                                     
  - Dashboard content (breakdowns, charts) now scrolls within a fixed viewport; Overview panel and StatusBar remain sticky
  - Scroll support for arrow keys and PgUp/PgDn                                                                                                                                                                                     
  - StatusBar split into two rows with separate navigation and period hints                                                                                                                                                                                                                                                                                             
  - Viewport height calculated from terminal rows minus fixed UI elements, adapts on resize  
  
  This makes the interactive terminal fixed within the available viewport, removing the need for mouse scroll and instead utilize keyboard keys to go trought the content which is consistent with existing naviation