### PR TITLE
feat(optimize): flag low-worth expensive sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   than the call's own cache buckets could contain. Threshold:
   >10 tools available, <20% coverage, observed in ≥2 sessions. Closes #2.
 - **Session cost outlier detector.** New `optimize` finding flags sessions costing more than 2x their peer-session average within the same project. Ignores sub-$1 outliers to avoid noise. Requires at least 3 sessions per project for a baseline.
+- **Worth-it score detector.** New `optimize` finding flags expensive sessions
+  with weak delivery signals, such as no edit turns or repeated retries when
+  no `git`/`gh` delivery command is observed. The finding is framed as a
+  conservative review candidate, not proof that a session was wasted.
 
 ### Fixed (CLI)
 - **`all` period semantics unified between CLI and dashboard.** The dashboard treated `--period all` as all-time (epoch start) while the CLI bounded it to the last 6 months. Both now consistently mean "Last 6 months". Period helpers (`Period`, `PERIODS`, `PERIOD_LABELS`, `toPeriod`, `getDateRange`) consolidated into `cli-date.ts`. Use `--from` / `--to` for unbounded historical ranges.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ Scans your sessions and your `~/.claude/` setup for waste patterns:
 - Ghost agents, skills, and slash commands defined in `~/.claude/` but never invoked
 - Bloated `CLAUDE.md` files (with `@-import` expansion counted)
 - Cache creation overhead and junk directory reads
+- Possibly low-worth expensive sessions with no edit turns or repeated retries
+  when no `git`/`gh` delivery command is observed
 
 Each finding shows the estimated token and dollar savings plus a ready-to-paste fix: a `CLAUDE.md` line, an environment variable, or a `mv` command to archive unused items. Findings are ranked by urgency (impact weighted against observed waste) and rolled up into an A to F setup health grade. Repeat runs classify each finding as new, improving, or resolved against a 48-hour recent window.
 

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -78,6 +78,12 @@ const MIN_SESSIONS_FOR_OUTLIER = 3
 const SESSION_OUTLIER_MULTIPLIER = 2
 const MIN_SESSION_OUTLIER_COST_USD = 1
 const SESSION_OUTLIER_PREVIEW = 5
+const WORTH_IT_MIN_COST_USD = 2
+const WORTH_IT_NO_EDIT_MIN_COST_USD = 3
+const WORTH_IT_MIN_RETRIES = 3
+const WORTH_IT_RETRY_WITH_EDIT_MIN_RETRIES = 2
+const WORTH_IT_PREVIEW = 5
+const WORTH_IT_TOKENS_SAVED_RATIO = 0.5
 
 // ============================================================================
 // Scoring constants
@@ -1213,6 +1219,121 @@ function sessionTokenTotal(session: ProjectSummary['sessions'][number]): number 
     + session.totalCacheWriteTokens
 }
 
