### PR TITLE
feat: add GitHub Copilot provider

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -42,6 +42,12 @@ const FALLBACK_PRICING: Record<string, ModelCosts> = {
   'gpt-5.4': { inputCostPerToken: 2.5e-6, outputCostPerToken: 10e-6, cacheWriteCostPerToken: 2.5e-6, cacheReadCostPerToken: 1.25e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 1 },
   'gpt-5.4-mini': { inputCostPerToken: 0.4e-6, outputCostPerToken: 1.6e-6, cacheWriteCostPerToken: 0.4e-6, cacheReadCostPerToken: 0.2e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 1 },
   'gpt-5': { inputCostPerToken: 2.5e-6, outputCostPerToken: 10e-6, cacheWriteCostPerToken: 2.5e-6, cacheReadCostPerToken: 1.25e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 1 },
+  'gpt-5-mini': { inputCostPerToken: 0.4e-6, outputCostPerToken: 1.6e-6, cacheWriteCostPerToken: 0.4e-6, cacheReadCostPerToken: 0.2e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 1 },
+  'gpt-4.1': { inputCostPerToken: 2e-6, outputCostPerToken: 8e-6, cacheWriteCostPerToken: 2e-6, cacheReadCostPerToken: 0.5e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 1 },
+  'gpt-4.1-mini': { inputCostPerToken: 0.4e-6, outputCostPerToken: 1.6e-6, cacheWriteCostPerToken: 0.4e-6, cacheReadCostPerToken: 0.1e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 1 },
+  'gpt-4.1-nano': { inputCostPerToken: 0.1e-6, outputCostPerToken: 0.4e-6, cacheWriteCostPerToken: 0.1e-6, cacheReadCostPerToken: 0.025e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 1 },
+  'o3': { inputCostPerToken: 10e-6, outputCostPerToken: 40e-6, cacheWriteCostPerToken: 10e-6, cacheReadCostPerToken: 2.5e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 1 },
+  'o4-mini': { inputCostPerToken: 1.1e-6, outputCostPerToken: 4.4e-6, cacheWriteCostPerToken: 1.1e-6, cacheReadCostPerToken: 0.275e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 1 },
 }
 
 let pricingCache: Map<string, ModelCosts> | null = null
