### PR TITLE
feat: add --format json to report, today, and month commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,40 @@ npx codeburn
 ## Usage
 
 ```bash
-codeburn                    # interactive dashboard (default: 7 days)
-codeburn today              # today's usage
-codeburn month              # this month's usage
-codeburn report -p 30days   # rolling 30-day window
-codeburn report -p all      # every recorded session
-codeburn report --refresh 60  # auto-refresh every 60 seconds
-codeburn status             # compact one-liner (today + month)
+codeburn                        # interactive dashboard (default: 7 days)
+codeburn today                  # today's usage
+codeburn month                  # this month's usage
+codeburn report -p 30days       # rolling 30-day window
+codeburn report -p all          # every recorded session
+codeburn report --format json   # full dashboard data as JSON
+codeburn report --refresh 60    # auto-refresh every 60 seconds
+codeburn status                 # compact one-liner (today + month)
 codeburn status --format json
-codeburn export             # CSV with today, 7 days, 30 days
-codeburn export -f json     # JSON export
+codeburn export                 # CSV with today, 7 days, 30 days
+codeburn export -f json         # JSON export
 ```
 
 Arrow keys switch between Today / 7 Days / 30 Days / Month / All Time. Press `q` to quit, `1` `2` `3` `4` `5` as shortcuts. The dashboard also shows average cost per session and the five most expensive sessions across all projects.
+
+### JSON output
+
+`report`, `today`, and `month` support `--format json` to output the full dashboard data as structured JSON to stdout:
+
+```bash
+codeburn report --format json             # 7-day JSON report
+codeburn today --format json              # today's data as JSON
+codeburn month --format json              # this month as JSON
+codeburn report -p 30days --format json   # 30-day window
+```
+
+The JSON includes all dashboard panels: overview (cost, calls, sessions, cache hit %), daily breakdown, projects, models with token counts, activities with one-shot rates, core tools, MCP servers, and shell commands. Pipe to `jq` for filtering:
+
+```bash
+codeburn report --format json | jq '.projects'
+codeburn today --format json | jq '.overview.cost'
+```
+
+For the lighter `status --format json` (today + month totals only) or file-based exports (`export -f json`), see above.
 
 ## Providers
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { exportCsv, exportJson, type PeriodExport } from './export.js'
 import { loadPricing } from './models.js'
 import { parseAllSessions } from './parser.js'
+import { getCostColumnHeader, convertCost } from './currency.js'
 import { renderStatusBar } from './format.js'
 import { installMenubar, renderMenubarFormat, type PeriodData, type ProviderCost, uninstallMenubar } from './menubar.js'
 import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory } from './types.js'
@@ -67,14 +68,150 @@ program.hook('preAction', async () => {
   await loadCurrency()
 })
 
