### PR TITLE
fix: add claude-opus-4-7 model mapping and pricing

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -24,6 +24,7 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const WEB_SEARCH_COST = 0.01
 
 const FALLBACK_PRICING: Record<string, ModelCosts> = {
+  'claude-opus-4-7': { inputCostPerToken: 5e-6, outputCostPerToken: 25e-6, cacheWriteCostPerToken: 6.25e-6, cacheReadCostPerToken: 0.5e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 6 },
   'claude-opus-4-6': { inputCostPerToken: 5e-6, outputCostPerToken: 25e-6, cacheWriteCostPerToken: 6.25e-6, cacheReadCostPerToken: 0.5e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 6 },
   'claude-opus-4-5': { inputCostPerToken: 5e-6, outputCostPerToken: 25e-6, cacheWriteCostPerToken: 6.25e-6, cacheReadCostPerToken: 0.5e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 1 },
   'claude-opus-4-1': { inputCostPerToken: 15e-6, outputCostPerToken: 75e-6, cacheWriteCostPerToken: 18.75e-6, cacheReadCostPerToken: 1.5e-6, webSearchCostPerRequest: WEB_SEARCH_COST, fastMultiplier: 1 },
@@ -175,6 +176,7 @@ export function calculateCost(
 export function getShortModelName(model: string): string {
   const canonical = getCanonicalName(model)
   const shortNames: Record<string, string> = {
+    'claude-opus-4-7': 'Opus 4.7',
     'claude-opus-4-6': 'Opus 4.6',
     'claude-opus-4-5': 'Opus 4.5',
     'claude-opus-4-1': 'Opus 4.1',

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -5,6 +5,7 @@ import { homedir } from 'os'
 import type { Provider, SessionSource, SessionParser } from './types.js'
 
 const shortNames: Record<string, string> = {
+  'claude-opus-4-7': 'Opus 4.7',
   'claude-opus-4-6': 'Opus 4.6',
   'claude-opus-4-5': 'Opus 4.5',
   'claude-opus-4-1': 'Opus 4.1',


### PR DESCRIPTION
Fixes #56.

Adds `claude-opus-4-7` to the three places that need it:

- `FALLBACK_PRICING` in `src/models.ts` — mirrors `claude-opus-4-6` pricing ($5/$25 per M tokens)
- `getShortModelName` in `src/models.ts` — maps to `'Opus 4.7'`
- `shortNames` in `src/providers/claude.ts` — maps to `'Opus 4.7'`

Without this, Opus 4.7 usage falls back to the `claude-opus-4` entry and displays as "Opus 4" with $15/$75 pricing instead of the correct $5/$25 rates.

All 114 tests pass.