@@ -182,11 +188,17 @@ export function getShortModelName(model: string): string {
     'claude-3-5-haiku': 'Haiku 3.5',
     'gpt-4o-mini': 'GPT-4o Mini',
     'gpt-4o': 'GPT-4o',
+    'gpt-4.1-nano': 'GPT-4.1 Nano',
+    'gpt-4.1-mini': 'GPT-4.1 Mini',
+    'gpt-4.1': 'GPT-4.1',
     'gpt-5.4-mini': 'GPT-5.4 Mini',
     'gpt-5.4': 'GPT-5.4',
     'gpt-5.3-codex': 'GPT-5.3 Codex',
+    'gpt-5-mini': 'GPT-5 Mini',
     'gpt-5': 'GPT-5',
     'gemini-2.5-pro': 'Gemini 2.5 Pro',
+    'o4-mini': 'o4-mini',
+    'o3': 'o3',
   }
   for (const [key, name] of Object.entries(shortNames)) {
     if (canonical.startsWith(key)) return name

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -27,7 +27,7 @@ const toolNameMap: Record<string, string> = {
   write_file: 'Edit',
   edit_file: 'Edit',
   create_file: 'Write',
-  delete_file: 'Edit',
+  delete_file: 'Delete',
   search_files: 'Grep',
   find_files: 'Glob',
   list_directory: 'LS',
@@ -39,6 +39,7 @@ const toolNameMap: Record<string, string> = {
 // Pre-sorted by key length descending so longer/more-specific keys match first
 const modelDisplayEntries = Object.entries(modelDisplayNames).sort((a, b) => b[0].length - a[0].length)
 
+// Fields marked optional document the on-disk schema; they are not read by the parser
 type ToolRequest = {
   name?: string
   toolCallId?: string
@@ -71,6 +72,16 @@ function getCopilotSessionStateDir(override?: string): string {
   return override ?? join(homedir(), '.copilot', 'session-state')
 }
 
+function parseCwd(yaml: string): string | null {
+  const match = yaml.match(/^cwd:\s*(.+)$/m)
+  if (!match?.[1]) return null
+  const raw = match[1]
+    .replace(/\s*#.*$/, '')    // strip trailing comment
+    .replace(/^['"]|['"]$/g, '') // strip surrounding quotes
+    .trim()
+  return raw || null
+}
+
 function createParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
   return {
     async *parse(): AsyncGenerator<ParsedProviderCall> {
@@ -83,7 +94,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
       const sessionId = basename(dirname(source.path))
       const lines = content.split('\n').filter(l => l.trim())
-      let currentModel = 'gpt-4.1'
+      let currentModel = ''
       let pendingUserMessage = ''
 
       for (const line of lines) {
@@ -107,6 +118,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         if (event.type === 'assistant.message') {
           const { messageId, outputTokens, toolRequests = [] } = event.data
           if (outputTokens === 0) continue
+          // Skip if no model has been identified yet - avoids silent misattribution
+          if (!currentModel) continue
 
           const dedupKey = `copilot:${sessionId}:${messageId}`
           if (seenKeys.has(dedupKey)) continue
@@ -117,6 +130,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             .filter(Boolean)
             .map(n => toolNameMap[n] ?? n)
 
+          // Copilot only logs outputTokens; inputTokens are not available in session logs.
+          // Cost will be lower than actual API cost.
           const costUSD = calculateCost(currentModel, 0, outputTokens, 0, 0, 0)
 
           yield {
@@ -164,8 +179,8 @@ async function discoverSessionsInDir(sessionStateDir: string): Promise<SessionSo
     let project = sessionId
     try {
       const yaml = await readFile(join(sessionStateDir, sessionId, 'workspace.yaml'), 'utf-8')
-      const cwdMatch = yaml.match(/^cwd:\s*(.+)$/m)
-      if (cwdMatch?.[1]) project = basename(cwdMatch[1].trim())
+      const cwd = parseCwd(yaml)
+      if (cwd) project = basename(cwd)
     } catch {}
 
     sources.push({ path: eventsPath, project, provider: 'copilot' })

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -1,0 +1,205 @@
+import { readdir, readFile, stat } from 'fs/promises'
+import { basename, dirname, join } from 'path'
+import { homedir } from 'os'
+
+import { calculateCost } from '../models.js'
+import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+
+const modelDisplayNames: Record<string, string> = {
+  'gpt-4.1-nano': 'GPT-4.1 Nano',
+  'gpt-4.1-mini': 'GPT-4.1 Mini',
+  'gpt-4.1': 'GPT-4.1',
+  'gpt-4o-mini': 'GPT-4o Mini',
+  'gpt-4o': 'GPT-4o',
+  'gpt-5-mini': 'GPT-5 Mini',
+  'gpt-5': 'GPT-5',
+  'claude-sonnet-4-5': 'Sonnet 4.5',
+  'claude-sonnet-4': 'Sonnet 4',
+  'claude-3-7-sonnet': 'Sonnet 3.7',
+  'claude-3-5-sonnet': 'Sonnet 3.5',
+  'o4-mini': 'o4-mini',
+  'o3': 'o3',
+}
+
+const toolNameMap: Record<string, string> = {
+  bash: 'Bash',
+  read_file: 'Read',
+  write_file: 'Edit',
+  edit_file: 'Edit',
+  create_file: 'Write',
+  delete_file: 'Edit',
+  search_files: 'Grep',
+  find_files: 'Glob',
+  list_directory: 'LS',
+  web_search: 'WebSearch',
+  fetch_webpage: 'WebFetch',
+  github_repo: 'GitHub',
+}
+
+// Pre-sorted by key length descending so longer/more-specific keys match first
+const modelDisplayEntries = Object.entries(modelDisplayNames).sort((a, b) => b[0].length - a[0].length)
+
+type ToolRequest = {
+  name?: string
+  toolCallId?: string
+  type?: string
+}
+
+type ModelChangeData = {
+  newModel: string
+  previousModel?: string
+}
+
+type UserMessageData = {
+  content: string
+  interactionId?: string
+}
+
+type AssistantMessageData = {
+  messageId: string
+  outputTokens: number
+  interactionId?: string
+  toolRequests?: ToolRequest[]
+}
+
+type CopilotEvent =
+  | { type: 'session.model_change'; timestamp?: string; data: ModelChangeData }
+  | { type: 'user.message'; timestamp?: string; data: UserMessageData }
+  | { type: 'assistant.message'; timestamp?: string; data: AssistantMessageData }
+
+function getCopilotSessionStateDir(override?: string): string {
+  return override ?? join(homedir(), '.copilot', 'session-state')
+}
+
+function createParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
+  return {
+    async *parse(): AsyncGenerator<ParsedProviderCall> {
+      let content: string
+      try {
+        content = await readFile(source.path, 'utf-8')
+      } catch {
+        return
+      }
+
+      const sessionId = basename(dirname(source.path))
+      const lines = content.split('\n').filter(l => l.trim())
+      let currentModel = 'gpt-4.1'
+      let pendingUserMessage = ''
+
+      for (const line of lines) {
+        let event: CopilotEvent
+        try {
+          event = JSON.parse(line) as CopilotEvent
+        } catch {
+          continue
+        }
+
+        if (event.type === 'session.model_change') {
+          currentModel = event.data.newModel ?? currentModel
+          continue
+        }
+
+        if (event.type === 'user.message') {
+          pendingUserMessage = event.data.content ?? ''
+          continue
+        }
+
+        if (event.type === 'assistant.message') {
+          const { messageId, outputTokens, toolRequests = [] } = event.data
+          if (outputTokens === 0) continue
+
+          const dedupKey = `copilot:${sessionId}:${messageId}`
+          if (seenKeys.has(dedupKey)) continue
+          seenKeys.add(dedupKey)
+
+          const tools = toolRequests
+            .map(t => t.name ?? '')
+            .filter(Boolean)
+            .map(n => toolNameMap[n] ?? n)
+
+          const costUSD = calculateCost(currentModel, 0, outputTokens, 0, 0, 0)
+
+          yield {
+            provider: 'copilot',
+            model: currentModel,
+            inputTokens: 0,
+            outputTokens,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            cachedInputTokens: 0,
+            reasoningTokens: 0,
+            webSearchRequests: 0,
+            costUSD,
+            tools,
+            bashCommands: [],
+            timestamp: event.timestamp ?? '',
+            speed: 'standard',
+            deduplicationKey: dedupKey,
+            userMessage: pendingUserMessage,
+            sessionId,
+          }
+
+          pendingUserMessage = ''
+        }
+      }
+    },
+  }
+}
+
+async function discoverSessionsInDir(sessionStateDir: string): Promise<SessionSource[]> {
+  const sources: SessionSource[] = []
+
+  let sessionDirs: string[]
+  try {
+    sessionDirs = await readdir(sessionStateDir)
+  } catch {
+    return sources
+  }
+
+  for (const sessionId of sessionDirs) {
+    const eventsPath = join(sessionStateDir, sessionId, 'events.jsonl')
+    const s = await stat(eventsPath).catch(() => null)
+    if (!s?.isFile()) continue
+
+    let project = sessionId
+    try {
+      const yaml = await readFile(join(sessionStateDir, sessionId, 'workspace.yaml'), 'utf-8')
+      const cwdMatch = yaml.match(/^cwd:\s*(.+)$/m)
+      if (cwdMatch?.[1]) project = basename(cwdMatch[1].trim())
+    } catch {}
+
+    sources.push({ path: eventsPath, project, provider: 'copilot' })
+  }
+
+  return sources
+}
+
+export function createCopilotProvider(sessionStateDir?: string): Provider {
+  const dir = getCopilotSessionStateDir(sessionStateDir)
+
+  return {
+    name: 'copilot',
+    displayName: 'Copilot',
+
+    modelDisplayName(model: string): string {
+      for (const [key, name] of modelDisplayEntries) {
+        if (model === key || model.startsWith(key + '-')) return name
+      }
+      return model
+    },
+
+    toolDisplayName(rawTool: string): string {
+      return toolNameMap[rawTool] ?? rawTool
+    },
+
+    async discoverSessions(): Promise<SessionSource[]> {
+      return discoverSessionsInDir(dir)
+    },
+
+    createSessionParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
+      return createParser(source, seenKeys)
+    },
+  }
+}
+
+export const copilot = createCopilotProvider()

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,6 @@
 import { claude } from './claude.js'
 import { codex } from './codex.js'
+import { copilot } from './copilot.js'
 import { pi } from './pi.js'
 import type { Provider, SessionSource } from './types.js'
 
@@ -33,7 +34,7 @@ async function loadOpenCode(): Promise<Provider | null> {
   }
 }
 
-const coreProviders: Provider[] = [claude, codex, pi]
+const coreProviders: Provider[] = [claude, codex, copilot, pi]
 
 export async function getAllProviders(): Promise<Provider[]> {
   const [cursor, opencode] = await Promise.all([loadCursor(), loadOpenCode()])

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -3,7 +3,7 @@ import { providers, getAllProviders } from '../src/providers/index.js'
 
 describe('provider registry', () => {
   it('has core providers registered synchronously', () => {
-    expect(providers.map(p => p.name)).toEqual(['claude', 'codex', 'pi'])
+    expect(providers.map(p => p.name)).toEqual(['claude', 'codex', 'copilot', 'pi'])
   })
 
   it('includes sqlite providers after async load', async () => {

--- a/tests/providers/copilot.test.ts
+++ b/tests/providers/copilot.test.ts
@@ -142,6 +142,23 @@ describe('copilot provider - JSONL parsing', () => {
     for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
     expect(calls).toHaveLength(0)
   })
+
+  it('skips assistant messages before the first model_change event', async () => {
+    const eventsPath = await createSessionDir('sess-no-model', [
+      assistantMessage({ messageId: 'msg-early', outputTokens: 50 }),
+      modelChange('gpt-4.1'),
+      assistantMessage({ messageId: 'msg-after', outputTokens: 80 }),
+    ])
+
+    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.messageId).toBeUndefined()
+    expect(calls[0]!.outputTokens).toBe(80)
+    expect(calls[0]!.model).toBe('gpt-4.1')
+  })
 })
 
 describe('copilot provider - discoverSessions', () => {
@@ -167,6 +184,19 @@ describe('copilot provider - discoverSessions', () => {
 
   it('reads project name from workspace.yaml cwd', async () => {
     await createSessionDir('sess-disc-003', [modelChange('gpt-4.1')], '/home/user/myapp')
+
+    const provider = createCopilotProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.project).toBe('myapp')
+  })
+
+  it('strips quotes and trailing comments from workspace.yaml cwd', async () => {
+    const sessionDir = join(tmpDir, 'sess-quoted')
+    await mkdir(sessionDir, { recursive: true })
+    await writeFile(join(sessionDir, 'workspace.yaml'), 'cwd: "/home/user/myapp"  # project root\n')
+    await writeFile(join(sessionDir, 'events.jsonl'), '\n')
 
     const provider = createCopilotProvider(tmpDir)
     const sessions = await provider.discoverSessions()
@@ -213,5 +243,11 @@ describe('copilot provider - metadata', () => {
     expect(copilot.modelDisplayName('o3')).toBe('o3')
     expect(copilot.modelDisplayName('o4-mini')).toBe('o4-mini')
     expect(copilot.modelDisplayName('unknown-model-xyz')).toBe('unknown-model-xyz')
+  })
+
+  it('longest-prefix match wins for versioned model IDs', () => {
+    // gpt-5-mini-2026-01-01 must match gpt-5-mini, not gpt-5
+    expect(copilot.modelDisplayName('gpt-5-mini-2026-01-01')).toBe('GPT-5 Mini')
+    expect(copilot.modelDisplayName('gpt-4.1-mini-2026-01-01')).toBe('GPT-4.1 Mini')
   })
 })

--- a/tests/providers/copilot.test.ts
+++ b/tests/providers/copilot.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { copilot, createCopilotProvider } from '../../src/providers/copilot.js'
+import type { ParsedProviderCall } from '../../src/providers/types.js'
+
+let tmpDir: string
+
+async function createSessionDir(sessionId: string, lines: string[], cwd = '/home/user/myproject') {
+  const sessionDir = join(tmpDir, sessionId)
+  await mkdir(sessionDir, { recursive: true })
+  await writeFile(join(sessionDir, 'workspace.yaml'), `id: ${sessionId}\ncwd: ${cwd}\n`)
+  await writeFile(join(sessionDir, 'events.jsonl'), lines.join('\n') + '\n')
+  return join(sessionDir, 'events.jsonl')
+}
+
+function modelChange(newModel: string, previousModel?: string) {
+  return JSON.stringify({ type: 'session.model_change', timestamp: '2026-04-15T10:00:01Z', data: { newModel, previousModel } })
+}
+
+function userMessage(content: string) {
+  return JSON.stringify({ type: 'user.message', timestamp: '2026-04-15T10:00:10Z', data: { content, interactionId: 'int-1' } })
+}
+
+function assistantMessage(opts: { messageId: string; outputTokens: number; tools?: string[]; timestamp?: string }) {
+  return JSON.stringify({
+    type: 'assistant.message',
+    timestamp: opts.timestamp ?? '2026-04-15T10:00:15Z',
+    data: {
+      messageId: opts.messageId,
+      outputTokens: opts.outputTokens,
+      interactionId: 'int-1',
+      toolRequests: (opts.tools ?? []).map(name => ({ name, toolCallId: `call-${name}`, type: 'function' })),
+    },
+  })
+}
+
+describe('copilot provider - JSONL parsing', () => {
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'copilot-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('parses a basic assistant message', async () => {
+    const eventsPath = await createSessionDir('sess-001', [
+      modelChange('gpt-4.1'),
+      userMessage('write a function'),
+      assistantMessage({ messageId: 'msg-1', outputTokens: 150 }),
+    ])
+
+    const source = { path: eventsPath, project: 'myproject', provider: 'copilot' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(1)
+    const call = calls[0]!
+    expect(call.provider).toBe('copilot')
+    expect(call.model).toBe('gpt-4.1')
+    expect(call.outputTokens).toBe(150)
+    expect(call.inputTokens).toBe(0)
+    expect(call.userMessage).toBe('write a function')
+    expect(call.sessionId).toBe('sess-001')
+    expect(call.bashCommands).toEqual([])
+    expect(call.costUSD).toBeGreaterThan(0)
+  })
+
+  it('tracks model changes mid-session', async () => {
+    const eventsPath = await createSessionDir('sess-002', [
+      modelChange('gpt-5-mini'),
+      userMessage('first'),
+      assistantMessage({ messageId: 'msg-1', outputTokens: 50, timestamp: '2026-04-15T10:00:10Z' }),
+      modelChange('gpt-4.1', 'gpt-5-mini'),
+      userMessage('second'),
+      assistantMessage({ messageId: 'msg-2', outputTokens: 80, timestamp: '2026-04-15T10:01:00Z' }),
+    ])
+
+    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]!.model).toBe('gpt-5-mini')
+    expect(calls[1]!.model).toBe('gpt-4.1')
+  })
+
+  it('extracts tool names from toolRequests', async () => {
+    const eventsPath = await createSessionDir('sess-003', [
+      modelChange('gpt-4.1'),
+      userMessage('run tests'),
+      assistantMessage({ messageId: 'msg-1', outputTokens: 60, tools: ['bash', 'read_file', 'write_file'] }),
+    ])
+
+    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+
+    expect(calls[0]!.tools).toEqual(['Bash', 'Read', 'Edit'])
+  })
+
+  it('skips assistant messages with zero outputTokens', async () => {
+    const eventsPath = await createSessionDir('sess-004', [
+      modelChange('gpt-4.1'),
+      assistantMessage({ messageId: 'msg-empty', outputTokens: 0 }),
+      assistantMessage({ messageId: 'msg-real', outputTokens: 42 }),
+    ])
+
+    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.outputTokens).toBe(42)
+  })
+
+  it('deduplicates messages across parser runs', async () => {
+    const eventsPath = await createSessionDir('sess-005', [
+      modelChange('gpt-4.1'),
+      assistantMessage({ messageId: 'msg-dup', outputTokens: 100 }),
+    ])
+
+    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const seenKeys = new Set<string>()
+
+    const calls1: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, seenKeys).parse()) calls1.push(call)
+
+    const calls2: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, seenKeys).parse()) calls2.push(call)
+
+    expect(calls1).toHaveLength(1)
+    expect(calls2).toHaveLength(0)
+  })
+
+  it('returns empty for missing file', async () => {
+    const source = { path: '/nonexistent/events.jsonl', project: 'test', provider: 'copilot' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+    expect(calls).toHaveLength(0)
+  })
+})
+
+describe('copilot provider - discoverSessions', () => {
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'copilot-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('discovers sessions from directory', async () => {
+    await createSessionDir('sess-disc-001', [modelChange('gpt-4.1')])
+    await createSessionDir('sess-disc-002', [modelChange('gpt-4.1')])
+
+    const provider = createCopilotProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions).toHaveLength(2)
+    expect(sessions.every(s => s.provider === 'copilot')).toBe(true)
+    expect(sessions.every(s => s.path.endsWith('events.jsonl'))).toBe(true)
+  })
+
+  it('reads project name from workspace.yaml cwd', async () => {
+    await createSessionDir('sess-disc-003', [modelChange('gpt-4.1')], '/home/user/myapp')
+
+    const provider = createCopilotProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.project).toBe('myapp')
+  })
+
+  it('returns empty when directory does not exist', async () => {
+    const provider = createCopilotProvider('/nonexistent/path')
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toHaveLength(0)
+  })
+
+  it('skips entries without events.jsonl', async () => {
+    const emptyDir = join(tmpDir, 'empty-session')
+    await mkdir(emptyDir, { recursive: true })
+
+    const provider = createCopilotProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toHaveLength(0)
+  })
+})
+
+describe('copilot provider - metadata', () => {
+  it('has correct name and displayName', () => {
+    expect(copilot.name).toBe('copilot')
+    expect(copilot.displayName).toBe('Copilot')
+  })
+
+  it('normalizes tool display names', () => {
+    expect(copilot.toolDisplayName('bash')).toBe('Bash')
+    expect(copilot.toolDisplayName('read_file')).toBe('Read')
+    expect(copilot.toolDisplayName('write_file')).toBe('Edit')
+    expect(copilot.toolDisplayName('web_search')).toBe('WebSearch')
+    expect(copilot.toolDisplayName('unknown_tool')).toBe('unknown_tool')
+  })
+
+  it('normalizes model display names', () => {
+    expect(copilot.modelDisplayName('gpt-4.1')).toBe('GPT-4.1')
+    expect(copilot.modelDisplayName('gpt-4.1-mini')).toBe('GPT-4.1 Mini')
+    expect(copilot.modelDisplayName('gpt-4.1-nano')).toBe('GPT-4.1 Nano')
+    expect(copilot.modelDisplayName('gpt-5-mini')).toBe('GPT-5 Mini')
+    expect(copilot.modelDisplayName('o3')).toBe('o3')
+    expect(copilot.modelDisplayName('o4-mini')).toBe('o4-mini')
+    expect(copilot.modelDisplayName('unknown-model-xyz')).toBe('unknown-model-xyz')
+  })
+})


### PR DESCRIPTION
- Parse ~/.copilot/session-state/*/events.jsonl
- Track model via session.model_change events
- Extract tools from assistant.message toolRequests
- Add fallback pricing for gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, gpt-5-mini, o3, o4-mini
- Note: only outputTokens available (Copilot does not log input tokens)
- 9 tests covering JSONL parsing, model tracking, tool extraction,
  deduplication, and metadata
- Fix modelDisplayName to match longest key first (gpt-4.1-mini before gpt-4.1)
- Update provider-registry test for new coreProviders list