### PR TITLE
Fix crash on timeframe switch with duplicate dates

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Views/FindingsSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/FindingsSection.swift
@@ -225,7 +225,7 @@ private func computeHistoryStats(history: [DailyHistoryEntry]) -> HistoryStats {
     }()
     let now = Date()
     let today = calendar.startOfDay(for: now)
-    let costByDate = Dictionary(uniqueKeysWithValues: history.map { ($0.date, $0.cost) })
+    let costByDate = Dictionary(history.map { ($0.date, $0.cost) }, uniquingKeysWith: +)
 
     let lastWeekStart = calendar.date(byAdding: .day, value: -6, to: today)
     let priorWeekStart = calendar.date(byAdding: .day, value: -13, to: today)

--- a/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
@@ -399,7 +399,7 @@ private func buildTrendBars(from days: [DailyHistoryEntry]) -> [TrendBar] {
         f.timeZone = .current
         return f
     }()
-    let entryByDate = Dictionary(uniqueKeysWithValues: days.map { ($0.date, $0) })
+    let entryByDate = Dictionary(days.map { ($0.date, $0) }, uniquingKeysWith: { _, new in new })
     let today = calendar.startOfDay(for: Date())
     let todayKey = formatter.string(from: today)
 
@@ -837,7 +837,7 @@ private func computeAllStats(payload: MenubarPayload) -> AllStats {
         peakDaySpend = "—"
     }
 
-    let costByDate = Dictionary(uniqueKeysWithValues: history.map { ($0.date, $0.cost) })
+    let costByDate = Dictionary(history.map { ($0.date, $0.cost) }, uniquingKeysWith: +)
 
     var currentStreak = 0
     for offset in 0..<400 {


### PR DESCRIPTION
Fixes #138

## Summary
- Replace `Dictionary(uniqueKeysWithValues:)` with `uniquingKeysWith` in three places
- Prevents assertion failure when history data contains duplicate dates (multiple providers)

## Changes
- `FindingsSection.swift`: sum costs for duplicate dates
- `HeatmapSection.swift`: sum costs and keep latest entry for duplicate dates