### PR TITLE
feat(git): attribute AI spend to commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 ### Added (CLI)
+- **Git cost attribution.** New `codeburn git-cost` command attributes local
+  AI coding spend to commits in the current git repository using a configurable
+  post-session attribution window, with text and JSON output for attributed
+  commits and unattributed sessions.
 - **Multiple subscription plans can be tracked at the same time.**
   `codeburn plan set` now stores plans in a provider-keyed `plans` map, so
   setting a Codex custom plan no longer overwrites an existing Claude plan.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ codeburn export -f json         # JSON export
 codeburn optimize               # find waste, get copy-paste fixes
 codeburn optimize -p week       # scope the scan to last 7 days
 codeburn compare                # side-by-side model comparison
+codeburn git-cost               # attribute AI spend to local git commits
 codeburn yield                  # track productive vs reverted/abandoned spend
 codeburn yield -p 30days        # yield analysis for last 30 days
 codeburn models                 # per-model token + cost table (last 30 days)
@@ -235,6 +236,21 @@ Or press `c` in the dashboard to enter compare mode. Arrow keys switch periods, 
 | Efficiency | Cache hit rate | Proportion of input from cache |
 
 Also compares per-category one-shot rates, delegation rate, planning rate, average tools per turn, and fast mode usage.
+
+### Git Cost
+
+```bash
+codeburn git-cost                       # last 7 days in the current git repo
+codeburn git-cost --since week          # same 7-day window
+codeburn git-cost --since 14days        # custom lookback window
+codeburn git-cost --provider claude     # provider-scoped attribution
+codeburn git-cost --window-minutes 60   # tighter post-session attribution window
+codeburn git-cost --json                # machine-readable output
+```
+
+`git-cost` attributes local AI spend to commits in the current repository. It matches only sessions whose recorded project path is inside the repo, then links each session to commits made between the session start and a configurable window after the session end. Commit matching uses git committer timestamps from the current checkout's `git log`, the same clock used by `git log --since/--until`. If a session maps to multiple commits, its cost is split evenly so totals are not double-counted. Sessions without matching commits are reported as unattributed spend.
+
+Attribution is intentionally heuristic: it shows which commits are close to usage sessions, not proof that a commit was AI-authored. It also depends on providers recording usable project paths. If a provider only exposes a project name, several repos share the same final directory name, or a path is normalized differently by an upstream parser, those sessions may appear as unattributed.
 
 ### Yield
 

