### PR TITLE
perf: optimize CLI startup and session parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,54 @@
-# CodeBurn Development Rules
+# CLAUDE.md
 
-## Verification
-- NEVER commit without running locally first and confirming it works
-- Run `npx tsx src/cli.ts report` and `npx tsx src/cli.ts today` to verify changes before any commit
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+CodeBurn is a CLI tool that shows where AI coding tokens go - by task, tool, model, and project. It reads session data directly from disk (no wrapper/proxy/API keys) for Claude Code, Codex, and Cursor. It has an interactive TUI dashboard built with Ink (React for terminals), CSV/JSON export, and a macOS menu bar widget.
+
+## Commands
+
+```bash
+# Development (run source directly)
+npx tsx src/cli.ts report          # interactive dashboard
+npx tsx src/cli.ts today           # today's dashboard
+npx tsx src/cli.ts report -p 30days
+
+# Tests
+npx vitest run                     # all tests
+npx vitest run tests/export.test.ts  # single test file
+npx vitest --watch                 # watch mode
+
+# Build
+npm run build                      # tsup -> dist/cli.js (single ESM bundle)
+```
+
+## Verification (before any commit)
+
+- Run `npx vitest run` - all tests must pass
+- Run `npx tsx src/cli.ts report` and `npx tsx src/cli.ts today` - confirm they work
 - For dashboard changes: run the interactive TUI and visually confirm rendering
-- For new features: test the happy path AND edge cases (empty data, missing config, pipe mode)
+- For new features: test happy path AND edge cases (empty data, missing config, pipe mode)
+
+## Architecture
+
+**Data flow**: CLI (`cli.ts`) -> Provider discovery (`providers/index.ts`) -> Session parsing (`parser.ts`) -> Cost calculation (`models.ts`) -> Classification (`classifier.ts`) -> Output (dashboard/format/export)
+
+**Provider plugin system**: Each provider implements the `Provider` interface in `providers/types.ts`:
+- `discoverSessions()` finds session files on disk
+- `createSessionParser()` returns an async generator of `ParsedProviderCall`
+- Tool names are normalized so the classifier works across providers
+- Cursor is lazy-loaded (optional `better-sqlite3` dep) via dynamic import in `providers/index.ts`
+- To add a new provider: create `src/providers/<name>.ts` implementing the `Provider` interface, register in `providers/index.ts`
+
+**Dashboard**: `dashboard.tsx` is an Ink (React) TUI. It renders gradient charts, responsive panels, and handles keyboard navigation. Period switching (Today/7d/30d/Month) re-parses sessions.
+
+**Pricing**: `models.ts` fetches LiteLLM pricing JSON, caches at `~/.cache/codeburn/` for 24h. Has hardcoded fallback pricing for all Claude/GPT models to prevent fuzzy-match mispricing. Pricing model names must match LiteLLM exactly.
+
+**Deduplication**: Each provider has its own dedup strategy (API message ID for Claude, cumulative token cross-check for Codex, conversation/timestamp for Cursor). Dedup keys are tracked in a `Set<string>` passed to each parser.
 
 ## Code Quality
+
 - Clean, minimal code. No dead code, no commented-out blocks, no TODO placeholders
 - No emoji anywhere in the codebase
 - No em dashes. Use hyphens or rewrite the sentence
@@ -14,19 +56,22 @@
 - No unnecessary abstractions. Three similar lines > premature helper function
 
 ## Accuracy
+
 - Every user-facing number (cost, tokens, calls) must be verified against real data
 - LiteLLM pricing model names must match exactly. No guessing model IDs
 - Date range calculations must be tested with edge cases (month boundaries, billing day > days in month)
 
 ## Style
+
 - TypeScript strict mode. No `any` types
 - No comments unless the WHY is non-obvious
 - Imports: node builtins first, then deps, then local (separated by blank line)
-- Single quotes, no semicolons inconsistency (follow existing: no trailing semicolons in most files)
+- Single quotes, no trailing semicolons (follow existing convention)
 
 ## Git
 
 ### Branching (strict)
+
 - NEVER commit directly to main. All work happens on branches
 - Branch naming: `feat/<name>`, `fix/<name>`, `chore/<name>`, `docs/<name>`
 - Merge to main ONLY after: tests pass, CLI verified, manual testing done
@@ -34,6 +79,7 @@
 - Tag releases: `git tag v0.X.0` after publish
 
 ### Creating a branch
+
 ```bash
 git checkout main && git pull origin main
 git checkout -b feat/my-feature
@@ -46,9 +92,11 @@ git push origin main
 ```
 
 ### Handling external PRs
+
 - NEVER rewrite a contributor's changes on your own branch. Always merge THEIR branch
 - Add your improvements as separate commits on top of their branch, not as replacements
 - This preserves their authorship in git history so GitHub shows them as a contributor
+
 ```bash
 gh pr checkout <number>           # checkout PR locally
 npx vitest run                    # test their code
@@ -61,6 +109,7 @@ gh pr comment <number> --body "Merged, thanks!"
 ```
 
 ### What gets committed
+
 - Source code: `src/`, `tests/`
 - Config: `package.json`, `tsconfig.json`, `tsup.config.ts`, `.gitignore`
 - Docs: `README.md`, `CHANGELOG.md`, `LICENSE`, `CLAUDE.md`
@@ -69,6 +118,7 @@ gh pr comment <number> --body "Merged, thanks!"
 - Check `git status` before every commit. Stage specific files, never `git add -A` or `git add .`
 
 ### Commit rules
+
 - Commits from: AgentSeal <hello@agentseal.org>
 - NEVER add Co-Authored-By lines
 - NEVER include personal names or usernames in commits

--- a/docs/specs/codebase-overview.md
+++ b/docs/specs/codebase-overview.md
@@ -1,0 +1,110 @@
+# CodeBurn Codebase Overview
+
+## Tech Stack
+
+- **Language**: TypeScript (strict mode), ESM modules
+- **Runtime**: Node.js >= 20
+- **Build**: tsup (single ESM bundle `dist/cli.js` with shebang)
+- **Test**: Vitest (5 test files)
+- **TUI**: Ink 7 (React 19 for terminals)
+- **CLI**: Commander.js
+- **Optional**: better-sqlite3 (for Cursor provider)
+
+## Architecture: Pipeline with Provider Plugin System
+
+```
+CLI (commander) -> Provider Discovery -> Session Parsing -> Cost Calculation -> Classification -> Output
+```
+
+Not layered, not hexagonal -- a straightforward data pipeline where each stage transforms the data forward. No dependency injection, no abstract interfaces beyond the `Provider` type.
+
+## Module Map (18 source files)
+
+| Module | Role | Lines |
+|--------|------|-------|
+| `cli.ts` | Entry point, Commander setup, 7 commands | 276 |
+| `types.ts` | Core domain types (TokenUsage, ParsedApiCall, SessionSummary, etc.) | 151 |
+| `parser.ts` | Main orchestrator: discovers sessions, parses JSONL, groups into turns, builds summaries | 508 |
+| `models.ts` | Pricing: fetches LiteLLM JSON, 24h disk cache, hardcoded fallbacks, cost calculation | 191 |
+| `classifier.ts` | Classifies turns into 13 categories by tool+keyword patterns | 163 |
+| `dashboard.tsx` | Ink/React TUI: gradient bars, responsive panels, keyboard navigation, auto-refresh | 668 |
+| `format.ts` | Token/cost formatting helpers, status bar renderer | 42 |
+| `export.ts` | CSV/JSON export with CSV injection protection | 217 |
+| `menubar.ts` | macOS SwiftBar/xbar plugin generation and install/uninstall | 264 |
+| `config.ts` | Read/write `~/.config/codeburn/config.json` | 37 |
+| `currency.ts` | Currency conversion via Frankfurter API, 24h cache | 141 |
+| `bash-utils.ts` | Extract command basenames from bash strings (handles pipes, `&&`, quotes) | 43 |
+| `sqlite.ts` | Lazy better-sqlite3 loader with typed wrapper | 59 |
+| `cursor-cache.ts` | Cache Cursor query results keyed by DB mtime+size | 64 |
+| `providers/types.ts` | Provider interface: `discoverSessions()`, `createSessionParser()` | 38 |
+| `providers/index.ts` | Provider registry, lazy Cursor loading | 50 |
+| `providers/claude.ts` | Claude Code: discovers JSONL dirs in `~/.claude/projects` + desktop app | 106 |
+| `providers/codex.ts` | Codex: discovers JSONL in `~/.codex/sessions/YYYY/MM/DD/`, async generator parser | 306 |
+| `providers/cursor.ts` | Cursor: queries SQLite `state.vscdb`, bubble-based token extraction | 284 |
+
+## Provider System
+
+Each provider implements the `Provider` interface:
+
+- **Claude**: Session discovery only (parsing happens in `parser.ts` via legacy JSONL path). `createSessionParser()` is a no-op -- Claude sessions are still parsed by `parser.ts`'s `scanProjectDirs` directly reading JSONL.
+- **Codex**: Full provider -- discovers sessions in dated directory structure, parses via async generator. Normalizes OpenAI token semantics (cached tokens included in input) to Anthropic semantics.
+- **Cursor**: Full provider -- reads SQLite `cursorDiskKV` table, extracts bubble data, deduplicates by conversation+timestamp+tokens. Results are cached to disk.
+
+**Key asymmetry**: Claude sessions go through `scanProjectDirs` -> `parseSessionFile` -> `groupIntoTurns` (the original codepath), while Codex/Cursor go through `parseProviderSources` which uses the `SessionParser` async generator interface. Both paths merge in `parseAllSessions`.
+
+## Data Model
+
+```
+Provider -> SessionSource (path, project, provider)
+         -> ParsedProviderCall (per API call, normalized)
+         -> ParsedTurn (user message + assistant calls)
+         -> ClassifiedTurn (+ category, retries, hasEdits)
+         -> SessionSummary (aggregated breakdowns)
+         -> ProjectSummary (grouped by project)
+```
+
+## Classification System
+
+13 task categories, two-phase classification:
+
+1. **Tool-based**: Plan mode -> delegation -> bash patterns (test/git/build) -> edits -> exploration
+2. **Keyword refinement**: Coding refines to debugging/refactoring/feature; exploration refines to debugging
+3. **Conversation fallback**: brainstorm/research/debug/feature keywords, file patterns, URLs
+
+## Caching Strategy
+
+- **LiteLLM pricing**: 24h disk cache at `~/.cache/codeburn/litellm-pricing.json`
+- **Exchange rates**: 24h disk cache at `~/.cache/codeburn/exchange-rate.json`
+- **Session results**: In-memory LRU (10 entries, 60s TTL) in `parser.ts`
+- **Cursor results**: Disk cache keyed by DB mtime+size at `~/.cache/codeburn/cursor-results.json`
+
+## Deduplication
+
+- **Claude**: API message ID (`msg.id`), tracked in `Set<string>` of seen IDs
+- **Codex**: Cumulative total token cross-check (skips if total unchanged), plus `codex:path:timestamp:total` dedup key
+- **Cursor**: `cursor:conversationId:createdAt:inputTokens:outputTokens` dedup key
+
+## CLI Commands
+
+1. `report` (default) -- interactive TUI dashboard with period switching
+2. `today` -- shortcut for `report -p today`
+3. `month` -- shortcut for `report -p month`
+4. `status` -- compact output, supports `--format menubar|json|terminal`
+5. `export` -- CSV/JSON with Today + 7d + 30d periods
+6. `install-menubar` / `uninstall-menubar` -- macOS SwiftBar/xbar plugin
+7. `currency [code]` -- set display currency
+
+## Testing Patterns
+
+- **Vitest** with temp directory fixtures (mkdtemp/rm)
+- Tests cover: bash command extraction, CSV injection prevention, provider registry, Codex JSONL parsing, Cursor provider basics
+- No tests for: `parser.ts` (the main orchestrator), `classifier.ts`, `dashboard.tsx`, `models.ts` pricing logic, `currency.ts`
+
+## Key Conventions
+
+- No `any` types, strict TypeScript
+- Single quotes, no trailing semicolons
+- No comments unless WHY is non-obvious
+- No dead code or commented blocks
+- All costs in USD internally, converted at display time
+- CSV export sanitizes formula-injection characters (`=`, `+`, `-`, `@`)

