### PR TITLE
Fix timezone handling for non-UTC users

### DIFF
--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -174,7 +174,10 @@ final class AppStore {
     /// last 7 days of dailyHistory. Used as the "tokens consumed in 7-day window" reading paired
     /// with the API-reported percent for capacity estimation.
     private func effectiveTokensInLast7Days(history: [DailyHistoryEntry], asOf now: Date) -> Double {
-        let cutoff = ISO8601DateFormatter().string(from: now.addingTimeInterval(-7 * 86400)).prefix(10)
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = .current
+        let cutoff = f.string(from: now.addingTimeInterval(-7 * 86400))
         return history
             .filter { $0.date >= cutoff }
             .reduce(0.0) { $0 + $1.effectiveTokens }

--- a/mac/Sources/CodeBurnMenubar/Views/FindingsSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/FindingsSection.swift
@@ -213,11 +213,11 @@ private struct HistoryStats {
 
 private func computeHistoryStats(history: [DailyHistoryEntry]) -> HistoryStats {
     var calendar = Calendar(identifier: .gregorian)
-    calendar.timeZone = TimeZone(identifier: "UTC")!
+    calendar.timeZone = .current
     let formatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "yyyy-MM-dd"
-        f.timeZone = TimeZone(identifier: "UTC")
+        f.timeZone = .current
         return f
     }()
     let now = Date()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import { convertCost } from './currency.js'
 import { renderStatusBar } from './format.js'
 import { type PeriodData, type ProviderCost } from './menubar-json.js'
 import { buildMenubarPayload } from './menubar-json.js'
-import { getDaysInRange, ensureCacheHydrated, emptyCache, MS_PER_DAY, BACKFILL_DAYS, toDateString } from './daily-cache.js'
+import { getDaysInRange, ensureCacheHydrated, emptyCache, BACKFILL_DAYS, toDateString } from './daily-cache.js'
 import { aggregateProjectsIntoDays, buildPeriodDataFromDays, dateKey } from './day-aggregator.js'
 import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory } from './types.js'
 import { renderDashboard } from './dashboard.js'
@@ -141,8 +141,19 @@ const program = new Command()
   .description('See where your AI coding tokens go - by task, tool, model, and project')
   .version(version)
   .option('--verbose', 'print warnings to stderr on read failures and skipped files')
+  .option('--timezone <zone>', 'IANA timezone for date grouping (e.g. Asia/Tokyo, America/New_York)')
 
 program.hook('preAction', async (thisCommand) => {
+  const tz = thisCommand.opts<{ timezone?: string }>().timezone ?? process.env['CODEBURN_TZ']
+  if (tz) {
+    try {
+      Intl.DateTimeFormat(undefined, { timeZone: tz })
+    } catch {
+      console.error(`\n  Invalid timezone: "${tz}". Use an IANA timezone like "America/New_York" or "Asia/Tokyo".\n`)
+      process.exit(1)
+    }
+    process.env.TZ = tz
+  }
   const config = await readConfig()
   setModelAliases(config.modelAliases ?? {})
   if (thisCommand.opts<{ verbose?: boolean }>().verbose) {
@@ -383,7 +394,7 @@ program
       const periodInfo = getDateRange(opts.period)
       const now = new Date()
       const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-      const yesterdayStr = toDateString(new Date(todayStart.getTime() - MS_PER_DAY))
+      const yesterdayStr = toDateString(new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1))
       const isAllProviders = pf === 'all'
 
       const cache = await hydrateCache()
@@ -454,7 +465,7 @@ program
       // Cache stores per-provider cost+calls per day in DailyEntry.providers, so we can derive
       // a provider-filtered history without re-parsing. Tokens aren't broken down per provider
       // in the cache, so the filtered view shows zero tokens (heatmap/trend still works on cost).
-      const historyStartStr = toDateString(new Date(todayStart.getTime() - BACKFILL_DAYS * MS_PER_DAY))
+      const historyStartStr = toDateString(new Date(now.getFullYear(), now.getMonth(), now.getDate() - BACKFILL_DAYS))
       const allCacheDays = getDaysInRange(cache, historyStartStr, yesterdayStr)
       // Parse only today for history; historical days come from cache
       const todayRangeForHistory: DateRange = { start: todayStart, end: new Date() }

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -165,7 +165,7 @@ export async function ensureCacheHydrated(
   const now = new Date()
   const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
   const yesterdayEnd = new Date(todayStart.getTime() - 1)
-  const yesterdayStr = toDateString(new Date(todayStart.getTime() - MS_PER_DAY))
+  const yesterdayStr = toDateString(new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1))
 
   return withDailyCacheLock(async () => {
     let c = await loadDailyCache()
@@ -183,7 +183,7 @@ export async function ensureCacheHydrated(
           parseInt(c.lastComputedDate.slice(5, 7)) - 1,
           parseInt(c.lastComputedDate.slice(8, 10)) + 1
         )
-      : new Date(todayStart.getTime() - BACKFILL_DAYS * MS_PER_DAY)
+      : new Date(now.getFullYear(), now.getMonth(), now.getDate() - BACKFILL_DAYS)
 
     if (gapStart.getTime() <= yesterdayEnd.getTime()) {
       const gapRange: DateRange = { start: gapStart, end: yesterdayEnd }


### PR DESCRIPTION
## Summary

- **Menubar UTC bug**: `computeHistoryStats` in FindingsSection.swift hardcoded `TimeZone(identifier: "UTC")` and `effectiveTokensInLast7Days` in AppStore.swift used `ISO8601DateFormatter()` (UTC default). Both now use `.current` to match the CLI's local-timezone date keys. This caused streaks, week deltas, and projections to be off by a day for non-UTC users.
- **`--timezone` flag**: New global `--timezone <zone>` option (and `CODEBURN_TZ` env var) lets users override the system timezone for all date grouping. Sets `process.env.TZ` before any Date operations so all existing code works unchanged. Useful for Docker, CI, cron, or viewing data in a different timezone.
- **DST spring-forward fix**: Replaced `todayStart.getTime() - MS_PER_DAY` with `new Date(y, m, d - 1)` for yesterday/backfill computations. Subtracting 86400000ms from midnight skips a day on DST spring-forward (23-hour day).

## Test plan

- [x] `npx tsx src/cli.ts report --period today --format json --timezone Asia/Singapore` outputs correct local date
- [x] `npx tsx src/cli.ts report --period today --format json --timezone Asia/Seoul` outputs correct local date
- [x] `npx tsx src/cli.ts report --timezone InvalidZone` prints error and exits 1
- [x] `CODEBURN_TZ=Asia/Tokyo npx tsx src/cli.ts report --period today --format json` picks up env var
- [x] `npx tsc --noEmit` passes
- [x] `swift build` passes for menubar app

Fixes #184