### PR TITLE
chore: release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.6.0 - 2026-04-16
+
+### Added
+- **GitHub Copilot provider.** Parses `~/.copilot/session-state/*/events.jsonl`
+  and tracks model changes via `session.model_change` events. Picks up six new
+  model prices (`gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-5-mini`, `o3`,
+  `o4-mini`). Contributed by @theodorosD. Note: Copilot logs only output
+  tokens, so cost rows will sit below actual API cost.
+- **All Time period (key `5`).** Shows every recorded session since CodeBurn
+  started tracking. Daily Activity expands to every available day instead of
+  the fixed 14- or 31-day window. `codeburn report -p all` also works from
+  the CLI. Contributed by @lfl1337.
+- **avg/s column in By Project.** Average cost per session next to the
+  existing total cost and session count. Surfaces projects where individual
+  sessions are expensive even if the total is modest. Contributed by @lfl1337.
+- **Top Sessions panel.** Highlights the five most expensive sessions across
+  all projects with date, project, cost, and API call count. Helps spot
+  outliers that drag weekly or monthly totals. Contributed by @lfl1337.
+
+### Fixed
+- `modelDisplayName` now matches longest key first so `gpt-4.1-mini` resolves
+  to `GPT-4.1 Mini` instead of `GPT-4.1`.
+- `TopSessions` handles missing `firstTimestamp` gracefully with a
+  `----------` placeholder instead of rendering a stray whitespace row.
+
 ## 0.5.0 - 2026-04-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <img src="https://raw.githubusercontent.com/AgentSeal/codeburn/main/assets/dashboard.jpg" alt="CodeBurn TUI dashboard" width="620" />
 </p>
 
-By task type, tool, model, MCP server, and project. Supports **Claude Code**, **Codex** (OpenAI), **Cursor**, **OpenCode**, and **Pi** with a provider plugin system. Tracks one-shot success rate per activity type so you can see where the AI nails it first try vs. burns tokens on edit/test/fix retries. Interactive TUI dashboard with gradient charts, responsive panels, and keyboard navigation. macOS menu bar widget via SwiftBar. CSV/JSON export.
+By task type, tool, model, MCP server, and project. Supports **Claude Code**, **Codex** (OpenAI), **Cursor**, **OpenCode**, **Pi**, and **GitHub Copilot** with a provider plugin system. Tracks one-shot success rate per activity type so you can see where the AI nails it first try vs. burns tokens on edit/test/fix retries. Interactive TUI dashboard with gradient charts, responsive panels, and keyboard navigation. macOS menu bar widget via SwiftBar. CSV/JSON export.
 
 Works by reading session data directly from disk. No wrapper, no proxy, no API keys. Pricing from LiteLLM (auto-cached, all models supported).
 
@@ -38,7 +38,7 @@ npx codeburn
 ### Requirements
 
 - Node.js 20+
-- Claude Code (`~/.claude/projects/`), Codex (`~/.codex/sessions/`), Cursor, OpenCode, and/or Pi (`~/.pi/agent/sessions/`)
+- Claude Code (`~/.claude/projects/`), Codex (`~/.codex/sessions/`), Cursor, OpenCode, Pi (`~/.pi/agent/sessions/`), and/or GitHub Copilot (`~/.copilot/session-state/`)
 - For Cursor/OpenCode support: `better-sqlite3` is installed automatically as an optional dependency
 
 ## Usage
@@ -48,6 +48,7 @@ codeburn                    # interactive dashboard (default: 7 days)
 codeburn today              # today's usage
 codeburn month              # this month's usage
 codeburn report -p 30days   # rolling 30-day window
+codeburn report -p all      # every recorded session
 codeburn report --refresh 60  # auto-refresh every 60 seconds
 codeburn status             # compact one-liner (today + month)
 codeburn status --format json
@@ -55,21 +56,22 @@ codeburn export             # CSV with today, 7 days, 30 days
 codeburn export -f json     # JSON export
 ```
 
-Arrow keys switch between Today / 7 Days / 30 Days / Month. Press `q` to quit, `1` `2` `3` `4` as shortcuts.
+Arrow keys switch between Today / 7 Days / 30 Days / Month / All Time. Press `q` to quit, `1` `2` `3` `4` `5` as shortcuts. The dashboard also shows average cost per session and the five most expensive sessions across all projects.
 
 ## Providers
 
 CodeBurn auto-detects which AI coding tools you use. If multiple providers have session data on disk, press `p` in the dashboard to toggle between them.
 
 ```bash
-codeburn report                    # all providers combined (default)
-codeburn report --provider claude  # Claude Code only
+codeburn report                      # all providers combined (default)
+codeburn report --provider claude    # Claude Code only
 codeburn report --provider codex     # Codex only
-codeburn report --provider cursor   # Cursor only
-codeburn report --provider opencode # OpenCode only
-codeburn report --provider pi       # Pi only
-codeburn today --provider codex     # Codex today
-codeburn export --provider claude  # export Claude data only
+codeburn report --provider cursor    # Cursor only
+codeburn report --provider opencode  # OpenCode only
+codeburn report --provider pi        # Pi only
+codeburn report --provider copilot   # GitHub Copilot only
+codeburn today --provider codex      # Codex today
+codeburn export --provider claude    # export Claude data only
 ```
 
 The `--provider` flag works on all commands: `report`, `today`, `month`, `status`, `export`.
@@ -84,11 +86,14 @@ The `--provider` flag works on all commands: `report`, `today`, `month`, `status
 | Cursor | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | Supported |
 | OpenCode | `~/.local/share/opencode/` (SQLite) | Supported |
 | Pi | `~/.pi/agent/sessions/` | Supported |
+| GitHub Copilot | `~/.copilot/session-state/` | Supported (output tokens only) |
 | Amp | -- | Planned (provider plugin system) |
 
 Codex tool names are normalized to match Claude's conventions (`exec_command` shows as `Bash`, `read_file` as `Read`, etc.) so the activity classifier and tool breakdown work across providers.
 
 Cursor reads token usage from its local SQLite database. Since Cursor's "Auto" mode hides the actual model used, costs are estimated using Sonnet pricing (labeled "Auto (Sonnet est.)" in the dashboard). The Cursor view shows a **Languages** panel (extracted from code blocks) instead of Core Tools/Shell/MCP panels, since Cursor does not log individual tool calls. First run on a large Cursor database may take up to a minute; results are cached and subsequent runs are instant.
+
+GitHub Copilot only logs output tokens in its session state, so Copilot cost rows sit below actual API cost. The model is tracked via `session.model_change` events; messages before the first model change are skipped to avoid silent misattribution.
 
 ### Adding a provider
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeburn",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeburn",
-      "version": "0.5.7",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeburn",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "description": "See where your AI coding tokens go - by task, tool, model, and project",
   "type": "module",
   "main": "./dist/cli.js",


### PR DESCRIPTION
## Summary

- Bump `package.json` and `package-lock.json` to 0.6.0
- CHANGELOG entry covers both merged features since 0.5.7
- README reflects the new provider and dashboard additions

## Contents

**Features shipping in 0.6.0** (already on main via their own PRs):

- #44 GitHub Copilot provider by @theodorosD
- #51 All Time period, avg/s column, Top Sessions panel by @lfl1337

## Test plan

- [x] \`npx vitest run\` -- 114 tests pass
- [x] \`node dist/cli.js --version\` prints 0.6.0
- [x] Build succeeds at 132KB
- [ ] Interactive dashboard spot-check (reviewer)