### PR TITLE
docs: backfill 0.8.7 changelog with OMP provider and model-alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 - **MiniMax-M2.7 and MiniMax-M2.7-highspeed pricing.** Added to `FALLBACK_PRICING` plus display names so MiniMax sessions show up with the right cost and readable labels when users route MiniMax through providers like OpenCode. Rates verified against MiniMax's live paygo pricing: base model $0.3/M input, $1.2/M output; highspeed $0.6/M input, $2.4/M output; cache read $0.06/M, cache write $0.375/M on both.
+- **OMP provider (Oh My Pi).** Auto-discovers sessions at `~/.omp/agent/sessions/*.jsonl` and tracks them alongside Pi. Shares Pi's JSONL parser via a `providerName` parameter, so OMP rows keep their own `omp:` dedup prefix and never cross-dedupe with Pi on a shared `conversationId` namespace. `codeburn report --provider omp` filters to OMP only; the default combined view includes both. Contributed by @cgrossde (#59).
+- **`codeburn model-alias` command.** Maps any provider-emitted model name to a canonical pricing name so cost rows no longer read `$0.00` when a proxy rewrites names. Aliases persist in `~/.config/codeburn/config.json` under `modelAliases`. Usage: `codeburn model-alias <from> <to>` to set, `--list` to view, `--remove <from>` to clear. User aliases resolve before the built-in list. Contributed by @cgrossde (#59).
+- **Built-in aliases for Anthropic-compatible proxy format.** `anthropic--claude-4.6-opus`, `anthropic--claude-4.6-sonnet`, `anthropic--claude-4.5-opus`, `anthropic--claude-4.5-sonnet`, and `anthropic--claude-4.5-haiku` now resolve to canonical Claude names and price correctly with no user configuration. `getCanonicalName` also strips `provider/` prefixes before alias resolution so double-wrapped forms like `anthropic/anthropic--claude-4.6-opus` work the same way. Contributed by @cgrossde (#59).
+
+### Fixed (CLI)
+- **Prototype pollution in alias resolution.** A model literally named `__proto__` leaked `Object.prototype` through the `??` fallback chain in `resolveAlias`, which then crashed `canonical.startsWith` downstream. The resolver now uses `Object.hasOwn` checks for both user and built-in alias maps. Caught by the existing prototype-pollution test suite during the #59 merge.
 
 ### Fixed (macOS menubar, shipped alongside via mac-v0.8.7)
 - **Menubar label froze in the background and only refreshed when you clicked the icon.** Three independent causes fixed:
@@ -16,7 +22,7 @@
 - 0.8.6 was never published to npm. The version was briefly planned and then skipped to align CLI and macOS menubar versioning at 0.8.7.
 
 ### Notes
-- CLI behaviour is identical to 0.8.5 aside from the MiniMax pricing addition. If you are on 0.8.5 and do not use MiniMax, you can safely stay there.
+- If you are on 0.8.5 and do not use MiniMax, Oh My Pi, or a proxy that rewrites model names to the `anthropic--claude-X.Y-tier` format, CLI behavior is unchanged and you can safely stay on 0.8.5.
 - macOS menubar users on `mac-v0.8.6` or earlier should update: the refresh loop only ticks reliably from `mac-v0.8.7` onward. The in-app update pill surfaces within 2 days, or quit and re-run `npx codeburn menubar` to pull immediately.
 
 ## 0.8.5 - 2026-04-21


### PR DESCRIPTION
## Context

PR #59 (OMP provider + model-alias) merged to main at commit ac31883. The 0.8.7 version bump commit cb44cc6 landed after that, so the code ships in 0.8.7, but the initial 0.8.7 changelog entry only covered MiniMax pricing and the macOS menubar fixes. This PR backfills the missing entries before 0.8.7 hits npm.

## Changes

- Adds three entries under \`### Added\` for 0.8.7: OMP provider, \`codeburn model-alias\` command, built-in Anthropic proxy aliases
- Adds one entry under a new \`### Fixed (CLI)\` section: prototype-pollution guard in \`resolveAlias\`
- Rewrites the CLI parity note in \`### Notes\` so users on 0.8.5 know whether the 0.8.7 upgrade actually matters to them

## Verification

- CHANGELOG.md only; no code or test changes
- Reads cleanly as a single 0.8.7 release note