+function sessionDeliveryCommand(session: ProjectSummary['sessions'][number]): string | null {
+  const commands = Object.keys(session.bashBreakdown)
+  const deliveryPatterns = [
+    /(?:^|[;&|]\s*)git\s+(?:commit|push)\b(?![^;&|]*--dry-run)/,
+    /(?:^|[;&|]\s*)gh\s+pr\s+(?:create|merge)\b(?![^;&|]*--dry-run)/,
+  ]
+  return commands.find(command => deliveryPatterns.some(pattern => pattern.test(command))) ?? null
+}
+
+function hasCategoryBreakdownData(session: ProjectSummary['sessions'][number]): boolean {
+  return Object.values(session.categoryBreakdown).some(category =>
+    category.turns > 0
+    || category.costUSD > 0
+    || category.retries > 0
+    || category.editTurns > 0
+    || category.oneShotTurns > 0
+  )
+}
+
+function sessionEditTurns(session: ProjectSummary['sessions'][number]): number {
+  const byCategory = Object.values(session.categoryBreakdown)
+    .reduce((sum, category) => sum + category.editTurns, 0)
+  if (hasCategoryBreakdownData(session)) return byCategory
+  return session.turns.filter(turn => turn.hasEdits).length
+}
+
+function sessionOneShotTurns(session: ProjectSummary['sessions'][number]): number {
+  const byCategory = Object.values(session.categoryBreakdown)
+    .reduce((sum, category) => sum + category.oneShotTurns, 0)
+  if (hasCategoryBreakdownData(session)) return byCategory
+  return session.turns.filter(turn => turn.hasEdits && turn.retries === 0).length
+}
+
+function sessionRetryCount(session: ProjectSummary['sessions'][number]): number {
+  const byCategory = Object.values(session.categoryBreakdown)
+    .reduce((sum, category) => sum + category.retries, 0)
+  if (hasCategoryBreakdownData(session)) return byCategory
+  return session.turns.reduce((sum, turn) => sum + turn.retries, 0)
+}
+
+export function detectLowWorthSessions(projects: ProjectSummary[]): WasteFinding | null {
+  type LowWorthSession = {
+    project: string
+    sessionId: string
+    date: string
+    cost: number
+    tokens: number
+    reasons: string[]
+  }
+
+  const candidates: LowWorthSession[] = []
+
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      if (session.totalCostUSD < WORTH_IT_MIN_COST_USD) continue
+      if (sessionDeliveryCommand(session)) continue
+
+      const editTurns = sessionEditTurns(session)
+      const oneShotTurns = sessionOneShotTurns(session)
+      const retries = sessionRetryCount(session)
+      const reasons: string[] = []
+
+      if (editTurns === 0 && session.totalCostUSD >= WORTH_IT_NO_EDIT_MIN_COST_USD) {
+        reasons.push('no edit turns')
+      }
+      if (retries >= WORTH_IT_MIN_RETRIES) {
+        reasons.push(`${retries} retries`)
+      }
+      if (
+        editTurns > 0
+        && oneShotTurns === 0
+        && retries >= WORTH_IT_RETRY_WITH_EDIT_MIN_RETRIES
+      ) {
+        reasons.push('no one-shot edit turns')
+      }
+
+      if (reasons.length === 0) continue
+
+      candidates.push({
+        project: project.project,
+        sessionId: session.sessionId,
+        date: session.firstTimestamp.slice(0, 10),
+        cost: session.totalCostUSD,
+        tokens: sessionTokenTotal(session),
+        reasons,
+      })
+    }
+  }
+
+  if (candidates.length === 0) return null
+
+  candidates.sort((a, b) => b.cost - a.cost)
+  const preview = candidates.slice(0, WORTH_IT_PREVIEW)
+  const list = preview
+    .map(s => `${s.project}/${s.sessionId} on ${s.date}: ${formatCost(s.cost)} (${s.reasons.join(', ')})`)
+    .join('; ')
+  const extra = candidates.length > preview.length ? `; +${candidates.length - preview.length} more` : ''
+  const tokensSaved = Math.round(
+    candidates.reduce((sum, s) => sum + s.tokens * WORTH_IT_TOKENS_SAVED_RATIO, 0),
+  )
+  const totalCost = candidates.reduce((sum, s) => sum + s.cost, 0)
+
+  return {
+    title: `${candidates.length} possibly low-worth expensive session${candidates.length === 1 ? '' : 's'}`,
+    explanation: `Sessions with meaningful spend but weak delivery signals: ${list}${extra}. This is a review candidate, not proof of waste: CodeBurn flags missing edit turns, repeated retries, and sessions without git delivery commands so you can tighten the next prompt before costs compound.`,
+    impact: candidates.length >= 3 || totalCost >= 10 ? 'high' : 'medium',
+    tokensSaved,
+    fix: {
+      type: 'paste',
+      label: 'Before continuing expensive work, define the stop rule:',
+      text: 'Summarize the smallest useful next patch, then work one file/task at a time. If tests fail twice or the approach repeats, stop and ask me to choose the next direction before spending more.',
+    },
+  }
+}
+
 export function detectSessionOutliers(projects: ProjectSummary[]): WasteFinding | null {
   type Outlier = {
     project: string
@@ -1399,6 +1520,7 @@ export async function scanAndDetect(
     () => detectDuplicateReads(toolCalls, dateRange),
     () => detectUnusedMcp(toolCalls, projects, projectCwds, mcpCoverage),
     () => detectMcpToolCoverage(projects, mcpCoverage),
+    () => detectLowWorthSessions(projects),
     () => detectSessionOutliers(projects),
     () => detectBloatedClaudeMd(projectCwds),
     () => detectBashBloat(),

--- a/tests/optimize.test.ts
+++ b/tests/optimize.test.ts
@@ -6,6 +6,7 @@ import {
   detectLowReadEditRatio,
   detectCacheBloat,
   detectBloatedClaudeMd,
+  detectLowWorthSessions,
   detectSessionOutliers,
   computeHealth,
   computeTrend,
@@ -23,37 +24,59 @@ function emptyProjects(): ProjectSummary[] {
   return []
 }
 
-function projectWithSessions(costs: number[], project = 'app'): ProjectSummary {
-  const sessions = costs.map((cost, i) => {
-    const tokens = Math.round(cost * 1000)
-    return {
-      sessionId: `s${i + 1}`,
-      project,
-      firstTimestamp: `2026-05-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
-      lastTimestamp: `2026-05-${String(i + 1).padStart(2, '0')}T10:30:00Z`,
-      totalCostUSD: cost,
-      totalInputTokens: tokens,
-      totalOutputTokens: tokens,
-      totalCacheReadTokens: 0,
-      totalCacheWriteTokens: 0,
-      apiCalls: 1,
-      turns: [],
-      modelBreakdown: {},
-      toolBreakdown: {},
-      mcpBreakdown: {},
-      bashBreakdown: {},
-      categoryBreakdown: {} as ProjectSummary['sessions'][number]['categoryBreakdown'],
-      skillBreakdown: {},
-    }
-  })
+type TestSession = ProjectSummary['sessions'][number]
+type TestTurn = TestSession['turns'][number]
 
+function turn(overrides: Partial<TestTurn> = {}): TestTurn {
+  return {
+    userMessage: 'do the work',
+    assistantCalls: [],
+    timestamp: '2026-05-01T10:00:00Z',
+    sessionId: 's1',
+    category: 'coding',
+    retries: 0,
+    hasEdits: false,
+    ...overrides,
+  }
+}
+
+function session(cost: number, i = 0, project = 'app', overrides: Partial<TestSession> = {}): TestSession {
+  const tokens = Math.round(cost * 1000)
+  const sessionId = `s${i + 1}`
+  return {
+    sessionId,
+    project,
+    firstTimestamp: `2026-05-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
+    lastTimestamp: `2026-05-${String(i + 1).padStart(2, '0')}T10:30:00Z`,
+    totalCostUSD: cost,
+    totalInputTokens: tokens,
+    totalOutputTokens: tokens,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    apiCalls: 1,
+    turns: [],
+    modelBreakdown: {},
+    toolBreakdown: {},
+    mcpBreakdown: {},
+    bashBreakdown: {},
+    categoryBreakdown: {} as TestSession['categoryBreakdown'],
+    skillBreakdown: {},
+    ...overrides,
+  }
+}
+
+function projectWithDetailedSessions(sessions: TestSession[], project = 'app'): ProjectSummary {
   return {
     project,
     projectPath: `/tmp/${project}`,
     sessions,
-    totalCostUSD: costs.reduce((sum, cost) => sum + cost, 0),
-    totalApiCalls: sessions.length,
+    totalCostUSD: sessions.reduce((sum, s) => sum + s.totalCostUSD, 0),
+    totalApiCalls: sessions.reduce((sum, s) => sum + s.apiCalls, 0),
   }
+}
+
+function projectWithSessions(costs: number[], project = 'app'): ProjectSummary {
+  return projectWithDetailedSessions(costs.map((cost, i) => session(cost, i, project)), project)
 }
 
 describe('detectJunkReads', () => {
@@ -238,6 +261,153 @@ describe('detectBloatedClaudeMd', () => {
   it('returns null for empty project set', () => {
     const result = detectBloatedClaudeMd(new Set())
     expect(result).toBeNull()
+  })
+})
+
+describe('detectLowWorthSessions', () => {
+  it('returns null for cheap sessions', () => {
+    const project = projectWithDetailedSessions([
+      session(1.99, 0, 'app', {
+        turns: [turn({ hasEdits: false })],
+      }),
+    ])
+
+    expect(detectLowWorthSessions([project])).toBeNull()
+  })
+
+  it('flags expensive sessions with no edit turns', () => {
+    const project = projectWithDetailedSessions([
+      session(4, 0, 'app', {
+        turns: [turn({ hasEdits: false })],
+      }),
+    ])
+
+    const finding = detectLowWorthSessions([project])
+    expect(finding).not.toBeNull()
+    expect(finding!.title).toContain('possibly low-worth')
+    expect(finding!.explanation).toContain('app/s1')
+    expect(finding!.explanation).toContain('no edit turns')
+    expect(finding!.impact).toBe('medium')
+    expect(finding!.tokensSaved).toBe(4000)
+  })
+
+  it('flags retry-heavy sessions', () => {
+    const project = projectWithDetailedSessions([
+      session(2.5, 0, 'app', {
+        turns: [
+          turn({ hasEdits: true, retries: 1 }),
+          turn({ hasEdits: true, retries: 2 }),
+        ],
+      }),
+    ])
+
+    const finding = detectLowWorthSessions([project])
+    expect(finding).not.toBeNull()
+    expect(finding!.explanation).toContain('3 retries')
+  })
+
+  it('keeps all reasons that apply to the same session', () => {
+    const project = projectWithDetailedSessions([
+      session(4, 0, 'app', {
+        turns: [
+          turn({ hasEdits: false, retries: 1 }),
+          turn({ hasEdits: false, retries: 2 }),
+        ],
+      }),
+    ])
+
+    const finding = detectLowWorthSessions([project])
+    expect(finding).not.toBeNull()
+    expect(finding!.explanation).toContain('no edit turns')
+    expect(finding!.explanation).toContain('3 retries')
+  })
+
+  it('flags edit sessions with retries but no one-shot edit turns', () => {
+    const project = projectWithDetailedSessions([
+      session(2.25, 0, 'app', {
+        categoryBreakdown: {
+          coding: { turns: 2, costUSD: 2.25, retries: 2, editTurns: 2, oneShotTurns: 0 },
+        } as TestSession['categoryBreakdown'],
+      }),
+    ])
+
+    const finding = detectLowWorthSessions([project])
+    expect(finding).not.toBeNull()
+    expect(finding!.explanation).toContain('no one-shot edit turns')
+  })
+
+  it('does not flag sessions with git delivery commands', () => {
+    const project = projectWithDetailedSessions([
+      session(8, 0, 'app', {
+        turns: [turn({ hasEdits: false })],
+        bashBreakdown: {
+          'cd /tmp/app && git commit -m "ship fix"': { calls: 1 },
+        },
+      }),
+    ])
+
+    expect(detectLowWorthSessions([project])).toBeNull()
+  })
+
+  it('treats GitHub PR creation as a delivery command', () => {
+    const project = projectWithDetailedSessions([
+      session(8, 0, 'app', {
+        turns: [turn({ hasEdits: false })],
+        bashBreakdown: {
+          'gh pr create --fill': { calls: 1 },
+        },
+      }),
+    ])
+
+    expect(detectLowWorthSessions([project])).toBeNull()
+  })
+
+  it('does not treat read-only git commands as delivery', () => {
+    const project = projectWithDetailedSessions([
+      session(8, 0, 'app', {
+        turns: [turn({ hasEdits: false })],
+        bashBreakdown: {
+          'git tag -l': { calls: 1 },
+        },
+      }),
+    ])
+
+    expect(detectLowWorthSessions([project])).not.toBeNull()
+  })
+
+  it('does not treat dry-run git commands as delivery', () => {
+    const project = projectWithDetailedSessions([
+      session(8, 0, 'app', {
+        turns: [turn({ hasEdits: false })],
+        bashBreakdown: {
+          'git push --dry-run origin main': { calls: 1 },
+        },
+      }),
+    ])
+
+    expect(detectLowWorthSessions([project])).not.toBeNull()
+  })
+
+  it('does not flag the no-edit cost boundary', () => {
+    const project = projectWithDetailedSessions([
+      session(2.99, 0, 'app', {
+        turns: [turn({ hasEdits: false })],
+      }),
+    ])
+
+    expect(detectLowWorthSessions([project])).toBeNull()
+  })
+
+  it('summarizes additional candidates after the preview limit', () => {
+    const project = projectWithDetailedSessions(
+      Array.from({ length: 6 }, (_, i) => session(4 + i, i, 'app', {
+        turns: [turn({ hasEdits: false })],
+      })),
+    )
+
+    const finding = detectLowWorthSessions([project])
+    expect(finding).not.toBeNull()
+    expect(finding!.explanation).toContain('; +1 more')
   })
 })
 


### PR DESCRIPTION
## Summary

This adds a Worth-it Score style detector to `codeburn optimize` so expensive sessions with weak delivery signals are easy to review before they become a habit.

- flags sessions above the spend floor when they have no edit turns, repeated retries, or edit turns with no one-shot success
- treats `git commit`, `git push`, `gh pr create`, and `gh pr merge` as delivery signals, while ignoring dry-run commands and read-only git commands like `git tag -l`
- keeps the detector conservative: findings are described as review candidates, not proof that a session was wasted
- lists the most expensive candidates first, caps the preview, and rolls the finding into the existing optimize urgency/health scoring
- documents the new detector in README and CHANGELOG

## Detection model

The detector is intentionally heuristic and bounded:

- sessions under `$2` are ignored entirely
- no-edit sessions need at least `$3` spend before they are reported
- retry-heavy sessions require at least 3 retries
- edit sessions with zero one-shot turns require at least 2 retries
- sessions with an observed delivery command are skipped so normal ship-work is not treated as suspect

For compatibility with older parsed data, the implementation reads aggregate `categoryBreakdown` data when present and falls back to raw `turns` when the aggregate is empty.

## Validation

- `npx vitest run tests/optimize.test.ts`
- `npm run build`
- `npx vitest run`
- `node dist/cli.js optimize --help`
- `git diff --check`

`npx tsc --noEmit` still fails on the existing Copilot provider type errors in `src/providers/copilot.ts`, outside this diff. The same failure is present on `origin/main`.