### PR TITLE
feat: add Pi provider for tracking Pi agent sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeburn",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeburn",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -927,6 +927,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1505,6 +1506,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2044,6 +2046,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2093,6 +2096,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2205,6 +2209,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2807,6 +2812,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2855,6 +2861,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2890,6 +2897,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "claude-code",
     "cursor",
     "codex",
+    "pi",
     "ai-coding",
     "token-usage",
     "cost-tracking",

--- a/src/bash-utils.ts
+++ b/src/bash-utils.ts
@@ -30,10 +30,12 @@ export function extractBashCommands(command: string): string[] {
     const segment = command.slice(start, end).trim()
     if (!segment) continue
 
-    const firstToken = segment.split(/\s+/)[0]
-    const base = basename(firstToken)
+    const tokens = segment.split(/\s+/)
+    let i = 0
+    while (i < tokens.length && /^\w+=/.test(tokens[i]!)) i++
+    const base = i < tokens.length ? basename(tokens[i]!) : ''
 
-    if (base && base !== 'cd') {
+    if (base && base !== 'cd' && base !== 'true' && base !== 'false') {
       commands.push(base)
     }
   }

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -15,9 +15,9 @@ const FILE_PATTERNS = /\.(py|js|ts|tsx|jsx|json|yaml|yml|toml|sql|sh|go|rs|java|
 const SCRIPT_PATTERNS = /\b(run\s+\S+\.\w+|execute|scrip?t|curl|api\s+\S+|endpoint|request\s+url|fetch\s+\S+|query|database|db\s+\S+)\b/i
 const URL_PATTERN = /https?:\/\/\S+/i
 
-const EDIT_TOOLS = new Set(['Edit', 'Write', 'FileEditTool', 'FileWriteTool', 'NotebookEdit', 'cursor:edit'])
-const READ_TOOLS = new Set(['Read', 'Grep', 'Glob', 'FileReadTool', 'GrepTool', 'GlobTool'])
-export const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool'])
+const EDIT_TOOLS = new Set(['Edit', 'Write', 'FileEditTool', 'FileWriteTool', 'NotebookEdit', 'cursor:edit', 'edit', 'write'])
+const READ_TOOLS = new Set(['Read', 'Grep', 'Glob', 'FileReadTool', 'GrepTool', 'GlobTool', 'read'])
+export const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool', 'bash'])
 const TASK_TOOLS = new Set(['TaskCreate', 'TaskUpdate', 'TaskGet', 'TaskList', 'TaskOutput', 'TaskStop', 'TodoWrite'])
 const SEARCH_TOOLS = new Set(['WebSearch', 'WebFetch', 'ToolSearch'])
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -367,7 +367,7 @@ function providerCallToTurn(call: ParsedProviderCall): ParsedTurn {
     hasPlanMode: tools.includes('EnterPlanMode'),
     speed: call.speed,
     timestamp: call.timestamp,
-    bashCommands: [],
+    bashCommands: call.bashCommands,
     deduplicationKey: call.deduplicationKey,
   }
 

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -259,6 +259,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             webSearchRequests: 0,
             costUSD,
             tools: pendingTools,
+            bashCommands: [],
             timestamp,
             speed: 'standard',
             deduplicationKey: dedupKey,

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -188,6 +188,7 @@ function parseBubbles(db: SqliteDatabase, seenKeys: Set<string>): { calls: Parse
         webSearchRequests: 0,
         costUSD,
         tools: cursorTools,
+        bashCommands: [],
         timestamp,
         speed: 'standard',
         deduplicationKey: dedupKey,

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,6 @@
 import { claude } from './claude.js'
 import { codex } from './codex.js'
+import { pi } from './pi.js'
 import type { Provider, SessionSource } from './types.js'
 
 let cursorProvider: Provider | null = null
@@ -17,7 +18,7 @@ async function loadCursor(): Promise<Provider | null> {
   }
 }
 
-const coreProviders: Provider[] = [claude, codex]
+const coreProviders: Provider[] = [claude, codex, pi]
 
 export async function getAllProviders(): Promise<Provider[]> {
   const cursor = await loadCursor()
@@ -46,4 +47,3 @@ export async function getProvider(name: string): Promise<Provider | undefined> {
   }
   return coreProviders.find(p => p.name === name)
 }
-

--- a/src/providers/pi.ts
+++ b/src/providers/pi.ts
@@ -1,0 +1,210 @@
+import { readdir, readFile, stat } from 'fs/promises'
+import { basename, join } from 'path'
+import { homedir } from 'os'
+
+import { calculateCost } from '../models.js'
+import { extractBashCommands } from '../bash-utils.js'
+import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+
+const modelDisplayNames: Record<string, string> = {
+  'gpt-5.4': 'GPT-5.4',
+  'gpt-5.4-mini': 'GPT-5.4 Mini',
+  'gpt-5': 'GPT-5',
+  'gpt-4o': 'GPT-4o',
+  'gpt-4o-mini': 'GPT-4o Mini',
+}
+
+type PiEntry = {
+  type: string
+  id?: string
+  timestamp?: string
+  cwd?: string
+  message?: {
+    role?: string
+    content?: Array<{ type?: string; text?: string; name?: string; arguments?: Record<string, unknown> }>
+    model?: string
+    responseId?: string
+    usage?: {
+      input: number
+      output: number
+      cacheRead: number
+      cacheWrite: number
+    }
+  }
+}
+
+function getPiSessionsDir(override?: string): string {
+  return override ?? join(homedir(), '.pi', 'agent', 'sessions')
+}
+
+async function readFirstEntry(filePath: string): Promise<PiEntry | null> {
+  try {
+    const content = await readFile(filePath, 'utf-8')
+    const line = content.split('\n')[0]
+    if (!line?.trim()) return null
+    return JSON.parse(line) as PiEntry
+  } catch {
+    return null
+  }
+}
+
+async function discoverSessionsInDir(sessionsDir: string): Promise<SessionSource[]> {
+  const sources: SessionSource[] = []
+
+  let projectDirs: string[]
+  try {
+    projectDirs = await readdir(sessionsDir)
+  } catch {
+    return sources
+  }
+
+  for (const dirName of projectDirs) {
+    const dirPath = join(sessionsDir, dirName)
+    const dirStat = await stat(dirPath).catch(() => null)
+    if (!dirStat?.isDirectory()) continue
+
+    let files: string[]
+    try {
+      files = await readdir(dirPath)
+    } catch {
+      continue
+    }
+
+    for (const file of files) {
+      if (!file.endsWith('.jsonl')) continue
+      const filePath = join(dirPath, file)
+      const fileStat = await stat(filePath).catch(() => null)
+      if (!fileStat?.isFile()) continue
+
+      const first = await readFirstEntry(filePath)
+      if (!first || first.type !== 'session') continue
+
+      const cwd = first.cwd ?? dirName
+      sources.push({ path: filePath, project: basename(cwd), provider: 'pi' })
+    }
+  }
+
+  return sources
+}
+
+function createParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
+  return {
+    async *parse(): AsyncGenerator<ParsedProviderCall> {
+      let content: string
+      try {
+        content = await readFile(source.path, 'utf-8')
+      } catch {
+        return
+      }
+
+      const lines = content.split('\n').filter(l => l.trim())
+      let sessionId = basename(source.path, '.jsonl')
+      let pendingUserMessage = ''
+
+      for (const [lineIdx, line] of lines.entries()) {
+        let entry: PiEntry
+        try {
+          entry = JSON.parse(line) as PiEntry
+        } catch {
+          continue
+        }
+
+        if (entry.type === 'session') {
+          sessionId = entry.id ?? sessionId
+          continue
+        }
+
+        if (entry.type !== 'message') continue
+
+        const msg = entry.message
+        if (!msg) continue
+
+        if (msg.role === 'user') {
+          const texts = (msg.content ?? [])
+            .filter(c => c.type === 'text')
+            .map(c => c.text ?? '')
+            .filter(Boolean)
+          if (texts.length > 0) pendingUserMessage = texts.join(' ')
+          continue
+        }
+
+        if (msg.role !== 'assistant' || !msg.usage) continue
+
+        const { input, output, cacheRead, cacheWrite } = msg.usage
+        if (input === 0 && output === 0) continue
+
+        const model = msg.model ?? 'gpt-5'
+        const responseId = msg.responseId ?? ''
+        const dedupKey = `pi:${source.path}:${responseId || entry.id || entry.timestamp || String(lineIdx)}`
+
+        if (seenKeys.has(dedupKey)) continue
+        seenKeys.add(dedupKey)
+
+        const toolCalls = (msg.content ?? []).filter(c => c.type === 'toolCall' && c.name)
+        const tools = toolCalls.map(c => c.name!)
+        const bashCommands = toolCalls
+          .filter(c => c.name === 'bash')
+          .flatMap(c => {
+            const cmd = c.arguments?.['command']
+            return typeof cmd === 'string' ? extractBashCommands(cmd) : []
+          })
+
+        const costUSD = calculateCost(model, input, output, cacheWrite, cacheRead, 0)
+        const timestamp = entry.timestamp ?? ''
+
+        yield {
+          provider: 'pi',
+          model,
+          inputTokens: input,
+          outputTokens: output,
+          cacheCreationInputTokens: cacheWrite,
+          cacheReadInputTokens: cacheRead,
+          cachedInputTokens: cacheRead,
+          reasoningTokens: 0,
+          webSearchRequests: 0,
+          costUSD,
+          tools,
+          bashCommands,
+          timestamp,
+          speed: 'standard',
+          deduplicationKey: dedupKey,
+          userMessage: pendingUserMessage,
+          sessionId,
+        }
+
+        pendingUserMessage = ''
+      }
+    },
+  }
+}
+
+export function createPiProvider(sessionsDir?: string): Provider {
+  const dir = getPiSessionsDir(sessionsDir)
+
+  return {
+    name: 'pi',
+    displayName: 'Pi',
+
+    modelDisplayName(model: string): string {
+      const entries = Object.entries(modelDisplayNames).sort((a, b) => b[0].length - a[0].length)
+      for (const [key, name] of entries) {
+        if (model.startsWith(key)) return name
+      }
+      return model
+    },
+
+    toolDisplayName(rawTool: string): string {
+      return rawTool
+    },
+
+    async discoverSessions(): Promise<SessionSource[]> {
+      return discoverSessionsInDir(dir)
+    },
+
+    createSessionParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
+      return createParser(source, seenKeys)
+    },
+  }
+}
+
+export const pi = createPiProvider()

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -20,6 +20,7 @@ export type ParsedProviderCall = {
   webSearchRequests: number
   costUSD: number
   tools: string[]
+  bashCommands: string[]
   timestamp: string
   speed: 'standard' | 'fast'
   deduplicationKey: string

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -3,7 +3,7 @@ import { providers, getAllProviders } from '../src/providers/index.js'
 
 describe('provider registry', () => {
   it('has core providers registered synchronously', () => {
-    expect(providers.map(p => p.name)).toEqual(['claude', 'codex'])
+    expect(providers.map(p => p.name)).toEqual(['claude', 'codex', 'pi'])
   })
 
   it('includes cursor after async load', async () => {

--- a/tests/providers/pi.test.ts
+++ b/tests/providers/pi.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { createPiProvider } from '../../src/providers/pi.js'
+import type { ParsedProviderCall } from '../../src/providers/types.js'
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'pi-test-'))
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+function sessionMeta(opts: { id?: string; cwd?: string } = {}) {
+  return JSON.stringify({
+    type: 'session',
+    version: 3,
+    id: opts.id ?? 'sess-001',
+    timestamp: '2026-04-14T10:00:00.000Z',
+    cwd: opts.cwd ?? '/Users/test/myproject',
+  })
+}
+
+function userMessage(text: string, timestamp?: string) {
+  return JSON.stringify({
+    type: 'message',
+    id: 'msg-user-1',
+    timestamp: timestamp ?? '2026-04-14T10:00:10.000Z',
+    message: {
+      role: 'user',
+      content: [{ type: 'text', text }],
+      timestamp: 1776023210000,
+    },
+  })
+}
+
+function assistantMessage(opts: {
+  id?: string
+  responseId?: string
+  timestamp?: string
+  model?: string
+  input?: number
+  output?: number
+  cacheRead?: number
+  cacheWrite?: number
+  tools?: Array<{ name: string; command?: string }>
+}) {
+  const content = (opts.tools ?? []).map(t => ({
+    type: 'toolCall',
+    id: `call-${t.name}`,
+    name: t.name,
+    arguments: t.command !== undefined ? { command: t.command } : {},
+  }))
+
+  return JSON.stringify({
+    type: 'message',
+    id: opts.id ?? 'msg-asst-1',
+    timestamp: opts.timestamp ?? '2026-04-14T10:00:30.000Z',
+    message: {
+      role: 'assistant',
+      content,
+      api: 'openai-codex-responses',
+      provider: 'openai-codex',
+      model: opts.model ?? 'gpt-5.4',
+      responseId: opts.responseId ?? 'resp-001',
+      usage: {
+        input: opts.input ?? 1000,
+        output: opts.output ?? 200,
+        cacheRead: opts.cacheRead ?? 0,
+        cacheWrite: opts.cacheWrite ?? 0,
+        totalTokens: (opts.input ?? 1000) + (opts.output ?? 200) + (opts.cacheRead ?? 0),
+        cost: { input: 0.0025, output: 0.003, cacheRead: 0, cacheWrite: 0, total: 0.0055 },
+      },
+      stopReason: 'stop',
+      timestamp: 1776023230000,
+    },
+  })
+}
+
+async function writeSession(projectDir: string, filename: string, lines: string[]) {
+  await mkdir(projectDir, { recursive: true })
+  const filePath = join(projectDir, filename)
+  await writeFile(filePath, lines.join('\n') + '\n')
+  return filePath
+}
+
+describe('pi provider - session discovery', () => {
+  it('discovers sessions grouped by project directory', async () => {
+    const projectDir = join(tmpDir, '--Users-test-myproject--')
+    await writeSession(projectDir, '2026-04-14T10-00-00-000Z_sess-001.jsonl', [
+      sessionMeta({ cwd: '/Users/test/myproject' }),
+      assistantMessage({}),
+    ])
+
+    const provider = createPiProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.provider).toBe('pi')
+    expect(sessions[0]!.project).toBe('myproject')
+    expect(sessions[0]!.path).toContain('sess-001.jsonl')
+  })
+
+  it('discovers sessions across multiple project directories', async () => {
+    const dir1 = join(tmpDir, '--Users-test-project-a--')
+    const dir2 = join(tmpDir, '--Users-test-project-b--')
+    await writeSession(dir1, 'session1.jsonl', [sessionMeta({ cwd: '/Users/test/project-a' }), assistantMessage({})])
+    await writeSession(dir2, 'session2.jsonl', [sessionMeta({ cwd: '/Users/test/project-b' }), assistantMessage({})])
+
+    const provider = createPiProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions).toHaveLength(2)
+    const projects = sessions.map(s => s.project).sort()
+    expect(projects).toEqual(['project-a', 'project-b'])
+  })
+
+  it('returns empty for non-existent directory', async () => {
+    const provider = createPiProvider('/nonexistent/path/that/does/not/exist')
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toEqual([])
+  })
+
+  it('skips files whose first line is not a session entry', async () => {
+    const projectDir = join(tmpDir, '--Users-test-myproject--')
+    await writeSession(projectDir, 'bad.jsonl', [
+      JSON.stringify({ type: 'message', id: 'x' }),
+    ])
+
+    const provider = createPiProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toEqual([])
+  })
+
+  it('skips non-jsonl files', async () => {
+    const projectDir = join(tmpDir, '--Users-test-myproject--')
+    await mkdir(projectDir, { recursive: true })
+    await writeFile(join(projectDir, 'notes.txt'), 'not a session')
+
+    const provider = createPiProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toEqual([])
+  })
+})
+
+describe('pi provider - JSONL parsing', () => {
+  it('extracts token usage and metadata from an assistant message', async () => {
+    const projectDir = join(tmpDir, '--Users-test-myproject--')
+    const filePath = await writeSession(projectDir, 'session.jsonl', [
+      sessionMeta({ id: 'sess-abc', cwd: '/Users/test/myproject' }),
+      userMessage('implement the feature'),
+      assistantMessage({
+        responseId: 'resp-abc',
+        timestamp: '2026-04-14T10:00:30.000Z',
+        model: 'gpt-5.4',
+        input: 2000,
+        output: 400,
+        cacheRead: 5000,
+        cacheWrite: 100,
+      }),
+    ])
+
+    const provider = createPiProvider(tmpDir)
+    const source = { path: filePath, project: 'myproject', provider: 'pi' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) {
+      calls.push(call)
+    }
+
+    expect(calls).toHaveLength(1)
+    const call = calls[0]!
+    expect(call.provider).toBe('pi')
+    expect(call.model).toBe('gpt-5.4')
+    expect(call.inputTokens).toBe(2000)
+    expect(call.outputTokens).toBe(400)
+    expect(call.cacheReadInputTokens).toBe(5000)
+    expect(call.cachedInputTokens).toBe(5000)
+    expect(call.cacheCreationInputTokens).toBe(100)
+    expect(call.sessionId).toBe('sess-abc')
+    expect(call.userMessage).toBe('implement the feature')
+    expect(call.timestamp).toBe('2026-04-14T10:00:30.000Z')
+    expect(call.costUSD).toBeGreaterThan(0)
+    expect(call.deduplicationKey).toContain('pi:')
+    expect(call.deduplicationKey).toContain('resp-abc')
+  })
+
+  it('collects tool names from toolCall content items', async () => {
+    const projectDir = join(tmpDir, '--Users-test-myproject--')
+    const filePath = await writeSession(projectDir, 'session.jsonl', [
+      sessionMeta(),
+      assistantMessage({
+        tools: [
+          { name: 'read' },
+          { name: 'edit' },
+          { name: 'bash', command: 'git status' },
+        ],
+      }),
+    ])
+
+    const provider = createPiProvider(tmpDir)
+    const source = { path: filePath, project: 'myproject', provider: 'pi' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) {
+      calls.push(call)
+    }
+
+    expect(calls[0]!.tools).toEqual(['read', 'edit', 'bash'])
+  })
+
+  it('extracts bash commands from bash tool arguments', async () => {
+    const projectDir = join(tmpDir, '--Users-test-myproject--')
+    const filePath = await writeSession(projectDir, 'session.jsonl', [
+      sessionMeta(),
+      assistantMessage({
+        tools: [
+          { name: 'bash', command: 'git status && bun test' },
+        ],
+      }),
+    ])
+
+    const provider = createPiProvider(tmpDir)
+    const source = { path: filePath, project: 'myproject', provider: 'pi' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) {
+      calls.push(call)
+    }
+
+    expect(calls[0]!.bashCommands).toEqual(['git', 'bun'])
+  })
+
+  it('skips assistant messages with zero tokens', async () => {
+    const projectDir = join(tmpDir, '--Users-test-myproject--')
+    const filePath = await writeSession(projectDir, 'session.jsonl', [
+      sessionMeta(),
+      assistantMessage({ input: 0, output: 0 }),
+    ])
+
+    const provider = createPiProvider(tmpDir)
+    const source = { path: filePath, project: 'myproject', provider: 'pi' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) {
+      calls.push(call)
+    }
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('deduplicates calls seen across multiple parses', async () => {
+    const projectDir = join(tmpDir, '--Users-test-myproject--')
+    const filePath = await writeSession(projectDir, 'session.jsonl', [
+      sessionMeta(),
+      assistantMessage({ responseId: 'resp-dup' }),
+    ])
+
+    const provider = createPiProvider(tmpDir)
+    const source = { path: filePath, project: 'myproject', provider: 'pi' }
+    const seenKeys = new Set<string>()
+
+    const firstRun: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, seenKeys).parse()) {
+      firstRun.push(call)
+    }
+
+    const secondRun: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, seenKeys).parse()) {
+      secondRun.push(call)
+    }
+
+    expect(firstRun).toHaveLength(1)
+    expect(secondRun).toHaveLength(0)
+  })
+
+  it('yields one call per assistant message in a multi-turn session', async () => {
+    const projectDir = join(tmpDir, '--Users-test-myproject--')
+    const filePath = await writeSession(projectDir, 'session.jsonl', [
+      sessionMeta({ id: 'sess-multi' }),
+      userMessage('first question'),
+      assistantMessage({ responseId: 'resp-1', timestamp: '2026-04-14T10:00:30.000Z', input: 500, output: 100 }),
+      userMessage('second question'),
+      assistantMessage({ responseId: 'resp-2', timestamp: '2026-04-14T10:01:00.000Z', input: 600, output: 120 }),
+    ])
+
+    const provider = createPiProvider(tmpDir)
+    const source = { path: filePath, project: 'myproject', provider: 'pi' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) {
+      calls.push(call)
+    }
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]!.userMessage).toBe('first question')
+    expect(calls[0]!.inputTokens).toBe(500)
+    expect(calls[1]!.userMessage).toBe('second question')
+    expect(calls[1]!.inputTokens).toBe(600)
+  })
+
+  it('handles missing session file gracefully', async () => {
+    const provider = createPiProvider(tmpDir)
+    const source = { path: '/nonexistent/session.jsonl', project: 'test', provider: 'pi' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) {
+      calls.push(call)
+    }
+    expect(calls).toHaveLength(0)
+  })
+})
+
+describe('pi provider - display names', () => {
+  const provider = createPiProvider('/tmp')
+
+  it('has correct name and displayName', () => {
+    expect(provider.name).toBe('pi')
+    expect(provider.displayName).toBe('Pi')
+  })
+
+  it('maps known models to readable names', () => {
+    expect(provider.modelDisplayName('gpt-5.4')).toBe('GPT-5.4')
+    expect(provider.modelDisplayName('gpt-5.4-mini')).toBe('GPT-5.4 Mini')
+    expect(provider.modelDisplayName('gpt-5')).toBe('GPT-5')
+  })
+
+  it('returns raw name for unknown models', () => {
+    expect(provider.modelDisplayName('some-future-model')).toBe('some-future-model')
+  })
+
+  it('returns tool name as-is', () => {
+    expect(provider.toolDisplayName('bash')).toBe('bash')
+    expect(provider.toolDisplayName('read')).toBe('read')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds support for Pi (pi.ai) as a new session provider.
- Pi sessions are stored as JSONL files under `~/.pi/agent/sessions/<project-dir>/` and use OpenAI-compatible model IDs (gpt-5, gpt-5.4, gpt-4o, etc.).

## Changes
- `src/providers/pi.ts` (new): Pi provider - discovers JSONL session files, parses assistant turns, extracts token counts, tool calls, and bash commands, deduplicates via response ID with line-index fallback
- `src/providers/types.ts`: added bashCommands field to `ParsedProviderCall` so all providers carry extracted bash command lists
- `src/providers/index.ts`: registered Pi as a core provider alongside Claude and Codex
- `src/providers/codex.ts`, `cursor.ts`: added `bashCommands: []` to satisfy the new required field on `ParsedProviderCall`
- `src/parser.ts`: fixed bug where `providerCallToTurn` always emitted an empty bashCommands array instead of passing through the parsed commands
- `src/classifier.ts`: added lowercase tool name variants (bash, edit, read, write) to match Pi's tool naming convention in JSONL output
- `src/bash-utils.ts`: exclude `true`, `false`, and shell variable assignments from extracted commands; scan past leading `NAME=val` tokens so `FOO=bar ls` correctly records `ls` rather than being dropped
- `package.json`: added pi to keywords
- `tests/providers/pi.test.ts` (new): 16 unit tests covering session discovery, multi-turn parsing, tool/bash extraction, deduplication, zero-token filtering, and display name mapping
- `tests/provider-registry.test.ts`: updated core provider list to include pi

## Testing
- [X] Unit tests pass (`npx vitest run`, 56 tests across 6 files);
- [X] Manually verified via `npx tsx src/cli.ts` report and showing Pi sessions alongside Claude and Codex in the dashboard.