### PR TITLE
chore: enable firstlook workflow_dispatch for backlog scans

### DIFF
--- a/.github/workflows/firstlook.yml
+++ b/.github/workflows/firstlook.yml
@@ -2,6 +2,12 @@ name: firstlook
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number to scan (leave empty for all open PRs)'
+        required: false
+        type: string
 
 jobs:
   assess:
@@ -12,5 +18,6 @@ jobs:
     steps:
       - uses: getagentseal/firstlook@main
         with:
+          pr-number: ${{ inputs.pr-number }}
           skip-users: 'dependabot[bot],renovate[bot]'
           fail-on: 'unknown'


### PR DESCRIPTION
Adds `workflow_dispatch` trigger to the firstlook workflow with a `pr-number` input so existing open PRs can be scanned without requiring a new push to each branch.

Usage after merge:
- Go to Actions tab, pick firstlook, click Run workflow
- Leave `pr-number` empty to assess every open PR in one run
- Supply a specific PR number to rescan just that one

The pull_request trigger for new opens / reopens / synchronizes is unchanged.