### PR TITLE
chore: add firstlook PR-author reputation check

### DIFF
--- a/.github/workflows/firstlook.yml
+++ b/.github/workflows/firstlook.yml
@@ -1,0 +1,16 @@
+name: firstlook
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  assess:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: getagentseal/firstlook@main
+        with:
+          skip-users: 'dependabot[bot],renovate[bot]'
+          fail-on: 'unknown'


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs \`getagentseal/firstlook@main\` on every pull_request open/reopen/synchronize. The action assigns a reputation score to the PR author; this config fails the check when the score is \`unknown\` so drive-by PRs from freshly-minted or untracked accounts need manual review before they can be merged.

Rules for this workflow:
- \`skip-users: dependabot[bot], renovate[bot]\` so bots pass through
- \`fail-on: unknown\` blocks unknown-score accounts (strictest setting short of \`caution\`)
- Permissions scoped to \`pull-requests: write\` and \`contents: read\`

Context: PR #118 earlier today was a drive-by from a 42-day-old automation account with 928 repos. Manually spotting that takes time. This screens it at the workflow level instead.