### PR TITLE
CI: npm OIDC trusted publishing workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,50 @@
+name: Publish to npm
+
+# Triggers when a semver tag (v*) is pushed. Publishes `codeburn` to the npm
+# registry using npm OIDC trusted publishing, so no NPM_TOKEN lives in
+# secrets. The `npm-publish` Environment requires a human approval before
+# the publish step runs.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write  # Required for npm OIDC provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify tag matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)" >&2
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test -- --run
+
+      - name: Publish with provenance
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-npm.yml` which publishes `codeburn` to npm on `v*` tag push (or manual workflow_dispatch), using npm OIDC trusted publishing.
- No NPM_TOKEN stored in repo secrets. OIDC exchanges short-lived tokens on demand.
- Uses a GitHub Environment `npm-publish` with required reviewers (both AgentSeal + Resham Joshi), so every release requires explicit human approval before publish runs.
- Adds `--provenance` flag, so every published version carries a cryptographic attestation linking it to the exact commit + workflow that built it.
- Fails fast if the tag version does not match `package.json` version. Runs tests before publishing.

## Prerequisites before merge actually produces a publish

1. Create GitHub Environment `npm-publish` at https://github.com/AgentSeal/codeburn/settings/environments with both AgentSeal + Resham Joshi as required reviewers.
2. Register Trusted Publisher on npmjs.com at https://www.npmjs.com/package/codeburn/access with owner=AgentSeal, repo=codeburn, workflow=publish-npm.yml, environment=npm-publish.
3. After OIDC is confirmed working on a test publish: revoke the existing classic NPM auth token.

Merging this PR does not trigger a publish by itself. The next `v*` tag push will.

## Test plan

- [ ] After merge, bump to a pre-release version (e.g. `0.7.4-rc.0`), tag `v0.7.4-rc.0`, push
- [ ] Confirm workflow starts and waits at the Environment approval gate
- [ ] Approve as AgentSeal; confirm it publishes with provenance
- [ ] Verify on npmjs.com that the version has a green "provenance" badge
- [ ] Revoke the old classic NPM token