### PR TITLE
Show per-model token counts in TUI

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -267,19 +267,21 @@ function ProjectBreakdown({ projects, pw, bw, budgets }: { projects: ProjectSumm
 }
 
 const MODEL_COL_COST = 8
+const MODEL_COL_TOKENS = 8
 const MODEL_COL_CACHE = 7
 const MODEL_COL_CALLS = 7
 const MODEL_NAME_WIDTH = 14
 
 function ModelBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; pw: number; bw: number }) {
-  const modelTotals: Record<string, { calls: number; costUSD: number; freshInput: number; cacheRead: number; cacheWrite: number }> = {}
+  const modelTotals: Record<string, { calls: number; costUSD: number; freshInput: number; output: number; cacheRead: number; cacheWrite: number }> = {}
   for (const project of projects) {
     for (const session of project.sessions) {
       for (const [model, data] of Object.entries(session.modelBreakdown)) {
-        if (!modelTotals[model]) modelTotals[model] = { calls: 0, costUSD: 0, freshInput: 0, cacheRead: 0, cacheWrite: 0 }
+        if (!modelTotals[model]) modelTotals[model] = { calls: 0, costUSD: 0, freshInput: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
         modelTotals[model].calls += data.calls
         modelTotals[model].costUSD += data.costUSD
         modelTotals[model].freshInput += data.tokens.inputTokens
+        modelTotals[model].output += data.tokens.outputTokens
         modelTotals[model].cacheRead += data.tokens.cacheReadInputTokens
         modelTotals[model].cacheWrite += data.tokens.cacheCreationInputTokens
       }
@@ -290,16 +292,19 @@ function ModelBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; pw: 
 
   return (
     <Panel title="By Model" color={PANEL_COLORS.model} width={pw}>
-      <Text dimColor wrap="truncate-end">{''.padEnd(bw + 1 + MODEL_NAME_WIDTH)}{'cost'.padStart(MODEL_COL_COST)}{'cache'.padStart(MODEL_COL_CACHE)}{'calls'.padStart(MODEL_COL_CALLS)}</Text>
+      <Text dimColor wrap="truncate-end">{''.padEnd(bw + 1 + MODEL_NAME_WIDTH)}{'cost'.padStart(MODEL_COL_COST)}{'tokens'.padStart(MODEL_COL_TOKENS)}{'cache'.padStart(MODEL_COL_CACHE)}{'calls'.padStart(MODEL_COL_CALLS)}</Text>
       {sorted.map(([model, data], i) => {
         const totalInput = data.freshInput + data.cacheRead + data.cacheWrite
+        const totalTokens = totalInput + data.output
         const cacheHit = totalInput > 0 ? (data.cacheRead / totalInput) * 100 : 0
         const cacheLabel = totalInput > 0 ? `${cacheHit.toFixed(1)}%` : '-'
+        const tokensLabel = totalTokens > 0 ? formatTokens(totalTokens) : '-'
         return (
           <Text key={`${model}-${i}`} wrap="truncate-end">
             <HBar value={data.costUSD} max={maxCost} width={bw} />
             <Text> {fit(model, MODEL_NAME_WIDTH)}</Text>
             <Text color={GOLD}>{formatCost(data.costUSD).padStart(MODEL_COL_COST)}</Text>
+            <Text>{tokensLabel.padStart(MODEL_COL_TOKENS)}</Text>
             <Text>{cacheLabel.padStart(MODEL_COL_CACHE)}</Text>
             <Text>{String(data.calls).padStart(MODEL_COL_CALLS)}</Text>
           </Text>

--- a/src/format.ts
+++ b/src/format.ts
@@ -8,6 +8,7 @@ import { formatCost } from './currency.js'
 export { formatCost }
 
 export function formatTokens(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
   return n.toString()

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
-import { formatCost } from '../src/format.js'
-import type { ProjectSummary, SessionSummary } from '../src/types.js'
+import { formatCost, formatTokens } from '../src/format.js'
+import type { ProjectSummary, SessionSummary, TokenUsage } from '../src/types.js'
 
 const EMPTY_CATEGORY_BREAKDOWN = {
   coding: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
@@ -108,5 +108,115 @@ describe('avg/s in ProjectBreakdown', () => {
     const sessions = [makeSession('s1', 2.0), makeSession('s2', 4.0)]
     const project = makeProject('proj', sessions)
     expect(avgCostLabel(project)).toBe(formatCost(3.0))
+  })
+})
+
+function zeroTokens(): TokenUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    cachedInputTokens: 0,
+    reasoningTokens: 0,
+    webSearchRequests: 0,
+  }
+}
+
+function aggregateModelTotals(projects: ProjectSummary[]) {
+  const totals: Record<string, { calls: number; costUSD: number; freshInput: number; output: number; cacheRead: number; cacheWrite: number }> = {}
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      for (const [model, data] of Object.entries(session.modelBreakdown)) {
+        if (!totals[model]) totals[model] = { calls: 0, costUSD: 0, freshInput: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+        totals[model].calls += data.calls
+        totals[model].costUSD += data.costUSD
+        totals[model].freshInput += data.tokens.inputTokens
+        totals[model].output += data.tokens.outputTokens
+        totals[model].cacheRead += data.tokens.cacheReadInputTokens
+        totals[model].cacheWrite += data.tokens.cacheCreationInputTokens
+      }
+    }
+  }
+  return totals
+}
+
+describe('formatTokens - size suffixes', () => {
+  it('formats billions with B suffix', () => {
+    expect(formatTokens(4_810_000_000)).toBe('4.81B')
+  })
+
+  it('formats millions with M suffix', () => {
+    expect(formatTokens(168_400_000)).toBe('168.4M')
+  })
+
+  it('formats thousands with K suffix', () => {
+    expect(formatTokens(23_500)).toBe('23.5K')
+  })
+
+  it('returns bare number for values under 1000', () => {
+    expect(formatTokens(0)).toBe('0')
+    expect(formatTokens(999)).toBe('999')
+  })
+})
+
+describe('ModelBreakdown - token aggregation', () => {
+  it('sums token fields across sessions and projects for a model', () => {
+    const session: SessionSummary = {
+      ...makeSession('s1', 10),
+      modelBreakdown: {
+        'Opus 4.6': {
+          calls: 5,
+          costUSD: 10,
+          tokens: {
+            ...zeroTokens(),
+            inputTokens: 1000,
+            outputTokens: 2000,
+            cacheReadInputTokens: 3_000_000,
+            cacheCreationInputTokens: 500_000,
+          },
+        },
+      },
+    }
+    const session2: SessionSummary = {
+      ...makeSession('s2', 5),
+      modelBreakdown: {
+        'Opus 4.6': {
+          calls: 3,
+          costUSD: 5,
+          tokens: {
+            ...zeroTokens(),
+            inputTokens: 500,
+            outputTokens: 1000,
+            cacheReadInputTokens: 1_000_000,
+            cacheCreationInputTokens: 200_000,
+          },
+        },
+      },
+    }
+    const project = makeProject('proj', [session, session2])
+    const totals = aggregateModelTotals([project])
+    const opus = totals['Opus 4.6']
+    expect(opus.calls).toBe(8)
+    expect(opus.freshInput).toBe(1500)
+    expect(opus.output).toBe(3000)
+    expect(opus.cacheRead).toBe(4_000_000)
+    expect(opus.cacheWrite).toBe(700_000)
+    const totalTokens = opus.freshInput + opus.output + opus.cacheRead + opus.cacheWrite
+    expect(formatTokens(totalTokens)).toBe('4.7M')
+  })
+
+  it('shows dash when a model has zero tokens recorded', () => {
+    const session: SessionSummary = {
+      ...makeSession('s1', 1),
+      modelBreakdown: {
+        'Empty Model': { calls: 1, costUSD: 1, tokens: zeroTokens() },
+      },
+    }
+    const totals = aggregateModelTotals([makeProject('proj', [session])])
+    const empty = totals['Empty Model']
+    const totalTokens = empty.freshInput + empty.output + empty.cacheRead + empty.cacheWrite
+    const label = totalTokens > 0 ? formatTokens(totalTokens) : '-'
+    expect(label).toBe('-')
   })
 })


### PR DESCRIPTION
## Summary

Surfaces per-model token totals in the `By Model` panel of the interactive dashboard. The token data (input, output, cacheRead, cacheWrite) was already computed in `session.modelBreakdown.tokens` and exposed in `codeburn report --format json`, but not rendered in the TUI. This adds a single compact `tokens` column between `cost` and `cache`.

- `formatTokens` extended to emit a `B` suffix for values at or above 1e9 so per-model cache totals (typically multi-billion) render as e.g. `4.09B` instead of overflowing.
- `ModelBreakdown` now aggregates `outputTokens` in addition to the existing input/cacheRead/cacheWrite, and shows the sum per row.
- Zero-token rows display `-` rather than `0`.

## Before / After

Before (no tokens column):

```
│ By Model                                                 │
│                              cost  cache  calls          │
│ ██████████ Opus 4.6       $879.94  96.1%   4817          │
│ ████░░░░░░ Opus 4.7       $373.89  94.8%   2325          │
```

After:

```
│ By Model                                                 │
│                              cost  tokens  cache  calls  │
│ ██████████ Opus 4.6       $879.94   1.14B  96.1%   4817  │
│ ████░░░░░░ Opus 4.7       $373.89  432.7M  94.8%   2325  │
│ █░░░░░░░░░ Sonnet 4.6      $93.68  156.3M  93.4%   3126  │
│ ░░░░░░░░░░ Haiku 4.5        $4.42   23.4M  92.8%    259  │
│ ░░░░░░░░░░ <synthetic>    $0.0000       -      -      1  │
```

## Test plan

- [x] `npm run build` succeeds
- [x] `npx vitest run` passes (244/244, 6 new tests covering `formatTokens` B suffix and the per-model aggregation)
- [x] `npx tsx src/cli.ts` rendered and visually checked at 80, 120, and 160 column widths
- [x] Period switching (1-5) still re-renders the panel correctly
- [x] Zero-token rows show `-`, not `0.00K`