### PR TITLE
Fix compare chart bar colors to always match legend

### DIFF
--- a/src/compare.tsx
+++ b/src/compare.tsx
@@ -273,14 +273,14 @@ function ComparisonResults({ modelA, modelB, rows, categories, workingStyle, onB
                 <Text color={DIM}>{'  '}{cat.category}</Text>
                 <Text>
                   <Text>{'  '}</Text>
-                  <Text color={cat.winner === 'a' ? BAR_A : DIM}>{FULL_BLOCK.repeat(Math.max(bwA, 1))}</Text>
+                  <Text color={BAR_A}>{FULL_BLOCK.repeat(Math.max(bwA, 1))}</Text>
                   <Text>{' '.repeat(Math.max(0, BAR_MAX_WIDTH - bwA))} </Text>
                   <Text color={cat.winner === 'a' ? GREEN : undefined}>{rateA.padStart(6)}</Text>
                   <Text color={DIM}> {turnsA}</Text>
                 </Text>
                 <Text>
                   <Text>{'  '}</Text>
-                  <Text color={cat.winner === 'b' ? BAR_B : DIM}>{FULL_BLOCK.repeat(Math.max(bwB, 1))}</Text>
+                  <Text color={BAR_B}>{FULL_BLOCK.repeat(Math.max(bwB, 1))}</Text>
                   <Text>{' '.repeat(Math.max(0, BAR_MAX_WIDTH - bwB))} </Text>
                   <Text color={cat.winner === 'b' ? GREEN : undefined}>{rateB.padStart(6)}</Text>
                   <Text color={DIM}> {turnsB}</Text>


### PR DESCRIPTION
## Summary
- Bars now always show their assigned colors (blue for model A, green for model B)
- Only the winner's percentage value is highlighted in green
- Fixes confusing display where non-winning bars were grayed out despite legend showing colors

## Before
Non-winning model's bar showed gray, contradicting the color legend

## After
Both bars show their legend colors; winner's percentage highlighted