### PR TITLE
Stream-parse Codex session files to fix oversize-cap drops on heavy users

### DIFF
--- a/src/fs-utils.ts
+++ b/src/fs-utils.ts
@@ -8,6 +8,13 @@ import { createInterface } from 'readline'
 export const MAX_SESSION_FILE_BYTES = 128 * 1024 * 1024
 export const STREAM_THRESHOLD_BYTES = 8 * 1024 * 1024
 
+// Line-by-line streaming has bounded memory (one line at a time) and is not
+// constrained by V8's string limit, so it can safely handle multi-GB session
+// files. The cap here is purely a sanity check against pathological inputs;
+// real Codex sessions for heavy users have been observed at 250+ MB and will
+// continue to grow as context windows expand.
+export const MAX_STREAM_SESSION_FILE_BYTES = 2 * 1024 * 1024 * 1024
+
 function verbose(): boolean {
   return process.env.CODEBURN_VERBOSE === '1'
 }
@@ -78,8 +85,10 @@ export async function* readSessionLines(filePath: string): AsyncGenerator<string
     return
   }
 
-  if (size > MAX_SESSION_FILE_BYTES) {
-    warn(`skipped oversize file ${filePath} (${size} bytes > cap ${MAX_SESSION_FILE_BYTES})`)
+  if (size > MAX_STREAM_SESSION_FILE_BYTES) {
+    warn(
+      `skipped oversize file ${filePath} (${size} bytes > stream cap ${MAX_STREAM_SESSION_FILE_BYTES})`,
+    )
     return
   }
 

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -4,7 +4,7 @@ import { createInterface } from 'readline'
 import { basename, join } from 'path'
 import { homedir } from 'os'
 
-import { readSessionFile } from '../fs-utils.js'
+import { readSessionLines } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
 import { readCachedCodexResults, writeCachedCodexResults, getCachedCodexProject, fingerprintFile } from '../codex-cache.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
@@ -201,9 +201,6 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       const fp = await fingerprintFile(source.path)
       if (!fp) return
 
-      const content = await readSessionFile(source.path)
-      if (content === null) return
-      const lines = content.split('\n').filter(l => l.trim())
       let sessionModel: string | undefined
       let sessionId = ''
       let prevCumulativeTotal = 0
@@ -215,9 +212,18 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       let pendingUserMessage = ''
       let pendingOutputChars = 0
       let estCounter = 0
+      let sawAnyLine = false
       const results: ParsedProviderCall[] = []
 
-      for (const line of lines) {
+      // Stream the session file line by line. Heavy Codex sessions can exceed
+      // 250 MB on disk; reading the entire file into a string would either hit
+      // the readSessionFile cap or push V8 toward its 512 MB string limit
+      // after split('\n'). readSessionLines streams via readline so memory
+      // stays bounded to the longest line.
+      for await (const rawLine of readSessionLines(source.path)) {
+        sawAnyLine = true
+        const line = rawLine.trim()
+        if (!line) continue
         let entry: CodexEntry
         try {
           entry = JSON.parse(line) as CodexEntry
@@ -390,6 +396,11 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           pendingOutputChars = 0
         }
       }
+
+      // If the stream yielded nothing the file was unreadable, oversized, or
+      // empty. Skip cache write so a transient failure can't pin an empty
+      // result set against a fingerprint that would otherwise be re-parsed.
+      if (!sawAnyLine) return
 
       await writeCachedCodexResults(source.path, source.project, results, fp)
 


### PR DESCRIPTION
## Context

Follow-up to #204. After installing 0.9.6 from Homebrew, both fixes from that issue (16 KB read cap + `info: null` estimation) work as advertised on my account. However, while testing with `--verbose` I noticed that one of my recent rollout files was being silently dropped:

```
codeburn: skipped oversize file /Users/.../sessions/2026/05/03/rollout-...jsonl
  (259470209 bytes > cap 134217728)
```

The session is **247 MB** in a single `.jsonl` file. `MAX_SESSION_FILE_BYTES = 128 MB` in `src/fs-utils.ts` rejects it before any parsing happens, so the entire session disappears from the dashboard with no on-screen indication unless the user explicitly passes `--verbose`.

Heavy users on long-running Codex sessions (large file contents in context, multi-hour coding pushes) hit this in practice.

## Why bumping the cap isn't enough

The Codex provider reads the file in full via `readSessionFile` and then does `content.split('\n')`. `split` roughly doubles the high-water memory while the new array of line strings is being built, so even with `readViaStream` keeping the read itself bounded, we'd push V8 toward its ~512 MB string limit on a single 250 MB session.

`readSessionLines` already exists in `fs-utils.ts` as the streaming counterpart and is used by `readFirstLine`. Memory there is bounded to one line at a time, which is what we want for full-file parsing too.

## Changes

**`src/fs-utils.ts`** — introduce `MAX_STREAM_SESSION_FILE_BYTES = 2 GB` and apply it in `readSessionLines` instead of the full-read cap. The smaller `MAX_SESSION_FILE_BYTES` (128 MB) stays in place for the two consumers that materialize the whole file (`readSessionFile`, `readSessionFileSync`), where the V8 string limit is still a real constraint.

**`src/providers/codex.ts`** — replace

```ts
const content = await readSessionFile(source.path)
if (content === null) return
const lines = content.split('\n').filter(l => l.trim())
for (const line of lines) { ... }
```

with

```ts
let sawAnyLine = false
for await (const rawLine of readSessionLines(source.path)) {
  sawAnyLine = true
  const line = rawLine.trim()
  if (!line) continue
  ...
}
if (!sawAnyLine) return  // preserves early-return on read failure
```

The `sawAnyLine` guard means a failed/oversized/empty stream still skips the cache write, so a transient read failure can't pin an empty result set against a fingerprint that would otherwise be re-parsed on the next run.

## Empirical impact

On my account with one 247 MB rollout file in the 7-day window:

| | Before (0.9.6 stock) | After this PR | Δ |
|---|---|---|---|
| Cost | €358.69 | **€550.67** | +€191.98 |
| Calls | 4,536 | **6,111** | +1,575 |
| Sessions | 61 | **62** | +1 |
| Input tokens | 20.1 M | **37.3 M** | +17.2 M |
| Output tokens | 1.91 M | **2.57 M** | +0.66 M |
| Cache read | 477 M | **702 M** | +225 M |

Sessions under 128 MB show identical numbers before and after, as expected.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 31 files / 419 tests pass
- [x] `node dist/cli.js report --period week --provider codex --format json` runs to completion on a directory containing the 247 MB rollout
- [x] `CODEBURN_VERBOSE=1` no longer prints `skipped oversize file` for that path
- [x] `CODEBURN_VERBOSE=1` does still print the warning if a file ever exceeds 2 GB (synthetic test by temporarily lowering `MAX_STREAM_SESSION_FILE_BYTES` locally)
- [x] Smaller sessions still parse with identical results to the previous code path

## Notes

- I deliberately kept `MAX_SESSION_FILE_BYTES` and the `readSessionFile` / `readSessionFileSync` exports unchanged. Other providers may rely on them and the V8 string-limit reasoning still applies there. Only the streaming path is allowed to grow.
- Happy to fold in a similar conversion for any other provider that's seeing the same warning, but didn't want to scope-creep this PR.