--- a/src/git-cost.ts
+++ b/src/git-cost.ts
@@ -1,0 +1,393 @@
+import { execFileSync } from 'child_process'
+import { isAbsolute, parse, resolve, sep } from 'path'
+
+import chalk from 'chalk'
+
+import { formatCost } from './currency.js'
+import { toDateString } from './daily-cache.js'
+import type { DateRange, ProjectSummary, SessionSummary } from './types.js'
+
+const GOLD = '#ffd700'
+const GREEN = '#5bf5a0'
+const ORANGE = '#ff8c42'
+const DIM = '#888888'
+const PANEL_WIDTH = 76
+const DEFAULT_TOP_LIMIT = 10
+const MS_PER_MINUTE = 60 * 1000
+const END_OF_DAY_HOURS = 23
+const END_OF_DAY_MINUTES = 59
+const END_OF_DAY_SECONDS = 59
+const END_OF_DAY_MS = 999
+
+export type GitCommit = {
+  sha: string
+  committerDate: string
+  authorName: string
+  subject: string
+}
+
+export type GitCostCommit = {
+  sha: string
+  shortSha: string
+  committerDate: string
+  authorName: string
+  subject: string
+  costUSD: number
+  sessions: number
+  calls: number
+}
+
+export type GitCostSession = {
+  project: string
+  sessionId: string
+  firstTimestamp: string
+  lastTimestamp: string
+  costUSD: number
+  calls: number
+}
+
+export type GitCostSummary = {
+  label: string
+  repoRoot: string
+  repoName: string
+  windowMinutes: number
+  totalCostUSD: number
+  attributedCostUSD: number
+  unattributedCostUSD: number
+  attributedPercent: number | null
+  commits: number
+  sessions: number
+  attributedSessions: number
+  unattributedSessions: number
+  calls: number
+}
+
+export type GitCostResult = {
+  summary: GitCostSummary
+  commits: GitCostCommit[]
+  unattributedSessions: GitCostSession[]
+}
+
+type MutableCommitCost = {
+  commit: GitCommit
+  costUSD: number
+  sessions: Set<string>
+  calls: number
+}
+
+function formatGitError(err: unknown): string {
+  const stderr = (err as { stderr?: string | Buffer }).stderr
+  const stderrMessage = stderr ? String(stderr).trim() : ''
+  if (stderrMessage) return stderrMessage
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+function runGit(args: string[], cwd: string): string | null {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim()
+  } catch (err) {
+    if (process.env['CODEBURN_VERBOSE'] === '1') {
+      console.error(`codeburn: git ${args.join(' ')} failed: ${formatGitError(err)}`)
+    }
+    return null
+  }
+}
+
+export function parseGitSince(value: string, now = new Date()): { range: DateRange; label: string } {
+  const end = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    END_OF_DAY_HOURS,
+    END_OF_DAY_MINUTES,
+    END_OF_DAY_SECONDS,
+    END_OF_DAY_MS,
+  )
+
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'today') {
+    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+    return { range: { start, end }, label: `Today (${toDateString(start)})` }
+  }
+  if (normalized === 'week' || normalized === '7days' || normalized === '7d') {
+    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7)
+    return { range: { start, end }, label: 'Last 7 Days' }
+  }
+  if (normalized === '30days' || normalized === '30d') {
+    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 30)
+    return { range: { start, end }, label: 'Last 30 Days' }
+  }
+  if (normalized === 'month') {
+    const start = new Date(now.getFullYear(), now.getMonth(), 1)
+    return { range: { start, end }, label: `${now.toLocaleString('default', { month: 'long' })} ${now.getFullYear()}` }
+  }
+
+  const daysMatch = normalized.match(/^(\d+)\s*(?:d|day|days)$/)
+  if (daysMatch) {
+    const days = Number(daysMatch[1])
+    if (!Number.isInteger(days) || days <= 0) {
+      throw new Error(`Invalid --since value "${value}": day count must be positive`)
+    }
+    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - days)
+    return { range: { start, end }, label: `Last ${days} ${days === 1 ? 'Day' : 'Days'}` }
+  }
+
+  throw new Error(`Invalid --since value "${value}": use today, week/7days/7d, 30days/30d, month, or Nd/Nday/Ndays`)
+}
+
+export function getGitRepoRoot(cwd: string): string | null {
+  return runGit(['rev-parse', '--show-toplevel'], cwd)
+}
+
+export function getGitCommits(cwd: string, range: DateRange): GitCommit[] {
+  const log = runGit([
+    'log',
+    `--since=${range.start.toISOString()}`,
+    `--until=${range.end.toISOString()}`,
+    '--format=%H%x1f%cI%x1f%an%x1f%s',
+  ], cwd)
+
+  if (!log) return []
+
+  return log.split('\n')
+    .filter(Boolean)
+    .map(line => {
+      const [sha = '', committerDate = '', authorName = '', subject = ''] = line.split('\x1f')
+      return { sha, committerDate, authorName, subject }
+    })
+    .filter(commit => commit.sha && !Number.isNaN(new Date(commit.committerDate).getTime()))
+}
+
+function normalizePath(path: string): string {
+  return resolve(path)
+}
+
+function isInsidePath(child: string, parent: string): boolean {
+  const normalizedChild = normalizePath(child)
+  const normalizedParent = normalizePath(parent)
+  if (normalizedParent === parse(normalizedParent).root) {
+    return normalizedChild.startsWith(normalizedParent)
+  }
+  return normalizedChild === normalizedParent || normalizedChild.startsWith(`${normalizedParent}${sep}`)
+}
+
+function projectBelongsToRepo(projectPath: string, repoRoot: string): boolean {
+  const candidates = isAbsolute(projectPath) ? [projectPath] : [`/${projectPath}`]
+  return candidates.some(candidate => isInsidePath(candidate, repoRoot))
+}
+
+function parseTime(timestamp: string): Date | null {
+  const date = new Date(timestamp)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function sessionKey(projectPath: string, session: SessionSummary): string {
+  return `${projectPath}:${session.sessionId}`
+}
+
+function sessionCalls(session: SessionSummary): number {
+  return session.apiCalls ?? session.turns.reduce((sum, turn) => sum + turn.assistantCalls.length, 0)
+}
+
+export function computeGitCost(
+  projects: ProjectSummary[],
+  commits: GitCommit[],
+  options: {
+    label: string
+    repoRoot: string
+    windowMinutes: number
+  },
+): GitCostResult {
+  const repoRoot = normalizePath(options.repoRoot)
+  const repoName = repoRoot.split(sep).filter(Boolean).at(-1) ?? repoRoot
+  const sortedCommits = [...commits]
+    .sort((a, b) => new Date(a.committerDate).getTime() - new Date(b.committerDate).getTime())
+  const commitMap = new Map<string, MutableCommitCost>()
+  const unattributedSessions: GitCostSession[] = []
+  let totalCostUSD = 0
+  let attributedCostUSD = 0
+  let sessions = 0
+  let attributedSessions = 0
+  let calls = 0
+
+  for (const project of projects) {
+    if (!projectBelongsToRepo(project.projectPath, repoRoot)) continue
+
+    for (const session of project.sessions) {
+      const start = parseTime(session.firstTimestamp)
+      const endBase = parseTime(session.lastTimestamp) ?? start
+      const callCount = sessionCalls(session)
+      if (!start || !endBase) continue
+
+      sessions += 1
+      calls += callCount
+      totalCostUSD += session.totalCostUSD
+
+      const end = new Date(endBase.getTime() + options.windowMinutes * MS_PER_MINUTE)
+      const matchingCommits = sortedCommits.filter(commit => {
+        const ts = new Date(commit.committerDate)
+        return ts >= start && ts <= end
+      })
+
+      if (matchingCommits.length === 0) {
+        unattributedSessions.push({
+          project: project.project,
+          sessionId: session.sessionId,
+          firstTimestamp: session.firstTimestamp,
+          lastTimestamp: session.lastTimestamp,
+          costUSD: session.totalCostUSD,
+          calls: callCount,
+        })
+        continue
+      }
+
+      attributedSessions += 1
+      attributedCostUSD += session.totalCostUSD
+      const costShare = session.totalCostUSD / matchingCommits.length
+      const callShare = callCount / matchingCommits.length
+
+      for (const commit of matchingCommits) {
+        const existing = commitMap.get(commit.sha) ?? {
+          commit,
+          costUSD: 0,
+          sessions: new Set<string>(),
+          calls: 0,
+        }
+        existing.costUSD += costShare
+        existing.sessions.add(sessionKey(project.projectPath, session))
+        existing.calls += callShare
+        commitMap.set(commit.sha, existing)
+      }
+    }
+  }
+
+  const commitRows = [...commitMap.values()]
+    .map(row => ({
+      sha: row.commit.sha,
+      shortSha: row.commit.sha.slice(0, 7),
+      committerDate: row.commit.committerDate,
+      authorName: row.commit.authorName,
+      subject: row.commit.subject,
+      costUSD: row.costUSD,
+      sessions: row.sessions.size,
+      calls: row.calls,
+    }))
+    .sort((a, b) => b.costUSD - a.costUSD)
+
+  unattributedSessions.sort((a, b) => b.costUSD - a.costUSD)
+
+  return {
+    summary: {
+      label: options.label,
+      repoRoot,
+      repoName,
+      windowMinutes: options.windowMinutes,
+      totalCostUSD,
+      attributedCostUSD,
+      unattributedCostUSD: totalCostUSD - attributedCostUSD,
+      attributedPercent: totalCostUSD > 0 ? (attributedCostUSD / totalCostUSD) * 100 : null,
+      commits: commitRows.length,
+      sessions,
+      attributedSessions,
+      unattributedSessions: unattributedSessions.length,
+      calls,
+    },
+    commits: commitRows,
+    unattributedSessions,
+  }
+}
+
+function formatCount(count: number): string {
+  return Number.isInteger(count) ? String(count) : count.toFixed(1)
+}
+
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return `${formatCount(count)} ${count === 1 ? singular : pluralForm}`
+}
+
+function formatPercent(value: number | null): string {
+  return value === null ? '-' : `${value.toFixed(1)}%`
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value
+  return `${value.slice(0, Math.max(0, maxLength - 3))}...`
+}
+
+export function renderGitCostText(result: GitCostResult): string {
+  const { summary } = result
+  const lines: string[] = []
+  lines.push('')
+  lines.push(`  ${formatTitle('CodeBurn git cost')}${formatDim('  ' + summary.label)}`)
+  lines.push(formatDim('  ' + '-'.repeat(PANEL_WIDTH)))
+  lines.push(`  Repo: ${summary.repoName} ${formatDim(summary.repoRoot)}`)
+  lines.push(`  Attribution window: ${summary.windowMinutes} minutes after session end`)
+  lines.push('')
+
+  if (summary.sessions === 0) {
+    lines.push(formatDim('  No usage sessions matched this git repository for the selected period.'))
+    lines.push('')
+    return lines.join('\n')
+  }
+
+  lines.push(`  Total repo spend:     ${formatGold(formatCost(summary.totalCostUSD))}`)
+  lines.push(`  Attributed spend:     ${formatGreen(formatCost(summary.attributedCostUSD))} ${formatDim(`(${formatPercent(summary.attributedPercent)})`)}`)
+  lines.push(`  Unattributed spend:   ${formatCost(summary.unattributedCostUSD)}`)
+  lines.push('  ' + [
+    plural(summary.commits, 'attributed commit'),
+    plural(summary.sessions, 'total session'),
+    plural(summary.calls, 'total call'),
+  ].join(formatDim('   ')))
+  lines.push('')
+
+  if (result.commits.length > 0) {
+    lines.push(`  ${formatBold('Top commit costs')}`)
+    for (const commit of result.commits.slice(0, DEFAULT_TOP_LIMIT)) {
+      const subject = truncate(commit.subject || '(no subject)', 52)
+      lines.push(`  ${formatGold(formatCost(commit.costUSD))}  ${commit.shortSha}  ${subject} ${formatDim(`(${plural(commit.sessions, 'session')}, ${plural(commit.calls, 'call')})`)}`)
+    }
+    lines.push('')
+  }
+
+  if (result.unattributedSessions.length > 0) {
+    lines.push(`  ${formatBold('Largest unattributed sessions')}`)
+    for (const session of result.unattributedSessions.slice(0, 5)) {
+      const target = truncate(`${session.project}/${session.sessionId}`, 58)
+      lines.push(`  ${formatCost(session.costUSD)}  ${target} ${formatDim(`(${plural(session.calls, 'call')})`)}`)
+    }
+    const hidden = result.unattributedSessions.length - 5
+    if (hidden > 0) {
+      lines.push(formatDim(`  ...and ${plural(hidden, 'more unattributed session')}.`))
+    }
+    lines.push('')
+  }
+
+  lines.push(formatDim('  Attribution is time-based and splits a session evenly across matching commits.'))
+  lines.push('')
+  return lines.join('\n')
+}
+
+function formatTitle(value: string): string {
+  return chalk.bold.hex(ORANGE)(value)
+}
+
+function formatBold(value: string): string {
+  return chalk.bold(value)
+}
+
+function formatDim(value: string): string {
+  return chalk.hex(DIM)(value)
+}
+
+function formatGold(value: string): string {
+  return chalk.hex(GOLD)(value)
+}
+
+function formatGreen(value: string): string {
+  return chalk.hex(GREEN)(value)
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { renderDashboard } from './dashboard.js'
 import { formatDateRangeLabel, parseDateRangeFlags, getDateRange, toPeriod, type Period } from './cli-date.js'
 import { runOptimize, scanAndDetect } from './optimize.js'
 import { renderCompare } from './compare.js'
+import { computeGitCost, getGitCommits, getGitRepoRoot, parseGitSince, renderGitCostText } from './git-cost.js'
 import { getAllProviders } from './providers/index.js'
 import { clearPlan, readConfig, readPlan, readPlans, saveConfig, savePlan, getConfigFilePath, type Plan, type PlanId, type PlanProvider } from './config.js'
 import { clampResetDay, getPlanUsageOrNull, getPlanUsages, type PlanUsage } from './plan-usage.js'
@@ -1058,6 +1059,57 @@ program
     console.log(`\n  Analyzing yield for ${label}...\n`)
     const summary = await computeYield(range, process.cwd())
     console.log(formatYieldSummary(summary))
+  })
+
+program
+  .command('git-cost')
+  .description('Attribute AI coding spend to local git commits')
+  .option('--since <period>', 'Lookback window: today, week/7days/7d, 30days/30d, month, or Nd/Nday/Ndays', '7days')
+  .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
+  .option('--window-minutes <n>', 'Minutes after a session ends to attribute commits', parseNumber, 120)
+  .option('--json', 'Print machine-readable JSON')
+  .action(async (opts) => {
+    const repoRoot = getGitRepoRoot(process.cwd())
+    if (!repoRoot) {
+      console.error('\n  git-cost must be run inside a git repository.\n')
+      process.exitCode = 1
+      return
+    }
+
+    if (!Number.isInteger(opts.windowMinutes) || opts.windowMinutes < 0) {
+      console.error(`\n  --window-minutes must be a non-negative integer; got ${opts.windowMinutes}.\n`)
+      process.exitCode = 1
+      return
+    }
+
+    let parsedSince: ReturnType<typeof parseGitSince>
+    try {
+      parsedSince = parseGitSince(opts.since)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`\n  Error: ${message}\n`)
+      process.exitCode = 1
+      return
+    }
+
+    await loadPricing()
+    const projects = await parseAllSessions(parsedSince.range, opts.provider)
+    const commitRange = {
+      start: parsedSince.range.start,
+      end: new Date(parsedSince.range.end.getTime() + opts.windowMinutes * 60 * 1000),
+    }
+    const commits = getGitCommits(repoRoot, commitRange)
+    const result = computeGitCost(projects, commits, {
+      label: parsedSince.label,
+      repoRoot,
+      windowMinutes: opts.windowMinutes,
+    })
+
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2))
+    } else {
+      console.log(renderGitCostText(result))
+    }
   })
 
 program.parse()

