### PR TITLE
fix(menubar): opt out of App Nap so refresh loop keeps ticking

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -30,10 +30,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private let store = AppStore()
     let updateChecker = UpdateChecker()
     private var refreshTask: Task<Void, Never>?
+    /// Held for the lifetime of the app to opt out of App Nap and Automatic Termination.
+    /// Without this the 15s refresh Task gets suspended whenever the user is interacting with
+    /// another app, and the status bar label freezes until they click the menubar icon (which
+    /// calls NSApp.activate and wakes the app back up).
+    private var backgroundActivity: NSObjectProtocol?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Menubar accessory -- no Dock icon, no app switcher entry.
         NSApp.setActivationPolicy(.accessory)
+
+        backgroundActivity = ProcessInfo.processInfo.beginActivity(
+            options: [.userInitiated, .automaticTerminationDisabled, .suddenTerminationDisabled],
+            reason: "CodeBurn menubar polls AI coding cost every 15 seconds while idle in the background."
+        )
 
         restorePersistedCurrency()
         setupStatusItem()


### PR DESCRIPTION
Root cause of the stuck-menubar-label / only-refreshes-on-click behaviour that survived the prefetchAll removal and the status-bar redraw fix.

Confirmed in the system log: \`_kLSApplicationWouldBeTerminatedByTALKey=1\` flips on a few seconds after the menubar icon goes idle. That is Automatic Termination / App Nap declaring the app a suspend candidate, which stretches the 15-second \`Task.sleep\` in the refresh loop indefinitely. Clicking the menubar icon calls \`NSApp.activate\` which wakes the app, the pending Tasks resume, the cache refreshes, the label updates. Matches the symptom exactly.

Fix: hold a \`ProcessInfo.beginActivity\` token with \`.userInitiated\`, \`.automaticTerminationDisabled\`, \`.suddenTerminationDisabled\` for the life of the app. Released automatically when the app quits.

Net change 8 lines. Swift build clean.