### PR TITLE
fix(menubar): force status bar redraw and lift subprocess QoS

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -158,6 +158,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             attributes: [.font: font, .foregroundColor: color]
         ))
         button.attributedTitle = composed
+        // Force immediate redraw. NSStatusItem sometimes defers the status bar paint for an
+        // accessory app that is not foreground, so the label visually freezes until the user
+        // opens the popover (which triggers NSApp.activate + a forced redraw cycle).
+        button.needsDisplay = true
+        button.display()
     }
 
     // MARK: - Popover

--- a/mac/Sources/CodeBurnMenubar/Security/CodeburnCLI.swift
+++ b/mac/Sources/CodeBurnMenubar/Security/CodeburnCLI.swift
@@ -41,6 +41,11 @@ enum CodeburnCLI {
         // `env --` treats everything following as argv, not VAR=val pairs -- guards against an
         // argument accidentally resembling an env assignment.
         process.arguments = ["--"] + baseArgv() + subcommand
+        // The menubar runs as an accessory app with no foreground window, and macOS
+        // background-throttles accessory apps and their children. Without this lift the
+        // codeburn subprocess parses 5-10x slower than the same command run from a
+        // user-interactive terminal, which starves the 15s refresh cadence on large corpora.
+        process.qualityOfService = .userInitiated
         return process
     }
 


### PR DESCRIPTION
After 0.8.5's prefetchAll removal the menubar still looked stuck: the label would freeze for a minute or more at a time, and only refreshed at the moment the user clicked the icon to open the popover. Two causes, both fixed here.

1. The status bar does not always paint \`attributedTitle\` changes immediately for an accessory app that is not foreground. Adding \`needsDisplay = true\` and \`display()\` after each update forces the paint every cycle. Opening the popover used to be the only thing that triggered a redraw because \`NSApp.activate\` ran as a side effect of the click handler.

2. The \`codeburn\` subprocess inherited the accessory app's default QualityOfService. macOS background-throttles accessory apps and their children. On measurement a user-interactive terminal runs the same command in 0.75 seconds, and the throttled version can be 5-10x slower, which overruns the 15s poll cadence. Setting \`process.qualityOfService = .userInitiated\` in \`CodeburnCLI.makeProcess\` keeps the subprocess at terminal speed.

Local \`swift build\` clean.