### PR TITLE
chore: point repo URLs at getagentseal org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://cdn.jsdelivr.net/gh/AgentSeal/codeburn@main/assets/logo.png" alt="CodeBurn" width="120" />
+  <img src="https://cdn.jsdelivr.net/gh/getagentseal/codeburn@main/assets/logo.png" alt="CodeBurn" width="120" />
 </p>
 
 <h1 align="center">CodeBurn</h1>
@@ -11,12 +11,12 @@
   <a href="https://www.npmjs.com/package/codeburn"><img src="https://img.shields.io/npm/dt/codeburn.svg" alt="total downloads" /></a>
   <a href="https://www.npmjs.com/package/codeburn"><img src="https://img.shields.io/npm/dm/codeburn.svg" alt="monthly downloads" /></a>
   <a href="https://bundlephobia.com/package/codeburn"><img src="https://img.shields.io/bundlephobia/min/codeburn" alt="install size" /></a>
-  <a href="https://github.com/agentseal/codeburn/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/codeburn.svg" alt="license" /></a>
-  <a href="https://github.com/agentseal/codeburn"><img src="https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg" alt="node version" /></a>
+  <a href="https://github.com/getagentseal/codeburn/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/codeburn.svg" alt="license" /></a>
+  <a href="https://github.com/getagentseal/codeburn"><img src="https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg" alt="node version" /></a>
 </p>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/AgentSeal/codeburn/main/assets/dashboard.jpg" alt="CodeBurn TUI dashboard" width="620" />
+  <img src="https://raw.githubusercontent.com/getagentseal/codeburn/main/assets/dashboard.jpg" alt="CodeBurn TUI dashboard" width="620" />
 </p>
 
 By task type, tool, model, MCP server, and project. Supports **Claude Code**, **Codex** (OpenAI), **Cursor**, **OpenCode**, **Pi**, and **GitHub Copilot** with a provider plugin system. Tracks one-shot success rate per activity type so you can see where the AI nails it first try vs. burns tokens on edit/test/fix retries. Interactive TUI dashboard with gradient charts, responsive panels, and keyboard navigation. Native macOS menubar app in `mac/`. CSV/JSON export.
@@ -156,7 +156,7 @@ The menu bar widget includes a currency picker with 17 common currencies. For an
 
 ## Menu Bar
 
-<img src="https://cdn.jsdelivr.net/gh/AgentSeal/codeburn@main/assets/menubar-0.7.2.png" alt="CodeBurn macOS menubar app" width="420" />
+<img src="https://cdn.jsdelivr.net/gh/getagentseal/codeburn@main/assets/menubar-0.7.2.png" alt="CodeBurn macOS menubar app" width="420" />
 
 ```bash
 npx codeburn menubar
@@ -212,7 +212,7 @@ These are starting points, not verdicts. A 60% cache hit on a single experimenta
 Once you know what to look for, `codeburn optimize` scans your sessions and your `~/.claude/` setup for the most common waste patterns and hands back exact, copy-paste fixes. It never writes to your files.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/AgentSeal/codeburn/main/assets/optimize.jpg" alt="CodeBurn optimize output" width="720" />
+  <img src="https://raw.githubusercontent.com/getagentseal/codeburn/main/assets/optimize.jpg" alt="CodeBurn optimize output" width="720" />
 </p>
 
 ```bash

--- a/mac/README.md
+++ b/mac/README.md
@@ -26,7 +26,7 @@ For contributors running a local build instead of the packaged release:
 
 ```bash
 npm install -g codeburn                       # CLI the app shells out to for data
-git clone https://github.com/AgentSeal/codeburn.git
+git clone https://github.com/getagentseal/codeburn.git
 cd codeburn/mac
 swift build -c release
 .build/release/CodeBurnMenubar                # launch

--- a/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
@@ -221,7 +221,7 @@ struct FlameMark: View {
     }
 }
 
-private let starBannerGitHubURL = URL(string: "https://github.com/AgentSeal/codeburn")!
+private let starBannerGitHubURL = URL(string: "https://github.com/getagentseal/codeburn")!
 
 /// Shown at the very bottom on first launch. A small terracotta strip nudges users to star the
 /// repo; clicking opens GitHub, clicking the close icon hides it forever (persisted to

--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
   },
   "author": "AgentSeal <hello@agentseal.org>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getagentseal/codeburn.git"
+  },
+  "bugs": {
+    "url": "https://github.com/getagentseal/codeburn/issues"
+  },
+  "homepage": "https://github.com/getagentseal/codeburn#readme",
   "dependencies": {
     "chalk": "^5.4.1",
     "commander": "^13.1.0",

--- a/src/menubar-installer.ts
+++ b/src/menubar-installer.ts
@@ -8,7 +8,7 @@ import { Readable } from 'node:stream'
 
 /// Public GitHub repo that hosts signed macOS release builds. `/releases/latest` returns the
 /// newest tagged release; we filter its assets list for our zipped .app bundle.
-const RELEASE_API = 'https://api.github.com/repos/AgentSeal/codeburn/releases/latest'
+const RELEASE_API = 'https://api.github.com/repos/getagentseal/codeburn/releases/latest'
 const APP_BUNDLE_NAME = 'CodeBurnMenubar.app'
 const ASSET_PATTERN = /^CodeBurnMenubar-.*\.zip$/
 const APP_PROCESS_NAME = 'CodeBurnMenubar'
@@ -73,7 +73,7 @@ async function fetchLatestReleaseAsset(): Promise<ReleaseAsset> {
   if (!asset) {
     throw new Error(
       `No ${APP_BUNDLE_NAME} zip found in release ${body.tag_name}. ` +
-      `Check https://github.com/AgentSeal/codeburn/releases.`
+      `Check https://github.com/getagentseal/codeburn/releases.`
     )
   }
   return asset


### PR DESCRIPTION
## Summary
- Add `repository`, `bugs`, and `homepage` fields to `package.json` (canonical org is now `getagentseal`)
- Swap hardcoded `AgentSeal/codeburn` URLs to `getagentseal/codeburn` in README, mac README, macOS menubar star banner, and the npm installer's release-API endpoint

301 redirects keep the old URLs working; this just makes the canonical links point at the current org.

## Test plan
- [x] `npm test` -- 230/230 passing
- [x] `npm run build` -- clean
- [ ] Manual: menubar installer fetches from new release URL on first run
- [ ] Visual: README badges/images render from getagentseal CDN paths