### PR TITLE
Fix Cursor provider dropping data older than 35 days

### DIFF
--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -174,8 +174,8 @@ function parseBubbles(db: SqliteDatabase, seenKeys: Set<string>): { calls: Parse
   const results: ParsedProviderCall[] = []
   let skipped = 0
 
-  const DEFAULT_LOOKBACK_DAYS = 35
-  const timeFloor = new Date(Date.now() - DEFAULT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString()
+  const LOOKBACK_DAYS = 180
+  const timeFloor = new Date(Date.now() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString()
 
   const userMessages = buildUserMessageMap(db, timeFloor)
 


### PR DESCRIPTION
## Summary

- Increase the Cursor `parseBubbles` lookback from 35 to 180 days so longer period views (30-day, month, all) surface historical data
- The hardcoded 35-day floor silently dropped all bubbles older than 5 weeks, making `--period all` return $0
- NULL `createdAt` handling (OR IS NULL in SQL, fallback timestamp) was already fixed in 0.9.2
- Period scoping is handled downstream by `parseProviderSources`; the cursor-cache prevents repeated full DB scans

Fixes #159, fixes #163

## Test plan

- [x] 374 tests pass
- [x] TypeScript type check clean