### PR TITLE
Fix streaming dedup: keep last message.id occurrence for accurate tokens and tools

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -121,6 +121,30 @@ function parseApiCall(entry: JournalEntry): ParsedApiCall | null {
   }
 }
 
+function dedupeStreamingMessageIds(entries: JournalEntry[]): JournalEntry[] {
+  const firstIdxById = new Map<string, number>()
+  const lastIdxById = new Map<string, number>()
+  for (let i = 0; i < entries.length; i++) {
+    const id = getMessageId(entries[i]!)
+    if (!id) continue
+    if (!firstIdxById.has(id)) firstIdxById.set(id, i)
+    lastIdxById.set(id, i)
+  }
+  if (lastIdxById.size === 0) return entries
+  const result: JournalEntry[] = []
+  for (let i = 0; i < entries.length; i++) {
+    const id = getMessageId(entries[i]!)
+    if (id && lastIdxById.get(id) !== i) continue
+    if (id && firstIdxById.get(id) !== i) {
+      const firstTs = entries[firstIdxById.get(id)!]!.timestamp
+      result.push({ ...entries[i]!, timestamp: firstTs ?? entries[i]!.timestamp })
+      continue
+    }
+    result.push(entries[i]!)
+  }
+  return result
+}
+
 function groupIntoTurns(entries: JournalEntry[], seenMsgIds: Set<string>): ParsedTurn[] {
   const turns: ParsedTurn[] = []
   let currentUserMessage = ''
@@ -291,7 +315,8 @@ async function parseSessionFile(
   if (entries.length === 0) return null
 
   const sessionId = basename(filePath, '.jsonl')
-  let turns = groupIntoTurns(entries, seenMsgIds)
+  const dedupedEntries = dedupeStreamingMessageIds(entries)
+  let turns = groupIntoTurns(dedupedEntries, seenMsgIds)
   if (dateRange) {
     // Bucket a turn by the timestamp of its first assistant call (when the cost was
     // actually incurred). Filtering entries directly produced orphan assistant calls


### PR DESCRIPTION
## Summary

- Claude Code writes the same `message.id` multiple times during streaming (message_start, intermediate, message_stop)
- Old parser kept the **first** occurrence (partial: 1 output token, 0 tool_use blocks)
- New parser keeps the **last** occurrence (authoritative: real token counts, all tool_use/MCP blocks) but preserves the first timestamp for date bucketing

## Validation (4 agents, 21,390 real session files)

| Metric | Finding |
|---|---|
| Sessions affected | 40.5% of all files have duplicate message IDs |
| Output tokens | +6.3% increase (was undercounted) |
| Cost | +0.77% increase |
| Tool counts | ~50% of tools were invisible (only in last occurrence) |
| MCP tools | 100% were dropped (playwright, context7, sequential_thinking) |
| Cross-midnight timestamps | 2 real cases where wrong timestamp would bucket cost to wrong day |

## Before/After comparison (6 days, Claude only)

```
Date       | ccusage Out  | Before Out   | After Out    | Fix Delta
2026-04-27 |       57,015 |       57,569 |       58,796 |       +1,227
2026-04-28 |       37,859 |       38,575 |       41,183 |       +2,608
2026-04-29 |      820,522 |      819,252 |      902,037 |      +82,785
2026-04-30 |    2,084,720 |    2,086,109 |    2,167,857 |      +81,748
2026-05-01 |      847,510 |      846,121 |      854,175 |       +8,054
2026-05-02 |      313,781 |      311,896 |      398,355 |      +86,459
TOTALS     |    4,161,407 |    4,159,522 |    4,422,403 |     +262,881
```

Old codeburn matched ccusage within 0.05% because both had the same keep-first bug.

## Scope

Only affects Claude Code session parsing. Other providers (Gemini, Cursor, Goose, etc.) have their own parsers and are unaffected.

Closes #110