### PR TITLE
feat(report): add --from/--to date range filtering and avgCostPerSession

### DIFF
--- a/src/cli-date.ts
+++ b/src/cli-date.ts
@@ -1,0 +1,39 @@
+import type { DateRange } from './types.js'
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+const END_OF_DAY_HOURS = 23
+const END_OF_DAY_MINUTES = 59
+const END_OF_DAY_SECONDS = 59
+const END_OF_DAY_MS = 999
+
+function parseLocalDate(s: string): Date {
+  if (!ISO_DATE_RE.test(s)) {
+    throw new Error(`Invalid date format "${s}": expected YYYY-MM-DD`)
+  }
+  const [y, m, d] = s.split('-').map(Number) as [number, number, number]
+  return new Date(y, m - 1, d)
+}
+
+export function parseDateRangeFlags(from: string | undefined, to: string | undefined): DateRange | null {
+  if (from === undefined && to === undefined) return null
+
+  const now = new Date()
+  const start = from !== undefined ? parseLocalDate(from) : new Date(0)
+
+  const endDate = to !== undefined ? parseLocalDate(to) : new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const end = new Date(
+    endDate.getFullYear(),
+    endDate.getMonth(),
+    endDate.getDate(),
+    END_OF_DAY_HOURS,
+    END_OF_DAY_MINUTES,
+    END_OF_DAY_SECONDS,
+    END_OF_DAY_MS,
+  )
+
+  if (start > end) {
+    throw new Error(`--from must not be after --to (got ${from} > ${to})`)
+  }
+  return { start, end }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,6 +141,9 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
     name: p.project,
     path: p.projectPath,
     cost: convertCost(p.totalCostUSD),
+    avgCostPerSession: p.sessions.length > 0
+      ? convertCost(p.totalCostUSD / p.sessions.length)
+      : null,
     calls: p.totalApiCalls,
     sessions: p.sessions.length,
   }))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { addNewDays, getDaysInRange, loadDailyCache, saveDailyCache, withDailyCa
 import { aggregateProjectsIntoDays, buildPeriodDataFromDays } from './day-aggregator.js'
 import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory } from './types.js'
 import { renderDashboard } from './dashboard.js'
+import { parseDateRangeFlags } from './cli-date.js'
 import { runOptimize, scanAndDetect } from './optimize.js'
 import { getAllProviders } from './providers/index.js'
 import { readConfig, saveConfig, getConfigFilePath } from './config.js'
@@ -236,18 +237,40 @@ program
   .command('report', { isDefault: true })
   .description('Interactive usage dashboard')
   .option('-p, --period <period>', 'Starting period: today, week, 30days, month, all', 'week')
+  .option('--from <date>', 'Start date (YYYY-MM-DD). Overrides --period when set')
+  .option('--to <date>', 'End date (YYYY-MM-DD). Overrides --period when set')
   .option('--provider <provider>', 'Filter by provider: all, claude, codex, cursor', 'all')
   .option('--format <format>', 'Output format: tui, json', 'tui')
   .option('--project <name>', 'Show only projects matching name (repeatable)', collect, [])
   .option('--exclude <name>', 'Exclude projects matching name (repeatable)', collect, [])
   .option('--refresh <seconds>', 'Auto-refresh interval in seconds', parseInt)
   .action(async (opts) => {
+    let customRange: DateRange | null = null
+    try {
+      customRange = parseDateRangeFlags(opts.from, opts.to)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`\n  Error: ${message}\n`)
+      process.exit(1)
+    }
+
     const period = toPeriod(opts.period)
     if (opts.format === 'json') {
-      await runJsonReport(period, opts.provider, opts.project, opts.exclude)
+      await loadPricing()
+      if (customRange) {
+        const label = `${opts.from ?? 'all'} to ${opts.to ?? 'today'}`
+        const projects = filterProjectsByName(
+          await parseAllSessions(customRange, opts.provider),
+          opts.project,
+          opts.exclude,
+        )
+        console.log(JSON.stringify(buildJsonReport(projects, label, 'custom'), null, 2))
+      } else {
+        await runJsonReport(period, opts.provider, opts.project, opts.exclude)
+      }
       return
     }
-    await renderDashboard(period, opts.provider, opts.refresh, opts.project, opts.exclude)
+    await renderDashboard(period, opts.provider, opts.refresh, opts.project, opts.exclude, customRange)
   })
 
 function buildPeriodData(label: string, projects: ProjectSummary[]): PeriodData {

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -2,7 +2,7 @@ import { homedir } from 'os'
 
 import React, { useState, useCallback, useEffect, useRef } from 'react'
 import { render, Box, Text, useInput, useApp, useWindowSize } from 'ink'
-import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory } from './types.js'
+import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory } from './types.js'
 import { formatCost, formatTokens } from './format.js'
 import { parseAllSessions, filterProjectsByName } from './parser.js'
 import { loadPricing } from './models.js'
@@ -719,9 +719,9 @@ function StaticDashboard({ projects, period, activeProvider }: { projects: Proje
   )
 }
 