--- a/tests/git-cost.test.ts
+++ b/tests/git-cost.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeGitCost, parseGitSince, renderGitCostText, type GitCommit } from '../src/git-cost.js'
+import type { ClassifiedTurn, ParsedApiCall, ProjectSummary, SessionSummary } from '../src/types.js'
+
+function commit(sha: string, committerDate: string, subject = `commit ${sha}`): GitCommit {
+  return {
+    sha,
+    committerDate,
+    authorName: 'Test User',
+    subject,
+  }
+}
+
+function makeCall(costUSD: number, timestamp: string): ParsedApiCall {
+  return {
+    provider: 'claude',
+    model: 'claude-sonnet-4-5',
+    usage: {
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      cachedInputTokens: 0,
+      reasoningTokens: 0,
+      webSearchRequests: 0,
+    },
+    costUSD,
+    tools: [],
+    mcpTools: [],
+    skills: [],
+    hasAgentSpawn: false,
+    hasPlanMode: false,
+    speed: 'standard',
+    timestamp,
+    bashCommands: [],
+    deduplicationKey: `${timestamp}:${costUSD}`,
+  }
+}
+
+function makeTurn(sessionId: string, timestamp: string, costUSD: number): ClassifiedTurn {
+  return {
+    userMessage: 'test',
+    assistantCalls: [makeCall(costUSD, timestamp)],
+    timestamp,
+    sessionId,
+    category: 'coding',
+    retries: 0,
+    hasEdits: true,
+  }
+}
+
+function makeSession(project: string, sessionId: string, first: string, last: string, costUSD: number): SessionSummary {
+  const turns = [
+    makeTurn(sessionId, first, costUSD / 2),
+    makeTurn(sessionId, last, costUSD / 2),
+  ]
+  return {
+    sessionId,
+    project,
+    firstTimestamp: first,
+    lastTimestamp: last,
+    totalCostUSD: costUSD,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    apiCalls: 2,
+    turns,
+    modelBreakdown: {},
+    toolBreakdown: {},
+    mcpBreakdown: {},
+    bashBreakdown: {},
+    categoryBreakdown: {} as SessionSummary['categoryBreakdown'],
+    skillBreakdown: {},
+  }
+}
+
+function makeProject(projectPath: string, sessions: SessionSummary[]): ProjectSummary {
+  return {
+    project: projectPath.split('/').filter(Boolean).at(-1) ?? 'repo',
+    projectPath,
+    sessions,
+    totalCostUSD: sessions.reduce((sum, session) => sum + session.totalCostUSD, 0),
+    totalApiCalls: sessions.reduce((sum, session) => sum + session.apiCalls, 0),
+  }
+}
+
+describe('parseGitSince', () => {
+  const now = new Date(2026, 4, 6, 12, 0, 0)
+
+  it('parses 7days aliases', () => {
+    const result = parseGitSince('7days', now)
+    expect(result.label).toBe('Last 7 Days')
+    expect(result.range.start).toEqual(new Date(2026, 3, 29))
+  })
+
+  it('parses week alias', () => {
+    expect(parseGitSince('week', now).label).toBe('Last 7 Days')
+  })
+
+  it('parses today, month, and 30days', () => {
+    expect(parseGitSince('today', now).label).toBe('Today (2026-05-06)')
+    expect(parseGitSince('month', now).label).toBe('May 2026')
+    expect(parseGitSince('30days', now).label).toBe('Last 30 Days')
+  })
+
+  it('parses arbitrary day windows', () => {
+    const result = parseGitSince('14d', now)
+    expect(result.label).toBe('Last 14 Days')
+    expect(result.range.start).toEqual(new Date(2026, 3, 22))
+  })
+
+  it('uses singular wording for one-day custom windows', () => {
+    expect(parseGitSince('1d', now).label).toBe('Last 1 Day')
+  })
+
+  it('rejects invalid values', () => {
+    expect(() => parseGitSince('forever', now)).toThrow('Invalid --since value')
+  })
+})
+
+describe('computeGitCost', () => {
+  it('attributes matching repo sessions to commits inside the session window', () => {
+    const session = makeSession(
+      'repo',
+      's1',
+      '2026-05-06T10:00:00Z',
+      '2026-05-06T10:30:00Z',
+      10,
+    )
+    const result = computeGitCost([
+      makeProject('/work/repo', [session]),
+    ], [
+      commit('abcdef123', '2026-05-06T11:00:00Z', 'ship feature'),
+    ], {
+      label: 'Last 7 Days',
+      repoRoot: '/work/repo',
+      windowMinutes: 120,
+    })
+
+    expect(result.summary.totalCostUSD).toBeCloseTo(10)
+    expect(result.summary.attributedCostUSD).toBeCloseTo(10)
+    expect(result.summary.unattributedCostUSD).toBeCloseTo(0)
+    expect(result.commits).toEqual([
+      expect.objectContaining({
+        shortSha: 'abcdef1',
+        subject: 'ship feature',
+        costUSD: 10,
+        sessions: 1,
+        calls: 2,
+      }),
+    ])
+  })
+
+  it('splits one session across multiple matching commits without double-counting total cost', () => {
+    const session = makeSession('repo', 's1', '2026-05-06T10:00:00Z', '2026-05-06T10:30:00Z', 12)
+    const result = computeGitCost([
+      makeProject('/work/repo', [session]),
+    ], [
+      commit('1111111', '2026-05-06T10:10:00Z'),
+      commit('2222222', '2026-05-06T10:45:00Z'),
+    ], {
+      label: 'Last 7 Days',
+      repoRoot: '/work/repo',
+      windowMinutes: 120,
+    })
+
+    expect(result.summary.attributedCostUSD).toBeCloseTo(12)
+    expect(result.commits).toHaveLength(2)
+    expect(result.commits.map(row => row.costUSD)).toEqual([6, 6])
+    expect(result.commits.map(row => row.calls)).toEqual([1, 1])
+  })
+
+  it('keeps sessions without matching commits unattributed', () => {
+    const session = makeSession('repo', 's1', '2026-05-06T10:00:00Z', '2026-05-06T10:30:00Z', 8)
+    const result = computeGitCost([
+      makeProject('/work/repo', [session]),
+    ], [
+      commit('abcdef123', '2026-05-06T13:00:00Z'),
+    ], {
+      label: 'Last 7 Days',
+      repoRoot: '/work/repo',
+      windowMinutes: 30,
+    })
+
+    expect(result.summary.attributedCostUSD).toBe(0)
+    expect(result.summary.unattributedCostUSD).toBeCloseTo(8)
+    expect(result.unattributedSessions[0]).toMatchObject({ sessionId: 's1', costUSD: 8 })
+  })
+
+  it('ignores projects outside the current git repo', () => {
+    const inside = makeSession('repo', 'inside', '2026-05-06T10:00:00Z', '2026-05-06T10:30:00Z', 5)
+    const parent = makeSession('home', 'parent', '2026-05-06T10:00:00Z', '2026-05-06T10:30:00Z', 100)
+    const sibling = makeSession('other', 'sibling', '2026-05-06T10:00:00Z', '2026-05-06T10:30:00Z', 100)
+
+    const result = computeGitCost([
+      makeProject('/work/repo/subdir', [inside]),
+      makeProject('/work', [parent]),
+      makeProject('/work/repo-other', [sibling]),
+    ], [
+      commit('abcdef123', '2026-05-06T10:15:00Z'),
+    ], {
+      label: 'Last 7 Days',
+      repoRoot: '/work/repo',
+      windowMinutes: 120,
+    })
+
+    expect(result.summary.totalCostUSD).toBeCloseTo(5)
+    expect(result.summary.sessions).toBe(1)
+  })
+
+  it('matches desanitized absolute paths that are missing the leading slash', () => {
+    const session = makeSession('repo', 's1', '2026-05-06T10:00:00Z', '2026-05-06T10:30:00Z', 5)
+    const result = computeGitCost([
+      makeProject('work/repo', [session]),
+    ], [
+      commit('abcdef123', '2026-05-06T10:15:00Z'),
+    ], {
+      label: 'Last 7 Days',
+      repoRoot: '/work/repo',
+      windowMinutes: 120,
+    })
+
+    expect(result.summary.totalCostUSD).toBeCloseTo(5)
+    expect(result.summary.attributedCostUSD).toBeCloseTo(5)
+  })
+
+  it('matches projects when the git repo root is the filesystem root', () => {
+    const session = makeSession('repo', 's1', '2026-05-06T10:00:00Z', '2026-05-06T10:30:00Z', 5)
+    const result = computeGitCost([
+      makeProject('/work/repo', [session]),
+    ], [
+      commit('abcdef123', '2026-05-06T10:15:00Z'),
+    ], {
+      label: 'Last 7 Days',
+      repoRoot: '/',
+      windowMinutes: 120,
+    })
+
+    expect(result.summary.totalCostUSD).toBeCloseTo(5)
+    expect(result.summary.attributedCostUSD).toBeCloseTo(5)
+  })
+})
+
+describe('renderGitCostText', () => {
+  it('renders an empty repo-period message', () => {
+    const result = computeGitCost([], [], {
+      label: 'Last 7 Days',
+      repoRoot: '/work/repo',
+      windowMinutes: 120,
+    })
+
+    expect(renderGitCostText(result)).toContain('No usage sessions matched this git repository')
+  })
+
+  it('renders populated commit and unattributed sections', () => {
+    const attributed = makeSession('repo', 'attributed', '2026-05-06T10:00:00Z', '2026-05-06T10:30:00Z', 10)
+    const missing = Array.from({ length: 7 }, (_, index) =>
+      makeSession('repo', `missing-${index}`, '2026-05-06T08:00:00Z', '2026-05-06T08:10:00Z', index + 1)
+    )
+    const result = computeGitCost([
+      makeProject('/work/repo', [attributed, ...missing]),
+    ], [
+      commit('abcdef123', '2026-05-06T10:15:00Z', 'ship feature'),
+    ], {
+      label: 'Last 7 Days',
+      repoRoot: '/work/repo',
+      windowMinutes: 120,
+    })
+
+    const text = renderGitCostText(result)
+    expect(text).toContain('Top commit costs')
+    expect(text).toContain('ship feature')
+    expect(text).toContain('Largest unattributed sessions')
+    expect(text).toContain('...and 2 more unattributed sessions.')
+  })
+
+  it('formats fractional per-commit call shares for display', () => {
+    const session = makeSession('repo', 'split-calls', '2026-05-06T10:00:00Z', '2026-05-06T10:10:00Z', 9)
+    const result = computeGitCost([
+      makeProject('/work/repo', [session]),
+    ], [
+      commit('1111111', '2026-05-06T10:02:00Z'),
+      commit('2222222', '2026-05-06T10:04:00Z'),
+      commit('3333333', '2026-05-06T10:06:00Z'),
+    ], {
+      label: 'Last 7 Days',
+      repoRoot: '/work/repo',
+      windowMinutes: 120,
+    })
+
+    const text = renderGitCostText(result)
+    expect(text).toContain('0.7 calls')
+    expect(text).not.toContain('0.666666')
+  })
+})


