### PR TITLE
chore: bump to 0.7.4-rc.0 for OIDC test publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeburn",
-  "version": "0.7.3",
+  "version": "0.7.4-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeburn",
-      "version": "0.7.3",
+      "version": "0.7.4-rc.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeburn",
-  "version": "0.7.3",
+  "version": "0.7.4-rc.0",
   "description": "See where your AI coding tokens go - by task, tool, model, and project",
   "type": "module",
   "main": "./dist/cli.js",


### PR DESCRIPTION
## Summary

Version bump for the first end-to-end test of npm OIDC trusted publishing.

- `package.json`: 0.7.3 → 0.7.4-rc.0
- `package-lock.json`: kept in sync (auto-updated by `npm version`)

## What happens after merge

1. Merge this PR to main
2. Tag `v0.7.4-rc.0` on main and push
3. `publish-npm.yml` workflow triggers, builds, tests, waits at Environment approval gate
4. Manual approval by AgentSeal or ReshamJoshi via Actions UI
5. Publish to npm with provenance attestation

## Test plan

- [x] Validator confirmed no WILL-FAIL items
- [x] `npm ci` clean-room install succeeded
- [x] 230 tests pass on clean build
- [ ] OIDC publish succeeds on first try
- [ ] Green provenance badge appears on npmjs.com