### PR TITLE
fix: prepend install-time node bin dir to menubar plugin PATH

### DIFF
--- a/src/menubar.ts
+++ b/src/menubar.ts
@@ -71,6 +71,11 @@ function getCodeburnBin(): string {
 
 function generatePlugin(bin: string): string {
   const home = homedir()
+  // Resolve the directory of the node binary used at install time so the
+  // plugin uses the same Node version codeburn was installed with — even
+  // when SwiftBar/xbar launch with a minimal PATH that finds an older
+  // system Node first.  Fixes #63.
+  const nodeBinDir = join(process.execPath, '..')
   return `#!/bin/bash
 # <xbar.title>CodeBurn</xbar.title>
 # <xbar.version>v0.1.0</xbar.version>
@@ -81,7 +86,8 @@ function generatePlugin(bin: string): string {
 # <xbar.abouturl>https://github.com/agentseal/codeburn</xbar.abouturl>
 # <xbar.dependencies>node</xbar.dependencies>
 
-export PATH="/usr/local/bin:/opt/homebrew/bin:$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"
+export HOME="${home}"
+export PATH="${nodeBinDir}:$HOME/.local/bin:$HOME/.npm-global/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
 ${bin} status --format menubar 2>/dev/null || echo "-- | sfimage=flame.fill"
 `


### PR DESCRIPTION
## Summary

Fixes #63 — the SwiftBar/xbar plugin fails silently when a system-installed Node older than v20.11 is found on PATH before the NVM-managed Node that codeburn was installed with.

## Problem

- SwiftBar launches plugins with a minimal environment
- The generated plugin places `/usr/local/bin` and `/opt/homebrew/bin` before user-local directories in `PATH`
- If an older Node (e.g. v18.x from Homebrew) exists there, it gets used instead of the NVM Node
- `string-width` uses the `/v` regex flag (Node ≥ 20.11), causing a `SyntaxError` swallowed by `2>/dev/null`
- Result: plugin shows `--` with no data

## Fix

In `generatePlugin()` in `src/menubar.ts`:
- Resolve the node binary directory at install time via `process.execPath` and prepend it to `PATH`
- Explicitly set `HOME`, which SwiftBar does not always inherit
- Reorder PATH so the install-time node directory comes first

## Testing

1. Installed codeburn via NVM Node v20.x with Homebrew Node v18.x also present
2. Before fix: plugin shows `--` (silent failure)
3. After fix: plugin displays cost data correctly