### PR TITLE
fix: restore SQLite-backed providers in ESM builds

### DIFF
--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -3,6 +3,8 @@
 /// so the dependency graph no longer pulls in the deprecated `prebuild-install` package
 /// (issue #75). Works across Cursor and OpenCode session DBs, both of which we only read.
 
+import { createRequire } from 'node:module'
+
 type Row = Record<string, unknown>
 
 export type SqliteDatabase = {
@@ -18,6 +20,7 @@ type DatabaseSyncCtor = new (path: string, options?: { readOnly?: boolean }) => 
 let DatabaseSync: DatabaseSyncCtor | null = null
 let loadAttempted = false
 let loadError: string | null = null
+const require = createRequire(import.meta.url)
 
 /// Lazily imports `node:sqlite`. On Node 22/23 it emits an ExperimentalWarning the first
 /// time the module is loaded; we silence that specific warning once so dashboards aren't
@@ -55,10 +58,7 @@ function loadDriver(): boolean {
   } as typeof process.emit
 
   try {
-    // Dynamic require via createRequire avoids TypeScript chasing types we don't need at
-    // build time (node:sqlite landed in @types/node much later than in Node itself).
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const mod = eval('require')('node:sqlite') as { DatabaseSync: DatabaseSyncCtor }
+    const mod = require('node:sqlite') as { DatabaseSync: DatabaseSyncCtor }
     DatabaseSync = mod.DatabaseSync
     return true
   } catch (err) {


### PR DESCRIPTION
Even though OpenCode support was added in https://github.com/getagentseal/codeburn/issues/31, I wasn't able to use it in 0.7.3.

Codeburn opened, but didn't show any activities. I had used OpenCode extensively for the past 2 months and I had a valid and populated `opencode.db` located in `~/.local/share/opencode/`, so I wasn't sure the issue was on my end.

After investigating, I've found this manifested, because Codeburn failed to import the sqlite module and this failed silently. Thus no usage data was returned to be analyzed. Reworking module import fixed this issue for me.

Operating System: Windows 10
Shell: Powershell 7.6.0
Node version: v25.9.0
OpenCode version: 1.4.11
Codeburn version: 0.7.3