### PR TITLE
feat(optimize): detect context-heavy sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
   than the call's own cache buckets could contain. Threshold:
   >10 tools available, <20% coverage, observed in ≥2 sessions. Closes #2.
 - **Session cost outlier detector.** New `optimize` finding flags sessions costing more than 2x their peer-session average within the same project. Ignores sub-$1 outliers to avoid noise. Requires at least 3 sessions per project for a baseline.
+- **Context bloat detector.** New `optimize` finding flags sessions where
+  effective input/cache tokens are large and disproportionate to output.
+  Cache reads are discounted in the estimate to avoid overstating cheap cached
+  context. The report highlights top sessions by imbalance, notes sharp
+  growth from the previous project session, and suggests starting fresh with
+  only the current goal, relevant files, failing output, and constraints.
 
 ### Fixed (CLI)
 - **`all` period semantics unified between CLI and dashboard.** The dashboard treated `--period all` as all-time (epoch start) while the CLI bounded it to the last 6 months. Both now consistently mean "Last 6 months". Period helpers (`Period`, `PERIODS`, `PERIOD_LABELS`, `toPeriod`, `getDateRange`) consolidated into `cli-date.ts`. Use `--from` / `--to` for unbounded historical ranges.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Scans your sessions and your `~/.claude/` setup for waste patterns:
 - Ghost agents, skills, and slash commands defined in `~/.claude/` but never invoked
 - Bloated `CLAUDE.md` files (with `@-import` expansion counted)
 - Cache creation overhead and junk directory reads
+- Context-heavy sessions where effective input/cache tokens swamp output
 
 Each finding shows the estimated token and dollar savings plus a ready-to-paste fix: a `CLAUDE.md` line, an environment variable, or a `mv` command to archive unused items. Findings are ranked by urgency (impact weighted against observed waste) and rolled up into an A to F setup health grade. Repeat runs classify each finding as new, improving, or resolved against a 48-hour recent window.
 

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -78,6 +78,13 @@ const MIN_SESSIONS_FOR_OUTLIER = 3
 const SESSION_OUTLIER_MULTIPLIER = 2
 const MIN_SESSION_OUTLIER_COST_USD = 1
 const SESSION_OUTLIER_PREVIEW = 5
+const CONTEXT_BLOAT_MIN_INPUT_TOKENS = 75_000
+const CONTEXT_BLOAT_MIN_RATIO = 25
+const CONTEXT_BLOAT_TARGET_RATIO = 15
+const CONTEXT_BLOAT_PREVIEW = 5
+const CONTEXT_BLOAT_HIGH_INPUT_TOKENS = 500_000
+const CONTEXT_BLOAT_GROWTH_RATIO = 2
+const CONTEXT_BLOAT_RATIO_DISPLAY_CAP = 1000
 
 // ============================================================================
 // Scoring constants
@@ -1213,6 +1220,101 @@ function sessionTokenTotal(session: ProjectSummary['sessions'][number]): number 
     + session.totalCacheWriteTokens
 }
 
