### PR TITLE
Add claude-max-5x preset for $100/month tier

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, mkdir, rename } from 'fs/promises'
 import { join } from 'path'
 import { homedir } from 'os'
 
-export type PlanId = 'claude-pro' | 'claude-max' | 'cursor-pro' | 'custom' | 'none'
+export type PlanId = 'claude-pro' | 'claude-max' | 'claude-max-5x' | 'cursor-pro' | 'custom' | 'none'
 export type PlanProvider = 'claude' | 'codex' | 'cursor' | 'all'
 
 export type Plan = {

--- a/src/plans.ts
+++ b/src/plans.ts
@@ -1,9 +1,9 @@
 import type { Plan, PlanId, PlanProvider } from './config.js'
 
 export const PLAN_PROVIDERS: PlanProvider[] = ['all', 'claude', 'codex', 'cursor']
-export const PLAN_IDS: PlanId[] = ['claude-pro', 'claude-max', 'cursor-pro', 'custom', 'none']
+export const PLAN_IDS: PlanId[] = ['claude-pro', 'claude-max', 'claude-max-5x', 'cursor-pro', 'custom', 'none']
 
-export const PRESET_PLANS: Record<'claude-pro' | 'claude-max' | 'cursor-pro', Omit<Plan, 'setAt'>> = {
+export const PRESET_PLANS: Record<'claude-pro' | 'claude-max' | 'claude-max-5x' | 'cursor-pro', Omit<Plan, 'setAt'>> = {
   'claude-pro': {
     id: 'claude-pro',
     monthlyUsd: 20,
@@ -13,6 +13,12 @@ export const PRESET_PLANS: Record<'claude-pro' | 'claude-max' | 'cursor-pro', Om
   'claude-max': {
     id: 'claude-max',
     monthlyUsd: 200,
+    provider: 'claude',
+    resetDay: 1,
+  },
+  'claude-max-5x': {
+    id: 'claude-max-5x',
+    monthlyUsd: 100,
     provider: 'claude',
     resetDay: 1,
   },
@@ -44,7 +50,9 @@ export function planDisplayName(id: PlanId): string {
     case 'claude-pro':
       return 'Claude Pro'
     case 'claude-max':
-      return 'Claude Max'
+      return 'Claude Max 20x'
+    case 'claude-max-5x':
+      return 'Claude Max 5x'
     case 'cursor-pro':
       return 'Cursor Pro'
     case 'custom':


### PR DESCRIPTION
Adds support for Claude Max 5x tier ($100/month) alongside existing Max 20x ($200/month).

- New preset: `claude-max-5x`
- Updated display name: `claude-max` → "Claude Max 20x"

Usage: `codeburn plan set claude-max-5x`

Closes #141