### PR TITLE
fix(mac): keep (today, all) cache fresh for menubar title and tab labels

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -73,10 +73,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         refreshTask = Task { [weak self] in
             while !Task.isCancelled {
                 guard let self else { return }
-                if self.store.selectedPeriod != .today {
-                    await self.store.refreshQuietly(period: .today)
-                }
-                // Optimize is fast (~1s warm-cache) so include findings on every refresh.
+                // Always keep the (today, all) payload warm. The menubar title and the
+                // agent tab strip both read from it, so it has to refresh every cycle
+                // regardless of whether the user is currently viewing Today or a
+                // different period / provider.
+                await self.store.refreshQuietly(period: .today)
+                // Refresh the currently-viewed payload. Optimize is fast (~1s warm-cache)
+                // so include findings on every refresh.
                 await self.store.refresh(includeOptimize: true)
                 try? await Task.sleep(nanoseconds: refreshIntervalNanos)
             }


### PR DESCRIPTION
## Summary

Bug reported live: Mac menubar title and agent tab strip show stale costs when the user is viewing the Today period and a specific provider (e.g., Claude tab). Hero section updates correctly, but menubar icon + tab labels lag.

Root cause: `startRefreshLoop()` only called `refreshQuietly(period: .today)` when the selected period was NOT Today. On Today, only the currently-viewed payload refreshed, leaving `(today, all)` stale. That's the cache both the menubar title and tab labels read from.

Fix: drop the guard, always refresh `(today, all)` every cycle.

## Validator verdict

Fresh-session validator checked:
- Fix matches description ✓
- No concurrent-fetch races ✓
- Reactive propagation wired (menubar + tab strip will pick up fresh values) ✓
- All edge cases (empty cache, offline, rapid tab switching, non-Today periods) safe ✓
- Zero MUST-FIX items

Flagged one polish issue (duplicate CLI spawn when user is on Today+All) as non-blocking. Follow-up work.

## Test plan

- [x] swift build clean
- [x] swift test passes 10/10
- [x] Package `.app` via `mac/Scripts/package-app.sh`, install locally, verify menubar title + tab labels update when provider cost changes
- [ ] Tag `mac-v0.7.4` after merge to ship to customers via `npx codeburn menubar`