+function sessionEffectiveContextTokens(session: ProjectSummary['sessions'][number]): number {
+  return session.totalInputTokens
+    + session.totalCacheReadTokens * CACHE_READ_DISCOUNT
+    + session.totalCacheWriteTokens * CACHE_WRITE_MULTIPLIER
+}
+
+function formatContextRatio(ratio: number): string {
+  if (ratio >= CONTEXT_BLOAT_RATIO_DISPLAY_CAP) return `${CONTEXT_BLOAT_RATIO_DISPLAY_CAP}+`
+  return ratio.toFixed(1)
+}
+
+export function detectContextBloat(projects: ProjectSummary[]): WasteFinding | null {
+  type ContextCandidate = {
+    project: string
+    sessionId: string
+    date: string
+    effectiveInputTokens: number
+    outputTokens: number
+    ratio: number
+    excessInputTokens: number
+    growthRatio: number | null
+  }
+
+  const candidates: ContextCandidate[] = []
+
+  for (const project of projects) {
+    const sessions = [...project.sessions].sort((a, b) =>
+      new Date(a.firstTimestamp).getTime() - new Date(b.firstTimestamp).getTime()
+    )
+    let previousInputTokens: number | null = null
+
+    for (const session of sessions) {
+      const inputTokens = sessionEffectiveContextTokens(session)
+      const outputTokens = session.totalOutputTokens
+      const ratio = inputTokens / Math.max(outputTokens, 1)
+      const growthRatio = previousInputTokens !== null && previousInputTokens > 0
+        ? inputTokens / previousInputTokens
+        : null
+
+      // Anchor growth to the immediately previous project session, even if
+      // that session is below threshold and never becomes a finding.
+      previousInputTokens = inputTokens
+
+      if (inputTokens < CONTEXT_BLOAT_MIN_INPUT_TOKENS) continue
+      if (ratio < CONTEXT_BLOAT_MIN_RATIO) continue
+
+      candidates.push({
+        project: project.project,
+        sessionId: session.sessionId,
+        date: session.firstTimestamp.slice(0, 10),
+        effectiveInputTokens: inputTokens,
+        outputTokens,
+        ratio,
+        excessInputTokens: Math.max(0, inputTokens - outputTokens * CONTEXT_BLOAT_TARGET_RATIO),
+        growthRatio,
+      })
+    }
+  }
+
+  if (candidates.length === 0) return null
+
+  candidates.sort((a, b) =>
+    b.excessInputTokens - a.excessInputTokens
+    || a.date.localeCompare(b.date)
+    || a.project.localeCompare(b.project)
+    || a.sessionId.localeCompare(b.sessionId)
+  )
+  const preview = candidates.slice(0, CONTEXT_BLOAT_PREVIEW)
+  const list = preview
+    .map(c => {
+      const growth = c.growthRatio !== null && c.growthRatio >= CONTEXT_BLOAT_GROWTH_RATIO
+        ? `, ${c.growthRatio.toFixed(1)}x previous session input`
+        : ''
+      return `${c.project}/${c.sessionId} on ${c.date}: ${formatTokens(c.effectiveInputTokens)} effective input/cache vs ${formatTokens(c.outputTokens)} output (${formatContextRatio(c.ratio)}:1${growth})`
+    })
+    .join('; ')
+  const extra = candidates.length > preview.length ? `; +${candidates.length - preview.length} more` : ''
+  // Savings estimate only counts context above a healthier 15:1 input-output ratio.
+  // Detection stays stricter at 25:1 so borderline sessions are not shown.
+  const tokensSaved = Math.round(candidates.reduce((sum, c) => sum + c.excessInputTokens, 0))
+  const totalInputTokens = candidates.reduce((sum, c) => sum + c.effectiveInputTokens, 0)
+
+  return {
+    title: `${candidates.length} context-heavy session${candidates.length === 1 ? '' : 's'}`,
+    explanation: `Effective input/cache tokens swamp output in these sessions: ${list}${extra}. This can come from stale context carryover, inherently context-heavy work, or abandoned runs that loaded too much context; starting fresh with only the current goal and relevant files can cut repeated prompt overhead.`,
+    impact: candidates.length >= 3 || totalInputTokens >= CONTEXT_BLOAT_HIGH_INPUT_TOKENS ? 'high' : 'medium',
+    tokensSaved,
+    fix: {
+      type: 'paste',
+      label: 'Start the next expensive thread with a fresh-context constraint:',
+      text: 'Start fresh before continuing. Use only the current goal, the relevant files, the failing command/output, and the constraints below. Restate the working context in under 10 bullets before editing.',
+    },
+  }
+}
+
 export function detectSessionOutliers(projects: ProjectSummary[]): WasteFinding | null {
   type Outlier = {
     project: string
@@ -1399,6 +1501,7 @@ export async function scanAndDetect(
     () => detectDuplicateReads(toolCalls, dateRange),
     () => detectUnusedMcp(toolCalls, projects, projectCwds, mcpCoverage),
     () => detectMcpToolCoverage(projects, mcpCoverage),
+    () => detectContextBloat(projects),
     () => detectSessionOutliers(projects),
     () => detectBloatedClaudeMd(projectCwds),
     () => detectBashBloat(),

--- a/tests/optimize.test.ts
+++ b/tests/optimize.test.ts
@@ -6,6 +6,7 @@ import {
   detectLowReadEditRatio,
   detectCacheBloat,
   detectBloatedClaudeMd,
+  detectContextBloat,
   detectSessionOutliers,
   computeHealth,
   computeTrend,
@@ -53,6 +54,45 @@ function projectWithSessions(costs: number[], project = 'app'): ProjectSummary {
     sessions,
     totalCostUSD: costs.reduce((sum, cost) => sum + cost, 0),
     totalApiCalls: sessions.length,
+  }
+}
+
+type TestSession = ProjectSummary['sessions'][number]
+
+function contextSession(
+  i: number,
+  overrides: Partial<TestSession>,
+  project = 'app',
+): TestSession {
+  return {
+    sessionId: `s${i + 1}`,
+    project,
+    firstTimestamp: `2026-05-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
+    lastTimestamp: `2026-05-${String(i + 1).padStart(2, '0')}T10:30:00Z`,
+    totalCostUSD: 1,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    apiCalls: 1,
+    turns: [],
+    modelBreakdown: {},
+    toolBreakdown: {},
+    mcpBreakdown: {},
+    bashBreakdown: {},
+    categoryBreakdown: {} as TestSession['categoryBreakdown'],
+    skillBreakdown: {},
+    ...overrides,
+  }
+}
+
+function projectWithContextSessions(sessions: TestSession[], project = 'app'): ProjectSummary {
+  return {
+    project,
+    projectPath: `/tmp/${project}`,
+    sessions,
+    totalCostUSD: sessions.reduce((sum, session) => sum + session.totalCostUSD, 0),
+    totalApiCalls: sessions.reduce((sum, session) => sum + session.apiCalls, 0),
   }
 }
 
@@ -238,6 +278,159 @@ describe('detectBloatedClaudeMd', () => {
   it('returns null for empty project set', () => {
     const result = detectBloatedClaudeMd(new Set())
     expect(result).toBeNull()
+  })
+})
+
+describe('detectContextBloat', () => {
+  it('returns null below the input/context token floor', () => {
+    const project = projectWithContextSessions([
+      contextSession(0, {
+        totalInputTokens: 74_999,
+        totalOutputTokens: 100,
+      }),
+    ])
+
+    expect(detectContextBloat([project])).toBeNull()
+  })
+
+  it('returns null when output is proportionate to input/context tokens', () => {
+    const project = projectWithContextSessions([
+      contextSession(0, {
+        totalInputTokens: 100_000,
+        totalOutputTokens: 5_000,
+      }),
+    ])
+
+    expect(detectContextBloat([project])).toBeNull()
+  })
+
+  it('discounts cache reads when estimating context pressure', () => {
+    const project = projectWithContextSessions([
+      contextSession(0, {
+        totalInputTokens: 5_000,
+        totalCacheReadTokens: 700_000,
+        totalOutputTokens: 5_000,
+      }),
+    ])
+
+    expect(detectContextBloat([project])).toBeNull()
+  })
+
+  it('weights cache writes when estimating context pressure', () => {
+    const project = projectWithContextSessions([
+      contextSession(0, {
+        totalInputTokens: 10_000,
+        totalCacheWriteTokens: 80_000,
+        totalOutputTokens: 3_000,
+      }),
+    ])
+
+    const finding = detectContextBloat([project])
+    expect(finding).not.toBeNull()
+    expect(finding!.explanation).toContain('110.0K effective input/cache')
+    expect(finding!.tokensSaved).toBe(65_000)
+  })
+
+  it('flags sessions where input/cache tokens swamp output', () => {
+    const project = projectWithContextSessions([
+      contextSession(0, {
+        totalInputTokens: 90_000,
+        totalCacheReadTokens: 30_000,
+        totalOutputTokens: 2_000,
+      }),
+    ])
+
+    const finding = detectContextBloat([project])
+    expect(finding).not.toBeNull()
+    expect(finding!.title).toContain('context-heavy session')
+    expect(finding!.explanation).toContain('app/s1')
+    expect(finding!.explanation).toContain('93.0K effective input/cache')
+    expect(finding!.explanation).toContain('46.5:1')
+    expect(finding!.impact).toBe('medium')
+    expect(finding!.tokensSaved).toBe(63_000)
+  })
+
+  it('includes context growth from the previous session when it is large', () => {
+    const project = projectWithContextSessions([
+      contextSession(0, {
+        totalInputTokens: 20_000,
+        totalOutputTokens: 1_000,
+      }),
+      contextSession(1, {
+        totalInputTokens: 100_000,
+        totalOutputTokens: 2_000,
+      }),
+    ])
+
+    const finding = detectContextBloat([project])
+    expect(finding).not.toBeNull()
+    expect(finding!.explanation).toContain('5.0x previous session input')
+  })
+
+  it('calculates context growth within each project only', () => {
+    const finding = detectContextBloat([
+      projectWithContextSessions([
+        contextSession(0, {
+          totalInputTokens: 20_000,
+          totalOutputTokens: 1_000,
+        }),
+        contextSession(1, {
+          totalInputTokens: 100_000,
+          totalOutputTokens: 2_000,
+        }),
+      ], 'app'),
+      projectWithContextSessions([
+        contextSession(0, {
+          totalInputTokens: 100_000,
+          totalOutputTokens: 2_000,
+        }, 'api'),
+      ], 'api'),
+    ])
+
+    expect(finding).not.toBeNull()
+    expect(finding!.explanation.match(/previous session input/g)).toHaveLength(1)
+  })
+
+  it('summarizes additional candidates after the preview limit', () => {
+    const project = projectWithContextSessions(
+      Array.from({ length: 6 }, (_, i) => contextSession(i, {
+        totalInputTokens: 80_000 + i * 10_000,
+        totalOutputTokens: 1_000,
+      })),
+    )
+
+    const finding = detectContextBloat([project])
+    expect(finding).not.toBeNull()
+    expect(finding!.explanation).toContain('app/s6')
+    expect(finding!.explanation).toContain('; +1 more')
+    expect(finding!.impact).toBe('high')
+  })
+
+  it('uses high impact for one very large context-heavy session', () => {
+    const project = projectWithContextSessions([
+      contextSession(0, {
+        totalInputTokens: 600_000,
+        totalOutputTokens: 10_000,
+      }),
+    ])
+
+    const finding = detectContextBloat([project])
+    expect(finding).not.toBeNull()
+    expect(finding!.impact).toBe('high')
+  })
+
+  it('handles zero-output sessions without dividing by zero', () => {
+    const project = projectWithContextSessions([
+      contextSession(0, {
+        totalInputTokens: 80_000,
+        totalOutputTokens: 0,
+      }),
+    ])
+
+    const finding = detectContextBloat([project])
+    expect(finding).not.toBeNull()
+    expect(finding!.explanation).toContain('1000+:1')
+    expect(finding!.tokensSaved).toBe(80_000)
   })
 })
 


### PR DESCRIPTION
## Summary

This adds a Context Bloat Analyzer finding to `codeburn optimize` so users can spot sessions where the effective input/cache footprint is much larger than the useful output. The goal is to make it obvious when a fresh thread or tighter context handoff would likely be cheaper than carrying everything forward.

- adds a new `detectContextBloat()` detector in the optimize pipeline
- measures effective input/cache tokens using the existing cache pricing assumptions: cache reads are discounted, cache writes use the cache-write multiplier
- flags sessions only when effective input/cache tokens are both large and disproportionate to output
- shows the top context-heavy sessions, their input/output ratio, and sharp growth from the previous project session
- caps extreme ratio display as `1000+:1` so zero-output sessions do not produce noisy numbers
- keeps candidate ordering deterministic for stable previews and tests
- documents the detector in README and CHANGELOG

## Detection model

The detector is intentionally conservative:

- effective input/cache floor: 75,000 tokens
- minimum effective input/output ratio: 25:1
- token-savings estimate: context above a healthier 15:1 ratio
- high impact when there are at least 3 candidates or at least 500K effective input/cache tokens across candidates
- growth is measured against the immediately previous session in the same project, even if that previous session is below the reporting threshold

This keeps raw cache-read-heavy sessions from being overstated while still catching sessions that are expensive in practice.

## Validation

- `npx vitest run tests/optimize.test.ts`
- `npm run build`
- `npx vitest run`
- `node dist/cli.js optimize --help`
- `git diff --check`

`npx tsc --noEmit` still fails on the existing Copilot provider type errors in `src/providers/copilot.ts`, outside this diff. The same failure is present on `origin/main`.

thats all i got for the moment :)