### PR TITLE
VSCode: correctly locate workspaceStorage when working inside a dev container

### DIFF
--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -318,6 +318,7 @@ function getVSCodeWorkspaceStorageDirs(): string[] {
   return [
     join(homedir(), '.config', 'Code', 'User', 'workspaceStorage'),
     join(homedir(), '.config', 'Code - Insiders', 'User', 'workspaceStorage'),
+    join(homedir(), '.vscode-server', 'data', 'User', 'workspaceStorage'),
   ]
 }
 


### PR DESCRIPTION
In a dev container, the path used is:

```
/home/vscode/.vscode-server/data/User/workspaceStorage
```

In other words, the vscode configuration is stored under `~/.vscode-server/data` instead of `~/.config/Code`.