### PR TITLE
Fix Codex provider to detect file edits from patch_apply_end events

### DIFF
--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -183,6 +183,11 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           continue
         }
 
+        if (entry.type === 'event_msg' && entry.payload?.type === 'patch_apply_end') {
+          pendingTools.push('Edit')
+          continue
+        }
+
         if (entry.type === 'response_item' && entry.payload?.type === 'message' && entry.payload?.role === 'user') {
           const texts = (entry.payload.content ?? [])
             .filter(c => c.type === 'input_text')


### PR DESCRIPTION
## Summary
- Fix Codex edit detection showing 0 edit turns despite actual file changes
- Detect `patch_apply_end` events as Edit tool usage
- Enables proper calculation of one-shot rates, retry rates for Codex sessions

## Problem
Codex records file modifications as `event_msg` entries with `type: patch_apply_end` rather than `function_call` tool invocations like `write_file`. The provider was only looking for tool calls, missing all the actual edits.

## Solution
Track `patch_apply_end` events and add "Edit" to the tools list when detected.

## Test plan
- [x] Verified locally: Codex now shows Edit: 29 calls
- [x] Coding 1-shot rate now shows 100% instead of "-"
- [ ] Run `codeburn compare` with Codex model to verify metrics