### PR TITLE
fix(tests): use local-time timestamps in day-aggregator test

### DIFF
--- a/tests/day-aggregator.test.ts
+++ b/tests/day-aggregator.test.ts
@@ -135,8 +135,8 @@ describe('aggregateProjectsIntoDays', () => {
         sessions: [{
           sessionId: 's1',
           project: 'p',
-          firstTimestamp: '2026-04-09T23:59:00Z',
-          lastTimestamp: '2026-04-10T00:10:00Z',
+          firstTimestamp: '2026-04-09T23:59:00',
+          lastTimestamp: '2026-04-10T00:10:00',
           totalCostUSD: 1,
           totalInputTokens: 0, totalOutputTokens: 0, totalCacheReadTokens: 0, totalCacheWriteTokens: 0,
           apiCalls: 0,


### PR DESCRIPTION
The test used 2026-04-09T23:59:00Z (UTC) which falls on April 10th in timezones ahead of UTC, causing dateKey() to return the wrong date.

Drop the Z suffix so timestamps are parsed as local time, matching dateKey() which uses getDate() (local). The original midnight-boundary scenario is preserved.