+function buildJsonReport(projects: ProjectSummary[], period: string) {
+  const sessions = projects.flatMap(p => p.sessions)
+  const { code } = getCurrency()
+
+  const totalCostUSD = projects.reduce((s, p) => s + p.totalCostUSD, 0)
+  const totalCalls = projects.reduce((s, p) => s + p.totalApiCalls, 0)
+  const totalSessions = projects.reduce((s, p) => s + p.sessions.length, 0)
+  const totalInput = sessions.reduce((s, sess) => s + sess.totalInputTokens, 0)
+  const totalOutput = sessions.reduce((s, sess) => s + sess.totalOutputTokens, 0)
+  const totalCacheRead = sessions.reduce((s, sess) => s + sess.totalCacheReadTokens, 0)
+  const totalCacheWrite = sessions.reduce((s, sess) => s + sess.totalCacheWriteTokens, 0)
+  const allInput = totalInput + totalCacheRead + totalCacheWrite
+  const cacheHitPercent = allInput > 0 ? Math.round((totalCacheRead / allInput) * 1000) / 10 : 0
+
+  // daily
+  const dailyMap: Record<string, { cost: number; calls: number }> = {}
+  for (const sess of sessions) {
+    for (const turn of sess.turns) {
+      if (!turn.timestamp) { continue }
+      const day = turn.timestamp.slice(0, 10)
+      if (!dailyMap[day]) { dailyMap[day] = { cost: 0, calls: 0 } }
+      for (const call of turn.assistantCalls) {
+        dailyMap[day].cost += call.costUSD
+        dailyMap[day].calls += 1
+      }
+    }
+  }
+  const daily = Object.entries(dailyMap).sort().map(([date, d]) => ({
+    date,
+    cost: convertCost(d.cost),
+    calls: d.calls,
+  }))
+
+  // projects
+  const projectList = projects.map(p => ({
+    name: p.project,
+    path: p.projectPath,
+    cost: convertCost(p.totalCostUSD),
+    calls: p.totalApiCalls,
+    sessions: p.sessions.length,
+  }))
+
+  // models
+  const modelMap: Record<string, { calls: number; cost: number; inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number }> = {}
+  for (const sess of sessions) {
+    for (const [model, d] of Object.entries(sess.modelBreakdown)) {
+      if (!modelMap[model]) { modelMap[model] = { calls: 0, cost: 0, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 } }
+      modelMap[model].calls += d.calls
+      modelMap[model].cost += d.costUSD
+      modelMap[model].inputTokens += d.tokens.inputTokens
+      modelMap[model].outputTokens += d.tokens.outputTokens
+      modelMap[model].cacheReadTokens += d.tokens.cacheReadInputTokens
+      modelMap[model].cacheWriteTokens += d.tokens.cacheCreationInputTokens
+    }
+  }
+  const models = Object.entries(modelMap)
+    .sort(([, a], [, b]) => b.cost - a.cost)
+    .map(([name, d]) => ({ name, cost: convertCost(d.cost), ...d, cost_usd: undefined }))
+    .map(({ cost_usd: _, ...rest }) => rest)
+
+  // activities
+  const catMap: Record<string, { turns: number; cost: number; editTurns: number; oneShotTurns: number }> = {}
+  for (const sess of sessions) {
+    for (const [cat, d] of Object.entries(sess.categoryBreakdown)) {
+      if (!catMap[cat]) { catMap[cat] = { turns: 0, cost: 0, editTurns: 0, oneShotTurns: 0 } }
+      catMap[cat].turns += d.turns
+      catMap[cat].cost += d.costUSD
+      catMap[cat].editTurns += d.editTurns
+      catMap[cat].oneShotTurns += d.oneShotTurns
+    }
+  }
+  const activities = Object.entries(catMap)
+    .sort(([, a], [, b]) => b.cost - a.cost)
+    .map(([cat, d]) => ({
+      category: CATEGORY_LABELS[cat as TaskCategory] ?? cat,
+      cost: convertCost(d.cost),
+      turns: d.turns,
+      editTurns: d.editTurns,
+      oneShotTurns: d.oneShotTurns,
+      oneShotRate: d.editTurns > 0 ? Math.round((d.oneShotTurns / d.editTurns) * 1000) / 10 : null,
+    }))
+
+  // tools
+  const toolMap: Record<string, number> = {}
+  const mcpMap: Record<string, number> = {}
+  const bashMap: Record<string, number> = {}
+  for (const sess of sessions) {
+    for (const [tool, d] of Object.entries(sess.toolBreakdown)) {
+      toolMap[tool] = (toolMap[tool] ?? 0) + d.calls
+    }
+    for (const [server, d] of Object.entries(sess.mcpBreakdown)) {
+      mcpMap[server] = (mcpMap[server] ?? 0) + d.calls
+    }
+    for (const [cmd, d] of Object.entries(sess.bashBreakdown)) {
+      bashMap[cmd] = (bashMap[cmd] ?? 0) + d.calls
+    }
+  }
+
+  const sortedMap = (m: Record<string, number>) =>
+    Object.entries(m).sort(([, a], [, b]) => b - a).map(([name, calls]) => ({ name, calls }))
+
+  return {
+    generated: new Date().toISOString(),
+    currency: code,
+    period,
+    overview: {
+      cost: convertCost(totalCostUSD),
+      calls: totalCalls,
+      sessions: totalSessions,
+      cacheHitPercent,
+      tokens: {
+        input: totalInput,
+        output: totalOutput,
+        cacheRead: totalCacheRead,
+        cacheWrite: totalCacheWrite,
+      },
+    },
+    daily,
+    projects: projectList,
+    models,
+    activities,
+    tools: sortedMap(toolMap),
+    mcpServers: sortedMap(mcpMap),
+    shellCommands: sortedMap(bashMap),
+  }
+}
+
 program
   .command('report', { isDefault: true })
   .description('Interactive usage dashboard')
   .option('-p, --period <period>', 'Starting period: today, week, 30days, month, all', 'week')
   .option('--provider <provider>', 'Filter by provider: all, claude, codex, cursor', 'all')