--- a/docs/specs/codeburn-full-audit.md
+++ b/docs/specs/codeburn-full-audit.md
@@ -1,0 +1,415 @@
+# CodeBurn -- Full Project Audit
+
+**Date:** 2026-04-15
+**Scope:** Architecture, implementation, security, testing, strengths, weaknesses
+**Codebase version:** 0.5.0 (3,591 lines across 19 TypeScript files)
+
+---
+
+## 1. What CodeBurn Does
+
+CodeBurn is a CLI tool that shows developers where their AI coding tokens go. It reads local session files from Claude Code, Cursor, and Codex (OpenAI), calculates costs using real model pricing, and presents the data as an interactive terminal dashboard, a macOS menu bar widget, or CSV/JSON exports.
+
+It answers questions like: "How much did I spend this week?", "Which task category burns the most tokens?", "Am I getting one-shot edits or burning retries?", and "Which model costs me the most?"
+
+Key capabilities:
+
+- Multi-provider support: Claude Code (JSONL), Cursor (SQLite), Codex (JSONL)
+- 13-category task classifier (coding, debugging, refactoring, testing, etc.) using rule-based pattern matching -- no LLM calls
+- Interactive TUI dashboard with gradient bar charts, keyboard navigation, period switching
+- Cost calculation with live model pricing from LiteLLM and currency conversion (162 currencies)
+- One-shot success rate tracking (detects edit-bash-edit retry cycles)
+- CSV/JSON export with formula injection protection
+- macOS menu bar plugin via SwiftBar/xbar
+
+---
+
+## 2. How It Works -- Architecture
+
+### 2.1 Architecture Diagram
+
+```mermaid
+graph TD
+    subgraph "Session Sources (Local Disk)"
+        CF["~/.claude/projects/<br/>JSONL files"]
+        CDF["Claude Desktop<br/>JSONL files"]
+        CXF["~/.codex/sessions/<br/>JSONL files"]
+        CUF["Cursor state.vscdb<br/>SQLite database"]
+    end
+
+    subgraph "Provider Layer"
+        CP["claude.ts<br/>Claude Provider"]
+        CXP["codex.ts<br/>Codex Provider"]
+        CUP["cursor.ts<br/>Cursor Provider"]
+    end
+
+    subgraph "Provider Support"
+        SQ["sqlite.ts<br/>SQLite Adapter"]
+        CC["cursor-cache.ts<br/>DB Fingerprint Cache"]
+    end
+
+    subgraph "Core Processing Pipeline"
+        PA["parser.ts<br/>Turn Grouping + Dedup"]
+        CL["classifier.ts<br/>13-Category Task Classifier"]
+        BU["bash-utils.ts<br/>Command Extraction"]
+        MO["models.ts<br/>Cost Calculation"]
+        CU["currency.ts<br/>Exchange Rates"]
+        TY["types.ts<br/>Type Definitions"]
+    end
+
+    subgraph "External Data (Read-Only)"
+        LL["LiteLLM Pricing<br/>raw.githubusercontent.com"]
+        FK["Frankfurter API<br/>api.frankfurter.app"]
+    end
+
+    subgraph "Local Cache (~/.cache/codeburn/)"
+        PC["litellm-pricing.json<br/>24h TTL"]
+        EC["exchange-rate.json<br/>24h TTL"]
+        CRC["cursor-results.json<br/>Fingerprint-based"]
+    end
+
+    subgraph "Configuration"
+        CFG["config.ts<br/>~/.config/codeburn/config.json"]
+    end
+
+    subgraph "Output Layer"
+        CLI["cli.ts<br/>Commander.js Entry Point"]
+        DB["dashboard.tsx<br/>Ink/React TUI"]
+        EX["export.ts<br/>CSV / JSON Export"]
+        MB["menubar.ts<br/>SwiftBar / xbar Plugin"]
+        FM["format.ts<br/>Status Bar Output"]
+    end
+
+    CF --> CP
+    CDF --> CP
+    CXF --> CXP
+    CUF --> CUP
+
+    CUP --> SQ
+    CUP --> CC
+    CC --> CRC
+
+    CP --> PA
+    CXP --> PA
+    CUP --> PA
+
+    PA --> CL
+    PA --> BU
+    PA --> MO
+    PA --> TY
+    CL --> TY
+
+    MO --> LL
+    LL -.->|"cached"| PC
+    CU --> FK
+    FK -.->|"cached"| EC
+    CFG --> CU
+
+    CLI --> PA
+    CLI --> CU
+    CLI --> MO
+    CLI --> DB
+    CLI --> EX
+    CLI --> MB
+    CLI --> FM
+
+    DB --> PA
+    EX --> PA
+    MB --> PA
+    FM --> PA
+
+    style CF fill:#e8f4f8,stroke:#2196F3
+    style CDF fill:#e8f4f8,stroke:#2196F3
+    style CXF fill:#fff3e0,stroke:#FF9800
+    style CUF fill:#f3e5f5,stroke:#9C27B0
+
+    style CP fill:#e8f4f8,stroke:#2196F3
+    style CXP fill:#fff3e0,stroke:#FF9800
+    style CUP fill:#f3e5f5,stroke:#9C27B0
+
+    style LL fill:#fce4ec,stroke:#e91e63
+    style FK fill:#fce4ec,stroke:#e91e63
+
+    style DB fill:#e8f5e9,stroke:#4CAF50
+    style EX fill:#e8f5e9,stroke:#4CAF50
+    style MB fill:#e8f5e9,stroke:#4CAF50
+    style FM fill:#e8f5e9,stroke:#4CAF50
+    style CLI fill:#e8f5e9,stroke:#4CAF50
+```
+
+### 2.2 Data Flow (Simplified)
+
+```txt
+Session files on disk (JSONL / SQLite)
+        |
+   [ Providers ]  -- discover files, parse into unified format
+        |
+   [ Parser ]     -- group API calls into turns, deduplicate
+        |
+   [ Classifier ] -- assign task categories by tool/keyword patterns
+        |
+   [ Aggregator ] -- build per-session and per-project summaries
+        |
+   [ Models ]     -- calculate USD cost from token counts + pricing
+        |
+   [ Currency ]   -- convert USD to user's chosen currency
+        |
+   [ Output ]     -- TUI dashboard / status bar / CSV / JSON / menubar
+```
+
+### 2.3 Module Map (19 files, 3,591 lines)
+
+| Module | Lines | Responsibility |
+| -------- | ------- | ---------------- |
+| cli.ts | 275 | Commander.js entry point, 8 commands |
+| parser.ts | 508 | JSONL reading, turn grouping, session aggregation |
+| dashboard.tsx | 667 | Ink/React TUI with responsive layout |
+| providers/codex.ts | 305 | Codex JSONL parsing with differential token calculation |
+| providers/cursor.ts | 283 | Cursor SQLite parsing, language extraction |
+| menubar.ts | 263 | SwiftBar/xbar plugin generation |
+| export.ts | 216 | CSV/JSON export with injection protection |
+| models.ts | 190 | LiteLLM pricing fetch, cost calculation |
+| classifier.ts | 163 | 13-category rule-based task classification |
+| types.ts | 150 | Core type definitions |
+| currency.ts | 140 | Exchange rates, formatting |
+| providers/claude.ts | 105 | Claude session discovery |
+| cursor-cache.ts | 63 | Cursor DB fingerprint cache |
+| sqlite.ts | 58 | Lazy-load better-sqlite3 adapter |
+| providers/index.ts | 49 | Provider registry |
+| bash-utils.ts | 42 | Shell command extraction |
+| format.ts | 41 | Token/cost formatting helpers |
+| providers/types.ts | 37 | Provider interface |
+| config.ts | 36 | Config file management |
+
+### 2.4 Dependencies
+
+Production (4): chalk, commander, ink, react
+Optional (1): better-sqlite3 (Cursor only)
+Dev (6): @types/better-sqlite3, @types/react, tsup, tsx, typescript, vitest
+
+No networking libraries. The two outbound HTTP requests use Node 20's built-in `fetch`.
+
+### 2.5 CLI Commands
+
+| Command | Description |
+| --------- | ------------- |
+| `report` (default) | Interactive TUI dashboard |
+| `today` | Today's dashboard |
+| `month` | This month's dashboard |
+| `status` | Compact output (terminal, menubar, or JSON) |
+| `export` | CSV or JSON export |
+| `currency [code]` | Set display currency |
+| `install-menubar` | Install macOS menu bar plugin |
+| `uninstall-menubar` | Remove menu bar plugin |
+
+---
+
+## 3. Implementation Deep Dive
+
+### 3.1 Provider System
+
+Each provider implements a common interface: `discoverSessions()`, `createSessionParser()`, `toolDisplayName()`, `modelDisplayName()`. This lets the parser module orchestrate all providers uniformly.
+
+**Claude provider** discovers sessions by scanning `~/.claude/projects/` directories (and Claude Desktop paths). It reads JSONL files where each line is a user or assistant message. The actual parsing happens in `parser.ts`, which extracts token counts from the `usage` object, tool names from `tool_use` content blocks, and user messages from `user` entries.
+
+**Codex provider** walks `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` with strict directory validation. It validates each file's first line is a `session_meta` entry with a Codex originator. Token calculation uses differential math: it tracks previous cumulative totals and computes deltas, converting OpenAI's "cached tokens included in input" semantics to Anthropic's "cached tokens separate" semantics via `Math.max(0, inputTokens - cachedInputTokens)`.
+
+**Cursor provider** reads a SQLite database at a platform-specific path. It queries the `cursorDiskKV` table for `bubbleId:*` keys, extracting tokens and model info via `json_extract()`. It also extracts programming languages from code blocks in responses. The SQLite dependency is optional and lazy-loaded; if missing, the provider gracefully returns empty results with a clear install message.
+
+### 3.2 Turn Grouping and Classification
+
+The parser groups raw API calls into "turns" -- a user message followed by one or more assistant API calls. This models the actual interaction pattern: the user asks something, and the assistant makes multiple API calls (tool use, thinking, responses) before the next user message.
+
+The classifier then assigns each turn to one of 13 task categories using a priority-based rule system:
+
+1. Tool-based rules fire first: `EnterPlanMode` tool means planning, `Agent` spawn means delegation, Edit tools mean coding, Bash with test commands means testing, etc.
+2. Keyword refinement runs second: if tools say "coding" but the user message contains "fix" or "bug", it becomes "debugging"; "refactor" or "rename" becomes refactoring; "add" or "create" becomes feature development.
+3. Retry detection counts edit-bash-edit cycles within a turn to distinguish one-shot successes from multi-attempt fixes.
+
+### 3.3 Cost Calculation
+
+Cost is computed as: `(input * inputRate + output * outputRate + cacheWrite * writeRate + cacheRead * readRate + webSearch * $0.01) * speedMultiplier`.
+
+Pricing comes from LiteLLM's public JSON file on GitHub, cached 24 hours locally. If the fetch fails, hardcoded fallback pricing for 17 models kicks in. The fast mode multiplier (6x for Opus 4.6) applies to the entire cost.
+
+Model name matching uses a fallback chain: exact match, then prefix matching in both directions, to handle version-dated model names like `claude-sonnet-4-5-20250414`.
+
+### 3.4 Caching Strategy
+
+The project uses four independent caches:
+
+- **Parser cache**: In-memory, 60-second TTL, 10 entries max. Keyed by date range + provider filter. Prevents re-parsing on rapid TUI re-renders.
+- **Pricing cache**: File-based at `~/.cache/codeburn/litellm-pricing.json`, 24-hour TTL.
+- **Currency cache**: File-based at `~/.cache/codeburn/exchange-rate.json`, 24-hour TTL.
+- **Cursor cache**: File-based at `~/.cache/codeburn/cursor-results.json`, invalidated by DB mtime + size fingerprint.
+
+### 3.5 TUI Dashboard
+
+Built with Ink (React for terminals). The `InteractiveDashboard` component manages period selection, provider switching, and data loading. It re-renders on state changes with a 600ms debounce on period switching.
+
+Layout is responsive: `getLayout(columns)` computes dashboard width (capped at 160), bar widths, and half-width panels. Minimum width is 90 columns. Gradient bar charts use computed RGB values for a blue-to-amber-to-orange heatmap.
+
+Panels include: Overview, Daily Activity (14-31 day chart), Project Breakdown (top 8), Activity Breakdown (13 categories), Model Breakdown, Tool Breakdown, MCP Server Breakdown, and Bash Command Breakdown.
+
+---
+
+## 4. Strong Points
+
+**Privacy-first design.** All session data stays local. The tool reads files already on disk and never wraps or proxies API calls. The only two outbound requests fetch public reference data (pricing and exchange rates) with no user data in the request.
+
+**Minimal dependency footprint.** Four production dependencies, all for CLI/UI rendering. No networking libraries, no telemetry, no cloud SDKs. The attack surface from third-party code is unusually small for a Node.js project.
+
+**Graceful degradation everywhere.** Missing config returns empty object. Pricing fetch failure falls back to hardcoded rates. Exchange rate failure returns 1.0. Missing SQLite driver returns empty results with a helpful message. Malformed JSONL lines are skipped. The tool never crashes on bad data.
+
+**Smart deduplication.** Each provider uses a different deduplication strategy suited to its data format: Claude uses API message IDs, Codex uses cumulative token fingerprints, Cursor uses composite keys. This prevents double-counting across re-reads.
+
+**CSV injection protection.** Export output prefixes formula-like cells (`=`, `+`, `-`, `@`) with a single quote to prevent spreadsheet macro execution. This is a real vulnerability in many export tools and is handled correctly here.
+
+**Deterministic classification.** Task categorization is fully rule-based with no LLM calls. This means it's fast, reproducible, and doesn't cost tokens to run. The 13-category system with retry detection provides genuinely useful insight into coding patterns.
+
+**Good TypeScript discipline.** Strict mode, no `any` types visible in the codebase, comprehensive type definitions for all data structures. The provider interface pattern makes it straightforward to add new providers.
+
+**Unified multi-provider view.** Aggregating Claude, Cursor, and Codex into a single dashboard with a common data model is a real convenience. The provider abstraction is clean and each provider handles its own format quirks internally.
+
+---
+
+## 5. Weak Points
+
+### 5.1 Memory: Full File Loading
+
+`parser.ts` line 270 reads entire JSONL files into memory with `readFile()`. Claude Code sessions can grow to tens of megabytes during long coding sessions. With multiple large sessions in a week's range, memory usage could spike significantly.
+
+**Recommendation:** Stream JSONL files line-by-line using `readline` or a streaming JSON parser. This bounds memory to one line at a time regardless of file size.
+
+### 5.2 Codex Differential Token Calculation is Fragile
+
+The Codex parser (lines 152-156, 209-215) maintains running state (`prevInput`, `prevCached`, `prevOutput`, `prevReasoning`) across loop iterations and computes deltas. If token counts are ever non-monotonic (due to a bug in Codex's logging, file corruption, or a format change), the differential calculation produces negative values or incorrect results. The `Math.max(0, ...)` on line 230 masks this partially, but the root data would still be wrong.
+
+**Recommendation:** Add explicit validation that cumulative totals are monotonically increasing. Log a warning (or skip the entry) when they aren't.
+
+### 5.3 No Streaming for Codex Parser
+
+Like the Claude parser, the Codex provider reads full JSONL files. Although Codex sessions are typically shorter, the same memory concern applies.
+
+### 5.4 Cursor's Hardcoded 35-Day Lookback
+
+`cursor.ts` line 138 hardcodes a 35-day lookback window for SQL queries. This means `codeburn report --period month` for a month that ended 36+ days ago would silently return no Cursor data. It also means the `all` period can never show Cursor data older than 35 days.
+
+**Recommendation:** Make the lookback window configurable or derive it from the requested date range.
+
+### 5.5 Test Coverage is Uneven
+
+39 test cases across 5 files. Provider registry and Codex parsing are well-tested. But:
+
+- Cursor provider tests are mostly stubs (no actual SQLite integration tests)
+- Export has only 1 test (CSV injection), nothing for normal export flow
+- Claude parser (the primary provider) has zero dedicated tests
+- Classifier has zero tests
+- Currency and menubar have zero tests
+- No integration tests combining multiple modules
+- No performance tests
+
+**Recommendation:** Prioritize tests for the Claude parser and the classifier, as these are the most-used code paths. Add at least basic integration tests for the export flow.
+
+### 5.6 Silent Error Swallowing
+
+Throughout the codebase, errors are caught with empty `catch {}` blocks (parser.ts line 31, providers/claude.ts line 90, config.ts line 26). While this contributes to the graceful degradation, it also means data can go missing silently. A user with a permission error on their session files would see zero data with no indication of why.
+
+**Recommendation:** Add an optional verbose/debug mode that logs skipped files and parsing errors. Even without verbose mode, consider counting skipped entries and showing "X sessions skipped due to errors" in the dashboard.
+
+### 5.7 Dashboard Performance
+
+The TUI renders individual Unicode block characters as separate React Text nodes in the `HBar` component. With 8+ panels, each containing multiple bars of 6-10 blocks, this creates 700+ component instances per render. Daily activity calculation iterates all projects, sessions, and turns on every render without memoization.
+
+**Recommendation:** Memoize breakdown components with `React.memo` or `useMemo`. Consider rendering bars as single string nodes rather than per-character components.
+
+### 5.8 No Config Validation on Load
+
+`config.ts` reads and writes JSON but doesn't validate the structure. A manually edited config file with an invalid currency code or unexpected fields would be accepted silently. The currency module does validate codes via `Intl.NumberFormat`, but only during the `currency` command -- not during `loadCurrency()` at startup.
+
+**Recommendation:** Validate config structure on load. Warn if the currency code is invalid.
+
+---
+
+## 6. Vulnerabilities and Security
+
+### 6.1 Network Surface (LOW risk)
+
+Two outbound HTTP requests, both read-only GETs for public data:
+
+| Request | URL | User data sent | Risk |
+|---------|-----|----------------|------|
+| Model pricing | `raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json` | None | LOW |
+| Exchange rate | `api.frankfurter.app/latest?from=USD&to={CODE}` | Currency code only | LOW |
+
+Neither request transmits session data, token counts, costs, project names, or any user-identifiable information. Both have local fallbacks if unavailable.
+
+**Note:** The LiteLLM URL points to a `main` branch file. If someone gained commit access to that repository, they could alter pricing data. This would affect cost display accuracy but not data exfiltration. Pinning to a specific commit hash would mitigate this.
+
+### 6.2 File Path Traversal in Export (LOW risk)
+
+`export.ts` line 186 uses `resolve(outputPath)` on user-provided paths but does no sanitization. A user running `codeburn export -o ../../../etc/cron.d/evil` could write to arbitrary locations they have permission to access. However, since this is a CLI tool run by the user themselves, the risk is negligible -- the user already has shell access and could write anywhere directly.
+
+### 6.3 No SQL Injection (SAFE)
+
+The Cursor provider's SQL queries use only hardcoded string literals and `LIKE` patterns. No user input is interpolated into SQL. The database is opened in read-only mode (`readonly: true`).
+
+### 6.4 JSONL Parsing of Untrusted Input (LOW risk)
+
+Session files are parsed with `JSON.parse()` on each line. If a session file contained a `__proto__` key, it could potentially cause prototype pollution. However, the parsed data is used as plain objects and not merged into any prototype chain, making this theoretical. Additionally, session files are written by the user's own AI coding tools, not by external actors.
+
+### 6.5 Symlink Following (LOW risk)
+
+Directory scanning with `readdir` and file reading with `readFile` follow symlinks without validation. A malicious symlink in the Claude projects directory could cause CodeBurn to read files outside the expected paths. Since the tool only reads and never writes to session directories, and the directory is under user control, the practical risk is minimal.
+
+### 6.6 No Telemetry or Analytics (SAFE)
+
+Zero tracking code. No Sentry, DataDog, Segment, LogRocket, or any analytics library. No postinstall hooks. No phone-home mechanisms of any kind.
+
+### 6.7 Dependency Supply Chain (LOW risk)
+
+Only 4 production dependencies, all widely-used and well-maintained packages (chalk, commander, ink, react). No transitive dependencies with known vulnerabilities were identified. The optional `better-sqlite3` is a native module with a long track record. npm audit could not be run due to sandbox network restrictions, but the dependency surface is minimal.
+
+---
+
+## 7. Code Quality Assessment
+
+### What's done well
+
+- Clean TypeScript with strict mode and no `any` types
+- No dead code or commented-out blocks visible
+- Consistent code style (single quotes, no trailing semicolons)
+- Imports organized: node builtins, then deps, then local
+- Types are comprehensive and well-structured
+- Provider abstraction is clean and extensible
+- Caching is layered and purpose-built for each use case
+- The codebase is small enough to fit in a developer's head
+
+### What could be better
+
+- Empty catch blocks should at least count occurrences for diagnostics
+- The 667-line dashboard.tsx could be split into smaller component files
+- Classifier rules could be data-driven (a config object) rather than imperative if-else chains
+- The parser module (508 lines) handles both Claude-specific JSONL parsing and cross-provider orchestration; these could be separated
+- No JSDoc or inline documentation on exported functions (the code is generally readable, but the provider interface and type definitions would benefit from doc comments)
+
+---
+
+## 8. Summary
+
+CodeBurn is a well-designed, privacy-conscious CLI tool with a small footprint and clean architecture. Its main strengths are its local-only data processing, minimal dependencies, graceful error handling, and the multi-provider abstraction that unifies three different AI coding tools into one dashboard.
+
+The main areas for improvement are memory management (streaming large files instead of loading them whole), test coverage (especially for the Claude parser, classifier, and Cursor integration), error visibility (replacing silent catch blocks with optional logging), and the Codex parser's fragile differential token calculation.
+
+From a security perspective, the tool is clean. No user data leaves the machine through any code path. The two outbound requests are limited to fetching public reference data. There are no injection vulnerabilities, no telemetry, and no supply chain concerns beyond the usual npm ecosystem risks -- which are mitigated by the unusually small dependency count.
+
+| Area | Rating | Notes |
+| ------ | -------- | ------- |
+| Architecture | Strong | Clean provider abstraction, good separation of concerns |
+| Privacy | Excellent | Zero data exfiltration, local-only processing |
+| Security | Good | No injection vectors, CSV protection, read-only DB access |
+| Error handling | Mixed | Graceful degradation is good; silent failures are not |
+| Test coverage | Weak | 39 tests, major gaps in Claude parser and classifier |
+| Performance | Adequate | Works for typical usage; large sessions could hit memory limits |
+| Code quality | Good | Clean TypeScript, minimal deps, no dead code |
+| Documentation | Adequate | README present, no inline docs on exports |

--- a/docs/specs/performance-analysis-v2.md
+++ b/docs/specs/performance-analysis-v2.md
@@ -1,0 +1,124 @@
+# Performance Analysis v2: Post-Optimization
+
+Date: 2026-04-17
+Baseline reference: `docs/specs/performance-analysis.md` (2026-04-15)
+
+## Context
+
+This report measures performance after implementing all 10 tasks from `docs/specs/performance-optimization-tasks.md`. Changes applied:
+
+| Optimization | Files Changed |
+|-------------|---------------|
+| Discovery result caching | `src/providers/index.ts` |
+| Widen-then-filter (parse once, derive subranges) | `src/cli.ts` |
+| JSONL streaming via readline (replaces readFile) | `src/parser.ts` |
+| Date pre-filter before JSON.parse | `src/parser.ts` |
+| Conditional bash extraction (extractBash flag) | `src/parser.ts`, `src/types.ts` |
+| filterProjectsByDateRange with aggregate recompute | `src/parser.ts` |
+| loadCurrency() moved out of preAction hook | `src/cli.ts` |
+
+Data volume: 21 projects, 129 sessions, ~57MB total JSONL (27MB CLI + 30MB desktop app), 6504 lines.
+
+## Results: Wall-Clock Time
+
+Built bundle (`node dist/cli.js`), median of 3 runs:
+
+| Command | Before | After | Change |
+|---------|--------|-------|--------|
+| `status --format json` | 900ms | **589ms** | -34% |
+| `status --format terminal` | ~1000ms | **587ms** | -41% |
+| `status --format menubar` | ~2500ms | **597ms** | -76% |
+| `export -f json` | N/A | **785ms** | -- |
+| `status --format json` (tsx) | 1500ms | **1243ms** | -17% |
+
+The menubar command saw the largest improvement (76%) because it previously made 6 separate parseAllSessions calls. It now makes 1 call and derives subranges with filterProjectsByDateRange.
+
+## Results: RSS Memory
+
+| Metric | Before | After | Change |
+|--------|--------|-------|--------|
+| Peak RSS (`status --format json`) | ~150MB | **185MB** | +23% |
+
+RSS increased slightly. The readline streaming approach uses comparable memory to readFile for this data volume since entries are accumulated in an array before processing. The cache also retains parsed results in memory. At 57MB of JSONL data, this is acceptable -- the spec target was RSS under 100MB for the `status --format json` path, which is not met.
+
+## CPU Profile: `status --format json` (built)
+
+Top functions by self-time (node --cpu-prof):
+
+| Self-time | Before | After | Function |
+|-----------|--------|-------|----------|
+| 66ms | 138ms | **66ms** | `parseJsonlLine` (JSON.parse) |
+| 47ms | 49ms | **47ms** | `write` (string_decoder) |
+| 26ms | -- | **26ms** | readline newline regex |
+| 18ms | 22ms | **18ms** | `compileSourceTextModule` |
+| 14ms | 13ms | **14ms** | GC |
+| 13ms | -- | **13ms** | `extractTimestampFromLine` |
+| 6ms | 57ms | **6ms** | `parseSessionFile` |
+| 0ms | 171ms | **0ms** | bash separator regex |
+
+Key observations:
+- **Bash regex eliminated**: 171ms -> 0ms. `extractBash: false` for the status command means the regex never runs.
+- **JSON.parse halved**: 138ms -> 66ms. The date pre-filter skips JSON.parse for lines with timestamps outside the month range.
+- **parseSessionFile collapsed**: 57ms -> 6ms. Streaming + single-pass parsing is more efficient than readFile + split + map.
+- **extractTimestampFromLine overhead**: 13ms for the string index scan. Acceptable tradeoff for the 72ms JSON.parse saving.
+
+## Phase Breakdown (instrumented probe)
+
+| Phase | Before | After | Change |
+|-------|--------|-------|--------|
+| Load pricing (cache hit) | 2ms | **2ms** | -- |
+| Load currency | 0ms | **0ms** | -- |
+| Parse month (cold, no bash) | 365ms | **281ms** | -23% |
+| Filter today (in-memory) | N/A | **0.4ms** | new |
+| Parse month (cached) | 343ms | **0.0ms** | -100% |
+| Parse month (with bash) | N/A | **387ms** | -- |
+
+The cache eliminates the second parse entirely (343ms -> 0ms). filterProjectsByDateRange runs in under 1ms for the in-memory filter.
+
+## Spec Target Assessment
+
+| Target | Status | Measured |
+|--------|--------|----------|
+| `status --format json` under 400ms (spec R1) | **NOT MET** | 589ms median |
+| RSS under 100MB (spec R5) | **NOT MET** | 185MB |
+| `filterProjectsByDateRange` cost invariant (spec R3) | **MET** | 7 tests pass |
+| No mutation of input data (spec R3) | **MET** | test verified |
+| Conditional bash extraction (spec R7) | **MET** | 0ms bash regex for status |
+| Discovery cache (spec R2) | **MET** | 0ms second call |
+
+The 400ms target was set for the built bundle. Current 589ms is 34% faster than the 900ms baseline but still 47% above target. Remaining bottleneck is the ~280ms single-pass parse of all month JSONL data.
+
+## Remaining Bottlenecks
+
+### 1. Parse time still dominates (~280ms)
+
+Even with streaming and date pre-filter, parsing ~6500 JSONL lines with JSON.parse takes 280ms. The date pre-filter helps most when querying narrow ranges (today) against large datasets, but for month range it skips very few lines.
+
+Possible next steps:
+- **Lazy content parsing**: Parse only the fields needed (model, usage, timestamp) instead of full JSON.parse. Would require a custom lightweight parser or regex extraction.
+- **SQLite result cache**: Persist parsed session summaries to disk. Subsequent runs would only parse new/modified files.
+
+### 2. RSS is high (~185MB)
+
+The full parsed dataset (21 projects, all turns with content blocks) is held in memory. The readline streaming doesn't reduce peak memory because entries are collected into an array.
+
+Possible next steps:
+- **Drop content blocks after classification**: After classifying turns and extracting costs, discard the raw message content to free memory.
+- **Two-pass parsing**: First pass extracts only metadata (cost, model, timestamp). Second pass (on demand) extracts tool details.
+
+### 3. Node.js startup (~50-70ms)
+
+Module loading and JIT compilation contribute ~18ms (compileSourceTextModule) plus ~50ms of assorted startup. This is a Node.js baseline cost that cannot be reduced without switching runtimes.
+
+## Summary
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| `status --format json` | 900ms | 589ms | 34% faster |
+| `status --format menubar` | 2500ms | 597ms | 76% faster |
+| Bash regex CPU | 171ms | 0ms | eliminated |
+| JSON.parse CPU | 138ms | 66ms | 52% faster |
+| Cache hit parse | 343ms | 0ms | eliminated |
+| In-memory filter | N/A | 0.4ms | new capability |
+
+The optimizations delivered the largest gains on multi-period commands (menubar: 76%, terminal: 41%) where widen-then-filter and discovery caching compound. The `status --format json` target of 400ms is not yet met -- reaching it would require either a lightweight JSON parser or persistent result caching.

--- a/docs/specs/performance-analysis.md
+++ b/docs/specs/performance-analysis.md
@@ -1,0 +1,140 @@
+# Performance Analysis: CodeBurn CLI
+
+Date: 2026-04-15
+
+## Baseline
+
+| Metric | Value |
+|--------|-------|
+| `status --format json` (built) | **0.9s** wall, 0.77s CPU |
+| `status --format json` (tsx) | **1.5s** wall |
+| `status --format terminal` (built) | ~1.0s |
+| `status --format menubar` (built) | ~2.5s (6 parse calls) |
+| `report` (interactive TUI, tsx) | ~5-8s startup |
+| RSS memory | ~150MB |
+| Data volume | 18 projects, 76 sessions, 225 turns, ~20MB JSONL, 58MB Cursor DB |
+
+**Target**: CLI startup under 500ms for `status --format json` (built bundle). Interactive `report` under 2s.
+
+## Phase Breakdown
+
+Measured via instrumented probe, median of 3 runs:
+
+| Phase | Time |
+|-------|------|
+| Imports | 9ms |
+| Load pricing (disk cache hit) | 2ms |
+| Load currency | 0ms |
+| Parse sessions (today, cold) | 222ms |
+| Parse sessions (month, cold) | 365ms |
+| Parse sessions (week, after month) | 343ms |
+| **Total (app-level)** | **940ms** |
+
+Key observation: each `parseAllSessions` call with a different date range is a cache miss and triggers a full re-discovery + re-parse cycle.
+
+## CPU Profile (built bundle, `status --format json`)
+
+Generated via `node --cpu-prof`. Top functions by self-time:
+
+| Self-time | Function | Location |
+|-----------|----------|----------|
+| 171ms | Bash separator regex | `bash-utils.ts:14` |
+| 138ms | `parseJsonlLine` (JSON.parse) | `parser.ts:27` |
+| 57ms | `parseSessionFile` | `parser.ts:262` |
+| 49ms | `write` (string_decoder) | Node internals |
+| 22ms | `compileSourceTextModule` | Node module loading |
+| 13ms | GC | -- |
+| 98ms | idle (I/O wait) | -- |
+
+Total sampled: ~800ms.
+
+## Filesystem Profile
+
+Desktop app session discovery (`findDesktopProjectDirs`):
+
+| Metric | Value |
+|--------|-------|
+| `readdir` calls | 427 |
+| `stat` calls | 879 |
+| Directories traversed | 450 |
+| JSONL files found | 15 |
+| Time | 36ms |
+
+Claude CLI session discovery:
+
+| Metric | Value |
+|--------|-------|
+| `readdir` calls | 16 |
+| `stat` calls | 5 |
+| Time | 1ms |
+
+## Bottlenecks (ranked by impact)
+
+### 1. Bash regex on every JSONL entry -- 171ms (21% of CPU)
+
+**Evidence**: CPU profile shows the bash separator regex at 171ms self-time -- the single hottest function.
+
+**Root cause**: `bash-utils.ts:14` -- the separator regex runs with `exec` in a while-loop over every bash command string in every JSONL entry. Called from `extractBashCommandsFromContent` in `parser.ts:48` on every assistant message content block.
+
+**Fix**: Skip bash extraction when not needed (e.g., `status --format json` does not render bash breakdown). Alternatively, pre-scan for `tool_use` blocks with bash tool names before running the regex.
+
+**Estimated gain**: 100-150ms
+
+### 2. JSON.parse all JSONL lines -- 138ms (17% of CPU)
+
+**Evidence**: CPU profile shows `parseJsonlLine` at 138ms self-time. Parsing ~6000 JSONL entries (many large with full content blocks) is inherently expensive.
+
+**Root cause**: Every JSONL line is fully parsed with `JSON.parse` in `parser.ts:27`, even lines outside the date range (date filtering happens after parsing). Lines contain full assistant message content blocks with tool inputs, which can be very large.
+
+**Fix**:
+- **Date pre-filter**: Extract timestamp with a simple string scan (e.g., regex on raw line) before full `JSON.parse`. Lines with timestamps outside the range can be skipped entirely.
+- **Lazy parsing**: For commands that do not need tool content or bash commands, a lightweight parse that skips content blocks would be faster.
+
+**Estimated gain**: 50-100ms (depends on how many lines fall outside the date range)
+
+### 3. Redundant session discovery -- ~37ms per call, multiplied
+
+**Evidence**: `parseAllSessions` calls `discoverAllSessions` on every cache miss. The `status --format menubar` command calls `parseAllSessions` 6 times (today + week + month + per-provider today), each triggering a full discovery including the desktop app recursive walk.
+
+**Root cause**: No caching of discovery results in `providers/index.ts`. The desktop app walk (`findDesktopProjectDirs` in `providers/claude.ts:35`) recursively walks up to depth 8 from `~/Library/Application Support/Claude/local-agent-mode-sessions/`, hitting 879 `stat` calls to find 15 files.
+
+**Fix**: Cache discovery results for the lifetime of the process. Session paths do not change during a single CLI invocation. A simple module-level variable would eliminate all repeated walks.
+
+**Estimated gain**: 30-180ms depending on command (menubar saves ~180ms; json saves ~37ms)
+
+### 4. Full re-parse for overlapping date ranges
+
+**Evidence**: `status` terminal format calls `parseAllSessions` once for month. But `menubar` format calls it 3 times with today/week/month -- ranges that are subsets of each other. Each cache miss triggers a full re-read and re-parse of all files.
+
+**Root cause**: The cache key in `parser.ts:448` is based on start+end+provider, so different date ranges never share results, even when month's data is a superset of today's.
+
+**Fix**: Parse the widest range once (e.g., month or 30 days), then filter the in-memory results by narrower date ranges. This is effectively what the dashboard already does when switching periods with arrow keys.
+
+**Estimated gain**: 200-400ms for `menubar`/`export` commands that query multiple periods
+
+### 5. `npx tsx` overhead -- ~600ms
+
+**Evidence**: Built bundle (0.9s) vs tsx (1.5s) = 600ms tsx overhead per invocation.
+
+**Root cause**: `npx tsx` resolves the package, loads the TypeScript transpiler, and JIT-compiles all imports. This is a development convenience, not a production concern (users install the published npm package which runs `node dist/cli.js`).
+
+**Impact on users**: None (published CLI uses the built bundle). Only affects development iteration.
+
+## Summary
+
+| Bottleneck | Self-time | Fix | Estimated Gain |
+|-----------|-----------|-----|----------------|
+| Bash regex on every entry | 171ms | Skip when not rendering bash panel | 100-150ms |
+| JSON.parse all JSONL lines | 138ms | Date pre-filter, lazy parse | 50-100ms |
+| Repeated session discovery | 37ms x N | Cache discovery per process | 30-180ms |
+| Overlapping date range re-parse | 200-400ms | Parse widest range, filter in-memory | 200-400ms |
+| npx tsx overhead | 600ms | N/A (dev only) | N/A |
+
+## Recommended Priority
+
+1. **Cache discovery results** -- trivial change (add module-level cache in `providers/index.ts`), prevents the expensive desktop walk from running multiple times per invocation
+2. **Parse widest range once, filter in-memory** -- biggest gain for `menubar`/`export` commands, moderate code change in `cli.ts`
+3. **Date pre-filter before JSON.parse** -- scan for timestamp string before full parse in `parser.ts`, moderate gain
+4. **Lazy bash extraction** -- skip the regex when the result will not be displayed, change in `parser.ts`
+
+Combined, these optimizations could bring `status --format json` from ~900ms to ~400ms and `menubar` from ~2.5s to under 1s.

--- a/docs/specs/performance-optimization-tasks.md
+++ b/docs/specs/performance-optimization-tasks.md
@@ -1,0 +1,272 @@
+# Tasks: CLI Performance Optimization
+
+**Generated from**: docs/specs/performance-optimization.md
+**Total tasks**: 10
+**Parallel groups**: 3
+**Estimated total effort**: 18h
+**Max parallel agents**: 3
+
+---
+
+## File Conflict Matrix
+
+| Task | Files Modified | Conflicts With |
+|------|---------------|----------------|
+| T1 | src/providers/index.ts, tests/provider-registry.test.ts | -- |
+| T2 | src/cli.ts | T3b, T6b |
+| T3a | src/parser.ts | T4, T5, T6a |
+| T3b | src/cli.ts | T2, T6b |
+| T3c | tests/filter-by-date-range.test.ts | -- |
+| T4 | src/parser.ts | T3a, T5, T6a |
+| T5a | src/parser.ts | T3a, T4, T6a |
+| T5b | tests/parser.test.ts | T6c |
+| T6a | src/parser.ts, src/types.ts | T3a, T4, T5a |
+| T6b | src/cli.ts, src/dashboard.tsx | T2, T3b |
+| T6c | tests/parser.test.ts | T5b |
+
+---
+
+## Task Graph
+
+```
+T1 ─────────────────────────────────────────────┐
+T2 ──→ T3b ──→ T6b                              │
+T3a ──→ T3b                                     ├──→ (done)
+T3a ──→ T3c                                     │
+T4 ──→ T5a ──→ T5b                              │
+T4 ──→ T6a ──→ T6b                              │
+                T6a ──→ T6c                      │
+                                                 │
+T1 ─────────────────────────────────────────────┘
+T2 ─────────────────────────────────────────────┘
+
+Dependency summary:
+  T1: no deps
+  T2: no deps
+  T3a: no deps (parser-only, no call site changes)
+  T3b: depends on T2, T3a
+  T3c: depends on T3a
+  T4: no deps
+  T5a: depends on T4 (builds on T4's streaming loop)
+  T5b: depends on T5a
+  T6a: depends on T4 (modifies parser.ts after streaming is in)
+  T6b: depends on T3b, T6a (rewrites cli.ts call sites after both are stable)
+  T6c: depends on T6a
+```
+
+---
+
+## Parallel Group 1: Independent Foundation (no dependencies)
+
+- [P] **T1**: Cache discovery results in providers/index.ts
+  - **Validates**: R1
+  - **Files**: src/providers/index.ts, tests/provider-registry.test.ts
+  - **Complexity**: low
+  - **Effort**: 1h
+  - **Depends on**: --
+  - **What to do**:
+    1. Add module-level `Map<string, SessionSource[]>` cache in src/providers/index.ts
+    2. In `discoverAllSessions` (line 29), check cache before running provider discovery; store result after
+    3. Cache key: `providerFilter ?? 'all'`
+    4. Export `clearDiscoveryCache()` that calls `discoveryCache.clear()`
+    5. Call `clearDiscoveryCache()` at top of refresh handler in src/dashboard.tsx (line ~565)
+  - **Tests**:
+    - In tests/provider-registry.test.ts: call `discoverAllSessions` twice, assert same reference (`toBe`)
+    - Call `clearDiscoveryCache` between calls, assert different reference
+    - Verify different `providerFilter` values are cached independently
+  - **AC**: AC-1a, AC-1b, AC-1c, AC-1d
+
+- [P] **T2**: Move loadCurrency() out of preAction hook
+  - **Validates**: R6
+  - **Files**: src/cli.ts
+  - **Complexity**: low
+  - **Effort**: 1h
+  - **Depends on**: --
+  - **What to do**:
+    1. Remove `program.hook('preAction', ...)` block at src/cli.ts:65-67
+    2. Add `await loadCurrency()` as first line of action handler for: `status`, `report`, `today`, `month`, `export`
+    3. Verify `currency` command's action handler already calls `loadCurrency()` in its display branch
+  - **Tests**:
+    - `npx vitest run` passes
+    - Manual: `codeburn status --format json` output unchanged
+    - Manual: `codeburn currency` displays current currency code
+  - **AC**: AC-2a, AC-2b, AC-2c, AC-2d
+
+- [P] **T4**: Stream JSONL files with readline in parseSessionFile
+  - **Validates**: R4
+  - **Files**: src/parser.ts
+  - **Complexity**: medium
+  - **Effort**: 2h
+  - **Depends on**: --
+  - **What to do**:
+    1. In src/parser.ts `parseSessionFile` (line 262), replace `readFile` + `split('\n')` with `readline.createInterface` + `for await`
+    2. Import `createReadStream` from `fs` and `createInterface` from `readline`
+    3. Wrap readline loop in `try/finally` that calls `rl.close()`
+    4. Preserve existing error handling: wrap `createReadStream` in try/catch, return `null` on file-not-found
+    5. Remove `readFile` import from parser.ts only if no longer used elsewhere in the file
+  - **Tests**:
+    - `npx vitest run` passes (existing integration tests cover parseSessionFile)
+    - Manual: `codeburn status --format json` output unchanged vs baseline
+    - Manual: check RSS with `process.memoryUsage().rss` log at exit
+  - **Invariants**:
+    - `parseSessionFile` must remain `async`
+    - `try/finally` around `rl.close()` must execute even on exception
+    - Files that don't exist must still return `null`
+  - **AC**: AC-4a, AC-4b
+
+---
+
+## Parallel Group 2: Filtering and Pre-filter (depends on Group 1 items)
+
+- [P] **T3a**: Implement filterProjectsByDateRange in parser.ts
+  - **Validates**: R2, R7
+  - **Files**: src/parser.ts
+  - **Complexity**: high
+  - **Effort**: 3h
+  - **Depends on**: --
+  - **What to do**:
+    1. Add `filterProjectsByDateRange(projects: ProjectSummary[], range: DateRange): ProjectSummary[]` in src/parser.ts
+    2. For each project: filter each session's `turns` by `turn.timestamp >= range.start && turn.timestamp <= range.end`
+    3. Recompute per-session: `totalCostUSD`, `totalApiCalls`, `totalInputTokens`, `totalOutputTokens`, `totalCacheReadTokens`, `totalCacheWriteTokens`, `modelBreakdown`, `toolBreakdown`, `mcpBreakdown`, `bashBreakdown`, `categoryBreakdown`, `firstTimestamp`, `lastTimestamp`
+    4. Exclude sessions with zero surviving turns; exclude projects with all sessions excluded
+    5. Recompute `ProjectSummary.totalCostUSD` and `totalApiCalls` from filtered sessions
+    6. Return new array; do not mutate input
+  - **Invariant**: `sessionSummary.totalCostUSD === sum(turn.assistantCalls[].costUSD)` must hold
+  - **AC**: AC-3c, AC-3d
+
+- [P] **T5a**: Add date pre-filter before JSON.parse in parseSessionFile
+  - **Validates**: R5
+  - **Files**: src/parser.ts
+  - **Complexity**: medium
+  - **Effort**: 2h
+  - **Depends on**: T4 (builds on T4's streaming loop structure)
+  - **What to do**:
+    1. Add `extractTimestampFromLine(line: string): Date | null` helper in src/parser.ts
+    2. Uses `line.indexOf('"timestamp":"')`, extracts date string, parses with `new Date()`, returns null if invalid
+    3. In the streaming line loop (from T4), add guard before `parseJsonlLine`: if `dateRange` exists and extracted timestamp is valid and out of range, `continue`
+    4. If `extractTimestampFromLine` returns null, always proceed to full `JSON.parse` (conservative path per R5)
+    5. Remove the post-parse date filter that currently runs after building entries array
+  - **AC**: AC-4c, AC-4d, AC-4e
+
+- [P] **T3c**: Add unit tests for filterProjectsByDateRange
+  - **Validates**: R2, R7
+  - **Files**: tests/filter-by-date-range.test.ts (new)
+  - **Complexity**: medium
+  - **Effort**: 2h
+  - **Depends on**: T3a
+  - **What to do**:
+    1. Create tests/filter-by-date-range.test.ts
+    2. Construct a `ProjectSummary` with turns spanning 3 days
+    3. Call `filterProjectsByDateRange` with a 1-day range
+    4. Assert returned totals equal sum of only in-range turns
+    5. Assert input `ProjectSummary` is not mutated
+    6. Test: session with all turns outside range is excluded entirely
+    7. Test: project with all sessions excluded is excluded from result
+    8. Test: full epoch-to-now range returns result equal to input
+    9. Verify invariant: `totalCostUSD === turns.flatMap(t => t.assistantCalls).reduce((s, c) => s + c.costUSD, 0)`
+  - **AC**: AC-3c, AC-3d
+
+---
+
+## Sequential Group 3: Call Site Rewrites (depends on Group 2)
+
+- **T3b**: Rewrite status and export command handlers to use widen-then-filter
+  - **Validates**: R2, R7
+  - **Files**: src/cli.ts
+  - **Complexity**: high
+  - **Effort**: 3h
+  - **Depends on**: T2, T3a
+  - **What to do**:
+    1. **menubar format** (src/cli.ts status handler): replace up to 6 `parseAllSessions` calls with one call using `getDateRange('month').range`, then derive `todayData`, `weekData`, `monthData` via `filterProjectsByDateRange`
+    2. **json format** (src/cli.ts:142-143): replace 2 `parseAllSessions` calls with one call using month range, derive `todayData` via `filterProjectsByDateRange`
+    3. **export command**: replace multiple `parseAllSessions` calls with one call using `getDateRange('30days').range`, derive `today`, `week`, `30days` via filter
+    4. Per-provider today costs: filter month result with today range, then filter by provider name in-memory
+  - **Tests**:
+    - `npx vitest run` passes
+    - Manual: diff `codeburn status --format menubar` output against baseline (byte-for-byte)
+    - Manual: diff `codeburn status --format json` output against baseline
+  - **AC**: AC-3a, AC-3b, AC-3c
+
+- **T5b**: Add unit tests for extractTimestampFromLine
+  - **Validates**: R5
+  - **Files**: tests/parser.test.ts (new or extend)
+  - **Complexity**: low
+  - **Effort**: 1h
+  - **Depends on**: T5a
+  - **What to do**:
+    1. Test with valid ISO timestamp line
+    2. Test with line without a timestamp (returns null)
+    3. Test with malformed timestamp (returns null)
+    4. Test with `"timestamp"` only inside a nested object value (returns a Date, must not throw)
+  - **AC**: AC-4d
+
+- **T6a**: Add ParseOptions type and thread extractBash through parser
+  - **Validates**: R3
+  - **Files**: src/parser.ts, src/types.ts
+  - **Complexity**: medium
+  - **Effort**: 2h
+  - **Depends on**: T4 (parser.ts must have streaming in place first)
+  - **What to do**:
+    1. Add `ParseOptions` type: `{ dateRange?: DateRange, providerFilter?: string, extractBash?: boolean }`
+    2. Change `parseAllSessions` signature from `(dateRange?, providerFilter?)` to `(opts?: ParseOptions)`
+    3. Update cache key to include `extractBash` (cached no-bash result must not be returned to bash-needing caller)
+    4. Thread `extractBash` down through `parseSessionFile` and `parseApiCall`
+    5. When `extractBash: false`, set `bashCommands: []` without calling `extractBashCommandsFromContent`
+    6. Default `extractBash` to `true` for backward compatibility
+  - **AC**: AC-6d
+
+- **T6b**: Update all parseAllSessions call sites to use ParseOptions
+  - **Validates**: R3
+  - **Files**: src/cli.ts, src/dashboard.tsx
+  - **Complexity**: medium
+  - **Effort**: 1.5h
+  - **Depends on**: T3b, T6a
+  - **Cannot parallelize**: modifies src/cli.ts which T3b also modifies
+  - **What to do**:
+    1. Verify all call sites with `grep -r 'parseAllSessions' src/`
+    2. `status --format json`: pass `{ extractBash: false }`
+    3. `status --format terminal`: pass `{ extractBash: false }`
+    4. `status --format menubar`: pass `{ extractBash: false }`
+    5. `report` (dashboard): pass `{ extractBash: true }` (bash panel displayed in dashboard.tsx:381)
+    6. `export`: pass `{ extractBash: true }` (export.ts:105 uses bashBreakdown)
+    7. `today`, `month`: pass `{ extractBash: false }`
+  - **AC**: AC-6a, AC-6b, AC-6c
+
+- **T6c**: Add tests for conditional bash extraction
+  - **Validates**: R3
+  - **Files**: tests/parser.test.ts
+  - **Complexity**: low
+  - **Effort**: 1h
+  - **Depends on**: T6a
+  - **What to do**:
+    1. Create synthetic JSONL fixture with Bash tool_use block containing `command: "git status && npm install"`
+    2. Parse with `extractBash: true`: assert `session.bashBreakdown` contains `{ git: { calls: 1 }, npm: { calls: 1 } }`
+    3. Parse with `extractBash: false`: assert `session.bashBreakdown` is `{}`
+  - **AC**: AC-6c, AC-6d
+
+---
+
+## Execution Order (recommended)
+
+```
+Phase 1 (parallel):  T1, T2, T4        -- independent foundation
+Phase 2 (parallel):  T3a, T5a          -- parser additions (after T4 merges)
+Phase 3 (parallel):  T3b, T3c, T5b     -- call site rewrite + tests (after T2, T3a, T5a)
+Phase 4 (sequential): T6a              -- ParseOptions type + threading (after T4)
+Phase 5 (parallel):  T6b, T6c          -- call site update + tests (after T3b, T6a)
+```
+
+---
+
+## Traceability
+
+| Requirement | Tasks |
+|-------------|-------|
+| R1 (Discovery cache) | T1 |
+| R2 (Widen-then-filter) | T3a, T3b, T3c |
+| R3 (Conditional bash) | T6a, T6b, T6c |
+| R4 (Streaming JSONL) | T4 |
+| R5 (Date pre-filter) | T5a, T5b |
+| R6 (Currency deferral) | T2 |
+| R7 (Output correctness) | T3a, T3b, T3c, T5a, T5b |
+| R8 (Test suite green) | All |

--- a/docs/specs/performance-optimization.md
+++ b/docs/specs/performance-optimization.md
@@ -1,0 +1,594 @@
+# Specification: CLI Performance Optimization
+
+**Status**: Draft
+**Date**: 2026-04-16
+**Version**: 1.1.0
+
+---
+
+## 1. Overview
+
+CodeBurn's `status --format json` command takes ~900ms (built bundle) on a machine with 18 projects, 76 sessions, and ~20MB of JSONL data. The interactive `report` TUI takes 5-8s to first render. RSS peaks at ~150MB.
+
+These times make the menu bar widget feel sluggish and undermine trust in the tool. This spec defines four targeted, independently shippable optimizations that together bring `status --format json` under 400ms (built) and reduce RSS to approximately 80-100MB, without changing any user-visible behavior.
+
+**Perspective**: This spec is written with an edge-case and defensive design lens. Every optimization task specifies its invariants, what can go wrong during the change, and how to verify correctness after the change.
+
+---
+
+## 2. Success Criteria
+
+| Metric | Baseline | Target | Measurement Method |
+|--------|----------|--------|-------------------|
+| `status --format json` wall time (built) | 900ms | < 400ms | `hyperfine --warmup 2 'codeburn status --format json'`, median of 10 runs |
+| `status --format menubar` wall time (built) | 2500ms | < 800ms | `hyperfine --warmup 2 'codeburn status --format menubar'`, median of 10 runs |
+| `report` TUI time-to-first-render (built) | 5000-8000ms | < 2000ms | Stopwatch from invocation to first Ink frame, 3 runs |
+| RSS at peak | ~150MB | < 100MB | `node --max-old-space-size=256 dist/cli.js status --format json` + `process.memoryUsage().rss` instrumented log |
+| Output correctness | baseline | identical | byte-for-byte diff of JSON output before and after (see AC-C1) |
+
+---
+
+## 3. Requirements
+
+### R1 -- Discovery result cache
+`discoverAllSessions` in `src/providers/index.ts` must cache its result for the lifetime of the process. Multiple calls with the same `providerFilter` argument within a single CLI invocation must return the same array instance without re-running any `readdir` or `stat` calls.
+
+### R2 -- Widen-then-filter parse strategy
+The `status` command must compute all required date-range results by parsing the widest required date range exactly once, then filtering the in-memory `ProjectSummary[]` data for narrower ranges. No path in `status` may call `parseAllSessions` with overlapping or nested date ranges more than once.
+
+### R3 -- Conditional bash extraction
+`extractBashCommandsFromContent` in `src/parser.ts` must be skipped when the caller does not need bash command data. A boolean parameter `extractBash: boolean` must be threaded from `parseAllSessions` down through `parseSessionFile` and `parseApiCall`. When `extractBash` is `false`, the `bashCommands` field on `ParsedApiCall` must be an empty array and no call to `extractBashCommands` in `src/bash-utils.ts` may be made.
+
+### R4 -- Streaming JSONL reads
+`parseSessionFile` in `src/parser.ts` must read JSONL files using Node.js `readline` streaming instead of loading the entire file into memory with `readFile`. Each line must be processed and either kept or discarded before the next is read. The entire file contents must not be held in a single string variable at any point during parsing.
+
+### R5 -- Date pre-filter before JSON.parse
+Within `parseSessionFile`, lines that can be determined to fall outside the requested `dateRange` from a raw string scan must be skipped before calling `JSON.parse`. The raw string scan must search for a `"timestamp":"` prefix in the line and extract the ISO 8601 date string without parsing the full JSON object. Lines that do not contain a parseable timestamp string must proceed to full `JSON.parse` (conservative: never skip a line that might contain in-range data).
+
+### R6 -- Currency load deferred to cost-rendering commands
+`loadCurrency()` must be removed from the `preAction` hook in `src/cli.ts`. It must be called explicitly only inside the action handlers for commands that display currency-converted costs: `status`, `report`, `today`, `month`, `export`. The `currency` management command must continue to call `loadCurrency()` when displaying current state.
+
+### R7 -- Correct output for all formats
+The output of `status --format json`, `status --format terminal`, and `status --format menubar` must be byte-for-byte identical to baseline output for the same dataset before and after all optimizations are applied. Token counts, costs, turn counts, and category breakdowns must not change.
+
+### R8 -- No regression in test suite
+`npx vitest run` must pass with zero failures after each task is committed.
+
+---
+
+## 4. Acceptance Criteria
+
+### Phase 1: Discovery Cache + Currency Deferral (Tasks T1, T2)
+
+**AC-1a** (R1) -- Given `status --format menubar` is invoked; when the command runs; then `discoverAllSessions` is called at most once per unique `providerFilter` value across the entire process lifetime, regardless of how many times `parseAllSessions` is called internally.
+
+**AC-1b** (R1) -- Given `discoverAllSessions` has been called once; when it is called again with the same filter before the process exits; then it returns without executing any `readdir` or `stat` filesystem calls.
+
+**AC-1c** (R1) -- Given the `--provider` flag is set to `cursor`; when `discoverAllSessions` is called; then only the Cursor provider's `discoverSessions()` runs, and the cached result is scoped to `cursor`, not shared with a subsequent call using `--provider all`.
+
+**AC-1d** (R1) -- Given the interactive dashboard is running; when the user triggers a refresh (press `r` or auto-refresh timer fires); then `clearDiscoveryCache()` is called before `parseAllSessions`, so new session files created since the last refresh are discovered.
+
+**AC-2a** (R6) -- Given `status --format json` is invoked; when the command runs; then no exchange rate file read and no network fetch to `api.frankfurter.app` occurs.
+
+**AC-2b** (R6) -- Given the `currency` command is invoked with no subcommand (display mode); when the command runs; then `loadCurrency()` is called and the current rate is displayed correctly.
+
+**AC-2c** (R6) -- Given `status --format json` output; when compared to baseline output captured before this change; then the JSON structure and all numeric values are identical (currency rate is 1 for USD, so output is unaffected).
+
+**AC-2d** (R6) -- Given a non-USD currency is configured (e.g., `codeburn currency GBP`); when `report`, `today`, or `month` is invoked; then costs are displayed in the configured currency with the correct exchange rate (verifying `loadCurrency()` is called before rendering).
+
+### Phase 2: Widen-then-Filter (Task T3)
+
+**AC-3a** (R2) -- Given `status --format menubar` is invoked; when the command runs; then `parseAllSessions` (or its internal JSONL reads) is called once for a date range that encompasses today, week, and month; and today/week results are derived by filtering that single parsed result in memory.
+
+**AC-3b** (R2) -- Given `status --format json` is invoked; when the command runs; then JSONL files are read at most once per file path across all date-range computations.
+
+**AC-3c** (R2, R7) -- Given the same dataset; when `status --format menubar` output is compared before and after this change; then the rendered output is byte-for-byte identical.
+
+**AC-3d** (R2) -- Given a session file containing turns from both today and last month; when `menubar` format is rendered; then the today-period total reflects only turns within today's date boundaries (00:00:00 to 23:59:59.999 local time), and the month-period total reflects all turns within the calendar month.
+
+### Phase 3: Streaming JSONL + Date Pre-filter (Tasks T4, T5)
+
+**AC-4a** (R4) -- Given a JSONL session file of 5MB or larger; when `parseSessionFile` processes it; then the peak RSS contribution of that single file's read does not exceed 2x the file size (i.e., streaming prevents loading the entire file plus a split array simultaneously).
+
+**AC-4b** (R4) -- Given a JSONL file with 10,000 lines; when it is parsed; then the resulting `SessionSummary` is identical to the one produced by the pre-streaming implementation for the same file.
+
+**AC-4c** (R5) -- Given a JSONL file where 80% of lines have timestamps outside the requested date range; when `parseSessionFile` runs with that date range; then `JSON.parse` is called on at most 25% of lines (lines outside the range and lines with no parseable timestamp prefix are both eligible for skip, but the implementation must never skip an in-range line).
+
+**AC-4d** (R5) -- Given a JSONL line that does not contain a `"timestamp":"` string literal; when the date pre-filter runs; then the line proceeds to full `JSON.parse` without being skipped.
+
+**AC-4e** (R5, R7) -- Given the same dataset used for baseline measurements; when `status --format json` output is compared before and after streaming+pre-filter; then the JSON output is byte-for-byte identical.
+
+### Phase 4: Conditional Bash Extraction (Task T6)
+
+**AC-6a** (R3) -- Given `status --format json` is invoked; when sessions are parsed; then the bash separator regex in `bash-utils.ts:16` (`separatorRegex.exec`) is not called at all during the parse.
+
+**AC-6b** (R3) -- Given `status --format terminal` is invoked; when sessions are parsed; then the bash separator regex in `bash-utils.ts:16` is not called (terminal format via `renderStatusBar` does not use `bashBreakdown`).
+
+**AC-6c** (R3) -- Given `report` is invoked; when the dashboard renders the bash command panel; then bash command counts are accurate and match the baseline for the same dataset.
+
+**AC-6d** (R3) -- Given `extractBash: false` is passed to `parseAllSessions`; when the resulting `ProjectSummary` is inspected; then every `SessionSummary.bashBreakdown` is an empty object `{}`.
+
+### End-to-End Acceptance
+
+**AC-E1** (R7, R8) -- Given the full test suite (`npx vitest run`); when run after all four phases are committed; then all tests pass with zero failures.
+
+**AC-E2** (Success Criteria) -- Given the machine used for baseline measurements; when `hyperfine --warmup 2 --runs 10 'codeburn status --format json'` is run on the built bundle; then the reported median is under 400ms.
+
+**AC-E3** (Success Criteria) -- Given the same machine; when `hyperfine --warmup 2 --runs 10 'codeburn status --format menubar'` is run; then the reported median is under 800ms.
+
+---
+
+## 5. Design Decisions
+
+### D1 -- Discovery cache is process-scoped, not TTL-based
+
+**Decision**: Cache `discoverAllSessions` results in a module-level `Map<string, SessionSource[]>` that is never expired during the process lifetime.
+
+**Rationale**: Session files are written to disk by the IDE (Claude Code, Codex, Cursor) asynchronously while the CLI runs. However, within a single CLI invocation (always < 10 seconds), no new session file will be discovered that was not present at the start. A TTL adds complexity without benefit. The existing parse-result TTL in `parser.ts` (60 seconds) is orthogonal and remains.
+
+**Risk**: If a future command runs in a long-lived daemon mode (e.g., `--watch`), stale discovery results could miss new session files. **Mitigation**: Add a `clearDiscoveryCache()` export that the auto-refresh code in `dashboard.tsx` must call at the start of each refresh cycle. If no daemon mode exists today, this export costs nothing.
+
+**Alternatives considered**: (a) TTL of 5 seconds -- adds time-dependency to tests. (b) Invalidation on file-system watch -- far too complex for the gain.
+
+### D2 -- Widen-then-filter in cli.ts, not in parseAllSessions
+
+**Decision**: The `menubar` and `export` command actions in `cli.ts` are rewritten to call `parseAllSessions` once with the widest needed range, then pass the result to a new pure function `filterByDateRange(projects: ProjectSummary[], range: DateRange): ProjectSummary[]`.
+
+**Rationale**: `parseAllSessions` already accepts a `DateRange` and filters at the entry level. Making it smarter about subrange caching would require it to know about the caller's intent, violating single responsibility. The simpler fix is at the call site: the commands in `cli.ts` know they need multiple periods and can request the superset once.
+
+`filterByDateRange` must filter `SessionSummary.turns` by `turn.timestamp` within the range, then recompute `totalCostUSD`, `totalApiCalls`, `totalInputTokens`, `totalOutputTokens`, `totalCacheReadTokens`, `totalCacheWriteTokens` from the filtered turns. It must not mutate the input `ProjectSummary[]`.
+
+**Risk**: The existing `buildSessionSummary` aggregates values during the single parse pass. `filterByDateRange` re-aggregates from the stored `turns` array. The invariant that `sessionSummary.totalCostUSD === sum(turn.assistantCalls[].costUSD)` must hold. If this invariant is broken anywhere in the codebase, `filterByDateRange` will produce different results. **Mitigation**: Add a test that constructs a `SessionSummary` via both paths and asserts equality.
+
+**Alternatives considered**: (a) Modify `parseAllSessions` to cache a "wide" result and serve subsets -- complex, harder to reason about. (b) Parse once and re-run all date-range queries in-memory inside `parseAllSessions` -- conflates concerns.
+
+### D3 -- extractBash flag threads through as a boolean parameter, not an options object
+
+**Decision**: Add `extractBash: boolean` as a named parameter in a new `ParseOptions` object passed to `parseAllSessions`, `parseSessionFile`, and `parseApiCall`. Do not use a global module-level flag.
+
+**Rationale**: A global flag is invisible at the call site and creates implicit coupling. A `ParseOptions` object at `parseAllSessions` is explicit, typed, and follows the existing pattern (dateRange and providerFilter already flow as plain parameters). An object wrapper is preferred over a bare boolean because it allows future options (e.g., `extractMcp`, `extractModels`) without changing function signatures again.
+
+The `ParseOptions` type:
+```
+type ParseOptions = {
+  dateRange?: DateRange
+  providerFilter?: string
+  extractBash?: boolean  // defaults to true for backward compatibility
+}
+```
+
+**Risk**: Callers that call `parseAllSessions` without specifying `extractBash` must default to `true` (extract bash) to preserve existing behavior. This is the safe default. Any caller that adds `extractBash: false` is explicitly opting into the optimization.
+
+**Alternatives considered**: (a) Bare boolean positional parameter -- breaks callers on parameter count change; worse readability. (b) Module-level `setBashExtraction(false)` -- global state, hard to test in isolation.
+
+### D4 -- Streaming uses readline, not a line-splitting stream transform
+
+**Decision**: Use Node.js built-in `readline.createInterface({ input: fs.createReadStream(filePath) })` with `for await (const line of rl)` to stream lines.
+
+**Rationale**: `readline` is a stable Node.js built-in with no additional dependencies. It handles partial-line buffering correctly at chunk boundaries. The `for await` async iterator pattern is consistent with the existing `async generator` pattern in `providers/codex.ts` and `providers/cursor.ts`. No new npm dependency is needed.
+
+**Risk**: The `readline` interface does not auto-close on early exit. If `parseSessionFile` returns early (e.g., all lines are outside the date range), the file stream must be explicitly closed to prevent handle leaks. **Mitigation**: Wrap the `readline` loop in a `try/finally` that calls `rl.close()` unconditionally.
+
+**Alternatives considered**: (a) `split2` npm package -- adds a dependency; no advantage over `readline` for this use case. (b) Manually chunking the stream -- more code, same result.
+
+### D5 -- Date pre-filter uses a simple string index scan, not a regex
+
+**Decision**: To pre-filter a raw JSONL line, use `line.indexOf('"timestamp":"')` and then extract 24 characters starting at the offset + 14 (the length of `"timestamp":"`). Parse the extracted string as a `Date` and compare to `dateRange`. If `indexOf` returns -1, proceed to full `JSON.parse`.
+
+**Rationale**: A regex like `/\"timestamp\":\"([^"]+)\"/` is more readable but runs a full NFA on every line. `indexOf` is a single linear scan with no backtracking. For lines that are 500-5000 characters long and contain `"timestamp":` near the beginning (as Claude JSONL entries do), `indexOf` will find the match in fewer iterations. The timestamp itself is always ISO 8601 and can be parsed with `new Date(str)` safely.
+
+**Risk**: If a JSONL entry has `"timestamp"` as a nested key inside another object (e.g., inside `message.content[]`), the pre-filter might match the wrong timestamp. **Mitigation**: The `"timestamp":"` string is only matched at the top level by convention in the Claude JSONL format (`entry.timestamp`), and the 24-character extraction produces a valid ISO date. If the extracted string is not a valid date (i.e., `isNaN(date.getTime())`), the line must proceed to full `JSON.parse`. This is the conservative fallback already specified in R5.
+
+**Alternatives considered**: (a) JSON streaming parser (e.g., `jsonstream`) -- adds a dependency; overkill for single-key extraction. (b) Regex -- functional but slower for this pattern.
+
+---
+
+## 6. Constraints
+
+### C1 -- No change to output format
+The text and JSON output of all existing commands must be unchanged. Any optimization that would alter a displayed token count, cost figure, turn count, model name, or date range label is out of scope for this spec and must not be included.
+
+### C2 -- No new npm dependencies (runtime)
+All four optimizations must be implemented using Node.js built-ins and existing package.json dependencies. `readline` (built-in), `fs` (built-in), and existing modules are available. Adding a new runtime dependency requires a separate decision record.
+
+### C3 -- TypeScript strict mode
+All new code must pass `tsc --strict` with no `any` types and no `@ts-ignore` suppressions.
+
+### C4 -- Existing test suite must pass
+`npx vitest run` must pass after each individual task commit, not only after all tasks are complete. Each task must be a shippable increment.
+
+### C5 -- No changes to `types.ts` domain types
+`ParsedApiCall.bashCommands` remains a `string[]` field. Adding `ParseOptions` is a new type addition, not a modification to existing domain types.
+
+### C6 -- No behavioral change to `report` or `today` or `month` commands
+These commands already call `parseAllSessions` once with a single date range. They must not be refactored as part of this spec. Only `status` and `export` are affected by the widen-then-filter change.
+
+---
+
+## 7. Tasks
+
+Tasks are ordered by impact-to-effort ratio. Each task is independently mergeable and must leave the test suite green.
+
+---
+
+### T1 -- Cache discovery results in providers/index.ts
+
+**Branch**: `fix/discovery-cache`
+**Effort**: ~20 lines changed
+**Requirements**: R1
+**Estimated gain**: 30-180ms depending on command
+
+**What to implement**:
+
+In `src/providers/index.ts`, add a module-level cache:
+
+```typescript
+const discoveryCache = new Map<string, SessionSource[]>()
+```
+
+In `discoverAllSessions`, before running provider discovery, check `discoveryCache.get(providerFilter ?? 'all')`. If present, return the cached array directly. After collecting results, store them in `discoveryCache`.
+
+Export a `clearDiscoveryCache(): void` function that calls `discoveryCache.clear()`. Call this function at the top of the refresh handler in `src/dashboard.tsx` (the function that runs when the user presses `r` or the auto-refresh timer fires).
+
+**Testing**:
+- Add a test in `tests/provider-registry.test.ts` that calls `discoverAllSessions` twice with the same filter and verifies the second call returns the same array reference (use `toBe`, not `toEqual`).
+- Verify `clearDiscoveryCache` resets the cache by calling it between the two calls and confirming the second call does not return the same reference.
+
+**Invariants to verify**:
+- Different `providerFilter` values (`'claude'`, `'cursor'`, `'all'`) are cached independently.
+- The exported `providers` array (used by `getAllProviders`) is not affected.
+
+---
+
+### T2 -- Move loadCurrency() out of preAction
+
+**Branch**: `fix/defer-currency-load`
+**Effort**: ~15 lines changed
+**Requirements**: R6
+**Estimated gain**: 2-20ms (disk read + possible network fetch deferred for `status --format json`)
+
+**What to implement**:
+
+Remove the `program.hook('preAction', ...)` block entirely from `src/cli.ts`.
+
+Add `await loadCurrency()` as the first line of the `action` handler for each of these commands: `report`, `today`, `month`, `status`, `export`.
+
+The `currency` command's action handler already calls `loadCurrency()` in its display branch -- verify it remains there.
+
+**Testing**:
+- Manually run `codeburn status --format json` and confirm output is unchanged.
+- Manually run `codeburn currency` (no subcommand) and confirm the current currency code is displayed.
+- `npx vitest run` must pass.
+
+**Invariants to verify**:
+- `getCurrency()` is always called after `loadCurrency()` in any command that formats costs.
+- The `currency set` subcommand (`codeburn currency GBP`) already calls `loadCurrency()` at the end of its action handler after saving -- this must remain.
+
+---
+
+### T3 -- Widen-then-filter for multi-period commands
+
+**Branch**: `fix/widen-then-filter`
+**Effort**: ~80 lines changed
+**Requirements**: R2, R7
+**Estimated gain**: 200-400ms for `status --format menubar`, ~150ms for `export`
+
+**What to implement**:
+
+**Step 1**: Add a new pure function in `src/parser.ts`:
+
+```typescript
+export function filterProjectsByDateRange(
+  projects: ProjectSummary[],
+  range: DateRange,
+): ProjectSummary[]
+```
+
+This function must:
+1. For each `ProjectSummary`, filter each `SessionSummary.turns` to only include turns where `turn.timestamp >= range.start && turn.timestamp <= range.end`.
+2. For each filtered `SessionSummary`, recompute all aggregated numeric fields from the remaining turns: `totalCostUSD`, `totalApiCalls`, `totalInputTokens`, `totalOutputTokens`, `totalCacheReadTokens`, `totalCacheWriteTokens`. Recompute `modelBreakdown`, `toolBreakdown`, `mcpBreakdown`, `bashBreakdown`, `categoryBreakdown` by iterating `turn.assistantCalls` for all surviving turns.
+3. Exclude sessions where the filtered turn count is zero.
+4. Exclude projects where all sessions are excluded.
+5. Recompute `ProjectSummary.totalCostUSD` and `totalApiCalls` from the filtered sessions' values (mirroring `parser.ts:339-340`).
+6. Return a new array; do not mutate the input.
+
+Note: `firstTimestamp` and `lastTimestamp` on each `SessionSummary` must be recomputed from surviving turns.
+
+**Step 2**: Rewrite the `status` command action handler for the `menubar` format in `src/cli.ts`:
+
+Current code calls `parseAllSessions` up to 6 times (3 for periods + N for per-provider today). Replace with:
+1. Call `parseAllSessions` once for `getDateRange('month').range` (the widest superset of today, week, and month).
+2. Derive `todayData`, `weekData`, `monthData` by calling `filterProjectsByDateRange` on the result.
+3. Derive per-provider today costs by calling `filterProjectsByDateRange` on the month result with the today range, then filtering by provider name in-memory.
+
+**Step 2b**: Rewrite the `status --format json` path in `src/cli.ts`:
+
+Current code at lines 142-143 calls `parseAllSessions` twice (today + month). Replace with:
+1. Call `parseAllSessions` once for `getDateRange('month').range`.
+2. Derive `todayData` by calling `filterProjectsByDateRange` with the today range.
+
+**Step 3**: Rewrite the `export` command action handler:
+1. Call `parseAllSessions` once for `getDateRange('30days').range`.
+2. Derive the three periods (`today`, `week`, `30days`) using `filterProjectsByDateRange`.
+
+**Testing**:
+- Add a unit test in a new file `tests/filter-by-date-range.test.ts` that:
+  - Constructs a `ProjectSummary` with turns spanning 3 days.
+  - Calls `filterProjectsByDateRange` with a 1-day range.
+  - Asserts that returned summary totals equal the sum of only the in-range turns.
+  - Asserts that the input `ProjectSummary` is not mutated.
+- Run `codeburn status --format menubar` and diff output against baseline.
+
+**Edge cases**:
+- A session with all turns outside the filter range must be excluded entirely.
+- A project with all sessions excluded must be excluded from the returned array.
+- The `'all'` period (range from epoch to now) used by the dashboard must not be broken; `filterProjectsByDateRange` with the full epoch-to-now range must return a result that equals the input.
+
+---
+
+### T4 -- Stream JSONL files with readline
+
+**Branch**: `fix/streaming-jsonl`
+**Effort**: ~40 lines changed
+**Requirements**: R4
+**Estimated gain**: 30-50% reduction in peak RSS
+
+**What to implement**:
+
+In `src/parser.ts`, replace the body of `parseSessionFile` from this pattern:
+
+```typescript
+const content = await readFile(filePath, 'utf-8')
+const lines = content.split('\n').filter(l => l.trim())
+const entries: JournalEntry[] = []
+for (const line of lines) { ... }
+```
+
+with:
+
+```typescript
+import { createReadStream } from 'fs'
+import { createInterface } from 'readline'
+
+const rl = createInterface({ input: createReadStream(filePath), crlfDelay: Infinity })
+const entries: JournalEntry[] = []
+try {
+  for await (const line of rl) {
+    if (!line.trim()) continue
+    // ... existing per-line logic
+  }
+} finally {
+  rl.close()
+}
+```
+
+The `readFile` import can be removed from `src/parser.ts` if it is no longer used elsewhere in the file. Verify before removing.
+
+**Testing**:
+- The existing behavior of `parseSessionFile` is fully covered by integration tests that run through `parseAllSessions`. Run `npx vitest run` and confirm all tests pass.
+- Manually run `codeburn status --format json` and confirm output is unchanged.
+- For the memory target: add a manual verification step: run `node --expose-gc dist/cli.js status --format json` with a console.log of `process.memoryUsage().rss` at exit and confirm it is below 100MB.
+
+**Invariants to verify**:
+- `parseSessionFile` is an `async function`. The `for await` loop requires it to remain `async`.
+- The `try/finally` block around `rl.close()` must execute even if an exception is thrown inside the loop.
+- Files that do not exist must still return `null` (the existing `try/catch` around the file open must be preserved -- wrap the `createReadStream` call, not the loop).
+
+---
+
+### T5 -- Date pre-filter before JSON.parse
+
+**Branch**: `fix/timestamp-prefilter`
+**Effort**: ~25 lines changed
+**Requirements**: R5
+**Estimated gain**: 50-100ms depending on what fraction of lines fall outside the date range
+
+**What to implement**:
+
+In `src/parser.ts`, within the line-reading loop in `parseSessionFile`, add a guard before calling `parseJsonlLine`:
+
+```typescript
+function extractTimestampFromLine(line: string): Date | null {
+  const key = '"timestamp":"'
+  const idx = line.indexOf(key)
+  if (idx === -1) return null
+  const start = idx + key.length
+  const end = line.indexOf('"', start)
+  if (end === -1) return null
+  const d = new Date(line.slice(start, end))
+  return isNaN(d.getTime()) ? null : d
+}
+```
+
+In the line loop, before `parseJsonlLine(line)`:
+
+```typescript
+if (dateRange) {
+  const ts = extractTimestampFromLine(line)
+  if (ts !== null && (ts < dateRange.start || ts > dateRange.end)) continue
+}
+```
+
+If `ts` is `null` (no valid timestamp found), do not skip the line -- proceed to full `JSON.parse`. This is the conservative path required by R5.
+
+Remove the post-parse date filter that currently runs after building the `entries` array. The pre-filter replaces it for timestamped lines; non-timestamped lines (type `'user'`) still need to be included, which is why null-timestamp lines must not be skipped.
+
+**Testing**:
+- Add a unit test in `tests/parser.test.ts` (create this file if it does not exist) that:
+  - Tests `extractTimestampFromLine` with a valid ISO timestamp line, a line without a timestamp, a line with a malformed timestamp, and a line where `"timestamp"` appears only inside a nested object value.
+  - The nested-object case must return a `Date` (may be wrong) but must not throw.
+- Run `codeburn status --format json` and diff output against baseline.
+
+**Invariants to verify**:
+- Lines of type `'user'` in Claude JSONL entries typically lack a top-level `"timestamp"` field in some older sessions. These must not be skipped (null return from `extractTimestampFromLine` prevents skip).
+- The `entry.type === 'user'` check in the existing post-parse filter (`return e.type === 'user'`) was specifically preserving user entries without timestamps. This behavior must be preserved: when `extractTimestampFromLine` returns null, the line is always passed to `JSON.parse`.
+
+---
+
+### T6 -- Conditional bash extraction via ParseOptions
+
+**Branch**: `fix/conditional-bash`
+**Effort**: ~50 lines changed
+**Requirements**: R3
+**Estimated gain**: 100-150ms for commands that do not render the bash panel
+
+**What to implement**:
+
+**Step 1**: Add to `src/types.ts` (or `src/parser.ts` if kept local to parsing):
+
+```typescript
+export type ParseOptions = {
+  dateRange?: DateRange
+  providerFilter?: string
+  extractBash?: boolean
+}
+```
+
+**Step 2**: Change the signature of `parseAllSessions` from:
+
+```typescript
+export async function parseAllSessions(dateRange?: DateRange, providerFilter?: string): Promise<ProjectSummary[]>
+```
+
+to:
+
+```typescript
+export async function parseAllSessions(opts?: ParseOptions): Promise<ProjectSummary[]>
+```
+
+Update the cache key function `cacheKey` to include `opts.extractBash` in the key so that a cached result with bash data is not returned to a caller that requested no bash data (which would be correct), but also a cached no-bash result is not returned to a caller that needs bash data (which would be incorrect).
+
+**Step 3**: Thread `extractBash` down through `parseSessionFile` and into `parseApiCall` and `extractBashCommandsFromContent`. When `extractBash` is `false`, `parseApiCall` must set `bashCommands: []` without calling `extractBashCommandsFromContent`.
+
+**Step 4**: Update call sites in `src/cli.ts`:
+- `status --format json`: pass `extractBash: false`
+- `status --format terminal`: pass `extractBash: false` (terminal format does not display bash breakdown -- confirmed: `src/format.ts:renderStatusBar` does not read `bashBreakdown`)
+- `status --format menubar`: pass `extractBash: false` (menubar format does not display bash breakdown -- confirmed: `src/menubar.ts` does not read `bashBreakdown`)
+- `report` (dashboard): pass `extractBash: true` (default -- bash panel is displayed in `src/dashboard.tsx:381`)
+- `export`: pass `extractBash: true` (`src/export.ts:105` builds bash rows from `bashBreakdown` for CSV/JSON output)
+- `today`, `month`: pass `extractBash: false` (these render the dashboard, which loads its own data with `extractBash: true` via `reloadData`)
+
+**Step 5**: Update all existing `parseAllSessions` call sites in `src/cli.ts` to use the new `ParseOptions` object. Because T3 already rewrites `cli.ts` partially, this task must be sequenced after T3 is merged, or both tasks must be done in a single branch. The preferred sequence is T3 merged first, T6 second.
+
+**Testing**:
+- Add a test in `tests/parser.test.ts` that:
+  - Parses a synthetic JSONL fixture containing a Bash tool_use block with `command: "git status && npm install"`.
+  - With `extractBash: true`: asserts `session.bashBreakdown` contains `{ git: { calls: 1 }, npm: { calls: 1 } }`.
+  - With `extractBash: false`: asserts `session.bashBreakdown` is `{}`.
+- Confirm `npx vitest run` passes.
+- Run `codeburn status --format json` and diff against baseline.
+
+**Invariants to verify**:
+- Existing callers of `parseAllSessions(dateRange, providerFilter)` that use positional arguments will be broken by the signature change. There must be no call sites outside `src/cli.ts` and `src/dashboard.tsx` -- verify with `grep -r 'parseAllSessions' src/`.
+- The cache key must distinguish `extractBash: true` from `extractBash: false`. A cached result without bash data must never be returned to a caller that requested bash data.
+
+---
+
+## 8. Testing Strategy
+
+### Unit tests (new)
+- `tests/filter-by-date-range.test.ts` -- covers T3's `filterProjectsByDateRange`
+- `tests/parser.test.ts` -- covers T5's `extractTimestampFromLine` and T6's bash extraction flag
+- `tests/provider-registry.test.ts` -- extend existing file to cover T1's discovery cache
+
+### Integration verification (manual, per task)
+Each task must be verified with `hyperfine --warmup 2 --runs 5 'codeburn status --format json'` before merging. Record the median time in the commit message.
+
+### Regression gate
+`npx vitest run` must pass with zero failures after each task commit. This is the only automated gate. The CI equivalent for this project is the CLAUDE.md verification checklist.
+
+### Output correctness check (AC-C1)
+Before starting any work, capture baseline output:
+```bash
+codeburn status --format json > /tmp/baseline-json.txt
+codeburn status --format terminal > /tmp/baseline-terminal.txt
+```
+After each task, run:
+```bash
+diff /tmp/baseline-json.txt <(codeburn status --format json)
+diff /tmp/baseline-terminal.txt <(codeburn status --format terminal)
+```
+Both diffs must be empty.
+
+---
+
+## 9. Risks
+
+### Risk-1: filterProjectsByDateRange produces different totals than parseAllSessions
+
+**Likelihood**: Medium. The `buildSessionSummary` function aggregates values during the parse pass. `filterProjectsByDateRange` re-aggregates from `turns`. If any aggregated value on `SessionSummary` is not derivable from its `turns` array alone, the totals will diverge.
+
+**Mitigation**: Before implementing T3, audit `buildSessionSummary` and confirm that `totalCostUSD === turns.flatMap(t => t.assistantCalls).reduce((s, c) => s + c.costUSD, 0)`. Add this as an assertion in the T3 unit test.
+
+**Rollback**: If the invariant does not hold, T3 must be scoped to only `status --format menubar` and not `export`, and the per-provider today computation must remain as separate `parseAllSessions` calls.
+
+### Risk-2: readline streaming changes error handling behavior
+
+**Likelihood**: Low. The current implementation uses `readFile` and catches all errors by returning `null`. The streaming implementation must preserve this contract.
+
+**Mitigation**: Wrap `createReadStream` in a try/catch at the point of creation. If the file does not exist or is not readable, return `null` immediately without entering the `readline` loop.
+
+### Risk-3: Date pre-filter skips lines it should not
+
+**Likelihood**: Low but high-impact. If a line is incorrectly skipped, tokens and costs are silently undercounted with no error.
+
+**Mitigation**: The pre-filter is conservative by design (R5): any line where `extractTimestampFromLine` returns `null` must proceed to full `JSON.parse`. Only lines with a valid, parseable, out-of-range timestamp are skipped. Add a test with a line that has a nested `"timestamp"` key to verify it does not produce a false positive skip.
+
+**Rollback**: This optimization can be disabled by removing the pre-filter guard and leaving the post-parse filter intact, with no other changes.
+
+### Risk-4: ParseOptions signature change breaks call sites
+
+**Likelihood**: Medium. `parseAllSessions` is called from `cli.ts` and `dashboard.tsx`. If the signature change is incomplete, TypeScript will catch it at compile time.
+
+**Mitigation**: The build step (`npm run build`) must succeed with zero type errors before merging T6.
+
+---
+
+## 10. Implementation Order and Sequence
+
+Tasks T1 and T2 are fully independent and can be implemented and merged in any order.
+
+T3 must be merged before T6 because T6 modifies the `parseAllSessions` call sites that T3 rewrites.
+
+T4 and T5 are independent of T3 and T6 and can be merged at any point. Merge T4 before T5 since T5 modifies code inside the loop body that T4 introduces.
+
+Recommended sequence:
+1. T2 (trivial, highest confidence, small diff)
+2. T1 (trivial, high confidence)
+3. T4 (streaming -- independent, good early RSS win)
+4. T5 (pre-filter -- builds on T4's loop structure)
+5. T3 (widen-then-filter -- largest correctness surface)
+6. T6 (bash extraction -- depends on T3's call site rewrite)
+
+---
+
+## 11. Traceability Matrix
+
+| Requirement | Tasks | Acceptance Criteria |
+|-------------|-------|---------------------|
+| R1 | T1 | AC-1a, AC-1b, AC-1c, AC-1d |
+| R2 | T3 | AC-3a, AC-3b, AC-3c, AC-3d |
+| R3 | T6 | AC-6a, AC-6b, AC-6c, AC-6d |
+| R4 | T4 | AC-4a, AC-4b |
+| R5 | T5 | AC-4c, AC-4d, AC-4e |
+| R6 | T2 | AC-2a, AC-2b, AC-2c, AC-2d |
+| R7 | T3, T4, T5, T6 | AC-3c, AC-4e, AC-E1 |
+| R8 | All | AC-E1 |
+
+---
+
+## 12. Out of Scope
+
+- `npx tsx` startup overhead (~600ms): this is a development tooling issue, not a production concern. Published builds use the compiled bundle.
+- Reducing Node.js module load time (`compileSourceTextModule`: 22ms): this requires bundle splitting or deferred imports and is a separate optimization track.
+- Cursor SQLite query optimization: the Cursor provider has its own cache (`cursor-cache.ts`) that is already keyed by DB mtime+size. This is not a bottleneck in the current profile.
+- Parallelizing JSONL reads with `Promise.all`: while this could reduce I/O wait time, it increases memory pressure (multiple large files in memory simultaneously) and conflicts with the streaming goal in T4. Defer until after RSS targets are met.
+
+---
+
+## 13. Changelog
+
+| Version | Date | Change |
+|---------|------|--------|
+| 1.0.0 | 2026-04-16 | Initial spec |
+| 1.1.0 | 2026-04-16 | Verification fixes: T6 extractBash true for export (bashBreakdown used in export.ts), AC-6b updated to match T6 terminal skip, AC-2d added for currency in report/today/month, T3 ProjectSummary recompute explicit, AC-1d for clearDiscoveryCache on dashboard refresh, T3 Step 2b for status --format json widen-then-filter |

--- a/docs/specs/security-audit-report.md
+++ b/docs/specs/security-audit-report.md
@@ -1,0 +1,79 @@
+# CodeBurn Security Audit Report
+
+**Date:** 2026-04-15
+**Scope:** Full source code review for external data transmission
+**Verdict:** No user data is leaked. Two outbound read-only HTTP requests exist for reference data only.
+
+---
+
+## Executive Summary
+
+CodeBurn reads local AI coding session files, calculates token costs locally, and displays results in the terminal. It does not transmit session data, token counts, cost figures, project names, or any user-identifiable information to any external system.
+
+Two outbound network requests exist, both fetching publicly available reference data. Neither sends user data in the request.
+
+---
+
+## Findings
+
+### Finding 1 -- LiteLLM Model Pricing Fetch
+
+- **File:** `src/models.ts`, line 22 and lines 69-87
+- **URL:** `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json`
+- **Direction:** Read-only GET request
+- **Data sent:** None (no query parameters, no request body, no headers with user data)
+- **Data received:** JSON file with AI model pricing per token
+- **Frequency:** Once per 24 hours, cached locally at `~/.cache/codeburn/litellm-pricing.json`
+- **Fallback:** Hardcoded pricing table used if the request fails (lines 26-45)
+- **Risk:** LOW -- This is a static JSON file hosted on GitHub. No user data leaves the machine.
+
+### Finding 2 -- Frankfurter Currency Exchange Rate Fetch
+
+- **File:** `src/currency.ts`, line 14 and lines 54-60
+- **URL:** `https://api.frankfurter.app/latest?from=USD&to={CODE}`
+- **Direction:** Read-only GET request
+- **Data sent:** Only the target currency code in the URL (e.g., `?to=BRL`)
+- **Data received:** JSON exchange rate for that currency pair
+- **Frequency:** Once per 24 hours, cached locally at `~/.cache/codeburn/exchange-rate.json`
+- **Fallback:** Returns rate of 1.0 if the request fails (line 91)
+- **Risk:** LOW -- The only variable in the request is a standard ISO currency code. No user data is transmitted.
+
+---
+
+## What Was Verified Clean
+
+| Area | Result |
+| ------ | -------- |
+| Session data (tokens, costs, projects) | Never transmitted. Processed entirely in memory. |
+| npm scripts (build, dev, test, prepublishOnly) | All local. No postinstall hooks or phone-home scripts. |
+| Dependencies (chalk, commander, ink, react) | UI/CLI only. No networking libraries. |
+| Optional deps (better-sqlite3) | Local SQLite reader for Cursor DB. No network use. |
+| Telemetry/analytics | None. No Sentry, DataDog, Segment, or similar. |
+| Cloud SDKs | None. No AWS, GCP, or Azure packages. |
+| Environment variables | Only `HOME`, `CLAUDE_CONFIG_DIR`, `CODEX_HOME` -- all for local path resolution. |
+| Export commands (CSV/JSON) | Write to user-specified local paths only. |
+| Config storage | `~/.config/codeburn/config.json` stores only currency preference locally. |
+| eval / dynamic code execution | None. |
+| Process spawning | None for network purposes. |
+
+---
+
+## Dependency Inventory
+
+**Production (4):** chalk, commander, ink, react
+**Optional (1):** better-sqlite3
+**Dev-only (5):** @types/better-sqlite3, @types/react, tsup, tsx, typescript, vitest
+
+None of these dependencies include built-in telemetry or analytics collection.
+
+---
+
+## Recommendations
+
+1. **No immediate action required.** The two outbound requests fetch public reference data and do not leak user information.
+
+2. **Optional hardening -- offline mode.** If fully air-gapped operation is desired, the fallback pricing and a fixed exchange rate already work when the network is unavailable. A `--offline` flag could be added to skip fetch attempts entirely.
+
+3. **Optional hardening -- pin external URLs.** The LiteLLM URL points to a `main` branch raw file that could change upstream. Pinning to a specific commit hash would prevent unexpected content changes.
+
+4. **Dependency auditing.** Run `npm audit` periodically. The current dependency set is minimal and low-risk, but transitive dependencies should be monitored.

--- a/journal.md
+++ b/journal.md
@@ -1,10 +1,12 @@
 # SDLC Toolkit Journal
 
 Tracks every sdlc-toolkit interaction: value delivered, limitations found, self-corrections observed.
+Summerizes the advances on improving the repository of Codeburn with the toolkit help.
+The purpose of this Journal is to give a well detailed, but still readble, feedback about the tool.
 
 ---
 
-### 2026-04-15 -- security-scan (Claude Cowork, Opus 4.6)
+## 2026-04-15 -- security-scan (Claude Cowork, Opus 4.6)
 
 **Action**: Full security audit of the codebase. Produced `docs/specs/security-audit-report.md`.
 **Value**: Confirmed zero user data leakage. Identified 2 outbound read-only HTTP requests (LiteLLM pricing, Frankfurter exchange rates) and verified neither transmits user data. Flagged 5 low-risk items (symlink following, JSONL prototype pollution, export path traversal) with clear reasoning for why each is acceptable.
@@ -13,25 +15,7 @@ Tracks every sdlc-toolkit interaction: value delivered, limitations found, self-
 
 ---
 
-### 2026-04-15 -- learn-codebase (Claude Cowork, Opus 4.6)
-
-**Action**: Generated `docs/specs/codebase-overview.md` -- full module map, architecture description, provider system analysis, caching strategy, and test coverage gaps.
-**Value**: Mapped all 18 source files with line counts and roles. Identified the key architectural asymmetry: Claude sessions use a legacy JSONL codepath while Codex/Cursor use the async generator `SessionParser` interface. Documented deduplication strategies per provider.
-**Limitations**: None.
-**Self-correction**: N/A.
-
----
-
-### 2026-04-15 -- performance-analysis
-
-**Action**: Profiled CLI startup with CPU profiling and filesystem instrumentation. Produced `docs/specs/performance-analysis.md`.
-**Value**: Identified 4 ranked bottlenecks with exact self-times: bash regex (171ms/21% CPU), JSON.parse all lines (138ms/17%), redundant discovery (37ms x N), overlapping date range re-parse (200-400ms). Set concrete targets: `status --format json` under 500ms, `report` under 2s.
-**Limitations**: None.
-**Self-correction**: N/A.
-
----
-
-### 2026-04-15 -- full audit (Claude Cowork, Opus 4.6)
+## 2026-04-15 -- full audit (Claude Cowork, Opus 4.6)
 
 **Action**: Comprehensive project audit covering architecture, implementation, security, testing, strengths, and weaknesses. Produced `docs/specs/codeburn-full-audit.md` (415 lines).
 **Value**: Rated 8 areas (architecture: Strong, privacy: Excellent, test coverage: Weak). Identified 8 specific weak points with actionable recommendations. Produced a complete architecture diagram in Mermaid and a module-level responsibility map.
@@ -40,7 +24,25 @@ Tracks every sdlc-toolkit interaction: value delivered, limitations found, self-
 
 ---
 
-### 2026-04-16 14:00 -- architect
+## 2026-04-15 -- learn-codebase (Claude Cowork, Opus 4.6)
+
+**Action**: Generated `docs/specs/codebase-overview.md` -- full module map, architecture description, provider system analysis, caching strategy, and test coverage gaps.
+**Value**: Mapped all 18 source files with line counts and roles. Identified the key architectural asymmetry: Claude sessions use a legacy JSONL codepath while Codex/Cursor use the async generator `SessionParser` interface. Documented deduplication strategies per provider.
+**Limitations**: None.
+**Self-correction**: N/A.
+
+---
+
+## 2026-04-15 -- performance-analysis
+
+**Action**: Profiled CLI startup with CPU profiling and filesystem instrumentation. Produced `docs/specs/performance-analysis.md`.
+**Value**: Identified 4 ranked bottlenecks with exact self-times: bash regex (171ms/21% CPU), JSON.parse all lines (138ms/17%), redundant discovery (37ms x N), overlapping date range re-parse (200-400ms). Set concrete targets: `status --format json` under 500ms, `report` under 2s.
+**Limitations**: None.
+**Self-correction**: N/A.
+
+---
+
+## 2026-04-16 14:00 -- architect
 
 **Action**: Evaluated whether CodeBurn should be rewritten in Rust, Go, Python, or Swift instead of TypeScript.
 **Value**: Produced a structured comparison across 10 dimensions (startup, memory, TUI ecosystem, SQLite, migration cost, etc.). Concluded: don't rewrite -- 4 targeted TypeScript fixes (~100-200 lines) can achieve 80% of the performance gains. Identified Go as the strongest rewrite candidate if TypeScript optimizations fail.
@@ -49,7 +51,7 @@ Tracks every sdlc-toolkit interaction: value delivered, limitations found, self-
 
 ---
 
-### 2026-04-16 15:00 -- spec-writer
+## 2026-04-16 15:00 -- spec-writer
 
 **Action**: Wrote `docs/specs/performance-optimization.md` (v1.0.0) -- a 580-line spec defining 6 tasks (T1-T6) to fix all identified performance bottlenecks.
 **Value**: Produced production-grade spec with 8 requirements, 15 acceptance criteria, 5 design decisions, risk analysis, and traceability matrix. Each task is independently shippable with its own branch, testing strategy, and invariants. Defensive design lens caught Risk-1 (filterProjectsByDateRange invariant) proactively.
@@ -58,7 +60,7 @@ Tracks every sdlc-toolkit interaction: value delivered, limitations found, self-
 
 ---
 
-### 2026-04-16 16:00 -- verify-spec
+## 2026-04-16 16:00 -- verify-spec
 
 **Action**: Structural and alignment verification of performance-optimization.md against the actual codebase.
 **Value**: Caught 2 errors and 3 warnings that would have caused bugs during implementation. Key find: T6 set `extractBash: false` for the `export` command, but `export.ts:buildBashRows()` reads `bashBreakdown` -- this would have silently emptied bash data in CSV/JSON exports. Also caught AC-6b contradicting T6 Step 4 for terminal format.
@@ -67,11 +69,47 @@ Tracks every sdlc-toolkit interaction: value delivered, limitations found, self-
 
 ---
 
-### 2026-04-16 16:30 -- spec fixes (follow-up to verify-spec)
+## 2026-04-16 16:30 -- spec fixes (follow-up to verify-spec)
 
 **Action**: Applied all 6 findings from verify-spec to the spec. Updated to v1.1.0.
 **Value**: Fixed 2 errors (extractBash for export, AC-6b contradiction), 3 warnings (missing ACs for currency loading, ProjectSummary recompute, clearDiscoveryCache), and 1 info (added widen-then-filter for `status --format json`). Traceability matrix and changelog updated.
 **Limitations**: None.
 **Self-correction**: This is the self-correction cycle: spec-writer produced a spec with latent bugs -> verify-spec found them -> fixes applied. The plugin caught its own output within one iteration.
+
+---
+
+### 2026-04-17 -- generate-tasks
+
+**Action**: Generated `docs/specs/performance-optimization-tasks.md` from the performance-optimization spec.
+**Value**: Decomposed 6 spec tasks into 10 right-sized tasks with file conflict matrix, dependency graph, and 5 execution phases (max parallelism: 3). Split T3 into T3a/T3b/T3c and T6 into T6a/T6b/T6c by concern. Surfaced hidden serialization constraints (T3b and T6b both touch src/cli.ts).
+**Limitations**: None.
+**Self-correction**: N/A.
+
+---
+
+### 2026-04-17 -- performance-analysis (v2, post-optimization)
+
+**Action**: Measured performance after implementing all 10 optimization tasks. Produced `docs/specs/performance-analysis-v2.md`.
+**Value**: Quantified every bottleneck fix with before/after numbers. Key results: `status --format menubar` 2500ms -> 597ms (76% faster), bash regex eliminated (171ms -> 0ms), JSON.parse halved (138ms -> 66ms), cache hit cost 343ms -> 0ms. Identified two unmet spec targets: `status --format json` still 589ms vs 400ms target, RSS 185MB vs 100MB target. Explained the remaining gap (full-month JSON.parse is the floor).
+**Limitations**: Could not measure before/after on the same dataset - data volume grew from 18 to 21 projects between measurements.
+**Self-correction**: N/A.
+
+---
+
+### 2026-04-17 -- code-review (performance-optimization implementation)
+
+**Action**: Five-axis review of all implementation changes from the performance-optimization tasks (166 lines of logic, 7 source files, 16 new tests).
+**Value**: Found 2 HIGH findings, 2 MEDIUM, 3 LOW/NIT. Key bug: menubar provider cost over-counts when a project has mixed providers (H1) -- the rewrite from per-provider `parseAllSessions` to `filterProjectsByDateRange` broke provider cost attribution by attributing full project cost to each provider that appears. Also found a fragility in H2 (non-user entries without timestamps silently dropped). Duplicate `filterProjectsByDateRange` call at cli.ts:129,132 (M2). Verdict: APPROVE with comments -- H1 must be fixed before merge.
+**Limitations**: Did not run the menubar format to visually verify the provider cost bug in practice.
+**Self-correction**: N/A.
+
+---
+
+### 2026-04-17 -- implement (performance-optimization tasks)
+
+**Action**: Implemented all 10 tasks from the performance-optimization task breakdown across 5 phases.
+**Value**: All 8 spec requirements (R1-R8) implemented. Key changes: discovery caching in `providers/index.ts` (T1), `loadCurrency()` moved out of preAction hook (T2), `filterProjectsByDateRange` reusing `buildSessionSummary` for correct aggregates (T3a), widen-then-filter in status/export commands (T3b), JSONL streaming via readline (T4), `extractTimestampFromLine` date pre-filter before JSON.parse (T5a), `ParseOptions` with conditional bash extraction threaded through all call sites (T6a/T6b). Wrote 16 new tests across 3 files covering filter logic, timestamp extraction, and discovery cache. All 56 tests pass.
+**Limitations**: Did not measure actual wall-clock improvement (spec targets: `status --format json` under 400ms, RSS under 100MB) -- would require before/after benchmarking on a machine with real session data at scale.
+**Self-correction**: N/A.
 
 ---

--- a/journal.md
+++ b/journal.md
@@ -1,0 +1,77 @@
+# SDLC Toolkit Journal
+
+Tracks every sdlc-toolkit interaction: value delivered, limitations found, self-corrections observed.
+
+---
+
+### 2026-04-15 -- security-scan (Claude Cowork, Opus 4.6)
+
+**Action**: Full security audit of the codebase. Produced `docs/specs/security-audit-report.md`.
+**Value**: Confirmed zero user data leakage. Identified 2 outbound read-only HTTP requests (LiteLLM pricing, Frankfurter exchange rates) and verified neither transmits user data. Flagged 5 low-risk items (symlink following, JSONL prototype pollution, export path traversal) with clear reasoning for why each is acceptable.
+**Limitations**: None.
+**Self-correction**: N/A.
+
+---
+
+### 2026-04-15 -- learn-codebase (Claude Cowork, Opus 4.6)
+
+**Action**: Generated `docs/specs/codebase-overview.md` -- full module map, architecture description, provider system analysis, caching strategy, and test coverage gaps.
+**Value**: Mapped all 18 source files with line counts and roles. Identified the key architectural asymmetry: Claude sessions use a legacy JSONL codepath while Codex/Cursor use the async generator `SessionParser` interface. Documented deduplication strategies per provider.
+**Limitations**: None.
+**Self-correction**: N/A.
+
+---
+
+### 2026-04-15 -- performance-analysis
+
+**Action**: Profiled CLI startup with CPU profiling and filesystem instrumentation. Produced `docs/specs/performance-analysis.md`.
+**Value**: Identified 4 ranked bottlenecks with exact self-times: bash regex (171ms/21% CPU), JSON.parse all lines (138ms/17%), redundant discovery (37ms x N), overlapping date range re-parse (200-400ms). Set concrete targets: `status --format json` under 500ms, `report` under 2s.
+**Limitations**: None.
+**Self-correction**: N/A.
+
+---
+
+### 2026-04-15 -- full audit (Claude Cowork, Opus 4.6)
+
+**Action**: Comprehensive project audit covering architecture, implementation, security, testing, strengths, and weaknesses. Produced `docs/specs/codeburn-full-audit.md` (415 lines).
+**Value**: Rated 8 areas (architecture: Strong, privacy: Excellent, test coverage: Weak). Identified 8 specific weak points with actionable recommendations. Produced a complete architecture diagram in Mermaid and a module-level responsibility map.
+**Limitations**: Could not run `npm audit` due to sandbox network restrictions.
+**Self-correction**: N/A.
+
+---
+
+### 2026-04-16 14:00 -- architect
+
+**Action**: Evaluated whether CodeBurn should be rewritten in Rust, Go, Python, or Swift instead of TypeScript.
+**Value**: Produced a structured comparison across 10 dimensions (startup, memory, TUI ecosystem, SQLite, migration cost, etc.). Concluded: don't rewrite -- 4 targeted TypeScript fixes (~100-200 lines) can achieve 80% of the performance gains. Identified Go as the strongest rewrite candidate if TypeScript optimizations fail.
+**Limitations**: Analysis was thorough but long. The agent produced a very detailed response that could have been more concise for decision-making.
+**Self-correction**: N/A.
+
+---
+
+### 2026-04-16 15:00 -- spec-writer
+
+**Action**: Wrote `docs/specs/performance-optimization.md` (v1.0.0) -- a 580-line spec defining 6 tasks (T1-T6) to fix all identified performance bottlenecks.
+**Value**: Produced production-grade spec with 8 requirements, 15 acceptance criteria, 5 design decisions, risk analysis, and traceability matrix. Each task is independently shippable with its own branch, testing strategy, and invariants. Defensive design lens caught Risk-1 (filterProjectsByDateRange invariant) proactively.
+**Limitations**: None apparent at writing time -- issues found later by verify-spec.
+**Self-correction**: N/A.
+
+---
+
+### 2026-04-16 16:00 -- verify-spec
+
+**Action**: Structural and alignment verification of performance-optimization.md against the actual codebase.
+**Value**: Caught 2 errors and 3 warnings that would have caused bugs during implementation. Key find: T6 set `extractBash: false` for the `export` command, but `export.ts:buildBashRows()` reads `bashBreakdown` -- this would have silently emptied bash data in CSV/JSON exports. Also caught AC-6b contradicting T6 Step 4 for terminal format.
+**Limitations**: Pre-implementation verification only (Level 1-2 depth). Cannot verify code alignment since no code exists yet.
+**Self-correction**: verify-spec caught spec-writer's mistakes. The spec-writer did not check whether `export.ts` uses `bashBreakdown` before setting `extractBash: false` for exports.
+
+---
+
+### 2026-04-16 16:30 -- spec fixes (follow-up to verify-spec)
+
+**Action**: Applied all 6 findings from verify-spec to the spec. Updated to v1.1.0.
+**Value**: Fixed 2 errors (extractBash for export, AC-6b contradiction), 3 warnings (missing ACs for currency loading, ProjectSummary recompute, clearDiscoveryCache), and 1 info (added widen-then-filter for `status --format json`). Traceability matrix and changelog updated.
+**Limitations**: None.
+**Self-correction**: This is the self-correction cycle: spec-writer produced a spec with latent bugs -> verify-spec found them -> fixes applied. The plugin caught its own output within one iteration.
+
+---

--- a/journal.md
+++ b/journal.md
@@ -105,6 +105,15 @@ The purpose of this Journal is to give a well detailed, but still readble, feedb
 
 ---
 
+### 2026-04-17 -- create-pr
+
+**Action**: Generated `gh pr create` command for `fix/performance-optimization`. Fixed H1 (menubar provider cost over-count: was using `proj.totalCostUSD` for all providers, now sums per-provider `assistantCalls`) and M2 (duplicate `filterProjectsByDateRange` call) before committing. Two commits: implementation+tests, then docs+journal. All 56 tests pass.
+**Value**: Caught uncommitted changes before PR creation. Fixed H1 correctness bug. Produced filled PR description with before/after performance table and conventional commit title.
+**Limitations**: Branch must be pushed before `gh pr create` runs (`git push -u origin fix/performance-optimization`).
+**Self-correction**: N/A.
+
+---
+
 ### 2026-04-17 -- implement (performance-optimization tasks)
 
 **Action**: Implemented all 10 tasks from the performance-optimization task breakdown across 5 phases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeburn",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeburn",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander'
 import { exportCsv, exportJson, type PeriodExport } from './export.js'
 import { loadPricing } from './models.js'
-import { parseAllSessions } from './parser.js'
+import { parseAllSessions, filterProjectsByDateRange } from './parser.js'
 import { renderStatusBar } from './format.js'
 import { installMenubar, renderMenubarFormat, type PeriodData, type ProviderCost, uninstallMenubar } from './menubar.js'
 import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory } from './types.js'
@@ -62,10 +62,6 @@ const program = new Command()
   .description('See where your AI coding tokens go - by task, tool, model, and project')
   .version(version)
 
-program.hook('preAction', async () => {
-  await loadCurrency()
-})
-
 program
   .command('report', { isDefault: true })
   .description('Interactive usage dashboard')
@@ -73,6 +69,7 @@ program
   .option('--provider <provider>', 'Filter by provider: all, claude, codex, cursor', 'all')
   .option('--refresh <seconds>', 'Auto-refresh interval in seconds', parseInt)
   .action(async (opts) => {
+    await loadCurrency()
     await renderDashboard(toPeriod(opts.period), opts.provider, opts.refresh)
   })
 
@@ -121,17 +118,26 @@ program
   .option('--format <format>', 'Output format: terminal, menubar, json', 'terminal')
   .option('--provider <provider>', 'Filter by provider: all, claude, codex, cursor', 'all')
   .action(async (opts) => {
+    await loadCurrency()
     await loadPricing()
     const pf = opts.provider
+    const monthRange = getDateRange('month').range
+    const monthProjects = await parseAllSessions({ dateRange: monthRange, providerFilter: pf, extractBash: false })
+
     if (opts.format === 'menubar') {
       const todayRange = getDateRange('today').range
-      const todayData = buildPeriodData('Today', await parseAllSessions(todayRange, pf))
-      const weekData = buildPeriodData('7 Days', await parseAllSessions(getDateRange('week').range, pf))
-      const monthData = buildPeriodData('Month', await parseAllSessions(getDateRange('month').range, pf))
+      const todayFiltered = filterProjectsByDateRange(monthProjects, todayRange)
+      const todayData = buildPeriodData('Today', todayFiltered)
+      const weekData = buildPeriodData('7 Days', filterProjectsByDateRange(monthProjects, getDateRange('week').range))
+      const monthData = buildPeriodData('Month', monthProjects)
       const todayProviders: ProviderCost[] = []
       for (const p of await getAllProviders()) {
-        const data = await parseAllSessions(todayRange, p.name)
-        const cost = data.reduce((s, proj) => s + proj.totalCostUSD, 0)
+        const cost = todayFiltered
+          .flatMap(proj => proj.sessions)
+          .flatMap(s => s.turns)
+          .flatMap(t => t.assistantCalls)
+          .filter(c => c.provider === p.name)
+          .reduce((s, c) => s + c.costUSD, 0)
         if (cost > 0) todayProviders.push({ name: p.displayName, cost })
       }
       console.log(renderMenubarFormat(todayData, weekData, monthData, todayProviders))
@@ -139,8 +145,8 @@ program
     }
 
     if (opts.format === 'json') {
-      const todayData = buildPeriodData('today', await parseAllSessions(getDateRange('today').range, pf))
-      const monthData = buildPeriodData('month', await parseAllSessions(getDateRange('month').range, pf))
+      const todayData = buildPeriodData('today', filterProjectsByDateRange(monthProjects, getDateRange('today').range))
+      const monthData = buildPeriodData('month', monthProjects)
       const { code, rate } = getCurrency()
       console.log(JSON.stringify({
         currency: code,
@@ -150,7 +156,6 @@ program
       return
     }
 
-    const monthProjects = await parseAllSessions(getDateRange('month').range, pf)
     console.log(renderStatusBar(monthProjects))
   })
 
@@ -160,6 +165,7 @@ program
   .option('--provider <provider>', 'Filter by provider: all, claude, codex, cursor', 'all')
   .option('--refresh <seconds>', 'Auto-refresh interval in seconds', parseInt)
   .action(async (opts) => {
+    await loadCurrency()
     await renderDashboard('today', opts.provider, opts.refresh)
   })
 
@@ -169,6 +175,7 @@ program
   .option('--provider <provider>', 'Filter by provider: all, claude, codex, cursor', 'all')
   .option('--refresh <seconds>', 'Auto-refresh interval in seconds', parseInt)
   .action(async (opts) => {
+    await loadCurrency()
     await renderDashboard('month', opts.provider, opts.refresh)
   })
 
@@ -179,12 +186,14 @@ program
   .option('-o, --output <path>', 'Output file path')
   .option('--provider <provider>', 'Filter by provider: all, claude, codex, cursor', 'all')
   .action(async (opts) => {
+    await loadCurrency()
     await loadPricing()
     const pf = opts.provider
+    const allData = await parseAllSessions({ dateRange: getDateRange('30days').range, providerFilter: pf, extractBash: true })
     const periods: PeriodExport[] = [
-      { label: 'Today', projects: await parseAllSessions(getDateRange('today').range, pf) },
-      { label: '7 Days', projects: await parseAllSessions(getDateRange('week').range, pf) },
-      { label: '30 Days', projects: await parseAllSessions(getDateRange('30days').range, pf) },
+      { label: 'Today', projects: filterProjectsByDateRange(allData, getDateRange('today').range) },
+      { label: '7 Days', projects: filterProjectsByDateRange(allData, getDateRange('week').range) },
+      { label: '30 Days', projects: allData },
     ]
 
     if (periods.every(p => p.projects.length === 0)) {

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -6,7 +6,7 @@ import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory } from './types
 import { formatCost, formatTokens } from './format.js'
 import { parseAllSessions } from './parser.js'
 import { loadPricing } from './models.js'
-import { getAllProviders } from './providers/index.js'
+import { getAllProviders, clearDiscoveryCache } from './providers/index.js'
 
 type Period = 'today' | 'week' | '30days' | 'month'
 
@@ -556,8 +556,9 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
 
   const reloadData = useCallback(async (p: Period, prov: string) => {
     setLoading(true)
+    clearDiscoveryCache()
     const range = getDateRange(p)
-    const data = await parseAllSessions(range, prov)
+    const data = await parseAllSessions({ dateRange: range, providerFilter: prov, extractBash: true })
     setProjects(data)
     setLoading(false)
   }, [])
@@ -648,7 +649,7 @@ function StaticDashboard({ projects, period, activeProvider }: { projects: Proje
 export async function renderDashboard(period: Period = 'week', provider: string = 'all', refreshSeconds?: number): Promise<void> {
   await loadPricing()
   const range = getDateRange(period)
-  const projects = await parseAllSessions(range, provider)
+  const projects = await parseAllSessions({ dateRange: range, providerFilter: provider, extractBash: true })
 
   const isTTY = process.stdin.isTTY && process.stdout.isTTY
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,7 @@
-import { readdir, readFile } from 'fs/promises'
+import { createReadStream } from 'fs'
+import { readdir } from 'fs/promises'
 import { basename, join } from 'path'
+import { createInterface } from 'readline'
 import { calculateCost, getShortModelName } from './models.js'
 import { discoverAllSessions, getProvider } from './providers/index.js'
 import type { ParsedProviderCall } from './providers/types.js'
@@ -10,6 +12,7 @@ import type {
   DateRange,
   JournalEntry,
   ParsedApiCall,
+  ParseOptions,
   ParsedTurn,
   ProjectSummary,
   SessionSummary,
@@ -73,7 +76,7 @@ function getMessageId(entry: JournalEntry): string | null {
   return msg?.id ?? null
 }
 
-function parseApiCall(entry: JournalEntry): ParsedApiCall | null {
+function parseApiCall(entry: JournalEntry, extractBash = true): ParsedApiCall | null {
   if (entry.type !== 'assistant') return null
   const msg = entry.message as AssistantMessageContent | undefined
   if (!msg?.usage || !msg?.model) return null
@@ -100,7 +103,7 @@ function parseApiCall(entry: JournalEntry): ParsedApiCall | null {
     usage.speed ?? 'standard',
   )
 
-  const bashCmds = extractBashCommandsFromContent(msg.content ?? [])
+  const bashCmds = extractBash ? extractBashCommandsFromContent(msg.content ?? []) : []
 
   return {
     provider: 'claude',
@@ -118,7 +121,7 @@ function parseApiCall(entry: JournalEntry): ParsedApiCall | null {
   }
 }
 
-function groupIntoTurns(entries: JournalEntry[], seenMsgIds: Set<string>): ParsedTurn[] {
+function groupIntoTurns(entries: JournalEntry[], seenMsgIds: Set<string>, extractBash = true): ParsedTurn[] {
   const turns: ParsedTurn[] = []
   let currentUserMessage = ''
   let currentCalls: ParsedApiCall[] = []
@@ -146,7 +149,7 @@ function groupIntoTurns(entries: JournalEntry[], seenMsgIds: Set<string>): Parse
       const msgId = getMessageId(entry)
       if (msgId && seenMsgIds.has(msgId)) continue
       if (msgId) seenMsgIds.add(msgId)
-      const call = parseApiCall(entry)
+      const call = parseApiCall(entry, extractBash)
       if (call) currentCalls.push(call)
     }
   }
@@ -259,40 +262,54 @@ function buildSessionSummary(
   }
 }
 
+export function extractTimestampFromLine(line: string): Date | null {
+  const key = '"timestamp":"'
+  const idx = line.indexOf(key)
+  if (idx === -1) return null
+  const start = idx + key.length
+  const end = line.indexOf('"', start)
+  if (end === -1) return null
+  const d = new Date(line.slice(start, end))
+  return isNaN(d.getTime()) ? null : d
+}
+
 async function parseSessionFile(
   filePath: string,
   project: string,
   seenMsgIds: Set<string>,
   dateRange?: DateRange,
+  extractBash = true,
 ): Promise<SessionSummary | null> {
-  let content: string
+  let rl
   try {
-    content = await readFile(filePath, 'utf-8')
+    rl = createInterface({ input: createReadStream(filePath), crlfDelay: Infinity })
   } catch {
     return null
   }
-  const lines = content.split('\n').filter(l => l.trim())
-  const entries: JournalEntry[] = []
 
-  for (const line of lines) {
-    const entry = parseJsonlLine(line)
-    if (entry) entries.push(entry)
+  const entries: JournalEntry[] = []
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) continue
+      if (dateRange) {
+        const ts = extractTimestampFromLine(line)
+        if (ts !== null && (ts < dateRange.start || ts > dateRange.end)) continue
+      }
+      const entry = parseJsonlLine(line)
+      if (!entry) continue
+      if (dateRange && !entry.timestamp && entry.type !== 'user') continue
+      entries.push(entry)
+    }
+  } catch {
+    return null
+  } finally {
+    rl.close()
   }
 
   if (entries.length === 0) return null
 
-  let filteredEntries = entries
-  if (dateRange) {
-    filteredEntries = entries.filter(e => {
-      if (!e.timestamp) return e.type === 'user'
-      const ts = new Date(e.timestamp)
-      return ts >= dateRange.start && ts <= dateRange.end
-    })
-    if (filteredEntries.length === 0) return null
-  }
-
   const sessionId = basename(filePath, '.jsonl')
-  const turns = groupIntoTurns(filteredEntries, seenMsgIds)
+  const turns = groupIntoTurns(entries, seenMsgIds, extractBash)
   const classified = turns.map(classifyTurn)
 
   return buildSessionSummary(sessionId, project, classified)
@@ -314,14 +331,14 @@ async function collectJsonlFiles(dirPath: string): Promise<string[]> {
   return jsonlFiles
 }
 
-async function scanProjectDirs(dirs: Array<{ path: string; name: string }>, seenMsgIds: Set<string>, dateRange?: DateRange): Promise<ProjectSummary[]> {
+async function scanProjectDirs(dirs: Array<{ path: string; name: string }>, seenMsgIds: Set<string>, dateRange?: DateRange, extractBash = true): Promise<ProjectSummary[]> {
   const projectMap = new Map<string, SessionSummary[]>()
 
   for (const { path: dirPath, name: dirName } of dirs) {
     const jsonlFiles = await collectJsonlFiles(dirPath)
 
     for (const filePath of jsonlFiles) {
-      const session = await parseSessionFile(filePath, dirName, seenMsgIds, dateRange)
+      const session = await parseSessionFile(filePath, dirName, seenMsgIds, dateRange, extractBash)
       if (session && session.apiCalls > 0) {
         const existing = projectMap.get(dirName) ?? []
         existing.push(session)
@@ -445,9 +462,9 @@ const CACHE_TTL_MS = 60_000
 const MAX_CACHE_ENTRIES = 10
 const sessionCache = new Map<string, { data: ProjectSummary[]; ts: number }>()
 
-function cacheKey(dateRange?: DateRange, providerFilter?: string): string {
+function cacheKey(dateRange?: DateRange, providerFilter?: string, extractBash?: boolean): string {
   const s = dateRange ? `${dateRange.start.getTime()}:${dateRange.end.getTime()}` : 'none'
-  return `${s}:${providerFilter ?? 'all'}`
+  return `${s}:${providerFilter ?? 'all'}:${extractBash === false ? 'nobash' : 'bash'}`
 }
 
 function cachePut(key: string, data: ProjectSummary[]) {
@@ -462,20 +479,35 @@ function cachePut(key: string, data: ProjectSummary[]) {
   sessionCache.set(key, { data, ts: now })
 }
 
-export async function parseAllSessions(dateRange?: DateRange, providerFilter?: string): Promise<ProjectSummary[]> {
-  const key = cacheKey(dateRange, providerFilter)
+export async function parseAllSessions(dateRangeOrOpts?: DateRange | ParseOptions, providerFilter?: string): Promise<ProjectSummary[]> {
+  let dateRange: DateRange | undefined
+  let pf: string | undefined
+  let extractBash = true
+
+  if (dateRangeOrOpts && 'start' in dateRangeOrOpts) {
+    dateRange = dateRangeOrOpts
+    pf = providerFilter
+  } else if (dateRangeOrOpts) {
+    dateRange = dateRangeOrOpts.dateRange
+    pf = dateRangeOrOpts.providerFilter
+    extractBash = dateRangeOrOpts.extractBash !== false
+  } else {
+    pf = providerFilter
+  }
+
+  const key = cacheKey(dateRange, pf, extractBash)
   const cached = sessionCache.get(key)
   if (cached && Date.now() - cached.ts < CACHE_TTL_MS) return cached.data
 
   const seenMsgIds = new Set<string>()
   const seenKeys = new Set<string>()
-  const allSources = await discoverAllSessions(providerFilter)
+  const allSources = await discoverAllSessions(pf)
 
   const claudeSources = allSources.filter(s => s.provider === 'claude')
   const nonClaudeSources = allSources.filter(s => s.provider !== 'claude')
 
   const claudeDirs = claudeSources.map(s => ({ path: s.path, name: s.project }))
-  const claudeProjects = await scanProjectDirs(claudeDirs, seenMsgIds, dateRange)
+  const claudeProjects = await scanProjectDirs(claudeDirs, seenMsgIds, dateRange, extractBash)
 
   const providerGroups = new Map<string, Array<{ path: string; project: string }>>()
   for (const source of nonClaudeSources) {
@@ -505,4 +537,36 @@ export async function parseAllSessions(dateRange?: DateRange, providerFilter?: s
   const result = Array.from(mergedMap.values()).sort((a, b) => b.totalCostUSD - a.totalCostUSD)
   cachePut(key, result)
   return result
+}
+
+export function filterProjectsByDateRange(
+  projects: ProjectSummary[],
+  range: DateRange,
+): ProjectSummary[] {
+  const filtered: ProjectSummary[] = []
+
+  for (const project of projects) {
+    const filteredSessions: SessionSummary[] = []
+
+    for (const session of project.sessions) {
+      const filteredTurns = session.turns.filter(turn => {
+        if (!turn.timestamp) return true
+        const ts = new Date(turn.timestamp)
+        return ts >= range.start && ts <= range.end
+      })
+      if (filteredTurns.length === 0) continue
+      filteredSessions.push(buildSessionSummary(session.sessionId, session.project, filteredTurns))
+    }
+
+    if (filteredSessions.length === 0) continue
+    filtered.push({
+      project: project.project,
+      projectPath: project.projectPath,
+      sessions: filteredSessions,
+      totalCostUSD: filteredSessions.reduce((s, sess) => s + sess.totalCostUSD, 0),
+      totalApiCalls: filteredSessions.reduce((s, sess) => s + sess.apiCalls, 0),
+    })
+  }
+
+  return filtered
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -26,7 +26,17 @@ export async function getAllProviders(): Promise<Provider[]> {
 
 export const providers = coreProviders
 
+const discoveryCache = new Map<string, SessionSource[]>()
+
+export function clearDiscoveryCache(): void {
+  discoveryCache.clear()
+}
+
 export async function discoverAllSessions(providerFilter?: string): Promise<SessionSource[]> {
+  const cacheKey = providerFilter ?? 'all'
+  const cached = discoveryCache.get(cacheKey)
+  if (cached) return cached
+
   const allProviders = await getAllProviders()
   const filtered = providerFilter && providerFilter !== 'all'
     ? allProviders.filter(p => p.name === providerFilter)
@@ -36,6 +46,7 @@ export async function discoverAllSessions(providerFilter?: string): Promise<Sess
     const sessions = await provider.discoverSessions()
     all.push(...sessions)
   }
+  discoveryCache.set(cacheKey, all)
   return all
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,12 @@ export type DateRange = {
   end: Date
 }
 
+export type ParseOptions = {
+  dateRange?: DateRange
+  providerFilter?: string
+  extractBash?: boolean
+}
+
 export const CATEGORY_LABELS: Record<TaskCategory, string> = {
   coding: 'Coding',
   debugging: 'Debugging',

--- a/tests/filter-by-date-range.test.ts
+++ b/tests/filter-by-date-range.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import { filterProjectsByDateRange } from '../src/parser.js'
+import type { ProjectSummary, SessionSummary, ClassifiedTurn, ParsedApiCall, TokenUsage } from '../src/types.js'
+
+function makeTurn(timestamp: string, costUSD: number, model = 'claude-sonnet-4-6'): ClassifiedTurn {
+  const usage: TokenUsage = {
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    cachedInputTokens: 0,
+    reasoningTokens: 0,
+    webSearchRequests: 0,
+  }
+  const call: ParsedApiCall = {
+    provider: 'claude',
+    model,
+    usage,
+    costUSD,
+    tools: ['Read'],
+    mcpTools: [],
+    hasAgentSpawn: false,
+    hasPlanMode: false,
+    speed: 'standard',
+    timestamp,
+    bashCommands: [],
+    deduplicationKey: `test:${timestamp}`,
+  }
+  return {
+    userMessage: 'test',
+    assistantCalls: [call],
+    timestamp,
+    sessionId: 'sess1',
+    category: 'coding',
+    retries: 0,
+    hasEdits: false,
+  }
+}
+
+function makeSession(turns: ClassifiedTurn[]): SessionSummary {
+  const totalCost = turns.reduce((s, t) => s + t.assistantCalls.reduce((a, c) => a + c.costUSD, 0), 0)
+  return {
+    sessionId: 'sess1',
+    project: 'test-project',
+    firstTimestamp: turns[0]?.timestamp ?? '',
+    lastTimestamp: turns[turns.length - 1]?.timestamp ?? '',
+    totalCostUSD: totalCost,
+    totalInputTokens: turns.length * 100,
+    totalOutputTokens: turns.length * 50,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    apiCalls: turns.length,
+    turns,
+    modelBreakdown: {},
+    toolBreakdown: {},
+    mcpBreakdown: {},
+    bashBreakdown: {},
+    categoryBreakdown: {} as SessionSummary['categoryBreakdown'],
+  }
+}
+
+function makeProject(sessions: SessionSummary[]): ProjectSummary {
+  return {
+    project: 'test-project',
+    projectPath: '/test/project',
+    sessions,
+    totalCostUSD: sessions.reduce((s, sess) => s + sess.totalCostUSD, 0),
+    totalApiCalls: sessions.reduce((s, sess) => s + sess.apiCalls, 0),
+  }
+}
+
+describe('filterProjectsByDateRange', () => {
+  const day1Turn = makeTurn('2026-04-15T10:00:00Z', 0.05)
+  const day2Turn = makeTurn('2026-04-16T10:00:00Z', 0.10)
+  const day3Turn = makeTurn('2026-04-17T10:00:00Z', 0.15)
+
+  const session = makeSession([day1Turn, day2Turn, day3Turn])
+  const project = makeProject([session])
+
+  it('filters turns to a 1-day range', () => {
+    const range = {
+      start: new Date('2026-04-16T00:00:00Z'),
+      end: new Date('2026-04-16T23:59:59.999Z'),
+    }
+    const result = filterProjectsByDateRange([project], range)
+    expect(result).toHaveLength(1)
+    expect(result[0].sessions[0].turns).toHaveLength(1)
+    expect(result[0].sessions[0].turns[0].timestamp).toBe('2026-04-16T10:00:00Z')
+  })
+
+  it('recomputes totals from filtered turns', () => {
+    const range = {
+      start: new Date('2026-04-16T00:00:00Z'),
+      end: new Date('2026-04-16T23:59:59.999Z'),
+    }
+    const result = filterProjectsByDateRange([project], range)
+    expect(result[0].totalCostUSD).toBeCloseTo(0.10)
+    expect(result[0].totalApiCalls).toBe(1)
+    expect(result[0].sessions[0].totalCostUSD).toBeCloseTo(0.10)
+  })
+
+  it('does not mutate input', () => {
+    const original = JSON.parse(JSON.stringify(project))
+    const range = {
+      start: new Date('2026-04-16T00:00:00Z'),
+      end: new Date('2026-04-16T23:59:59.999Z'),
+    }
+    filterProjectsByDateRange([project], range)
+    expect(project.sessions[0].turns).toHaveLength(3)
+    expect(project.totalCostUSD).toBeCloseTo(original.totalCostUSD)
+  })
+
+  it('excludes sessions with all turns outside range', () => {
+    const range = {
+      start: new Date('2026-04-20T00:00:00Z'),
+      end: new Date('2026-04-20T23:59:59.999Z'),
+    }
+    const result = filterProjectsByDateRange([project], range)
+    expect(result).toHaveLength(0)
+  })
+
+  it('excludes projects where all sessions are excluded', () => {
+    const range = {
+      start: new Date('2026-04-20T00:00:00Z'),
+      end: new Date('2026-04-20T23:59:59.999Z'),
+    }
+    const result = filterProjectsByDateRange([project], range)
+    expect(result).toHaveLength(0)
+  })
+
+  it('full range returns equivalent data', () => {
+    const range = {
+      start: new Date(0),
+      end: new Date('2030-01-01T00:00:00Z'),
+    }
+    const result = filterProjectsByDateRange([project], range)
+    expect(result).toHaveLength(1)
+    expect(result[0].sessions[0].turns).toHaveLength(3)
+    expect(result[0].totalCostUSD).toBeCloseTo(project.totalCostUSD)
+  })
+
+  it('cost invariant: totalCostUSD equals sum of turn costs', () => {
+    const range = {
+      start: new Date('2026-04-15T00:00:00Z'),
+      end: new Date('2026-04-16T23:59:59.999Z'),
+    }
+    const result = filterProjectsByDateRange([project], range)
+    const sess = result[0].sessions[0]
+    const sumFromTurns = sess.turns
+      .flatMap(t => t.assistantCalls)
+      .reduce((s, c) => s + c.costUSD, 0)
+    expect(sess.totalCostUSD).toBeCloseTo(sumFromTurns)
+  })
+})

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { extractTimestampFromLine } from '../src/parser.js'
+
+describe('extractTimestampFromLine', () => {
+  it('extracts valid ISO timestamp', () => {
+    const line = '{"type":"assistant","timestamp":"2026-04-15T10:30:00Z","message":{}}'
+    const result = extractTimestampFromLine(line)
+    expect(result).toBeInstanceOf(Date)
+    expect(result!.toISOString()).toBe('2026-04-15T10:30:00.000Z')
+  })
+
+  it('returns null when no timestamp field', () => {
+    const line = '{"type":"user","message":"hello"}'
+    expect(extractTimestampFromLine(line)).toBeNull()
+  })
+
+  it('returns null for malformed timestamp value', () => {
+    const line = '{"type":"assistant","timestamp":"not-a-date"}'
+    expect(extractTimestampFromLine(line)).toBeNull()
+  })
+
+  it('finds first timestamp when multiple exist', () => {
+    const line = '{"timestamp":"2026-04-15T08:00:00Z","nested":{"timestamp":"2026-04-16T09:00:00Z"}}'
+    const result = extractTimestampFromLine(line)
+    expect(result!.toISOString()).toBe('2026-04-15T08:00:00.000Z')
+  })
+
+  it('handles timestamp with offset', () => {
+    const line = '{"timestamp":"2026-04-15T10:00:00+05:00"}'
+    const result = extractTimestampFromLine(line)
+    expect(result).toBeInstanceOf(Date)
+    expect(result!.toISOString()).toBe('2026-04-15T05:00:00.000Z')
+  })
+
+  it('returns null for empty line', () => {
+    expect(extractTimestampFromLine('')).toBeNull()
+  })
+})

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { providers, getAllProviders } from '../src/providers/index.js'
+import { providers, getAllProviders, discoverAllSessions, clearDiscoveryCache } from '../src/providers/index.js'
 
 describe('provider registry', () => {
   it('has core providers registered synchronously', () => {
@@ -48,5 +48,31 @@ describe('provider registry', () => {
     expect(cursor.modelDisplayName('claude-4.5-opus-high-thinking')).toBe('Opus 4.5 (Thinking)')
     expect(cursor.modelDisplayName('grok-code-fast-1')).toBe('Grok Code Fast')
     expect(cursor.modelDisplayName('unknown-model')).toBe('unknown-model')
+  })
+})
+
+describe('discovery cache', () => {
+  it('returns same reference on second call', async () => {
+    clearDiscoveryCache()
+    const first = await discoverAllSessions()
+    const second = await discoverAllSessions()
+    expect(second).toBe(first)
+  })
+
+  it('clearDiscoveryCache resets the cache', async () => {
+    clearDiscoveryCache()
+    const first = await discoverAllSessions()
+    clearDiscoveryCache()
+    const third = await discoverAllSessions()
+    expect(third).not.toBe(first)
+    expect(third).toEqual(first)
+  })
+
+  it('caches different filters independently', async () => {
+    clearDiscoveryCache()
+    const all = await discoverAllSessions()
+    const claude = await discoverAllSessions('claude')
+    expect(claude).not.toBe(all)
+    expect(claude.length).toBeLessThanOrEqual(all.length)
   })
 })


### PR DESCRIPTION
# Why

CLI startup was too slow for interactive use. `status --format menubar` took 2500ms, `status --format json` took 900ms. Six separate `parseAllSessions` calls were made for the menubar format, and bash regex ran on every line even when bash breakdown was not needed.

# What

- Discovery caching: session file discovery cached per provider filter, eliminating redundant disk scans
- Widen-then-filter: parse the widest date range once, derive subranges in-memory via `filterProjectsByDateRange`
- JSONL streaming: `readline.createInterface` replaces `readFile + split`, enabling early termination
- Date pre-filter: `extractTimestampFromLine` skips `JSON.parse` for lines outside the requested range
- Conditional bash extraction: `extractBash` flag avoids the 171ms separator regex for `status` and `json` formats
- Fix provider cost over-count in `status --format menubar`: was using `proj.totalCostUSD` (all providers) instead of summing only matching `assistantCalls`
- `loadCurrency()` moved out of `preAction` hook to avoid redundant HTTP calls
- 16 new tests for filter logic, timestamp extraction, and discovery cache

# How

All changes go through the existing data flow: `cli.ts` -> `providers/index.ts` -> `parser.ts`. No new abstractions introduced.

`ParseOptions` replaces the old `DateRange` parameter on `parseAllSessions`, adding `extractBash` and `providerFilter` flags. Backward compatibility preserved via overloaded signature.

`filterProjectsByDateRange` recomputes `totalCostUSD`, `totalInputTokens`, `totalOutputTokens` from `assistantCalls` rather than copying stale project-level aggregates.

# Results

| Command | Before | After | Change |
|---------|--------|-------|--------|
| `status --format menubar` | 2500ms | 597ms | -76% |
| `status --format terminal` | 1000ms | 587ms | -41% |
| `status --format json` | 900ms | 589ms | -34% |
| Bash regex CPU | 171ms | 0ms | eliminated |
| Cache hit parse | 343ms | 0ms | eliminated |

# Checklist
- [x] Tests updated (56 tests, 16 new)
- [x] Build passed
- [x] Code check passed
- [ ] Docs updated

## Pull request type
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Documentation