### PR DESCRIPTION
## Summary

This adds a new `codeburn git-cost` command for attributing local AI coding spend to commits in the current git repository.

The goal is to answer a question that the existing aggregate reports cannot answer directly: after spending on AI sessions inside a repo, which nearby commits are those sessions most likely associated with, and how much spend remains unattributed?

## What changed

- add `codeburn git-cost` as a new CLI command
- support `--since` windows for `today`, `week` / `7days` / `7d`, `30days` / `30d`, `month`, and custom day windows such as `14d` / `14days`
- support `--provider` filtering so attribution can be scoped to one provider
- support `--window-minutes` to control how long after a session ends commits can still be linked to that session
- support `--json` for scripts and downstream tooling
- document the command in the README and add an Unreleased changelog entry

## Attribution model

`git-cost` only considers usage sessions whose recorded project path belongs to the current git repository. For each matched session, it looks for commits in the current checkout's `git log` whose committer timestamp falls between:

- the session's first usage timestamp
- the session's last usage timestamp plus the configured post-session window

If a session maps to exactly one commit, that commit receives the session's full cost. If a session maps to multiple commits, the session cost and call count are split evenly across those commits so the report does not double-count spend. Sessions without a matching commit are kept visible as unattributed spend.

The command uses git committer timestamps (`%cI`) because that is the same timestamp family used by `git log --since/--until`. That avoids dropping rebased, amended, or cherry-picked commits because of older author dates.

## Output behavior

The text output shows:

- repository name and path
- selected period and attribution window
- total repo spend
- attributed and unattributed spend
- top attributed commit costs
- largest unattributed sessions

The JSON output exposes the same summary plus commit rows and unattributed session rows for automation.

## Caveats

This is intentionally heuristic. It identifies commits that are close to AI usage sessions in time; it does not prove that a commit was AI-authored.

Attribution also depends on providers recording usable project paths. If a provider only exposes a project name, multiple repos share the same final directory name, or an upstream parser normalizes a path differently, some sessions may appear as unattributed.

## Validation

- `npx vitest run tests/git-cost.test.ts`
- `npm run build`
- `node dist/cli.js git-cost --help`
- `node dist/cli.js git-cost --window-minutes 1.5` exits with code 1 and the expected validation error
- `npx vitest run`
- `git diff --cached --check`

`npx tsc --noEmit` is still blocked by existing `src/providers/copilot.ts` type errors on `main`; this branch does not touch that provider path.