+  .option('--format <format>', 'Output format: tui, json', 'tui')
   .option('--refresh <seconds>', 'Auto-refresh interval in seconds', parseInt)
   .action(async (opts) => {
-    await renderDashboard(toPeriod(opts.period), opts.provider, opts.refresh)
+    const period = toPeriod(opts.period)
+    if (opts.format === 'json') {
+      await loadPricing()
+      const { range, label } = getDateRange(period)
+      const projects = await parseAllSessions(range, opts.provider)
+      console.log(JSON.stringify(buildJsonReport(projects, label), null, 2))
+      return
+    }
+    await renderDashboard(period, opts.provider, opts.refresh)
   })
 
 function buildPeriodData(label: string, projects: ProjectSummary[]): PeriodData {
@@ -160,8 +297,16 @@ program
   .command('today')
   .description('Today\'s usage dashboard')
   .option('--provider <provider>', 'Filter by provider: all, claude, codex, cursor', 'all')
+  .option('--format <format>', 'Output format: tui, json', 'tui')
   .option('--refresh <seconds>', 'Auto-refresh interval in seconds', parseInt)
   .action(async (opts) => {
+    if (opts.format === 'json') {
+      await loadPricing()
+      const { range, label } = getDateRange('today')
+      const projects = await parseAllSessions(range, opts.provider)
+      console.log(JSON.stringify(buildJsonReport(projects, label), null, 2))
+      return
+    }
     await renderDashboard('today', opts.provider, opts.refresh)
   })
 
@@ -169,8 +314,16 @@ program
   .command('month')
   .description('This month\'s usage dashboard')
   .option('--provider <provider>', 'Filter by provider: all, claude, codex, cursor', 'all')
+  .option('--format <format>', 'Output format: tui, json', 'tui')
   .option('--refresh <seconds>', 'Auto-refresh interval in seconds', parseInt)
   .action(async (opts) => {
+    if (opts.format === 'json') {
+      await loadPricing()
+      const { range, label } = getDateRange('month')
+      const projects = await parseAllSessions(range, opts.provider)
+      console.log(JSON.stringify(buildJsonReport(projects, label), null, 2))
+      return
+    }
     await renderDashboard('month', opts.provider, opts.refresh)
   })
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -125,8 +125,7 @@ function buildJsonReport(projects: ProjectSummary[], period: string) {
   }
   const models = Object.entries(modelMap)
     .sort(([, a], [, b]) => b.cost - a.cost)
-    .map(([name, d]) => ({ name, cost: convertCost(d.cost), ...d, cost_usd: undefined }))
-    .map(({ cost_usd: _, ...rest }) => rest)
+    .map(([name, { cost, ...rest }]) => ({ name, ...rest, cost: convertCost(cost) }))
 
   // activities
   const catMap: Record<string, { turns: number; cost: number; editTurns: number; oneShotTurns: number }> = {}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,7 +82,6 @@ function buildJsonReport(projects: ProjectSummary[], period: string) {
   const allInput = totalInput + totalCacheRead + totalCacheWrite
   const cacheHitPercent = allInput > 0 ? Math.round((totalCacheRead / allInput) * 1000) / 10 : 0
 
-  // daily
   const dailyMap: Record<string, { cost: number; calls: number }> = {}
   for (const sess of sessions) {
     for (const turn of sess.turns) {
@@ -101,7 +100,6 @@ function buildJsonReport(projects: ProjectSummary[], period: string) {
     calls: d.calls,
   }))
 
-  // projects
   const projectList = projects.map(p => ({
     name: p.project,
     path: p.projectPath,
@@ -110,7 +108,6 @@ function buildJsonReport(projects: ProjectSummary[], period: string) {
     sessions: p.sessions.length,
   }))
 
-  // models
   const modelMap: Record<string, { calls: number; cost: number; inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number }> = {}
   for (const sess of sessions) {
     for (const [model, d] of Object.entries(sess.modelBreakdown)) {
@@ -127,7 +124,6 @@ function buildJsonReport(projects: ProjectSummary[], period: string) {
     .sort(([, a], [, b]) => b.cost - a.cost)
     .map(([name, { cost, ...rest }]) => ({ name, ...rest, cost: convertCost(cost) }))
 
-  // activities
   const catMap: Record<string, { turns: number; cost: number; editTurns: number; oneShotTurns: number }> = {}
   for (const sess of sessions) {
     for (const [cat, d] of Object.entries(sess.categoryBreakdown)) {
@@ -149,7 +145,6 @@ function buildJsonReport(projects: ProjectSummary[], period: string) {
       oneShotRate: d.editTurns > 0 ? Math.round((d.oneShotTurns / d.editTurns) * 1000) / 10 : null,
     }))
 
-  // tools
   const toolMap: Record<string, number> = {}
   const mcpMap: Record<string, number> = {}
   const bashMap: Record<string, number> = {}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,7 +68,7 @@ program.hook('preAction', async () => {
   await loadCurrency()
 })
 
-function buildJsonReport(projects: ProjectSummary[], period: string) {
+function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: string) {
   const sessions = projects.flatMap(p => p.sessions)
   const { code } = getCurrency()
 
@@ -163,10 +163,16 @@ function buildJsonReport(projects: ProjectSummary[], period: string) {
   const sortedMap = (m: Record<string, number>) =>
     Object.entries(m).sort(([, a], [, b]) => b - a).map(([name, calls]) => ({ name, calls }))
 
+  const topSessions = projects
+    .flatMap(p => p.sessions.map(s => ({ project: p.project, sessionId: s.sessionId, date: s.firstTimestamp?.slice(0, 10) ?? null, cost: convertCost(s.totalCostUSD), calls: s.apiCalls })))
+    .sort((a, b) => b.cost - a.cost)
+    .slice(0, 5)
+
   return {
     generated: new Date().toISOString(),
     currency: code,
     period,
+    periodKey,
     overview: {
       cost: convertCost(totalCostUSD),
       calls: totalCalls,
@@ -186,6 +192,7 @@ function buildJsonReport(projects: ProjectSummary[], period: string) {
     tools: sortedMap(toolMap),
     mcpServers: sortedMap(mcpMap),
     shellCommands: sortedMap(bashMap),
+    topSessions,
   }
 }
 
@@ -202,7 +209,7 @@ program
       await loadPricing()
       const { range, label } = getDateRange(period)
       const projects = await parseAllSessions(range, opts.provider)
-      console.log(JSON.stringify(buildJsonReport(projects, label), null, 2))
+      console.log(JSON.stringify(buildJsonReport(projects, label, period), null, 2))
       return
     }
     await renderDashboard(period, opts.provider, opts.refresh)
@@ -298,7 +305,7 @@ program
       await loadPricing()
       const { range, label } = getDateRange('today')
       const projects = await parseAllSessions(range, opts.provider)
-      console.log(JSON.stringify(buildJsonReport(projects, label), null, 2))
+      console.log(JSON.stringify(buildJsonReport(projects, label, 'today'), null, 2))
       return
     }
     await renderDashboard('today', opts.provider, opts.refresh)
@@ -315,7 +322,7 @@ program
       await loadPricing()
       const { range, label } = getDateRange('month')
       const projects = await parseAllSessions(range, opts.provider)
-      console.log(JSON.stringify(buildJsonReport(projects, label), null, 2))
+      console.log(JSON.stringify(buildJsonReport(projects, label, 'month'), null, 2))
       return
     }
     await renderDashboard('month', opts.provider, opts.refresh)


### PR DESCRIPTION
## Summary

Adds `--format json` to the `report`, `today`, and `month` commands, outputting full dashboard data as structured JSON to stdout.

The existing JSON options (`status --format json` and `export -f json`) are limited — status only gives today/month cost+calls, and export writes to a file. This adds a comprehensive JSON output that mirrors everything in the TUI dashboard.

## JSON structure

```json
{
  "generated": "2026-04-16T...",
  "currency": "USD",
  "period": "Last 7 Days",
  "overview": { "cost", "calls", "sessions", "cacheHitPercent", "tokens": {...} },
  "daily": [{ "date", "cost", "calls" }],
  "projects": [{ "name", "path", "cost", "calls", "sessions" }],
  "models": [{ "name", "cost", "calls", "inputTokens", "outputTokens", ... }],
  "activities": [{ "category", "cost", "turns", "editTurns", "oneShotTurns", "oneShotRate" }],
  "tools": [{ "name", "calls" }],
  "mcpServers": [{ "name", "calls" }],
  "shellCommands": [{ "name", "calls" }]
}
```

## Usage

```bash
codeburn report --format json             # 7-day JSON report
codeburn today --format json              # today as JSON
codeburn month --format json              # this month as JSON
codeburn report -p 30days --format json   # 30-day window
codeburn report --format json | jq '.projects'
```

## Changes

- **`src/cli.ts`** — `buildJsonReport()` function + `--format` option on `report`, `today`, `month`
- **`README.md`** — documented JSON output with examples

## Test plan

- [x] `report --format json` outputs valid JSON with all sections
- [x] `today --format json` works
- [x] `month --format json` works
- [x] Currency conversion applied to cost fields
- [x] Default `--format tui` still launches interactive dashboard
- [x] `--help` shows new option
- [x] Clean build with `tsup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)