### PR TITLE
chore: bump to 0.8.7, align CLI and menubar release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.8.7 - 2026-04-21
+
+### Added
+- **MiniMax-M2.7 and MiniMax-M2.7-highspeed pricing.** Added to `FALLBACK_PRICING` plus display names so MiniMax sessions show up with the right cost and readable labels when users route MiniMax through providers like OpenCode. Rates verified against MiniMax's live paygo pricing: base model $0.3/M input, $1.2/M output; highspeed $0.6/M input, $2.4/M output; cache read $0.06/M, cache write $0.375/M on both.
+
+### Fixed (macOS menubar, shipped alongside via mac-v0.8.7)
+- **Menubar label froze in the background and only refreshed when you clicked the icon.** Three independent causes fixed:
+  - `prefetchAll` on launch spawned four concurrent `codeburn` subprocesses that competed with the main refresh loop for disk and parser time. Removed; period tabs now fetch lazily on first click.
+  - `NSStatusItem` sometimes deferred the status bar paint for an accessory app, so `attributedTitle` updates hit memory but not the screen until the popover opened. Explicit `needsDisplay` + `display()` after each update forces the paint.
+  - **The real root cause:** macOS App Nap / Automatic Termination was suspending the app whenever the icon sat idle in the background, stretching the 15-second refresh Task's sleep indefinitely. Holding a `ProcessInfo.beginActivity` token for the life of the app opts out. Confirmed via `log show`: `_kLSApplicationWouldBeTerminatedByTALKey` now stays at 0.
+- Subprocess `QualityOfService` lifted to `.userInitiated` so `codeburn` runs at terminal speed when spawned from the menubar.
+
+### Skipped
+- 0.8.6 was never published to npm. The version was briefly planned and then skipped to align CLI and macOS menubar versioning at 0.8.7.
+
+### Notes
+- CLI behaviour is identical to 0.8.5 aside from the MiniMax pricing addition. If you are on 0.8.5 and do not use MiniMax, you can safely stay there.
+- macOS menubar users on `mac-v0.8.6` or earlier should update: the refresh loop only ticks reliably from `mac-v0.8.7` onward. The in-app update pill surfaces within 2 days, or quit and re-run `npx codeburn menubar` to pull immediately.
+
 ## 0.8.5 - 2026-04-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeburn",
-  "version": "0.8.5",
+  "version": "0.8.7",
   "description": "See where your AI coding tokens go - by task, tool, model, and project",
   "type": "module",
   "main": "./dist/cli.js",


### PR DESCRIPTION
Bumps the CLI to 0.8.7 so it ships alongside \`mac-v0.8.7\` with matching version numbers. 0.8.6 is intentionally skipped on npm.

Contents of this release:

**CLI (ships via \`npm publish codeburn@0.8.7\`)**
- MiniMax-M2.7 and MiniMax-M2.7-highspeed pricing added to \`FALLBACK_PRICING\` plus display names (PR #120 already merged)

**macOS menubar (ships via \`mac-v0.8.7\` tag + \`.github/workflows/release-menubar.yml\`)**
- PR #123: drop \`prefetchAll\` so the main refresh loop is not starved by background period prefetch subprocesses
- PR #125: force status bar redraw + lift subprocess \`qualityOfService\` to \`.userInitiated\`
- PR #126 (the actual root cause): opt out of App Nap via \`ProcessInfo.beginActivity\` so the refresh Task's 15-second sleep does not stretch indefinitely while the icon sits idle in the background. Verified locally: status label now updates on cadence for 10+ minutes of background idle.

CHANGELOG entry explains the Skipped-0.8.6 decision and notes that CLI-only users on 0.8.5 can stay there if they don't use MiniMax.