### PR TITLE
fix(cli-date): reject month/day overflow in parseLocalDate

### DIFF
--- a/src/cli-date.ts
+++ b/src/cli-date.ts
@@ -12,7 +12,11 @@ function parseLocalDate(s: string): Date {
     throw new Error(`Invalid date format "${s}": expected YYYY-MM-DD`)
   }
   const [y, m, d] = s.split('-').map(Number) as [number, number, number]
-  return new Date(y, m - 1, d)
+  const parsed = new Date(y, m - 1, d)
+  if (parsed.getFullYear() !== y || parsed.getMonth() !== m - 1 || parsed.getDate() !== d) {
+    throw new Error(`Invalid date "${s}": month or day out of range`)
+  }
+  return parsed
 }
 
 export function parseDateRangeFlags(from: string | undefined, to: string | undefined): DateRange | null {

--- a/tests/date-range-filter.test.ts
+++ b/tests/date-range-filter.test.ts
@@ -48,6 +48,16 @@ describe('parseDateRangeFlags', () => {
       .toThrow('Invalid date format')
   })
 
+  it('throws on month out of range', () => {
+    expect(() => parseDateRangeFlags('2026-13-01', undefined))
+      .toThrow('month or day out of range')
+  })
+
+  it('throws on day out of range for month', () => {
+    expect(() => parseDateRangeFlags('2026-02-30', undefined))
+      .toThrow('month or day out of range')
+  })
+
   it('same day is valid (start midnight, end 23:59:59)', () => {
     const range = parseDateRangeFlags('2026-04-10', '2026-04-10')
     expect(range).not.toBeNull()


### PR DESCRIPTION
## Summary

Follow-up to #80, which introduced `parseLocalDate`. The regex-only
validation there accepts structurally valid but semantically invalid
dates like `2026-13-45` or `2026-02-30`. The `Date` constructor
silently rolls them forward into a different valid date, so `--from` /
`--to` then produce a misleading `"must not be after"` error instead
of rejecting the input.

## Fix

After constructing the `Date`, compare the round-tripped
`year / month / day` back to the parsed numbers. If they diverge,
throw a clear `"month or day out of range"` error.

## Before

```
$ codeburn report --from 2026-13-45
Error: --from must not be after --to (got 2026-13-45 > undefined)
```

## After

```
$ codeburn report --from 2026-13-45
Error: Invalid date "2026-13-45": month or day out of range

$ codeburn report --from 2026-02-30
Error: Invalid date "2026-02-30": month or day out of range
```

## Tests

Two new cases in `tests/date-range-filter.test.ts` cover month and day
overflow. Full file 10/10 green.