### PR TITLE
chore: ignore local Discord brand assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ npm-debug.log*
 
 # Build artifacts
 *.tsbuildinfo
+
+# Local Discord brand / promo assets not yet ready to publish
+assets/discord-*.png


### PR DESCRIPTION
## Summary

Adds `assets/discord-*.png` to `.gitignore` so local Discord promo/branding PNGs don't show up as untracked noise in `git status`.

## Test plan

- [x] Diff is strictly 3 lines of `.gitignore` additions, no other files touched
- [ ] After merge, `git status` on a clean checkout does not list the four discord PNGs as untracked