### PR TITLE
fix(ci): use Node 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -25,15 +25,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          # Node 24 (LTS) ships with npm 11.x, which supports OIDC trusted
+          # publishing natively. Node 22 on GitHub hosted runners currently
+          # pins to a broken npm 10.9.7 (runner-images#13883) and any
+          # self-upgrade from within that toolcache crashes on a missing
+          # promise-retry module, so bumping the runtime is the cleanest
+          # fix.
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm for trusted publishing
-        # Node 22 ships with npm 10.x; npm OIDC trusted publishing requires
-        # npm 11.5.1+. Without this, the publish step silently falls back
-        # to the empty NODE_AUTH_TOKEN written by setup-node and the
-        # registry returns 404.
-        run: npm install -g npm@latest
 
       - name: Verify tag matches package.json
         run: |


### PR DESCRIPTION
## Summary

First two OIDC test publishes failed due to two compounding issues:

1. `v0.7.4-rc.0`: Node 22 ships with npm 10.x, which doesn't know how to exchange GitHub OIDC for a registry token. Registry PUT returned 404.
2. `v0.7.4-rc.1`: Added `npm install -g npm@latest` but hit a known GitHub runner-image bug where Node 22.22.2 ships with a broken npm 10.9.7 missing `promise-retry`. Self-upgrade crashes before install runs.

Validator report (fresh-session, researched sources):
- `actions/runner-images#13883` documents the bug
- `nodejs/node#62430` is the upstream tracker
- npm official docs recommend Node 24 for trusted publishing

## Fix

Bump `node-version` from `'22'` to `'24'` and delete the upgrade step. Node 24 LTS bundles npm 11.x, which supports OIDC trusted publishing natively. One change, zero workarounds.

## Test plan

- [ ] Merge
- [ ] Bump to `0.7.4-rc.2`
- [ ] Tag + push, approve deploy
- [ ] Publish succeeds, provenance badge appears on npmjs.com