### PR TITLE
chore: reset version to 0.7.3 to match published npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeburn",
-  "version": "0.7.4-rc.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeburn",
-      "version": "0.7.4-rc.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeburn",
-  "version": "0.7.4-rc.2",
+  "version": "0.7.3",
   "description": "See where your AI coding tokens go - by task, tool, model, and project",
   "type": "module",
   "main": "./dist/cli.js",


### PR DESCRIPTION
main was at 0.7.4-rc.2 from the OIDC test cycle that was reverted. Bringing it back in sync with the actually-published npm version (0.7.3) so the next manual publish bumps cleanly from a correct base.