### PR TITLE
fix(cli): use local time in toDateString to fix UTC+ date shift

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,10 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000
 const BACKFILL_DAYS = 365
 
 function toDateString(date: Date): string {
-  return date.toISOString().slice(0, 10)
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
 }
 
 function getDateRange(period: string): { range: DateRange; label: string } {


### PR DESCRIPTION
## Summary

`toDateString` called `toISOString()` which returns UTC. For any timezone east of UTC, midnight local time resolves to the previous calendar day in UTC — so `yesterdayStr` was calculated as one day too early, and the most recent day was silently dropped from the menubar history payload.

- Affects all users in UTC+ timezones (Europe, Asia, Australia, Africa)
- Reported in issue #93

## Fix

Build the `YYYY-MM-DD` string from `getFullYear()` / `getMonth()` / `getDate()` so the date reflects the user's local clock.

```ts
// Before
function toDateString(date: Date): string {
  return date.toISOString().slice(0, 10)
}

// After
function toDateString(date: Date): string {
  const y = date.getFullYear()
  const m = String(date.getMonth() + 1).padStart(2, '0')
  const d = String(date.getDate()).padStart(2, '0')
  return `${y}-${m}-${d}`
}
```

## Test plan
- [x] Verified menubar correctly shows yesterday's data when running in BST (UTC+1)
- [x] Fix confirmed by contributor @lfl1337 in issue #93