### PR TITLE
fix(security): use lstat in claude session discovery to skip symlinks (#153 — gap 2)

### DIFF
--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -1,4 +1,4 @@
-import { readdir, stat } from 'fs/promises'
+import { lstat, readdir } from 'fs/promises'
 import { basename, join } from 'path'
 import { homedir } from 'os'
 
@@ -35,20 +35,24 @@ function getDesktopSessionsDir(): string {
 
 async function findDesktopProjectDirs(base: string): Promise<string[]> {
   const results: string[] = []
+  // `lstat` (not `stat`) so we never descend into symbolic links. A malicious or
+  // misconfigured session tree could otherwise redirect us anywhere on the filesystem
+  // the calling user can read — outside the Claude sessions sandbox by design.
   async function walk(dir: string, depth: number): Promise<void> {
     if (depth > 8) return
     const entries = await readdir(dir).catch(() => [])
     for (const entry of entries) {
       if (entry === 'node_modules' || entry === '.git') continue
       const full = join(dir, entry)
-      const s = await stat(full).catch(() => null)
-      if (!s?.isDirectory()) continue
+      const s = await lstat(full).catch(() => null)
+      if (!s || s.isSymbolicLink() || !s.isDirectory()) continue
       if (entry === 'projects') {
         const projectDirs = await readdir(full).catch(() => [])
         for (const pd of projectDirs) {
           const pdFull = join(full, pd)
-          const pdStat = await stat(pdFull).catch(() => null)
-          if (pdStat?.isDirectory()) results.push(pdFull)
+          const pdStat = await lstat(pdFull).catch(() => null)
+          if (!pdStat || pdStat.isSymbolicLink() || !pdStat.isDirectory()) continue
+          results.push(pdFull)
         }
       } else {
         await walk(full, depth + 1)
@@ -83,10 +87,9 @@ export const claude: Provider = {
       const entries = await readdir(projectsDir)
       for (const dirName of entries) {
         const dirPath = join(projectsDir, dirName)
-        const dirStat = await stat(dirPath).catch(() => null)
-        if (dirStat?.isDirectory()) {
-          sources.push({ path: dirPath, project: dirName, provider: 'claude' })
-        }
+        const dirStat = await lstat(dirPath).catch(() => null)
+        if (!dirStat || dirStat.isSymbolicLink() || !dirStat.isDirectory()) continue
+        sources.push({ path: dirPath, project: dirName, provider: 'claude' })
       }
     } catch {}
 

--- a/tests/providers/claude-symlink.test.ts
+++ b/tests/providers/claude-symlink.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm, symlink } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { claude } from '../../src/providers/claude.js'
+
+let tmpDir: string
+let claudeDir: string
+let realTarget: string
+let originalConfigDir: string | undefined
+let originalHome: string | undefined
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'claude-symlink-test-'))
+  claudeDir = join(tmpDir, 'claude-config')
+  realTarget = join(tmpDir, 'outside-the-sandbox')
+  await mkdir(join(claudeDir, 'projects'), { recursive: true })
+  await mkdir(realTarget, { recursive: true })
+  await writeFile(join(realTarget, 'sneaky.jsonl'), '{"type":"hello"}\n')
+
+  originalConfigDir = process.env['CLAUDE_CONFIG_DIR']
+  originalHome = process.env['HOME']
+  process.env['CLAUDE_CONFIG_DIR'] = claudeDir
+  process.env['HOME'] = tmpDir
+})
+
+afterEach(async () => {
+  if (originalConfigDir === undefined) delete process.env['CLAUDE_CONFIG_DIR']
+  else process.env['CLAUDE_CONFIG_DIR'] = originalConfigDir
+  if (originalHome === undefined) delete process.env['HOME']
+  else process.env['HOME'] = originalHome
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+describe('claude provider — symlink protection in session discovery', () => {
+  it('skips symbolic-link entries pointing outside the projects dir', async () => {
+    const realProjectDir = join(claudeDir, 'projects', 'real-project')
+    await mkdir(realProjectDir, { recursive: true })
+    await symlink(realTarget, join(claudeDir, 'projects', 'shady-link'))
+
+    const sources = await claude.discoverSessions()
+    const claudeSources = sources.filter(s => s.provider === 'claude')
+    const projects = claudeSources.map(s => s.project)
+
+    expect(projects).toContain('real-project')
+    expect(projects).not.toContain('shady-link')
+    for (const s of claudeSources) {
+      expect(s.path.startsWith(realTarget)).toBe(false)
+    }
+  })
+
+  it('still discovers regular project directories', async () => {
+    await mkdir(join(claudeDir, 'projects', 'plain'), { recursive: true })
+
+    const sources = await claude.discoverSessions()
+    const claudeSources = sources.filter(s => s.provider === 'claude')
+    const projects = claudeSources.map(s => s.project)
+
+    expect(projects).toContain('plain')
+  })
+})

--- a/tests/providers/claude-symlink.test.ts
+++ b/tests/providers/claude-symlink.test.ts
@@ -34,10 +34,20 @@ afterEach(async () => {
 })
 
 describe('claude provider — symlink protection in session discovery', () => {
-  it('skips symbolic-link entries pointing outside the projects dir', async () => {
+  it('skips symbolic-link entries pointing outside the projects dir', async ({ skip }) => {
     const realProjectDir = join(claudeDir, 'projects', 'real-project')
     await mkdir(realProjectDir, { recursive: true })
-    await symlink(realTarget, join(claudeDir, 'projects', 'shady-link'))
+    try {
+      const symlinkType = process.platform === 'win32' ? 'junction' : undefined
+      await symlink(realTarget, join(claudeDir, 'projects', 'shady-link'), symlinkType)
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code
+      if (code === 'EPERM' || code === 'EACCES') {
+        skip(`symlink creation not permitted in this environment (${code})`)
+        return
+      }
+      throw err
+    }
 
     const sources = await claude.discoverSessions()
     const claudeSources = sources.filter(s => s.provider === 'claude')


### PR DESCRIPTION
## Summary

Addresses gap **#2** of #153 ("Walk functions (providers/claude.ts) don't check for symlinks. Use lstat, skip symbolic links.").

`findDesktopProjectDirs` and `discoverSessions` in `src/providers/claude.ts` walk the session tree with `stat`, which transparently follows symbolic links. A symlink under `~/.claude/projects/` (or anywhere within the macOS / Linux / Windows Claude Desktop sessions trees) lets the walk descend to any path the calling user can read — outside the intended sandbox.

## Fix

Switch the imports from `stat` → `lstat` and explicitly skip symbolic links:

```ts
const s = await lstat(full).catch(() => null)
if (!s || s.isSymbolicLink() || !s.isDirectory()) continue
```

Regular directories behave identically; only symlinks are refused. Three call sites in `claude.ts`:
- top-level walk in `findDesktopProjectDirs`
- inner `projects/*` walk in `findDesktopProjectDirs`
- `~/.claude/projects/` walk in `discoverSessions`

## Verification

- [x] Baseline: 355 pass, 0 fail
- [x] Post-fix: 357 pass, 0 fail (+2 symlink tests, 0 regressions)
- [x] New `tests/providers/claude-symlink.test.ts` fails on the unfixed code (verified by stashing the fix and re-running — `'shady-link'` was discovered)
- [x] `npx tsc --noEmit` clean
- [x] No bracket-assign on `{}`-init maps in `src/parser.ts` or `src/providers/` (semgrep guard)

## Out of scope

Gap #1 of #153 (ANSI sanitization of displayed strings) is the companion PR.

The same `stat`-vs-`lstat` pattern exists in other providers (`pi`, `codex`, `copilot`). Per the issue text the symptom was reported in `providers/claude.ts`, and a single-provider PR is easier to review than a sweep. Happy to follow up across the other providers in a separate PR if you'd like.

## Files changed

| File | Change |
|---|---|
| `src/providers/claude.ts` | `stat` → `lstat`; explicit symlink skip at 3 call sites |
| `tests/providers/claude-symlink.test.ts` | new — symlink dropped, regular dir kept |

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
