### PR TITLE
fix(security): strip ANSI escapes from session-derived bash commands (#153 — gap 1)

### DIFF
--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -1,0 +1,17 @@
+/// Removes ANSI escape sequences from strings sourced from session JSONL before they're
+/// rendered by the dashboard / CLI / JSON export. The regex below covers CSI (`ESC [`),
+/// OSC (`ESC ]`), and other 7-bit / 8-bit control sequences as defined by ECMA-48 — same
+/// shape used by the well-known `ansi-regex` package, kept inline here to avoid a direct
+/// dependency. Any non-string input is passed through unchanged.
+
+const ANSI_PATTERN = new RegExp(
+  [
+    '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))',
+  ].join('|'),
+  'g',
+)
+
+export function stripAnsi(input: string): string {
+  return input.replace(ANSI_PATTERN, '')
+}

--- a/src/bash-utils.ts
+++ b/src/bash-utils.ts
@@ -1,12 +1,18 @@
 import { basename } from 'path'
 
+import { stripAnsi } from './ansi.js'
+
 function stripQuotedStrings(command: string): string {
   return command.replace(/"[^"]*"|'[^']*'/g, match => ' '.repeat(match.length))
 }
 
-export function extractBashCommands(command: string): string[] {
-  if (!command || !command.trim()) return []
+export function extractBashCommands(rawCommand: string): string[] {
+  if (!rawCommand || !rawCommand.trim()) return []
 
+  // Bash inputs in session JSONL can carry ANSI escape sequences (terminal pastes,
+  // colorized command-line snippets). Stripping here keeps `bashBreakdown` keys
+  // and any other downstream display free of raw escape codes.
+  const command = stripAnsi(rawCommand)
   const stripped = stripQuotedStrings(command)
 
   const separatorRegex = /\s*(?:&&|;|\|)\s*/g

--- a/tests/ansi.test.ts
+++ b/tests/ansi.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+
+import { stripAnsi } from '../src/ansi.js'
+
+describe('stripAnsi', () => {
+  it('removes basic SGR colour codes', () => {
+    expect(stripAnsi('[31mred[0m')).toBe('red')
+    expect(stripAnsi('[1;33mwarn[0m')).toBe('warn')
+  })
+
+  it('removes 256-color and truecolor codes', () => {
+    expect(stripAnsi('[38;5;208mfg[0m[48;2;10;20;30mbg[0m')).toBe('fgbg')
+  })
+
+  it('removes cursor-movement sequences', () => {
+    expect(stripAnsi('top[2Aleft[5D')).toBe('topleft')
+  })
+
+  it('removes OSC hyperlink sequences (ESC ] … BEL)', () => {
+    expect(stripAnsi(']8;;https://example.orgclicky]8;;')).toBe('clicky')
+  })
+
+  it('removes 8-bit CSI introducer (\\u009B)', () => {
+    expect(stripAnsi('31mred0m')).toBe('red')
+  })
+
+  it('leaves non-ANSI input untouched', () => {
+    expect(stripAnsi('npm install --save')).toBe('npm install --save')
+    expect(stripAnsi('')).toBe('')
+    expect(stripAnsi('emoji 🔥 ok')).toBe('emoji 🔥 ok')
+  })
+})

--- a/tests/bash-commands.test.ts
+++ b/tests/bash-commands.test.ts
@@ -47,6 +47,11 @@ describe('extractBashCommands', () => {
     expect(extractBashCommands('  git   status  ')).toEqual(['git'])
   })
 
+  it('strips ANSI escape codes before extracting basenames (no escapes leak into bashBreakdown keys)', () => {
+    expect(extractBashCommands('[31mnpm[0m install')).toEqual(['npm'])
+    expect(extractBashCommands('[1;33mgit[0m status && [36mls[0m')).toEqual(['git', 'ls'])
+  })
+
   it('handles command with quotes containing separators', () => {
     expect(extractBashCommands('echo "hello && world"')).toEqual(['echo'])
   })


### PR DESCRIPTION
## Summary

Addresses gap **#1** of #153 ("ANSI escapes in session JSONL render raw in the dashboard. Add strip-ansi to displayed strings.").

Bash command strings extracted from session JSONL feed `bashBreakdown` keys, which the dashboard (`src/dashboard.tsx`), CLI status (`src/cli.ts`), and JSON export all render directly. ANSI escapes in those strings (a paste of colorized terminal output, OSC hyperlinks, cursor-movement codes) currently render raw.

## Fix

- New `src/ansi.ts` with a self-contained `stripAnsi` (CSI / OSC / ECMA-48 patterns, no dependency added).
- `src/bash-utils.ts:extractBashCommands` strips ANSI before token splitting / basename extraction. This single chokepoint covers every caller — `parser.ts` (Claude), `providers/pi.ts`, `providers/opencode.ts`.

## Why a chokepoint, not per-caller

Stripping at `extractBashCommands` guarantees `bashBreakdown` keys are clean across every provider — Claude, Pi, OpenCode — without touching each one. New providers added later inherit the cleanup for free.

## Verification

- [x] Baseline: 355 pass, 0 fail
- [x] Post-fix: 362 pass, 0 fail (+6 ANSI unit tests, +1 bash-commands integration assertion)
- [x] New `bash-commands` test fails on the unfixed code (verified by stashing the fix and re-running — returned `["^[[31mnpm^[[0m"]` instead of `["npm"]`)
- [x] `npx tsc --noEmit` clean
- [x] No bracket-assign on `{}`-init maps in `src/parser.ts` or `src/providers/` (semgrep guard)

## Out of scope

Gap #2 from #153 (symlink protection in `walk` functions — `lstat`-based, skip symbolic links) is intentionally a separate PR for cleaner review.

## Files changed

| File | Change |
|---|---|
| `src/ansi.ts` | new — inline `stripAnsi` |
| `src/bash-utils.ts` | call `stripAnsi(rawCommand)` before parsing |
| `tests/ansi.test.ts` | new — 6 unit tests covering CSI / OSC / 8-bit CSI / passthrough |
| `tests/bash-commands.test.ts` | +1 test ensuring ANSI in inputs doesn't leak into basenames |

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
