### PR TITLE
fix(menubar): drop prefetchAll to keep Today label fresh

### DIFF
--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -89,15 +89,6 @@ final class AppStore {
         }
     }
 
-    /// Prefetch all periods so tab switching is instant. Skips any period already cached.
-    func prefetchAll() async {
-        for period in Period.allCases {
-            let key = PayloadCacheKey(period: period, provider: .all)
-            if cache[key] != nil { continue }
-            await refreshQuietly(period: period)
-        }
-    }
-
     /// Background refresh for a period other than the visible one (e.g. keeping today fresh for the menubar badge).
     /// Does not toggle isLoading, so the popover's loading overlay is unaffected.
     /// Always uses the .all provider since the menubar badge shows total spend.

--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -88,14 +88,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             }
         }
 
-        // Prefetch the remaining periods in a detached task. This used to be awaited inside the
-        // refresh loop, but on large corpora the All Time / Month period can take 60+ seconds to
-        // parse and blocked Today's refresh for that whole window, so the status label drifted
-        // out of sync with the CLI until prefetchAll finally returned.
-        Task { @MainActor [weak self] in
-            guard let s = self else { return }
-            await s.store.prefetchAll()
-        }
+        // Period tabs are fetched lazily when the user first clicks them in the popover.
+        // An earlier version prefetched every period on launch to make tab switching instant,
+        // but on large session corpora that spawned four concurrent codeburn subprocesses
+        // competing with the main refresh loop for disk and parser time, and the status label
+        // drifted stale for minutes. A per-tab first-click cost of a few seconds is the better
+        // tradeoff on user machines that track thousands of sessions.
     }
 
     private func observeStore() {


### PR DESCRIPTION
After shipping 0.8.5, the menubar still drifted stale on large session corpora. Root cause: the detached \`prefetchAll\` task spawns four \`codeburn\` subprocesses (week, 30days, month, all) that compete with the main refresh loop's Today fetch for disk and parser. On 5,000+ file corpora this queued the Today refresh behind slow parallel work, and the label could freeze for minutes at a time. Clicking a provider tab in the popover coincided with the queue clearing, so it looked like the click unstuck things.

This drops the prefetch entirely. Period tabs now fetch lazily when the user first clicks them in the popover, paying a 3-10 second cost once per app lifetime per period. Today's label stays fresh because nothing else is hammering the parser in the background.

Tradeoff: tab switching is no longer instant on the first click after launch. Second click onward is instant (in-memory cache). The previous behaviour regressed Today freshness, which is the more important of the two.

Follow-up to PR #119 commit \`2467578\` (which detached prefetch from the refresh loop but kept the contention).