### PR TITLE
chore(ci): add semgrep guard against prototype pollution regressions in provider hot paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
 
 jobs:
@@ -17,4 +17,5 @@ jobs:
       - name: Run Semgrep bracket-assign guard
         run: |
           semgrep --config .semgrep/rules/no-bracket-assign-hot-paths.yml \
-            src/providers/ src/parser.ts --error
+            --error --strict \
+            src/providers/ src/parser.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
 
       - name: Run Semgrep bracket-assign guard
         run: |
+          set -e
           semgrep --config .semgrep/rules/no-bracket-assign-hot-paths.yml \
-            --error --strict \
-            src/providers/ src/parser.ts
+            --strict --json \
+            src/providers/ src/parser.ts > semgrep-out.json
+          FINDINGS=$(jq '.results | length' semgrep-out.json)
+          if [ "$FINDINGS" -gt 0 ]; then
+            jq -r '.results[] | "::error file=\(.path),line=\(.start.line)::\(.extra.message)"' semgrep-out.json
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Semgrep
+        run: pip install semgrep
+
+      - name: Run Semgrep bracket-assign guard
+        run: |
+          semgrep --config .semgrep/rules/no-bracket-assign-hot-paths.yml \
+            src/providers/ src/parser.ts --error

--- a/.semgrep/rules/no-bracket-assign-hot-paths.yml
+++ b/.semgrep/rules/no-bracket-assign-hot-paths.yml
@@ -3,15 +3,20 @@ rules:
     languages: [typescript]
     severity: ERROR
     message: >
-      Bracket-assign accumulator on a map created with `{}` allows prototype
-      pollution if the key comes from external data. Initialize the map with
+      Bracket-assign on a map created with `{}` allows prototype pollution when
+      the key comes from external data. Initialize the map with
       `Object.create(null)` instead.
     patterns:
-      - pattern: $MAP[$KEY] = $MAP[$KEY] ?? $INIT
+      - pattern-either:
+          - pattern: $MAP[$KEY] = $MAP[$KEY] ?? $INIT
+          - pattern: $MAP[$KEY] = $MAP[$KEY] || $INIT
+          - pattern: $MAP[$KEY] ??= $INIT
+          - pattern: |
+              if (!$MAP[$KEY]) $MAP[$KEY] = $INIT
       - pattern-not-inside: |
           const $MAP = Object.create(null)
           ...
     paths:
       include:
-        - src/providers/*.ts
-        - src/parser.ts
+        - '/src/providers/*.ts'
+        - '/src/parser.ts'

--- a/.semgrep/rules/no-bracket-assign-hot-paths.yml
+++ b/.semgrep/rules/no-bracket-assign-hot-paths.yml
@@ -1,0 +1,17 @@
+rules:
+  - id: no-bracket-assign-on-literal-object-map
+    languages: [typescript]
+    severity: ERROR
+    message: >
+      Bracket-assign accumulator on a map created with `{}` allows prototype
+      pollution if the key comes from external data. Initialize the map with
+      `Object.create(null)` instead.
+    patterns:
+      - pattern: $MAP[$KEY] = $MAP[$KEY] ?? $INIT
+      - pattern-not-inside: |
+          const $MAP = Object.create(null)
+          ...
+    paths:
+      include:
+        - src/providers/*.ts
+        - src/parser.ts

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -173,7 +173,7 @@ function buildSessionSummary(
   const toolBreakdown: SessionSummary['toolBreakdown'] = Object.create(null)
   const mcpBreakdown: SessionSummary['mcpBreakdown'] = Object.create(null)
   const bashBreakdown: SessionSummary['bashBreakdown'] = Object.create(null)
-  const categoryBreakdown: SessionSummary['categoryBreakdown'] = {} as SessionSummary['categoryBreakdown']
+  const categoryBreakdown: SessionSummary['categoryBreakdown'] = Object.create(null)
 
   let totalCost = 0
   let totalInput = 0


### PR DESCRIPTION
## Summary

Adds a Semgrep rule + GitHub Actions workflow that catches bracket-assign accumulator patterns on \`{}\`-initialized maps in \`src/providers/\` and \`src/parser.ts\`. This is the structural follow-up to the HIGH-1 prototype pollution fix (PR #67) - the fix itself used \`Object.create(null)\`, but there was no guardrail preventing a future contributor from re-introducing the vulnerable pattern with a fresh map.

## What it catches

Any of these patterns on a map not declared with \`Object.create(null)\`:
- \`\$MAP[\$KEY] = \$MAP[\$KEY] ?? \$INIT\`
- \`\$MAP[\$KEY] = \$MAP[\$KEY] || \$INIT\`
- \`\$MAP[\$KEY] ??= \$INIT\`
- \`if (!\$MAP[\$KEY]) \$MAP[\$KEY] = \$INIT\`

## Bonus

While writing the rule I noticed \`categoryBreakdown\` in \`parser.ts\` was still initialized with \`{}\` instead of \`Object.create(null)\`, inconsistent with its three sibling maps. Fixed for consistency. Not exploitable because the keys are internal \`TaskCategory\` enum values, but defense-in-depth.

Overlap note: PR #77 independently found the same \`categoryBreakdown\` inconsistency. Happy to rebase on top of whichever lands first.

## Implementation notes

- Uses \`jq\`-based finding count rather than \`semgrep --error\`, because \`--error\` returns exit 0 on findings in semgrep 1.159 (semgrep/semgrep#7661)
- \`--strict\` added so broken YAML fails CI loudly
- Push trigger limited to \`main\` to avoid double-runs on PR branches

## Test plan
- [x] Negative scan on current code: 0 findings, exit 0
- [x] Positive scan with seeded bad patterns: 4 findings, exit 1
- [x] \`npm test\` green (230/230)
- [ ] CI workflow runs on this PR