### PR TITLE
fix(mac): show correct cost in trend tooltip for per-provider views

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
@@ -209,7 +209,7 @@ private struct TrendChart: View {
             // Floats below the chart without taking layout space. Opaque dark card hides
             // whatever sits beneath it (mini stats, activity rows).
             if let hoveredBar {
-                BarTooltipCard(bar: hoveredBar, formatValue: formatValue)
+                BarTooltipCard(bar: hoveredBar, value: metric(hoveredBar), formatValue: formatValue)
                     .padding(.top, 6)
                     .offset(y: 92)
                     .transition(.opacity)
@@ -260,6 +260,12 @@ private struct BarColumn: View {
 
 private struct BarTooltipCard: View {
     let bar: TrendBar
+    /// Value to display in the tooltip header. Matches the metric the trend chart
+    /// is currently using (tokens when the .all-providers view has token data,
+    /// cost when provider-filtered views force a $ fallback). Passing this in keeps
+    /// the tooltip in sync with the chart instead of always reading bar.tokens,
+    /// which is zero for provider-filtered days.
+    let value: Double
     let formatValue: (Double) -> String
     @Environment(\.colorScheme) private var colorScheme
 
@@ -290,7 +296,7 @@ private struct BarTooltipCard: View {
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(primaryText)
                 Spacer()
-                Text("\(formatValue(bar.tokens))")
+                Text("\(formatValue(value))")
                     .font(.codeMono(size: 10.5, weight: .semibold))
                     .foregroundStyle(Theme.brandAccent)
             }
@@ -313,10 +319,6 @@ private struct BarTooltipCard: View {
                         }
                     }
                 }
-            } else {
-                Text("No model breakdown available")
-                    .font(.system(size: 10))
-                    .foregroundStyle(tertiaryText)
             }
         }
         .padding(11)


### PR DESCRIPTION
## Summary

When a provider-specific tab is selected (Claude, Codex, Cursor, Pi), hovering a bar in the trend chart showed $0.00 and "No model breakdown available". Pre-existing in mac-v0.7.3 and mac-v0.7.4.

Root cause: the tooltip read `bar.tokens` which is always 0 for provider-filtered views (CLI only carries per-provider cost+calls in the daily cache, not tokens). The chart's main metric already fell back to cost correctly via the `metric` closure; the tooltip just wasn't reusing that same metric.

## Fix

1. `BarTooltipCard` now takes a `value: Double` parameter. Parent passes `metric(hoveredBar)` so the tooltip header matches what the chart is rendering.
2. Removed the "No model breakdown available" fallback text — legitimately empty for provider-filtered views, and the error-sounding message was misleading. Tooltip now shows just date + cost when no model data is available.

## Validator verdict

Fresh-session validator: READY TO SHIP. No must-fix. No regression to the .all-providers view. All edge cases clean.

## Test plan

- [x] swift build + swift test pass
- [x] Verified locally: Claude tab hover shows correct cost per day, no misleading message
- [ ] Ship as `mac-v0.7.5` after merge