### PR TITLE
feat(cli): add session replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Added (CLI)
+- **Session replay.** New `codeburn replay <session-id>` command renders a
+  local turn-by-turn timeline for a recorded session, including per-turn cost,
+  category, models, tools, MCP tools, skills, shell commands, retries, edit
+  flags, and token counts. Supports period, date range, provider, project,
+  exclude filters, `--json`, and `--no-prompts` for metadata-only output.
 - **Multiple subscription plans can be tracked at the same time.**
   `codeburn plan set` now stores plans in a provider-keyed `plans` map, so
   setting a Codex custom plan no longer overwrites an existing Claude plan.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ codeburn export -f json         # JSON export
 codeburn optimize               # find waste, get copy-paste fixes
 codeburn optimize -p week       # scope the scan to last 7 days
 codeburn compare                # side-by-side model comparison
+codeburn replay <session-id>    # turn-by-turn session timeline
 codeburn yield                  # track productive vs reverted/abandoned spend
 codeburn yield -p 30days        # yield analysis for last 30 days
 codeburn models                 # per-model token + cost table (last 30 days)
@@ -127,7 +128,7 @@ Provider logos are trademarks of their respective owners. The icon set was sourc
 
 CodeBurn auto-detects which AI coding tools you use. If multiple providers have session data on disk, press `p` in the dashboard to toggle between them.
 
-The `--provider` flag filters any command to a single provider: `codeburn report --provider claude`, `codeburn today --provider codex`, `codeburn export --provider cursor`. Works on all commands: `report`, `today`, `month`, `status`, `export`, `optimize`, `compare`, `yield`.
+The `--provider` flag filters any command to a single provider: `codeburn report --provider claude`, `codeburn today --provider codex`, `codeburn export --provider cursor`. Works on all commands: `report`, `today`, `month`, `status`, `export`, `optimize`, `compare`, `replay`, `yield`.
 
 ### Provider Notes
 
