### PR TITLE
fix(ci): upgrade npm to 11.5.1+ for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,6 +28,13 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for trusted publishing
+        # Node 22 ships with npm 10.x; npm OIDC trusted publishing requires
+        # npm 11.5.1+. Without this, the publish step silently falls back
+        # to the empty NODE_AUTH_TOKEN written by setup-node and the
+        # registry returns 404.
+        run: npm install -g npm@latest
+
       - name: Verify tag matches package.json
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"


### PR DESCRIPTION
## Summary

First OIDC test publish (`v0.7.4-rc.0`) failed with npm error 404 on the publish PUT request, even though sigstore provenance signing succeeded. Root cause: Node 22 ships with npm 10.x, which does not support exchanging the GitHub OIDC id-token for a short-lived npm token. The publish step silently fell back to the empty `NODE_AUTH_TOKEN` written by `setup-node`.

Fix: one new step that runs `npm install -g npm@latest` after `setup-node` and before `npm publish`. Bumps to npm 11+, which knows how to use OIDC trusted publishing.

## Test plan

- [ ] Merge
- [ ] Bump to `0.7.4-rc.1`
- [ ] Tag + push, approve deploy
- [ ] Publish succeeds, provenance badge appears on npmjs.com