### PR TITLE
fix: respect SwiftBar settings when installing the menu bar

### DIFF
--- a/src/menubar.ts
+++ b/src/menubar.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process'
+import { execFileSync, execSync } from 'child_process'
 import { existsSync } from 'fs'
 import { chmod, mkdir, unlink, writeFile } from 'fs/promises'
 import { homedir, platform } from 'os'
@@ -7,6 +7,8 @@ import { formatCost, formatTokens } from './format.js'
 import { getCurrency } from './currency.js'
 
 const PLUGIN_REFRESH = '5m'
+const SWIFTBAR_PREFERENCES_DOMAIN = 'com.ameba.SwiftBar'
+const SWIFTBAR_PLUGIN_DIRECTORY_KEY = 'PluginDirectory'
 
 function getSwiftBarPluginDir(): string {
   return join(homedir(), 'Library', 'Application Support', 'SwiftBar', 'plugins')
@@ -14,6 +16,49 @@ function getSwiftBarPluginDir(): string {
 
 function getXbarPluginDir(): string {
   return join(homedir(), 'Library', 'Application Support', 'xbar', 'plugins')
+}
+
+export function parsePluginDirectoryPreference(value: string): string | undefined {
+  const pluginDir = value.trim()
+  if (!pluginDir) return undefined
+  if (pluginDir === '~') return homedir()
+  if (pluginDir.startsWith('~/')) return join(homedir(), pluginDir.slice(2))
+  return pluginDir
+}
+
+function getConfiguredSwiftBarPluginDir(): string | undefined {
+  if (platform() !== 'darwin') return undefined
+
+  try {
+    return parsePluginDirectoryPreference(execFileSync('defaults', [
+      'read',
+      SWIFTBAR_PREFERENCES_DOMAIN,
+      SWIFTBAR_PLUGIN_DIRECTORY_KEY,
+    ], { encoding: 'utf-8' }))
+  } catch {
+    return undefined
+  }
+}
+
+function getSwiftBarPluginDirs(): string[] {
+  const dirs = [getConfiguredSwiftBarPluginDir(), getSwiftBarPluginDir()]
+  return dirs.filter((dir, index): dir is string => dir !== undefined && dirs.indexOf(dir) === index)
+}
+
+export function chooseMenubarPluginDir(
+  swiftBarPluginDirs: string[],
+  xbarPluginDir: string,
+  pathExists: (path: string) => boolean,
+): { pluginDir: string; appName: string } {
+  const preferredSwiftBarDir = swiftBarPluginDirs[0] ?? getSwiftBarPluginDir()
+
+  for (const pluginDir of swiftBarPluginDirs) {
+    if (pathExists(pluginDir)) return { pluginDir, appName: 'SwiftBar' }
+  }
+
+  if (pathExists(xbarPluginDir)) return { pluginDir: xbarPluginDir, appName: 'xbar' }
+
+  return { pluginDir: preferredSwiftBarDir, appName: 'SwiftBar' }
 }
 
 function getCodeburnBin(): string {
@@ -225,18 +270,9 @@ export async function installMenubar(): Promise<string> {
   const bin = getCodeburnBin()
   const pluginContent = generatePlugin(bin)
 
-  let pluginDir: string
-  let appName: string
+  const { pluginDir, appName } = chooseMenubarPluginDir(getSwiftBarPluginDirs(), getXbarPluginDir(), existsSync)
 
-  if (existsSync(getSwiftBarPluginDir())) {
-    pluginDir = getSwiftBarPluginDir()
-    appName = 'SwiftBar'
-  } else if (existsSync(getXbarPluginDir())) {
-    pluginDir = getXbarPluginDir()
-    appName = 'xbar'
-  } else {
-    pluginDir = getSwiftBarPluginDir()
-    appName = 'SwiftBar'
+  if (!existsSync(pluginDir)) {
     await mkdir(pluginDir, { recursive: true })
   }
 
@@ -264,7 +300,7 @@ export async function installMenubar(): Promise<string> {
 
 export async function uninstallMenubar(): Promise<string> {
   const paths = [
-    join(getSwiftBarPluginDir(), `codeburn.${PLUGIN_REFRESH}.sh`),
+    ...getSwiftBarPluginDirs().map(dir => join(dir, `codeburn.${PLUGIN_REFRESH}.sh`)),
     join(getXbarPluginDir(), `codeburn.${PLUGIN_REFRESH}.sh`),
   ]
 

--- a/tests/menubar.test.ts
+++ b/tests/menubar.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { join } from 'path'
+import { homedir } from 'os'
+
+import { chooseMenubarPluginDir, parsePluginDirectoryPreference } from '../src/menubar.js'
+
+describe('parsePluginDirectoryPreference', () => {
+  it('trims defaults output and preserves spaces in paths', () => {
+    expect(parsePluginDirectoryPreference('/Users/test/Documents/Tech stuff/swiftbar_plugins\n')).toBe('/Users/test/Documents/Tech stuff/swiftbar_plugins')
+  })
+
+  it('expands tilde paths', () => {
+    expect(parsePluginDirectoryPreference('~/swiftbar_plugins')).toBe(join(homedir(), 'swiftbar_plugins'))
+  })
+
+  it('ignores blank preference values', () => {
+    expect(parsePluginDirectoryPreference('  \n')).toBeUndefined()
+  })
+})
+
+describe('chooseMenubarPluginDir', () => {
+  const configuredSwiftBarDir = '/Users/test/Documents/Tech stuff/swiftbar_plugins'
+  const defaultSwiftBarDir = '/Users/test/Library/Application Support/SwiftBar/plugins'
+  const xbarDir = '/Users/test/Library/Application Support/xbar/plugins'
+
+  it('uses SwiftBar configured plugin directory before the default directory', () => {
+    const existing = new Set([configuredSwiftBarDir, defaultSwiftBarDir])
+    const result = chooseMenubarPluginDir(
+      [configuredSwiftBarDir, defaultSwiftBarDir],
+      xbarDir,
+      path => existing.has(path),
+    )
+
+    expect(result).toEqual({ pluginDir: configuredSwiftBarDir, appName: 'SwiftBar' })
+  })
+
+  it('falls back to xbar when no SwiftBar plugin directory exists', () => {
+    const existing = new Set([xbarDir])
+    const result = chooseMenubarPluginDir(
+      [defaultSwiftBarDir],
+      xbarDir,
+      path => existing.has(path),
+    )
+
+    expect(result).toEqual({ pluginDir: xbarDir, appName: 'xbar' })
+  })
+
+  it('creates the preferred SwiftBar directory when no plugin directory exists', () => {
+    const result = chooseMenubarPluginDir(
+      [configuredSwiftBarDir, defaultSwiftBarDir],
+      xbarDir,
+      () => false,
+    )
+
+    expect(result).toEqual({ pluginDir: configuredSwiftBarDir, appName: 'SwiftBar' })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes `codeburn install-menubar` so it installs the SwiftBar plugin into the plugin directory configured in SwiftBar settings.

Previously, CodeBurn always preferred the default SwiftBar plugin folder:

```bash
~/Library/Application Support/SwiftBar/plugins
```

That ignored custom SwiftBar plugin locations such as:

```bash
~/Documents/Tech stuff/swiftbar_plugins
```

## Changes

- **`src/menubar.ts`** - reads SwiftBar's `PluginDirectory` preference from `com.ameba.SwiftBar`
- **`src/menubar.ts`** - prefers the configured SwiftBar plugin directory before the default SwiftBar path or xbar
- **`src/menubar.ts`** - checks the configured SwiftBar plugin directory when uninstalling the plugin
- **`tests/menubar.test.ts`** - adds coverage for preference parsing, paths with spaces, tilde expansion, xbar fallback, and missing directory behavior

## Test plan

- [x] `npm ci`
- [x] `npx vitest run`
- [x] `npx tsc --noEmit`
- [x] `npx tsx src/cli.ts report`
- [x] `npx tsx src/cli.ts today`
- [x] `npx tsx src/cli.ts install-menubar`
- [x] Verified plugin installed to configured SwiftBar path