### PR TITLE
fix(codex): read complete session_meta line during discovery

### DIFF
--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -1,4 +1,6 @@
-import { readdir, stat, open } from 'fs/promises'
+import { readdir, stat } from 'fs/promises'
+import { createReadStream } from 'fs'
+import { createInterface } from 'readline'
 import { basename, join } from 'path'
 import { homedir } from 'os'
 
@@ -70,21 +72,29 @@ function sanitizeProject(cwd: string): string {
 }
 
 async function readFirstLine(filePath: string): Promise<CodexEntry | null> {
-  let fh
+  // Codex CLI 0.128+ writes a session_meta line that can exceed 20 KB because
+  // it embeds the full base_instructions / system prompt. A fixed-size buffer
+  // would miss the trailing newline and reject the session as invalid.
+  // Stream the file via readline to read the first line regardless of length.
+  const stream = createReadStream(filePath, { encoding: 'utf-8' })
+  const rl = createInterface({ input: stream, crlfDelay: Infinity })
+  let firstLine: string | undefined
   try {
-    fh = await open(filePath, 'r')
-    const buf = Buffer.alloc(16384)
-    const { bytesRead } = await fh.read(buf, 0, 16384, 0)
-    if (bytesRead === 0) return null
-    const text = buf.toString('utf-8', 0, bytesRead)
-    const nl = text.indexOf('\n')
-    const line = nl >= 0 ? text.slice(0, nl) : text
-    if (!line.trim()) return null
-    return JSON.parse(line) as CodexEntry
+    for await (const line of rl) {
+      firstLine = line
+      break
+    }
   } catch {
     return null
   } finally {
-    await fh?.close()
+    rl.close()
+    stream.destroy()
+  }
+  if (!firstLine || !firstLine.trim()) return null
+  try {
+    return JSON.parse(firstLine) as CodexEntry
+  } catch {
+    return null
   }
 }
 

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -80,19 +80,21 @@ async function readFirstLine(filePath: string): Promise<CodexEntry | null> {
   // Codex CLI 0.128+ writes a session_meta line that can exceed 20 KB because
   // it embeds the full base_instructions / system prompt. A fixed-size buffer
   // would miss the trailing newline and reject the session as invalid.
-  // Stream the file via readline so we can read the first line regardless of
-  // length, with `end` capping the read to keep memory bounded.
+  // Stream the file via readline so we can read the first line up to
+  // FIRST_LINE_READ_CAP, which keeps memory bounded if the file has no newline.
   const stream = createReadStream(filePath, {
     encoding: 'utf-8',
     start: 0,
     end: FIRST_LINE_READ_CAP - 1,
   })
+  // Silence stream errors so a late read-ahead error after we've already
+  // returned the first line cannot escape as an unhandled 'error' event.
+  // readline's async iterator re-throws underlying stream errors (ENOENT,
+  // EACCES, etc.) on Node 16+, which the catch below handles for the cases
+  // that matter for validation.
+  stream.on('error', () => {})
   const rl = createInterface({ input: stream, crlfDelay: Infinity })
   let firstLine: string | undefined
-  // readline's async iterator re-throws underlying stream errors (ENOENT,
-  // EACCES, etc.) on Node 16+, which the catch below handles. Don't track a
-  // separate streamError flag: it can race with the read-ahead and reject a
-  // valid first line if a *later* chunk errors after we've already broken.
   try {
     for await (const line of rl) {
       firstLine = line

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -71,14 +71,26 @@ function sanitizeProject(cwd: string): string {
   return cwd.replace(/^\//, '').replace(/\//g, '-')
 }
 
+// Cap how many bytes we'll read while looking for the first newline. Real
+// Codex session_meta lines are ~22-27 KB; this leaves plenty of headroom while
+// keeping memory bounded if a corrupt file has no newline at all.
+const FIRST_LINE_READ_CAP = 1024 * 1024
+
 async function readFirstLine(filePath: string): Promise<CodexEntry | null> {
   // Codex CLI 0.128+ writes a session_meta line that can exceed 20 KB because
   // it embeds the full base_instructions / system prompt. A fixed-size buffer
   // would miss the trailing newline and reject the session as invalid.
-  // Stream the file via readline to read the first line regardless of length.
-  const stream = createReadStream(filePath, { encoding: 'utf-8' })
+  // Stream the file via readline so we can read the first line regardless of
+  // length, with `end` capping the read to keep memory bounded.
+  const stream = createReadStream(filePath, {
+    encoding: 'utf-8',
+    start: 0,
+    end: FIRST_LINE_READ_CAP - 1,
+  })
   const rl = createInterface({ input: stream, crlfDelay: Infinity })
   let firstLine: string | undefined
+  let streamError: unknown
+  stream.once('error', (err) => { streamError = err })
   try {
     for await (const line of rl) {
       firstLine = line
@@ -90,7 +102,7 @@ async function readFirstLine(filePath: string): Promise<CodexEntry | null> {
     rl.close()
     stream.destroy()
   }
-  if (!firstLine || !firstLine.trim()) return null
+  if (streamError || !firstLine || !firstLine.trim()) return null
   try {
     return JSON.parse(firstLine) as CodexEntry
   } catch {

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -89,8 +89,10 @@ async function readFirstLine(filePath: string): Promise<CodexEntry | null> {
   })
   const rl = createInterface({ input: stream, crlfDelay: Infinity })
   let firstLine: string | undefined
-  let streamError: unknown
-  stream.once('error', (err) => { streamError = err })
+  // readline's async iterator re-throws underlying stream errors (ENOENT,
+  // EACCES, etc.) on Node 16+, which the catch below handles. Don't track a
+  // separate streamError flag: it can race with the read-ahead and reject a
+  // valid first line if a *later* chunk errors after we've already broken.
   try {
     for await (const line of rl) {
       firstLine = line
@@ -102,7 +104,7 @@ async function readFirstLine(filePath: string): Promise<CodexEntry | null> {
     rl.close()
     stream.destroy()
   }
-  if (streamError || !firstLine || !firstLine.trim()) return null
+  if (!firstLine || !firstLine.trim()) return null
   try {
     return JSON.parse(firstLine) as CodexEntry
   } catch {

--- a/tests/providers/codex.test.ts
+++ b/tests/providers/codex.test.ts
@@ -123,6 +123,32 @@ describe('codex provider - session discovery', () => {
     expect(sessions).toHaveLength(1)
   })
 
+  it('accepts session_meta lines larger than 16 KB (Codex CLI 0.128+)', async () => {
+    // Codex CLI 0.128+ embeds the full base_instructions / system prompt in the
+    // first session_meta line, often pushing it past 20 KB. Regression guard
+    // against a fixed-size buffer in readFirstLine.
+    const bigPayload = JSON.stringify({
+      type: 'session_meta',
+      timestamp: '2026-05-02T00:00:00Z',
+      payload: {
+        cwd: '/Users/test/big',
+        originator: 'codex-tui',
+        session_id: 'sess-big',
+        model: 'gpt-5.5',
+        base_instructions: { text: 'x'.repeat(40_000) },
+      },
+    })
+    await writeSession(tmpDir, '2026-05-02', 'rollout-big.jsonl', [
+      bigPayload,
+      tokenCount({ last: { input: 100, output: 50 }, total: { total: 150 } }),
+    ])
+
+    const provider = createCodexProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.path).toContain('rollout-big.jsonl')
+  })
+
   it('skips files without codex session_meta', async () => {
     const [year, month, day] = '2026-04-14'.split('-')
     const sessionDir = join(tmpDir, 'sessions', year!, month!, day!)

--- a/tests/providers/codex.test.ts
+++ b/tests/providers/codex.test.ts
@@ -147,6 +147,43 @@ describe('codex provider - session discovery', () => {
     const sessions = await provider.discoverSessions()
     expect(sessions).toHaveLength(1)
     expect(sessions[0]!.path).toContain('rollout-big.jsonl')
+    // Confirm the large meta line was actually parsed (cwd extracted),
+    // not just that some path was registered.
+    expect(sessions[0]!.project).toBe('Users-test-big')
+  })
+
+  it('handles a session_meta line without trailing newline', async () => {
+    const [year, month, day] = '2026-05-02'.split('-')
+    const sessionDir = join(tmpDir, 'sessions', year!, month!, day!)
+    await mkdir(sessionDir, { recursive: true })
+    // Write a single session_meta line, deliberately without a trailing \n.
+    await writeFile(
+      join(sessionDir, 'rollout-no-nl.jsonl'),
+      JSON.stringify({
+        type: 'session_meta',
+        timestamp: '2026-05-02T00:00:00Z',
+        payload: {
+          cwd: '/Users/test/nonl',
+          originator: 'codex-tui',
+          session_id: 'sess-nonl',
+          model: 'gpt-5.5',
+        },
+      }),
+    )
+    const provider = createCodexProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.project).toBe('Users-test-nonl')
+  })
+
+  it('returns no sessions for an empty rollout file', async () => {
+    const [year, month, day] = '2026-05-02'.split('-')
+    const sessionDir = join(tmpDir, 'sessions', year!, month!, day!)
+    await mkdir(sessionDir, { recursive: true })
+    await writeFile(join(sessionDir, 'rollout-empty.jsonl'), '')
+    const provider = createCodexProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toHaveLength(0)
   })
 
   it('skips files without codex session_meta', async () => {

--- a/tests/providers/codex.test.ts
+++ b/tests/providers/codex.test.ts
@@ -176,6 +176,45 @@ describe('codex provider - session discovery', () => {
     expect(sessions[0]!.project).toBe('Users-test-nonl')
   })
 
+  it('handles a session_meta line that spans multiple stream chunks', async () => {
+    // createReadStream defaults to a 64 KiB highWaterMark, so a >64 KiB first
+    // line forces readline to assemble the line across chunk boundaries.
+    const bigPayload = JSON.stringify({
+      type: 'session_meta',
+      timestamp: '2026-05-02T00:00:00Z',
+      payload: {
+        cwd: '/Users/test/multichunk',
+        originator: 'codex-tui',
+        session_id: 'sess-multichunk',
+        model: 'gpt-5.5',
+        base_instructions: { text: 'y'.repeat(120_000) },
+      },
+    })
+    await writeSession(tmpDir, '2026-05-02', 'rollout-multichunk.jsonl', [
+      bigPayload,
+      tokenCount({ last: { input: 100, output: 50 }, total: { total: 150 } }),
+    ])
+    const provider = createCodexProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.project).toBe('Users-test-multichunk')
+  })
+
+  it('rejects truncated/torn first-line writes without throwing', async () => {
+    // Simulate a partial write where Codex started the session_meta object
+    // but hasn't flushed the rest yet (no closing brace, no newline).
+    const [year, month, day] = '2026-05-02'.split('-')
+    const sessionDir = join(tmpDir, 'sessions', year!, month!, day!)
+    await mkdir(sessionDir, { recursive: true })
+    await writeFile(
+      join(sessionDir, 'rollout-torn.jsonl'),
+      '{"type":"session_meta","timestamp":"2026-05-02T00:00:00Z","payload":{"cwd":"/x","originator":"codex-tui","session_id":"s","model":"gpt',
+    )
+    const provider = createCodexProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toHaveLength(0)
+  })
+
   it('returns no sessions for an empty rollout file', async () => {
     const [year, month, day] = '2026-05-02'.split('-')
     const sessionDir = join(tmpDir, 'sessions', year!, month!, day!)


### PR DESCRIPTION
## Problem

Codex sessions created with **Codex CLI 0.128+** whose first `session_meta` line exceeds 16 KB are silently excluded from totals. Symptom: the Codex tab in the menubar (and `codeburn report --provider codex`) shows €0 / 0 calls for "today" while an active Codex session has been running for hours.

## Root cause

`readFirstLine` (in `src/providers/codex.ts`) allocates a fixed 16 KB buffer:

```ts
const buf = Buffer.alloc(16384)
const { bytesRead } = await fh.read(buf, 0, 16384, 0)
...
const nl = text.indexOf('\n')
const line = nl >= 0 ? text.slice(0, nl) : text
```

Codex CLI 0.128+ writes the full `base_instructions` / system prompt inside the `session_meta` line, which now runs **22–27 KB** in practice. The 16 KB read never reaches a newline, the partial buffer fails `JSON.parse`, `readFirstLine` returns `null`, and `isValidCodexSession` rejects the file in `discoverSessionsInDir`. Affected sessions never reach the parser. (Cached sessions bypass discovery, which is why historical data stays intact.)

Concrete reproduction on my machine (Codex CLI 0.128.0):

```
sessions/2026/04/28/  → 30 .jsonl files
                       28 with first-line 22-27 KB  → silently dropped
                       2  with first-line ~7 KB     → parsed normally
~/.cache/codeburn/codex-results.json contains exactly those 2.
```

After this patch on the same data:
- 30-day Codex total: **€267 → €878** (the missing half was real spend)
- Today: **€0 / 0 calls → €17 / 188 calls** (the active 14 MB session is now counted)

## Fix

Stream the file via `readline` so the first line is read up to a 1 MiB cap, comfortably handling the current 22–27 KB Codex `session_meta` lines while still bounding memory if a malformed file ever has no newline:

```ts
const FIRST_LINE_READ_CAP = 1024 * 1024

const stream = createReadStream(filePath, {
  encoding: 'utf-8',
  start: 0,
  end: FIRST_LINE_READ_CAP - 1,
})
const rl = createInterface({ input: stream, crlfDelay: Infinity })
for await (const line of rl) { firstLine = line; break }
```

This avoids hardcoding any new buffer size that would break again the next time Codex grows its system prompt. `readline`'s async iterator re-throws underlying stream errors on Node 16+, so a missing/unreadable file falls through the existing `catch` block.

## Tests

Added in `tests/providers/codex.test.ts`:

- `accepts session_meta lines larger than 16 KB (Codex CLI 0.128+)` — 40 KB `base_instructions.text`; asserts both discovery and that `project` was correctly extracted from the long line. Fails on `main`.
- `handles a session_meta line that spans multiple stream chunks` — 120 KB line forces readline to assemble the line across `createReadStream`'s default 64 KiB highWaterMark.
- `handles a session_meta line without trailing newline` — single-line rollout file with no `\n` at EOF is still accepted.
- `rejects truncated/torn first-line writes without throwing` — partial mid-write payload is silently skipped.
- `returns no sessions for an empty rollout file` — explicit guard.

Full suite (`npx vitest run`) passes (419/419).

## Risk

- `readline` is already used elsewhere in the codebase (`src/fs-utils.ts` `readViaStream`).
- No change to parser semantics, model resolution, or cost calculation.
- Read window capped at 1 MiB per discovery validation; real Codex `session_meta` lines are 22–27 KB, ~40× headroom.