### PR TITLE
fix(copilot): guard legacy event data shapes

### DIFF
--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -72,6 +72,22 @@ type LegacyCopilotEvent =
   | { type: 'assistant.message'; timestamp?: string; data: { messageId: string; outputTokens: number; interactionId?: string; toolRequests?: LegacyToolRequest[] } }
   | { type: string; timestamp?: string; data: Record<string, unknown> }
 
+function legacyStringField(data: Record<string, unknown>, key: string): string {
+  const value = data[key]
+  return typeof value === 'string' ? value : ''
+}
+
+function legacyNumberField(data: Record<string, unknown>, key: string): number {
+  const value = data[key]
+  return typeof value === 'number' ? value : 0
+}
+
+function legacyToolRequests(data: Record<string, unknown>): LegacyToolRequest[] {
+  const value = data['toolRequests']
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is LegacyToolRequest => item !== null && typeof item === 'object')
+}
+
 function parseLegacyEvents(content: string, sessionId: string, seenKeys: Set<string>): ParsedProviderCall[] {
   const results: ParsedProviderCall[] = []
   const lines = content.split('\n').filter(l => l.trim())
@@ -87,23 +103,26 @@ function parseLegacyEvents(content: string, sessionId: string, seenKeys: Set<str
     }
 
     // Some newer events include the model ID explicitly.
-    const data = event.data as { newModel?: string; model?: string }
-    if (typeof data.model === 'string' && data.model) {
-      currentModel = data.model
+    const data = event.data
+    const model = legacyStringField(data, 'model')
+    if (model) {
+      currentModel = model
     }
 
     if (event.type === 'session.model_change') {
-      currentModel = data.newModel ?? currentModel
+      currentModel = legacyStringField(data, 'newModel') || currentModel
       continue
     }
 
     if (event.type === 'user.message') {
-      pendingUserMessage = event.data.content ?? ''
+      pendingUserMessage = legacyStringField(data, 'content')
       continue
     }
 
     if (event.type === 'assistant.message') {
-      const { messageId, outputTokens, toolRequests = [] } = event.data
+      const messageId = legacyStringField(data, 'messageId')
+      const outputTokens = legacyNumberField(data, 'outputTokens')
+      const toolRequests = legacyToolRequests(data)
       if (outputTokens === 0) continue
       if (!currentModel) continue
 
@@ -112,7 +131,7 @@ function parseLegacyEvents(content: string, sessionId: string, seenKeys: Set<str
       seenKeys.add(dedupKey)
 
       const tools = toolRequests
-        .map(t => t.name ?? '')
+        .map(t => typeof t.name === 'string' ? t.name : '')
         .filter(Boolean)
         .map(n => toolNameMap[n] ?? n)
 

--- a/tests/providers/copilot.test.ts
+++ b/tests/providers/copilot.test.ts
@@ -183,6 +183,33 @@ describe('copilot provider - JSONL parsing', () => {
     expect(calls[0]!.model).toBe('gpt-4.1')
   })
 
+  it('handles generic legacy event shapes without losing valid assistant messages', async () => {
+    const eventsPath = await createSessionDir('sess-generic-shapes', [
+      JSON.stringify({ type: 'user.message', timestamp: '2026-04-15T10:00:10Z', data: { content: 42 } }),
+      JSON.stringify({ type: 'assistant.message', timestamp: '2026-04-15T10:00:11Z', data: { messageId: 'bad', outputTokens: '50', toolRequests: [{ name: 12 }] } }),
+      JSON.stringify({
+        type: 'assistant.message',
+        timestamp: '2026-04-15T10:00:15Z',
+        data: {
+          model: 'gpt-4.1',
+          messageId: 'msg-valid',
+          outputTokens: 55,
+          toolRequests: [{ name: 'read_file' }, { name: 12 }, null],
+        },
+      }),
+    ])
+
+    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.model).toBe('gpt-4.1')
+    expect(calls[0]!.outputTokens).toBe(55)
+    expect(calls[0]!.userMessage).toBe('')
+    expect(calls[0]!.tools).toEqual(['Read'])
+  })
+
   it('infers OpenAI auto bucket for transcript toolCallId prefix call_', async () => {
     const eventsPath = await createSessionDir('sess-tr-call', [
       transcriptSessionStart('sess-tr-call'),


### PR DESCRIPTION
## Summary

`origin/main` currently fails `npx tsc --noEmit` in `src/providers/copilot.ts` after the legacy Copilot parser gained a catch-all event variant:

```ts
| { type: string; timestamp?: string; data: Record<string, unknown> }
```

That catch-all is useful for newer/unknown Copilot events, but it also widens the discriminated union. TypeScript can no longer prove that `event.data` has `content`, `outputTokens`, `messageId`, or `toolRequests` inside the `user.message` / `assistant.message` branches, so the parser trips strict type errors.

This PR keeps the catch-all behavior and adds small local field readers for legacy event data instead of destructuring from an unsafe union shape.

## What changed

- Add typed helpers for legacy event fields:
  - `legacyStringField()`
  - `legacyNumberField()`
  - `legacyToolRequests()`
- Use those helpers in `parseLegacyEvents()` for model IDs, user content, assistant IDs, token counts, and tool requests.
- Keep valid legacy event behavior the same: same model, dedup key, token counts, mapped tools, timestamps, user message, and session ID.
- Make malformed/newer event payloads safer: non-string messages become `''`, non-number `outputTokens` become `0`, and malformed tool request entries are ignored.
- Add a regression test covering generic/malformed legacy event shapes while preserving a valid assistant message that carries `data.model` directly.

## Why this shape

The parser already needs to tolerate unknown Copilot event types. Removing the catch-all would make the type error disappear, but it would also weaken the intent of the previous Copilot parsing change. Reading the few required fields from `Record<string, unknown>` keeps the parser tolerant while satisfying strict TypeScript.

## Validation

- `npx tsc --noEmit`
- `npx vitest run tests/providers/copilot.test.ts`
- `npx vitest run`
- `npm run build`