-export async function renderDashboard(period: Period = 'week', provider: string = 'all', refreshSeconds?: number, projectFilter?: string[], excludeFilter?: string[]): Promise<void> {
+export async function renderDashboard(period: Period = 'week', provider: string = 'all', refreshSeconds?: number, projectFilter?: string[], excludeFilter?: string[], customRange?: DateRange | null): Promise<void> {
   await loadPricing()
-  const range = getDateRange(period)
+  const range = customRange ?? getDateRange(period)
   const projects = filterProjectsByName(await parseAllSessions(range, provider), projectFilter, excludeFilter)
   const isTTY = process.stdin.isTTY && process.stdout.isTTY
   if (isTTY) {

--- a/src/export.ts
+++ b/src/export.ts
@@ -182,6 +182,7 @@ function buildProjectRows(projects: ProjectSummary[]): Row[] {
     .map(p => ({
       Project: p.projectPath,
       [`Cost (${code})`]: round2(convertCost(p.totalCostUSD)),
+      [`Avg/Session (${code})`]: p.sessions.length > 0 ? round2(convertCost(p.totalCostUSD / p.sessions.length)) : '',
       'Share (%)': pct(p.totalCostUSD, total),
       'API Calls': p.totalApiCalls,
       Sessions: p.sessions.length,

--- a/tests/date-range-filter.test.ts
+++ b/tests/date-range-filter.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { parseDateRangeFlags } from '../src/cli-date.js'
+
+describe('parseDateRangeFlags', () => {
+  it('returns null when neither flag is provided', () => {
+    expect(parseDateRangeFlags(undefined, undefined)).toBeNull()
+  })
+
+  it('parses a symmetric range in local time', () => {
+    const range = parseDateRangeFlags('2026-04-07', '2026-04-10')
+    expect(range).not.toBeNull()
+    expect(range!.start.getFullYear()).toBe(2026)
+    expect(range!.start.getMonth()).toBe(3)
+    expect(range!.start.getDate()).toBe(7)
+    expect(range!.start.getHours()).toBe(0)
+    expect(range!.end.getDate()).toBe(10)
+    expect(range!.end.getHours()).toBe(23)
+    expect(range!.end.getMinutes()).toBe(59)
+    expect(range!.end.getSeconds()).toBe(59)
+  })
+
+  it('accepts --from alone (open-ended to today 23:59:59)', () => {
+    const range = parseDateRangeFlags('2026-04-01', undefined)
+    expect(range).not.toBeNull()
+    expect(range!.start.getDate()).toBe(1)
+    expect(range!.end.getHours()).toBe(23)
+  })
+
+  it('accepts --to alone (start = epoch)', () => {
+    const range = parseDateRangeFlags(undefined, '2026-04-10')
+    expect(range).not.toBeNull()
+    expect(range!.start.getTime()).toBe(new Date(0).getTime())
+    expect(range!.end.getDate()).toBe(10)
+  })
+
+  it('throws when --from > --to', () => {
+    expect(() => parseDateRangeFlags('2026-04-10', '2026-04-07'))
+      .toThrow('--from must not be after --to')
+  })
+
+  it('throws on a non-ISO string', () => {
+    expect(() => parseDateRangeFlags('April 7', undefined))
+      .toThrow('Invalid date format')
+  })
+
+  it('throws on wrong digit count', () => {
+    expect(() => parseDateRangeFlags('26-4-7', undefined))
+      .toThrow('Invalid date format')
+  })
+
+  it('same day is valid (start midnight, end 23:59:59)', () => {
+    const range = parseDateRangeFlags('2026-04-10', '2026-04-10')
+    expect(range).not.toBeNull()
+    expect(range!.start.getDate()).toBe(10)
+    expect(range!.end.getDate()).toBe(10)
+  })
+})


### PR DESCRIPTION
## Summary

Partial close on #12 (power-user proposals, point 3) and additive context for #5 (billing period breakdown).

- \`codeburn report --from 2026-04-07 --to 2026-04-10\` filters sessions to that range
- JSON report \`projects[]\` entries now include \`avgCostPerSession\`
- CSV/JSON export gains an \`Avg/Session (<currency>)\` column

## Design notes

- \`--from\` / \`--to\` accept \`YYYY-MM-DD\` in the process-local timezone, matching the existing \`getDateRange()\` pattern (no UTC skew on DST days)
- Either flag alone is valid: \`--from\` alone runs from the given date to today 23:59:59.999, \`--to\` alone runs from epoch to the given date
- Inverted range (\`--from > --to\`) exits with a clear error message, not a crash
- When \`--from\`/\`--to\` is set, the TUI initial load uses it. Interactive period keys (1-5) still switch to predefined periods - custom range is an override for the initial render, not a locked mode. Intentional YAGNI.
- \`avgCostPerSession\` in the TUI was already shipped; this PR adds the same metric to JSON and CSV surfaces

## Test plan
- [x] \`npm test\` green (238/238, +8 new tests for \`parseDateRangeFlags\`)
- [x] \`tsc --noEmit\` clean
- [x] Smoke: inverted range errors out with exit 1 and readable message
- [x] Smoke: bad date format errors out before any I/O
- [x] Smoke: JSON output includes \`avgCostPerSession\` for each project