### PR TITLE
fix: switch scanJsonlFile and parseSessionFile to readSessionLines to prevent OOM

### DIFF
--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -4,7 +4,7 @@ import { existsSync, statSync } from 'fs'
 import { basename, join } from 'path'
 import { homedir } from 'os'
 
-import { readSessionFile, readSessionFileSync } from './fs-utils.js'
+import { readSessionLines, readSessionFileSync } from './fs-utils.js'
 import { discoverAllSessions } from './providers/index.js'
 import type { DateRange, ProjectSummary } from './types.js'
 import { formatCost } from './currency.js'
@@ -224,9 +224,6 @@ export async function scanJsonlFile(
   dateRange: DateRange | undefined,
   recentCutoffMs = Date.now() - RECENT_WINDOW_MS,
 ): Promise<ScanFileResult> {
-  const content = await readSessionFile(filePath)
-  if (content === null) return { calls: [], cwds: [], apiCalls: [], userMessages: [] }
-
   const calls: ToolCall[] = []
   const cwds: string[] = []
   const apiCalls: ApiCallMeta[] = []
@@ -234,7 +231,7 @@ export async function scanJsonlFile(
   const sessionId = basename(filePath, '.jsonl')
   let lastVersion = ''
 
-  for (const line of content.split('\n')) {
+  for await (const line of readSessionLines(filePath)) {
     if (!line.trim()) continue
     let entry: Record<string, unknown>
     try { entry = JSON.parse(line) } catch { continue }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,6 @@
 import { readdir, stat } from 'fs/promises'
 import { basename, join } from 'path'
-import { readSessionFile } from './fs-utils.js'
+import { readSessionLines } from './fs-utils.js'
 import { calculateCost, getShortModelName } from './models.js'
 import { discoverAllSessions, getProvider } from './providers/index.js'
 import type { ParsedProviderCall } from './providers/types.js'
@@ -275,15 +275,16 @@ async function parseSessionFile(
       if (s.mtimeMs < dateRange.start.getTime()) return null
     } catch { /* fall through to normal read; missing stat shouldn't break parsing */ }
   }
-  const content = await readSessionFile(filePath)
-  if (content === null) return null
-  const lines = content.split('\n').filter(l => l.trim())
   const entries: JournalEntry[] = []
+  let hasLines = false
 
-  for (const line of lines) {
+  for await (const line of readSessionLines(filePath)) {
+    hasLines = true
     const entry = parseJsonlLine(line)
     if (entry) entries.push(entry)
   }
+
+  if (!hasLines) return null
 
   if (entries.length === 0) return null
 

--- a/tests/optimize-fs.test.ts
+++ b/tests/optimize-fs.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterAll, beforeEach, vi } from 'vitest'
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import * as fsUtils from '../src/fs-utils.js'
 
 vi.mock('os', async () => {
   const actual = await vi.importActual<typeof import('os')>('os')
@@ -311,6 +312,40 @@ describe('scanJsonlFile', () => {
     writeFile(filePath, 'this is not json\n{broken\n{"type":"assistant","message":{"content":[]}}\n')
     const result = await scanJsonlFile(filePath, 'p1', undefined)
     expect(result.calls).toEqual([])
+  })
+
+  it('uses readSessionLines (streaming) rather than readSessionFile (full-string load)', async () => {
+    const readSessionLinesSpy = vi.spyOn(fsUtils, 'readSessionLines')
+    const readSessionFileSpy = vi.spyOn(fsUtils, 'readSessionFile')
+    const root = makeFixtureRoot()
+    const filePath = join(root, 'session.jsonl')
+    const now = new Date().toISOString()
+    writeFile(filePath, JSON.stringify({
+      type: 'assistant', timestamp: now,
+      message: { content: [{ type: 'tool_use', name: 'Bash', input: {} }] },
+    }))
+    await scanJsonlFile(filePath, 'p1', undefined)
+    expect(readSessionLinesSpy).toHaveBeenCalledWith(filePath)
+    expect(readSessionFileSpy).not.toHaveBeenCalled()
+    readSessionLinesSpy.mockRestore()
+    readSessionFileSpy.mockRestore()
+  })
+
+  it('processes all entries in a large multi-line file without truncation', async () => {
+    const root = makeFixtureRoot()
+    const filePath = join(root, 'session.jsonl')
+    const now = new Date().toISOString()
+    const ENTRY_COUNT = 500
+    const lines = Array.from({ length: ENTRY_COUNT }, (_, i) =>
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: now,
+        message: { content: [{ type: 'tool_use', name: 'Read', input: { file_path: `/file-${i}.ts` } }] },
+      }),
+    )
+    writeFile(filePath, lines.join('\n'))
+    const result = await scanJsonlFile(filePath, 'p1', undefined)
+    expect(result.calls).toHaveLength(ENTRY_COUNT)
   })
 
   it('respects date-range filter for assistant entries', async () => {


### PR DESCRIPTION
Fixes #131

## Problem

`readViaStream` (the code path for files ≥ 8 MB introduced in #67) reassembles the entire file into a single string via `chunks.join('\n')`, giving the same peak allocation as a plain `readFile`. Callers then do `content.split('\n')`, creating a second full copy. With `FILE_READ_CONCURRENCY = 16` and files up to 128 MB, theoretical peak heap usage is ~6 GB — right where the crash lands:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
...
v8::internal::JsonParser<unsigned short>::ParseJson
```

## Fix

`readSessionLines` already exists in `src/fs-utils.ts` as a proper async generator that yields one line at a time and never holds the full file in memory. This PR switches the two hot-path callers to iterate it directly:

- `scanJsonlFile` in `src/optimize.ts`
- `parseSessionFile` in `src/parser.ts`

No concurrency change needed — with true line-by-line streaming, 16 concurrent files each hold only one line at a time.

## Tests

Two new tests added to `tests/optimize-fs.test.ts`:

- **Spy test** — confirms `readSessionLines` is called and `readSessionFile` is not called by `scanJsonlFile`
- **500-entry correctness test** — verifies all entries in a large multi-line file are processed without truncation

## Checklist

- [x] `npm run build` passes
- [x] `npm test` passes (323 tests, 0 failures)
- [x] No Claude/Anthropic co-author trailers in commits