@@ -333,6 +334,18 @@ codeburn today --format json | jq '.overview.cost'
 ```
 
 For lighter output, use `status --format json` (today and month totals only) or file exports (`export -f json`).
+
+### Session Replay
+
+```bash
+codeburn replay abc123                  # find by session id or prefix
+codeburn replay abc123 -p 30days        # search a wider period
+codeburn replay abc123 --provider claude
+codeburn replay abc123 --no-prompts     # hide user prompts in stdout
+codeburn replay abc123 --json           # structured timeline
+```
+
+`replay` turns one recorded session into a local turn-by-turn timeline. It shows each turn's prompt, category, cost, models, tools, MCP tools, skills, shell commands, retries, edit flag, and token counts. It does not upload data; output is printed locally. Use `--no-prompts` when you want timing, cost, and tool flow without exposing prompt text. This is not a full redaction mode: shell commands and tool names remain visible.
 
 ## Menu Bar
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { renderDashboard } from './dashboard.js'
 import { formatDateRangeLabel, parseDateRangeFlags, getDateRange, toPeriod, type Period } from './cli-date.js'
 import { runOptimize, scanAndDetect } from './optimize.js'
 import { renderCompare } from './compare.js'
+import { buildReplayResult, findReplaySessions, renderReplayCandidates, renderReplayText } from './replay.js'
 import { getAllProviders } from './providers/index.js'
 import { clearPlan, readConfig, readPlan, readPlans, saveConfig, savePlan, getConfigFilePath, type Plan, type PlanId, type PlanProvider } from './config.js'
 import { clampResetDay, getPlanUsageOrNull, getPlanUsages, type PlanUsage } from './plan-usage.js'
@@ -989,6 +990,61 @@ program
     await loadPricing()
     const { range } = getDateRange(opts.period)
     await renderCompare(range, opts.provider)
+  })
+
+program
+  .command('replay')
+  .description('Replay a session as a turn-by-turn timeline')
+  .argument('<session-id>', 'Session id or prefix')
+  .option('-p, --period <period>', 'Search period: today, week, 30days, month, all', 'week')
+  .option('--from <date>', 'Start date (YYYY-MM-DD). Overrides --period when set')
+  .option('--to <date>', 'End date (YYYY-MM-DD). Overrides --period when set')
+  .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
+  .option('--project <name>', 'Search only projects matching name (repeatable)', collect, [])
+  .option('--exclude <name>', 'Exclude projects matching name (repeatable)', collect, [])
+  .option('--json', 'Print machine-readable JSON')
+  .option('--no-prompts', 'Hide user prompts from output')
+  .action(async (sessionId, opts) => {
+    let customRange: DateRange | null = null
+    try {
+      customRange = parseDateRangeFlags(opts.from, opts.to)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`\n  Error: ${message}\n`)
+      process.exitCode = 1
+      return
+    }
+
+    await loadPricing()
+
+    const period = toPeriod(opts.period)
+    const rangeInfo = customRange
+      ? { range: customRange, label: formatDateRangeLabel(opts.from, opts.to) }
+      : getDateRange(period)
+    const projects = filterProjectsByName(
+      await parseAllSessions(rangeInfo.range, opts.provider),
+      opts.project,
+      opts.exclude,
+    )
+    const matches = findReplaySessions(projects, sessionId)
+
+    if (matches.length === 0) {
+      console.error(`\n  No session matched "${sessionId}" in ${rangeInfo.label}.\n`)
+      process.exitCode = 1
+      return
+    }
+    if (matches.length > 1) {
+      console.error(renderReplayCandidates(matches, sessionId))
+      process.exitCode = 1
+      return
+    }
+
+    const result = buildReplayResult(matches[0]!, { includePrompts: opts.prompts !== false })
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2))
+    } else {
+      console.log(renderReplayText(result))
+    }
   })
 
 program

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -1,0 +1,275 @@
+import chalk from 'chalk'
+
+import { formatCost } from './currency.js'
+import { CATEGORY_LABELS, type ProjectSummary, type SessionSummary, type TaskCategory, type TokenUsage } from './types.js'
+
+const ORANGE = '#ff8c42'
+const GOLD = '#ffd700'
+const DIM = '#888888'
+const PANEL_WIDTH = 76
+const TURN_PROMPT_LIMIT = 220
+const LIST_LIMIT = 5
+
+export type ReplayMatch = {
+  project: ProjectSummary
+  session: SessionSummary
+}
+
+export type ReplayCall = {
+  provider: string
+  model: string
+  costUSD: number
+  usage: TokenUsage
+  tools: string[]
+  mcpTools: string[]
+  skills: string[]
+  bashCommands: string[]
+  speed: 'standard' | 'fast'
+}
+
+export type ReplayTurn = {
+  index: number
+  timestamp: string
+  category: TaskCategory
+  subCategory?: string
+  userMessage: string | null
+  costUSD: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  calls: ReplayCall[]
+  tools: Record<string, number>
+  mcpTools: Record<string, number>
+  skills: Record<string, number>
+  bashCommands: string[]
+  retries: number
+  hasEdits: boolean
+}
+
+export type ReplayResult = {
+  project: string
+  projectPath: string
+  sessionId: string
+  firstTimestamp: string
+  lastTimestamp: string
+  totalCostUSD: number
+  apiCalls: number
+  turns: ReplayTurn[]
+}
+
+function normalizeQuery(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+export function findReplaySessions(projects: ProjectSummary[], query: string): ReplayMatch[] {
+  const normalized = normalizeQuery(query)
+  if (!normalized) return []
+
+  const matches: ReplayMatch[] = []
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      if (session.sessionId.toLowerCase() === normalized) {
+        matches.push({ project, session })
+      }
+    }
+  }
+  if (matches.length > 0) return matches
+
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      if (session.sessionId.toLowerCase().startsWith(normalized)) {
+        matches.push({ project, session })
+      }
+    }
+  }
+  return matches
+}
+
+function increment(map: Map<string, number>, key: string): void {
+  if (!key) return
+  map.set(key, (map.get(key) ?? 0) + 1)
+}
+
+function sortedRecord(map: Map<string, number>): Record<string, number> {
+  return Object.fromEntries([...map.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])))
+}
+
+function turnCost(calls: ReplayCall[]): number {
+  return calls.reduce((sum, call) => sum + call.costUSD, 0)
+}
+
+function tokenSum(calls: ReplayCall[], key: keyof TokenUsage): number {
+  return calls.reduce((sum, call) => sum + call.usage[key], 0)
+}
+
+export function buildReplayResult(match: ReplayMatch, options: { includePrompts: boolean }): ReplayResult {
+  const turns: ReplayTurn[] = match.session.turns.map((turn, index) => {
+    const tools = new Map<string, number>()
+    const mcpTools = new Map<string, number>()
+    const skills = new Map<string, number>()
+    const bashCommands: string[] = []
+    const calls = turn.assistantCalls.map(call => {
+      for (const tool of call.tools) increment(tools, tool)
+      for (const tool of call.mcpTools) increment(mcpTools, tool)
+      for (const skill of call.skills) increment(skills, skill)
+      for (const command of call.bashCommands) {
+        if (command) bashCommands.push(command)
+      }
+
+      return {
+        provider: call.provider,
+        model: call.model,
+        costUSD: call.costUSD,
+        usage: call.usage,
+        tools: call.tools,
+        mcpTools: call.mcpTools,
+        skills: call.skills,
+        bashCommands: call.bashCommands,
+        speed: call.speed,
+      }
+    })
+
+    return {
+      index: index + 1,
+      timestamp: turn.timestamp,
+      category: turn.category,
+      ...(turn.subCategory ? { subCategory: turn.subCategory } : {}),
+      userMessage: options.includePrompts ? turn.userMessage : null,
+      costUSD: turnCost(calls),
+      inputTokens: tokenSum(calls, 'inputTokens'),
+      outputTokens: tokenSum(calls, 'outputTokens'),
+      cacheReadTokens: tokenSum(calls, 'cacheReadInputTokens'),
+      cacheWriteTokens: tokenSum(calls, 'cacheCreationInputTokens'),
+      calls,
+      tools: sortedRecord(tools),
+      mcpTools: sortedRecord(mcpTools),
+      skills: sortedRecord(skills),
+      bashCommands,
+      retries: turn.retries,
+      hasEdits: turn.hasEdits,
+    }
+  })
+
+  return {
+    project: match.project.project,
+    projectPath: match.project.projectPath,
+    sessionId: match.session.sessionId,
+    firstTimestamp: match.session.firstTimestamp,
+    lastTimestamp: match.session.lastTimestamp,
+    totalCostUSD: match.session.totalCostUSD,
+    apiCalls: match.session.apiCalls,
+    turns,
+  }
+}
+
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralForm}`
+}
+
+function truncate(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= maxLength) return normalized
+  return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`
+}
+
+function formatTokens(value: number): string {
+  return value.toLocaleString('en-US')
+}
+
+function categoryLabel(category: TaskCategory, subCategory?: string): string {
+  const base = CATEGORY_LABELS[category] ?? category
+  return subCategory ? `${base} / ${subCategory}` : base
+}
+
+function formatCountRecord(record: Record<string, number>, limit = LIST_LIMIT): string {
+  const entries = Object.entries(record)
+  if (entries.length === 0) return '-'
+  const shown = entries.slice(0, limit).map(([name, count]) => `${name}${count > 1 ? ` x${count}` : ''}`)
+  const hidden = entries.length - shown.length
+  return hidden > 0 ? `${shown.join(', ')} +${hidden} more` : shown.join(', ')
+}
+
+function formatModels(calls: ReplayCall[]): string {
+  const models = new Map<string, number>()
+  for (const call of calls) increment(models, call.model)
+  return formatCountRecord(sortedRecord(models))
+}
+
+function formatShell(commands: string[]): string {
+  if (commands.length === 0) return '-'
+  const shown = commands.slice(0, 3).map(command => truncate(command, 52))
+  const hidden = commands.length - shown.length
+  return hidden > 0 ? `${shown.join(' | ')} +${hidden} more` : shown.join(' | ')
+}
+
+export function renderReplayText(result: ReplayResult): string {
+  const lines: string[] = []
+  const totalInput = result.turns.reduce((sum, turn) => sum + turn.inputTokens, 0)
+  const totalOutput = result.turns.reduce((sum, turn) => sum + turn.outputTokens, 0)
+  const totalCacheRead = result.turns.reduce((sum, turn) => sum + turn.cacheReadTokens, 0)
+  const totalCacheWrite = result.turns.reduce((sum, turn) => sum + turn.cacheWriteTokens, 0)
+
+  lines.push('')
+  lines.push(`  ${chalk.bold.hex(ORANGE)('CodeBurn session replay')}`)
+  lines.push(chalk.hex(DIM)(`  ${'-'.repeat(PANEL_WIDTH)}`))
+  lines.push(`  Project: ${chalk.bold(result.project)} ${chalk.hex(DIM)(result.projectPath)}`)
+  lines.push(`  Session: ${result.sessionId}`)
+  lines.push(`  Window:  ${result.firstTimestamp} -> ${result.lastTimestamp}`)
+  lines.push(`  Spend:   ${chalk.hex(GOLD)(formatCost(result.totalCostUSD))}  ${plural(result.turns.length, 'turn')}  ${plural(result.apiCalls, 'call')}`)
+  lines.push(`  Tokens:  in ${formatTokens(totalInput)}  out ${formatTokens(totalOutput)}  cache read ${formatTokens(totalCacheRead)}  cache write ${formatTokens(totalCacheWrite)}`)
+  lines.push('')
+
+  if (result.turns.length === 0) {
+    lines.push(chalk.hex(DIM)('  No turns found in this session.'))
+    lines.push('')
+    return lines.join('\n')
+  }
+
+  for (const turn of result.turns) {
+    const title = `Turn ${turn.index}`
+    const meta = [
+      turn.timestamp || 'unknown time',
+      categoryLabel(turn.category, turn.subCategory),
+      formatCost(turn.costUSD),
+      plural(turn.calls.length, 'call'),
+    ].join('  ')
+
+    lines.push(`  ${chalk.bold(title)} ${chalk.hex(DIM)(meta)}`)
+    if (turn.userMessage !== null) {
+      lines.push(`    Prompt: ${truncate(turn.userMessage || '(empty)', TURN_PROMPT_LIMIT)}`)
+    } else {
+      lines.push(chalk.hex(DIM)('    Prompt: hidden by --no-prompts'))
+    }
+    lines.push(`    Models: ${formatModels(turn.calls)}`)
+    lines.push(`    Tools:  ${formatCountRecord(turn.tools)}`)
+    if (Object.keys(turn.mcpTools).length > 0) {
+      lines.push(`    MCP:    ${formatCountRecord(turn.mcpTools)}`)
+    }
+    if (Object.keys(turn.skills).length > 0) {
+      lines.push(`    Skills: ${formatCountRecord(turn.skills)}`)
+    }
+    lines.push(`    Shell:  ${formatShell(turn.bashCommands)}`)
+    if (turn.retries > 0 || turn.hasEdits) {
+      lines.push(chalk.hex(DIM)(`    Flags:  ${turn.hasEdits ? 'edits' : 'no edits'}${turn.retries > 0 ? `, ${plural(turn.retries, 'retry', 'retries')}` : ''}`))
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+export function renderReplayCandidates(matches: ReplayMatch[], query: string): string {
+  const lines: string[] = []
+  lines.push('')
+  lines.push(`  Multiple sessions matched "${query}":`)
+  for (const { project, session } of matches.slice(0, 10)) {
+    lines.push(`  ${session.sessionId}  ${project.project}  ${formatCost(session.totalCostUSD)}  ${session.firstTimestamp}`)
+  }
+  const hidden = matches.length - 10
+  if (hidden > 0) lines.push(`  ...and ${plural(hidden, 'more match', 'more matches')}`)
+  lines.push('')
+  lines.push('  Use a longer session id prefix to select exactly one session.')
+  lines.push('')
+  return lines.join('\n')
+}

--- a/tests/replay.test.ts
+++ b/tests/replay.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildReplayResult, findReplaySessions, renderReplayCandidates, renderReplayText } from '../src/replay.js'
+import type { ClassifiedTurn, ParsedApiCall, ProjectSummary, SessionSummary } from '../src/types.js'
+
+function makeCall(model: string, costUSD: number, opts: {
+  provider?: string
+  tools?: string[]
+  mcpTools?: string[]
+  skills?: string[]
+  bashCommands?: string[]
+  timestamp?: string
+} = {}): ParsedApiCall {
+  const timestamp = opts.timestamp ?? '2026-05-06T10:00:00Z'
+  return {
+    provider: opts.provider ?? 'claude',
+    model,
+    usage: {
+      inputTokens: 1000,
+      outputTokens: 250,
+      cacheCreationInputTokens: 100,
+      cacheReadInputTokens: 500,
+      cachedInputTokens: 0,
+      reasoningTokens: 0,
+      webSearchRequests: 0,
+    },
+    costUSD,
+    tools: opts.tools ?? [],
+    mcpTools: opts.mcpTools ?? [],
+    skills: opts.skills ?? [],
+    hasAgentSpawn: false,
+    hasPlanMode: false,
+    speed: 'standard',
+    timestamp,
+    bashCommands: opts.bashCommands ?? [],
+    deduplicationKey: `${model}:${timestamp}:${costUSD}`,
+  }
+}
+
+function makeTurn(sessionId: string, index: number, userMessage: string, calls: ParsedApiCall[]): ClassifiedTurn {
+  return {
+    userMessage,
+    assistantCalls: calls,
+    timestamp: `2026-05-06T10:0${index}:00Z`,
+    sessionId,
+    category: index === 1 ? 'coding' : 'testing',
+    retries: index === 2 ? 1 : 0,
+    hasEdits: index === 1,
+  }
+}
+
+function makeSession(sessionId: string, turns: ClassifiedTurn[]): SessionSummary {
+  return {
+    sessionId,
+    project: 'api',
+    firstTimestamp: turns[0]?.timestamp ?? '',
+    lastTimestamp: turns[turns.length - 1]?.timestamp ?? '',
+    totalCostUSD: turns.flatMap(turn => turn.assistantCalls).reduce((sum, call) => sum + call.costUSD, 0),
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    apiCalls: turns.reduce((sum, turn) => sum + turn.assistantCalls.length, 0),
+    turns,
+    modelBreakdown: {},
+    toolBreakdown: {},
+    mcpBreakdown: {},
+    bashBreakdown: {},
+    categoryBreakdown: {} as SessionSummary['categoryBreakdown'],
+    skillBreakdown: {},
+  }
+}
+
+function makeProject(project: string, sessions: SessionSummary[]): ProjectSummary {
+  return {
+    project,
+    projectPath: `/work/${project}`,
+    sessions,
+    totalCostUSD: sessions.reduce((sum, session) => sum + session.totalCostUSD, 0),
+    totalApiCalls: sessions.reduce((sum, session) => sum + session.apiCalls, 0),
+  }
+}
+
+function makeTinyProject(index: number): ProjectSummary {
+  const sessionId = `ambiguous-${String(index).padStart(2, '0')}`
+  return makeProject(`project-${index}`, [
+    makeSession(sessionId, [
+      makeTurn(sessionId, 1, `session ${index}`, [makeCall('claude-sonnet-4-5', 0.01)]),
+    ]),
+  ])
+}
+
+function fixtureProjects(): ProjectSummary[] {
+  const session = makeSession('abcdef123456', [
+    makeTurn('abcdef123456', 1, 'implement the replay command', [
+      makeCall('claude-sonnet-4-5', 0.12, {
+        tools: ['Read', 'Edit', 'Edit'],
+        mcpTools: ['mcp__github__get_issue'],
+        skills: ['planning'],
+        bashCommands: ['npm test'],
+      }),
+    ]),
+    makeTurn('abcdef123456', 2, 'run the focused tests', [
+      makeCall('claude-sonnet-4-5', 0.08, {
+        tools: ['Bash'],
+        bashCommands: ['npx vitest run tests/replay.test.ts'],
+      }),
+    ]),
+  ])
+  return [
+    makeProject('api', [session]),
+    makeProject('web', [
+      makeSession('abc999', [
+        makeTurn('abc999', 1, 'other session', [makeCall('gpt-5.3-codex', 0.5)]),
+      ]),
+    ]),
+  ]
+}
+
+describe('findReplaySessions', () => {
+  it('matches exact session ids before prefix matches', () => {
+    const matches = findReplaySessions(fixtureProjects(), 'abc999')
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.project.project).toBe('web')
+    expect(matches[0]?.session.sessionId).toBe('abc999')
+  })
+
+  it('finds sessions by id prefix', () => {
+    const matches = findReplaySessions(fixtureProjects(), 'abcdef')
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.session.sessionId).toBe('abcdef123456')
+  })
+
+  it('returns multiple prefix matches for ambiguous queries', () => {
+    const matches = findReplaySessions(fixtureProjects(), 'abc')
+    expect(matches.map(match => match.session.sessionId).sort()).toEqual(['abc999', 'abcdef123456'])
+  })
+
+  it('handles empty and uppercase queries', () => {
+    expect(findReplaySessions(fixtureProjects(), '')).toEqual([])
+    expect(findReplaySessions(fixtureProjects(), 'ABCDEF')).toHaveLength(1)
+  })
+})
+
+describe('buildReplayResult', () => {
+  it('builds a per-turn timeline with costs, tokens, tools, and shell commands', () => {
+    const [match] = findReplaySessions(fixtureProjects(), 'abcdef')
+    const result = buildReplayResult(match!, { includePrompts: true })
+
+    expect(result.totalCostUSD).toBeCloseTo(0.2)
+    expect(result.apiCalls).toBe(2)
+    expect(result.turns).toHaveLength(2)
+    expect(result.turns[0]).toEqual(expect.objectContaining({
+      userMessage: 'implement the replay command',
+      costUSD: 0.12,
+      inputTokens: 1000,
+      outputTokens: 250,
+      cacheReadTokens: 500,
+      cacheWriteTokens: 100,
+      tools: { Edit: 2, Read: 1 },
+      mcpTools: { mcp__github__get_issue: 1 },
+      skills: { planning: 1 },
+      bashCommands: ['npm test'],
+    }))
+  })
+
+  it('can hide prompt text from the replay result', () => {
+    const [match] = findReplaySessions(fixtureProjects(), 'abcdef')
+    const result = buildReplayResult(match!, { includePrompts: false })
+    expect(result.turns[0]?.userMessage).toBeNull()
+  })
+})
+
+describe('renderReplayText', () => {
+  it('renders a readable timeline', () => {
+    const [match] = findReplaySessions(fixtureProjects(), 'abcdef')
+    match!.session.turns[0]!.subCategory = 'implementation'
+    const text = renderReplayText(buildReplayResult(match!, { includePrompts: true }))
+
+    expect(text).toContain('CodeBurn session replay')
+    expect(text).toContain('Coding / implementation')
+    expect(text).toContain('implement the replay command')
+    expect(text).toContain('claude-sonnet-4-5')
+    expect(text).toContain('Edit x2')
+    expect(text).toContain('npm test')
+    expect(text).toContain('1 retry')
+  })
+
+  it('does not render prompt text when prompts are hidden', () => {
+    const [match] = findReplaySessions(fixtureProjects(), 'abcdef')
+    const text = renderReplayText(buildReplayResult(match!, { includePrompts: false }))
+
+    expect(text).toContain('Prompt: hidden by --no-prompts')
+    expect(text).not.toContain('implement the replay command')
+  })
+})
+
+describe('renderReplayCandidates', () => {
+  it('renders ambiguous matches with project names', () => {
+    const matches = findReplaySessions(fixtureProjects(), 'abc')
+    const text = renderReplayCandidates(matches, 'abc')
+
+    expect(text).toContain('Multiple sessions matched "abc"')
+    expect(text).toContain('abcdef123456')
+    expect(text).toContain('abc999')
+    expect(text).toContain('Use a longer session id prefix')
+  })
+
+  it('pluralizes hidden candidate counts', () => {
+    const matches = findReplaySessions(Array.from({ length: 12 }, (_, index) => makeTinyProject(index)), 'ambiguous')
+    const text = renderReplayCandidates(matches, 'ambiguous')
+
+    expect(text).toContain('...and 2 more matches')
+    expect(text).not.toContain('more matchs')
+  })
+})


### PR DESCRIPTION
## Summary

This adds `codeburn replay <session-id>`, a local session timeline for reviewing one recorded AI coding session turn by turn.

The existing dashboard and reports are good at aggregate cost visibility, but they do not make it easy to answer what happened inside a specific expensive or interesting session. `replay` fills that gap with a focused CLI view: prompt, cost, model, tools, shell commands, retries, edit flag, and token counts per turn.

## What changed

- add a new `codeburn replay <session-id>` command
- search sessions by exact session id or session id prefix
- support the same practical filters users expect elsewhere:
  - `--period`
  - `--from` / `--to`
  - `--provider`
  - `--project`
  - `--exclude`
- add `--json` for scripts and downstream analysis
- add `--no-prompts` for metadata-only replay output when users do not want prompt text in stdout
- render ambiguous prefix matches as a candidate list instead of picking one silently
- document the workflow and add an Unreleased changelog entry

## Output behavior

The text view prints a compact timeline with:

- project name and path
- session id and time window
- total spend, turn count, call count, and token totals
- per-turn category and cost
- user prompt, unless `--no-prompts` is set
- models used in the turn
- core tools, MCP tools, skills, and shell commands
- retry and edit flags

The JSON view returns the same structured replay data, with `userMessage: null` when `--no-prompts` is used.

## Privacy model

`replay` is local-only and does not upload data. By default it shows prompt text because the command is meant to help users understand a specific session.

`--no-prompts` hides user prompts in both text and JSON output, but it is not a full redaction mode. Shell commands and tool names remain visible because they are part of the execution timeline. The README calls this out explicitly so users do not mistake it for a share-safe export.

## Edge cases

- exact session id matches are preferred over prefix matches
- ambiguous prefixes fail with a visible candidate list and exit code 1
- empty queries return no matches in the library helper
- session id matching is case-insensitive
- candidate overflow pluralization is covered for more than 10 matches

## Validation

- `npx vitest run tests/replay.test.ts`
- `npm run build`
- `node dist/cli.js replay --help`
- `node dist/cli.js replay does-not-exist-hopefully --from 2999-01-01 --to 2999-01-02 --json` exits with code 1 and the expected not-found message
- `npx vitest run`
- `git diff --cached --check`

`npx tsc --noEmit` is still blocked by existing `src/providers/copilot.ts` type errors on `main`; this branch does not touch that provider path.
