### PR TITLE
Fix NSStatusItem not rendering on macOS Tahoe (26.x)

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -33,7 +33,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var backgroundActivity: NSObjectProtocol?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        NSApp.setActivationPolicy(.accessory)
+        // On macOS Tahoe (26.x), accessory apps may fail to render their status item
+        // if the activation policy is set before the status item is created. Starting
+        // as a regular app and switching to accessory after setup works around this.
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
 
         ProcessInfo.processInfo.automaticTerminationSupportEnabled = false
         ProcessInfo.processInfo.disableSuddenTermination()
@@ -45,6 +49,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         restorePersistedCurrency()
         setupStatusItem()
         setupPopover()
+
+        // Switch to accessory policy after status item is set up to hide from Dock
+        DispatchQueue.main.async {
+            NSApp.setActivationPolicy(.accessory)
+        }
         observeStore()
         startRefreshLoop()
         setupWakeObservers()
@@ -239,10 +248,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private func setupStatusItem() {
         statusItem = NSStatusBar.system.statusItem(withLength: statusItemWidth)
         guard let button = statusItem.button else { return }
+
+        // Set a simple SF Symbol image immediately to ensure the status item renders.
+        // On macOS Tahoe, status items may fail to appear if only an attributed title
+        // is set during initial setup.
+        let flameConfig = NSImage.SymbolConfiguration(pointSize: menubarTitleFontSize, weight: .medium)
+        let flame = NSImage(systemSymbolName: "flame.fill", accessibilityDescription: "CodeBurn")?
+            .withSymbolConfiguration(flameConfig)
+        flame?.isTemplate = true
+        button.image = flame
+        button.imagePosition = .imageLeading
+
         button.target = self
         button.action = #selector(handleButtonClick(_:))
         button.sendAction(on: [.leftMouseUp, .rightMouseUp])
-        refreshStatusButton()
+
+        // Defer the full attributed title setup to ensure initial render completes
+        DispatchQueue.main.async { [weak self] in
+            self?.refreshStatusButton()
+        }
     }
 
     /// Composes the menubar title as a single attributed string with the flame as an inline


### PR DESCRIPTION
## Summary
- Fix menubar icon not appearing on macOS 26.4+ (Tahoe)
- Start as `.regular` app, activate, set simple image first, then switch to `.accessory`
- Workaround for window server registration issue on newer macOS

## Problem
On macOS 26.4.1 Tahoe, the status item draw code executes but nothing renders in the menu bar. The app process runs, no crashes, but the icon is invisible.

## Solution
1. Start as `.regular` app and call `activate()` to ensure window server registration
2. Set a simple SF Symbol image immediately on the status button
3. Defer the attributed title update to ensure initial render completes
4. Switch to `.accessory` policy after setup to hide from Dock

## Test plan
- [ ] Verify menubar icon appears on macOS Tahoe (26.4+)
- [ ] Verify icon still works on macOS 14/15
- [ ] Verify app hides from Dock after launch

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)