### PR TITLE
test(day-aggregator): drop Z suffix so firstTimestamp test is timezone-stable

### DIFF
--- a/tests/day-aggregator.test.ts
+++ b/tests/day-aggregator.test.ts
@@ -135,8 +135,8 @@ describe('aggregateProjectsIntoDays', () => {
         sessions: [{
           sessionId: 's1',
           project: 'p',
-          firstTimestamp: '2026-04-09T23:59:00Z',
-          lastTimestamp: '2026-04-10T00:10:00Z',
+          firstTimestamp: '2026-04-09T23:59:00',
+          lastTimestamp: '2026-04-10T00:10:00',
           totalCostUSD: 1,
           totalInputTokens: 0, totalOutputTokens: 0, totalCacheReadTokens: 0, totalCacheWriteTokens: 0,
           apiCalls: 0,


### PR DESCRIPTION
## Summary

`tests/day-aggregator.test.ts > counts a session under its
firstTimestamp date` feeds `'2026-04-09T23:59:00Z'` into `dateKey()`.
`dateKey` reads local-time fields off the `Date` (which is correct
after the switch to local daily bucketing). In any UTC+ timezone that
input resolves to `2026-04-10 01:59` local, and the assertion
`date === '2026-04-09'` fails for every contributor east of UTC while
passing on CI and for US-based runs.

## Fix

Drop the `Z`. ISO strings without a timezone designator are parsed as
local time by `new Date`, so 23:59 on `2026-04-09` stays on
`2026-04-09` everywhere. The test still exercises the boundary-date
bucketing intent (`firstTimestamp` at 23:59, `lastTimestamp` crosses
midnight) but no longer depends on the runner's timezone.

## Verification

Full suite: 274/274 green in UTC+2 (was 273/274 before).