### PR TITLE
feat(accounts): add account control center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Added (CLI)
+- **Account control center.** `codeburn accounts` groups usage by detected
+  Claude config account, lets users attach plan/budget metadata with
+  `accounts set`, and exposes account rollups in JSON reports and exports.
+  Account filters now work across report, today/month, status, export,
+  optimize, and compare.
 - **Multiple subscription plans can be tracked at the same time.**
   `codeburn plan set` now stores plans in a provider-keyed `plans` map, so
   setting a Codex custom plan no longer overwrites an existing Claude plan.

--- a/README.md
+++ b/README.md
@@ -301,10 +301,11 @@ codeburn report --project myapp                  # show only projects matching "
 codeburn report --exclude myapp                  # show everything except "myapp"
 codeburn report --exclude myapp --exclude tests  # exclude multiple projects
 codeburn month --project api --project web       # include multiple projects
+codeburn report --account work                   # show only usage from matching accounts
 codeburn export --project inventory              # export only "inventory" project data
 ```
 
-Filter by provider, project name (case-insensitive substring), or exact date range. The `--project` and `--exclude` flags work on all commands and can be combined with `--provider`.
+Filter by provider, project name (case-insensitive substring), account label/path, or exact date range. The `--project`, `--exclude`, and `--account` flags work on report-style commands and can be combined with `--provider`.
 
 ```bash
 codeburn report --from 2026-04-01 --to 2026-04-10   # explicit window
@@ -333,6 +334,18 @@ codeburn today --format json | jq '.overview.cost'
 ```
 
 For lighter output, use `status --format json` (today and month totals only) or file exports (`export -f json`).
+
+### Accounts
+
+When Claude usage comes from multiple config roots, CodeBurn keeps those roots separate instead of merging projects with the same sanitized path:
+
+```bash
+CLAUDE_CONFIG_DIRS="$HOME/.claude-work:$HOME/.claude-personal" codeburn accounts
+codeburn accounts set work --plan "Claude Max" --monthly-usd 200 --budget-usd 300
+codeburn accounts work --format json
+```
+
+`codeburn accounts` shows spend, sessions, projects, top models, subscription efficiency, budget utilization, duplicate-project signals, and account/path mismatch signals. Account rollups also appear in JSON reports and exports.
 
 ## Menu Bar
 

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,0 +1,275 @@
+import type { AccountConfig } from './config.js'
+import type { ProjectSummary } from './types.js'
+
+export type AccountModelSummary = {
+  name: string
+  calls: number
+  costUSD: number
+}
+
+export type AccountProjectSummary = {
+  project: string
+  projectPath: string
+  costUSD: number
+  sessions: number
+}
+
+export type AccountSummary = {
+  account: string
+  accountPath?: string
+  configured?: AccountConfig
+  totalCostUSD: number
+  totalApiCalls: number
+  sessions: number
+  projects: number
+  editTurns: number
+  oneShotTurns: number
+  costPerSessionUSD: number | null
+  costPerEditUSD: number | null
+  subscriptionCostPerSessionUSD: number | null
+  subscriptionCostPerEditUSD: number | null
+  budgetUtilizationPercent: number | null
+  subscriptionUtilizationPercent: number | null
+  topModels: AccountModelSummary[]
+  topProjects: AccountProjectSummary[]
+}
+
+export type AccountRisk = {
+  type: 'duplicate-project' | 'path-account-mismatch' | 'underused-subscription' | 'over-budget'
+  account?: string
+  projectPath?: string
+  accounts?: string[]
+  message: string
+}
+
+export type AccountReport = {
+  accounts: AccountSummary[]
+  risks: AccountRisk[]
+}
+
+const UNLABELLED_ACCOUNT = 'unlabelled'
+const TOP_LIMIT = 5
+const UNDERUSED_SUBSCRIPTION_PERCENT = 10
+const WORK_MARKERS = ['work', 'client', 'company', 'corp', 'office']
+const PERSONAL_MARKERS = ['personal', 'private', 'home']
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+export function projectAccount(project: Pick<ProjectSummary, 'account'>): string {
+  return project.account?.trim() || UNLABELLED_ACCOUNT
+}
+
+export function filterProjectsByAccount(projects: ProjectSummary[], include?: string[]): ProjectSummary[] {
+  const patterns = include?.map(s => s.trim().toLowerCase()).filter(Boolean) ?? []
+  if (patterns.length === 0) return projects
+
+  return projects.filter(project => {
+    const account = projectAccount(project).toLowerCase()
+    const accountPath = (project.accountPath ?? '').toLowerCase()
+    return patterns.some(pattern => {
+      const accountScopedProject = pattern.includes(':') && (
+        `${account}:${project.project.toLowerCase()}`.includes(pattern)
+        || `${account}:${project.projectPath.toLowerCase()}`.includes(pattern)
+      )
+      return account.includes(pattern) || accountPath.includes(pattern) || accountScopedProject
+    })
+  })
+}
+
+function sortedEntries<T extends { costUSD: number }>(map: Map<string, T>): T[] {
+  return [...map.values()].sort((a, b) => b.costUSD - a.costUSD).slice(0, TOP_LIMIT)
+}
+
+function utilization(spendUSD: number, configuredUSD?: number): number | null {
+  if (configuredUSD === undefined || configuredUSD <= 0) return null
+  return round2((spendUSD / configuredUSD) * 100)
+}
+
+function addModelCost(
+  map: Map<string, AccountModelSummary>,
+  name: string,
+  calls: number,
+  costUSD: number,
+) {
+  const existing = map.get(name) ?? { name, calls: 0, costUSD: 0 }
+  existing.calls += calls
+  existing.costUSD += costUSD
+  map.set(name, existing)
+}
+
+function accountLooksLike(account: string, markers: string[]): boolean {
+  const tokens = account.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)
+  return markers.some(marker => tokens.includes(marker))
+}
+
+function pathLooksLike(path: string, markers: string[]): boolean {
+  const lower = path.toLowerCase()
+  return markers.some(marker => lower.includes(`/${marker}/`) || lower.includes(`-${marker}-`) || lower.endsWith(`/${marker}`))
+}
+
+export function buildAccountReport(
+  projects: ProjectSummary[],
+  accountConfig: Record<string, AccountConfig> = {},
+): AccountReport {
+  type Accum = {
+    account: string
+    accountPaths: Set<string>
+    totalCostUSD: number
+    totalApiCalls: number
+    sessions: number
+    projectPaths: Set<string>
+    editTurns: number
+    oneShotTurns: number
+    models: Map<string, AccountModelSummary>
+    projects: Map<string, AccountProjectSummary>
+  }
+
+  const byAccount = new Map<string, Accum>()
+  const projectAccounts = new Map<string, Set<string>>()
+  const risks: AccountRisk[] = []
+  const configByAccount = new Map(Object.entries(accountConfig).map(([account, config]) => [account.toLowerCase(), config]))
+
+  for (const project of projects) {
+    const account = projectAccount(project)
+    const existing = byAccount.get(account) ?? {
+      account,
+      accountPaths: new Set<string>(),
+      totalCostUSD: 0,
+      totalApiCalls: 0,
+      sessions: 0,
+      projectPaths: new Set<string>(),
+      editTurns: 0,
+      oneShotTurns: 0,
+      models: new Map<string, AccountModelSummary>(),
+      projects: new Map<string, AccountProjectSummary>(),
+    }
+
+    if (project.accountPath) existing.accountPaths.add(project.accountPath)
+    existing.totalCostUSD += project.totalCostUSD
+    existing.totalApiCalls += project.totalApiCalls
+    existing.sessions += project.sessions.length
+    existing.projectPaths.add(project.projectPath)
+
+    if (project.account?.trim()) {
+      const projectKey = project.projectPath.toLowerCase()
+      const accountsForProject = projectAccounts.get(projectKey) ?? new Set<string>()
+      accountsForProject.add(account)
+      projectAccounts.set(projectKey, accountsForProject)
+    }
+
+    const projectSummary = existing.projects.get(project.projectPath) ?? {
+      project: project.project,
+      projectPath: project.projectPath,
+      costUSD: 0,
+      sessions: 0,
+    }
+    projectSummary.costUSD += project.totalCostUSD
+    projectSummary.sessions += project.sessions.length
+    existing.projects.set(project.projectPath, projectSummary)
+
+    if (accountLooksLike(account, PERSONAL_MARKERS) && pathLooksLike(project.projectPath, WORK_MARKERS)) {
+      risks.push({
+        type: 'path-account-mismatch',
+        account,
+        projectPath: project.projectPath,
+        message: `${project.projectPath} looks work/client-related but ran on ${account}.`,
+      })
+    }
+    if (accountLooksLike(account, WORK_MARKERS) && pathLooksLike(project.projectPath, PERSONAL_MARKERS)) {
+      risks.push({
+        type: 'path-account-mismatch',
+        account,
+        projectPath: project.projectPath,
+        message: `${project.projectPath} looks personal/private but ran on ${account}.`,
+      })
+    }
+
+    for (const session of project.sessions) {
+      for (const [model, data] of Object.entries(session.modelBreakdown)) {
+        addModelCost(existing.models, model, data.calls, data.costUSD)
+      }
+      for (const breakdown of Object.values(session.categoryBreakdown)) {
+        existing.editTurns += breakdown.editTurns
+        existing.oneShotTurns += breakdown.oneShotTurns
+      }
+    }
+
+    byAccount.set(account, existing)
+  }
+
+  for (const [projectPath, accounts] of projectAccounts) {
+    if (accounts.size <= 1) continue
+    const list = [...accounts].sort()
+    risks.push({
+      type: 'duplicate-project',
+      projectPath,
+      accounts: list,
+      message: `${projectPath} appears on multiple accounts: ${list.join(', ')}.`,
+    })
+  }
+
+  for (const account of Object.keys(accountConfig)) {
+    const lower = account.toLowerCase()
+    if ([...byAccount.keys()].some(existing => existing.toLowerCase() === lower)) continue
+    byAccount.set(account, {
+      account,
+      accountPaths: new Set<string>(),
+      totalCostUSD: 0,
+      totalApiCalls: 0,
+      sessions: 0,
+      projectPaths: new Set<string>(),
+      editTurns: 0,
+      oneShotTurns: 0,
+      models: new Map<string, AccountModelSummary>(),
+      projects: new Map<string, AccountProjectSummary>(),
+    })
+  }
+
+  const accounts = [...byAccount.values()]
+    .map(acc => {
+      const configured = configByAccount.get(acc.account.toLowerCase())
+      const subscriptionUtilizationPercent = utilization(acc.totalCostUSD, configured?.monthlyUsd)
+      const budgetUtilizationPercent = utilization(acc.totalCostUSD, configured?.budgetUsd)
+      const summary: AccountSummary = {
+        account: acc.account,
+        ...(acc.accountPaths.size > 0 ? { accountPath: [...acc.accountPaths].sort().join(',') } : {}),
+        ...(configured ? { configured } : {}),
+        totalCostUSD: acc.totalCostUSD,
+        totalApiCalls: acc.totalApiCalls,
+        sessions: acc.sessions,
+        projects: acc.projectPaths.size,
+        editTurns: acc.editTurns,
+        oneShotTurns: acc.oneShotTurns,
+        costPerSessionUSD: acc.sessions > 0 ? acc.totalCostUSD / acc.sessions : null,
+        costPerEditUSD: acc.editTurns > 0 ? acc.totalCostUSD / acc.editTurns : null,
+        subscriptionCostPerSessionUSD: configured?.monthlyUsd && acc.sessions > 0 ? configured.monthlyUsd / acc.sessions : null,
+        subscriptionCostPerEditUSD: configured?.monthlyUsd && acc.editTurns > 0 ? configured.monthlyUsd / acc.editTurns : null,
+        budgetUtilizationPercent,
+        subscriptionUtilizationPercent,
+        topModels: sortedEntries(acc.models),
+        topProjects: sortedEntries(acc.projects),
+      }
+
+      if (configured?.monthlyUsd && subscriptionUtilizationPercent !== null && subscriptionUtilizationPercent < UNDERUSED_SUBSCRIPTION_PERCENT) {
+        risks.push({
+          type: 'underused-subscription',
+          account: acc.account,
+          message: `${acc.account} used ${subscriptionUtilizationPercent}% of its ${configured.plan ?? 'subscription'} monthly price in API-equivalent spend.`,
+        })
+      }
+      if (configured?.budgetUsd && budgetUtilizationPercent !== null && budgetUtilizationPercent > 100) {
+        risks.push({
+          type: 'over-budget',
+          account: acc.account,
+          message: `${acc.account} is at ${budgetUtilizationPercent}% of its monthly budget.`,
+        })
+      }
+
+      return summary
+    })
+    .sort((a, b) => b.totalCostUSD - a.totalCostUSD)
+
+  return { accounts, risks }
+}

--- a/src/compare.tsx
+++ b/src/compare.tsx
@@ -5,6 +5,7 @@ import type { ModelStats, ComparisonRow, CategoryComparison, WorkingStyleRow } f
 import { aggregateModelStats, computeComparison, computeCategoryComparison, computeWorkingStyle, scanSelfCorrections } from './compare-stats.js'
 import { formatCost } from './format.js'
 import { parseAllSessions } from './parser.js'
+import { filterProjectsByAccount } from './accounts.js'
 import { getAllProviders } from './providers/index.js'
 import type { ProjectSummary, DateRange } from './types.js'
 import { patchStdoutForWindows } from './ink-win.js'
@@ -466,7 +467,7 @@ export function CompareView({ projects, onBack }: CompareViewProps) {
   )
 }
 
-export async function renderCompare(range: DateRange, provider: string): Promise<void> {
+export async function renderCompare(range: DateRange, provider: string, accountFilter?: string[]): Promise<void> {
   const isTTY = process.stdin.isTTY && process.stdout.isTTY
   if (!isTTY) {
     process.stdout.write('Model comparison requires an interactive terminal.\n')
@@ -474,7 +475,7 @@ export async function renderCompare(range: DateRange, provider: string): Promise
   }
 
   patchStdoutForWindows()
-  const projects = await parseAllSessions(range, provider)
+  const projects = filterProjectsByAccount(await parseAllSessions(range, provider), accountFilter)
   const { waitUntilExit } = render(
     <CompareView projects={projects} onBack={() => process.exit(0)} />
   )

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,14 @@ export type PlanConfig = Omit<Plan, 'provider' | 'setAt'> & Partial<Pick<Plan, '
 export type PlanConfigMap = Partial<Record<PlanProvider, PlanConfig>>
 export type PlanMap = Partial<Record<PlanProvider, Plan>>
 
+export type AccountConfig = {
+  plan?: string
+  monthlyUsd?: number
+  budgetUsd?: number
+  resetDay?: number
+  setAt?: string
+}
+
 export type CodeburnConfig = {
   currency?: {
     code: string
@@ -26,6 +34,7 @@ export type CodeburnConfig = {
   }
   plan?: Plan
   plans?: PlanConfigMap
+  accounts?: Record<string, AccountConfig>
   modelAliases?: Record<string, string>
 }
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -6,6 +6,7 @@ import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory
 import { formatCost, formatTokens } from './format.js'
 import { aggregateModelEfficiency } from './model-efficiency.js'
 import { parseAllSessions, filterProjectsByName } from './parser.js'
+import { filterProjectsByAccount } from './accounts.js'
 import { loadPricing } from './models.js'
 import { getAllProviders } from './providers/index.js'
 import { scanAndDetect, type WasteFinding, type WasteAction, type OptimizeResult } from './optimize.js'
@@ -723,7 +724,7 @@ function DashboardContent({ projects, period, columns, activeProvider, budgets, 
   )
 }
 
-function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider, initialPlanUsages, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel }: {
+function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider, initialPlanUsages, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel, accountFilter }: {
   initialProjects: ProjectSummary[]
   initialPeriod: Period
   initialProvider: string
@@ -733,6 +734,7 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
   excludeFilter?: string[]
   customRange?: DateRange | null
   customRangeLabel?: string
+  accountFilter?: string[]
 }) {
   const { exit } = useApp()
   const [period, setPeriod] = useState<Period>(initialPeriod)
@@ -819,7 +821,7 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
       const data = await parseAllSessions(range, prov)
       if (reloadGenerationRef.current !== generation) return
 
-      const filteredProjects = filterProjectsByName(data, projectFilter, excludeFilter)
+      const filteredProjects = filterProjectsByAccount(filterProjectsByName(data, projectFilter, excludeFilter), accountFilter)
       if (reloadGenerationRef.current !== generation) return
 
       setProjects(filteredProjects)
@@ -840,7 +842,7 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
         void reloadData(pending.period, pending.provider)
       }
     }
-  }, [projectFilter, excludeFilter])
+  }, [projectFilter, excludeFilter, accountFilter])
 
   const loadOptimizeResult = useCallback(async () => {
     if (!optimizeAvailable || projects.length === 0 || optimizeLoading) return
@@ -985,16 +987,16 @@ function StaticDashboard({ projects, period, activeProvider, planUsages }: { pro
   )
 }
 
-export async function renderDashboard(period: Period = 'week', provider: string = 'all', refreshSeconds?: number, projectFilter?: string[], excludeFilter?: string[], customRange?: DateRange | null, customRangeLabel?: string): Promise<void> {
+export async function renderDashboard(period: Period = 'week', provider: string = 'all', refreshSeconds?: number, projectFilter?: string[], excludeFilter?: string[], customRange?: DateRange | null, customRangeLabel?: string, accountFilter?: string[]): Promise<void> {
   await loadPricing()
   const range = customRange ?? getPeriodRange(period)
-  const filteredProjects = filterProjectsByName(await parseAllSessions(range, provider), projectFilter, excludeFilter)
+  const filteredProjects = filterProjectsByAccount(filterProjectsByName(await parseAllSessions(range, provider), projectFilter, excludeFilter), accountFilter)
   const planUsages = await getPlanUsages()
   const isTTY = process.stdin.isTTY && process.stdout.isTTY
   patchStdoutForWindows()
   if (isTTY) {
     const { waitUntilExit } = render(
-      <InteractiveDashboard initialProjects={filteredProjects} initialPeriod={period} initialProvider={provider} initialPlanUsages={planUsages} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} />
+      <InteractiveDashboard initialProjects={filteredProjects} initialPeriod={period} initialProvider={provider} initialPlanUsages={planUsages} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} accountFilter={accountFilter} />
     )
     await waitUntilExit()
   } else {

--- a/src/export.ts
+++ b/src/export.ts
@@ -5,6 +5,8 @@ import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory } from './types
 import { getCurrency, convertCost, roundForActiveCurrency } from './currency.js'
 import { dateKey } from './day-aggregator.js'
 import { aggregateModelEfficiency } from './model-efficiency.js'
+import { buildAccountReport } from './accounts.js'
+import type { AccountConfig } from './config.js'
 
 function escCsv(s: string): string {
   const sanitized = /^[\t\r=+\-@]/.test(s) ? `'${s}` : s
@@ -192,6 +194,8 @@ function buildProjectRows(projects: ProjectSummary[]): Row[] {
     .slice()
     .sort((a, b) => b.totalCostUSD - a.totalCostUSD)
     .map(p => ({
+      Account: p.account ?? '',
+      'Account Path': p.accountPath ?? '',
       Project: p.projectPath,
       [`Cost (${code})`]: roundForActiveCurrency(convertCost(p.totalCostUSD)),
       [`Avg/Session (${code})`]: p.sessions.length > 0 ? roundForActiveCurrency(convertCost(p.totalCostUSD / p.sessions.length)) : '',
@@ -207,6 +211,8 @@ function buildSessionRows(projects: ProjectSummary[]): Row[] {
   for (const p of projects) {
     for (const s of p.sessions) {
       rows.push({
+        Account: p.account ?? '',
+        'Account Path': p.accountPath ?? '',
         Project: p.projectPath,
         'Session ID': s.sessionId,
         'Started At': s.firstTimestamp ?? '',
@@ -217,6 +223,30 @@ function buildSessionRows(projects: ProjectSummary[]): Row[] {
     }
   }
   return rows.sort((a, b) => (b[`Cost (${code})`] as number) - (a[`Cost (${code})`] as number))
+}
+
+function buildAccountRows(projects: ProjectSummary[], accountConfig: Record<string, AccountConfig> = {}): Row[] {
+  const { code } = getCurrency()
+  const total = projects.reduce((s, p) => s + p.totalCostUSD, 0)
+  return buildAccountReport(projects, accountConfig).accounts.map(account => ({
+    Account: account.account,
+    'Account Path': account.accountPath ?? '',
+    Plan: account.configured?.plan ?? '',
+    'Monthly USD': account.configured?.monthlyUsd ?? '',
+    'Budget USD': account.configured?.budgetUsd ?? '',
+    'Subscription Used (%)': account.subscriptionUtilizationPercent ?? '',
+    'Budget Used (%)': account.budgetUtilizationPercent ?? '',
+    [`Cost (${code})`]: round2(convertCost(account.totalCostUSD)),
+    [`Avg/Session (${code})`]: account.costPerSessionUSD !== null ? round2(convertCost(account.costPerSessionUSD)) : '',
+    [`Avg/Edit (${code})`]: account.costPerEditUSD !== null ? round2(convertCost(account.costPerEditUSD)) : '',
+    'Share (%)': pct(account.totalCostUSD, total),
+    'API Calls': account.totalApiCalls,
+    Sessions: account.sessions,
+    Projects: account.projects,
+    'Edit Turns': account.editTurns,
+    'Top Model': account.topModels[0]?.name ?? '',
+    'Top Project': account.topProjects[0]?.projectPath ?? '',
+  }))
 }
 
 export type PeriodExport = {
@@ -256,6 +286,7 @@ function buildReadme(periods: PeriodExport[]): string {
     '-----',
     '  summary.csv           One row per period. Headline totals.',
     '  daily.csv             Day-by-day breakdown, Period column distinguishes the window.',
+    '  accounts.csv          Spend, sessions, models, and projects per detected account.',
     '  activity.csv          Time spent per task category (Coding, Debugging, Exploration, etc.).',
     '  models.csv            Spend per model with token totals and cache usage.',
     '  projects.csv          Spend per project folder for the selected detail period.',
@@ -292,7 +323,11 @@ async function clearCodeburnExportFolder(path: string): Promise<void> {
 /// ends in `.csv` the extension is stripped to form the folder name. Refuses to delete a
 /// pre-existing file or a non-codeburn folder, so a typo like `-o ~/.ssh/id_ed25519` can't
 /// wipe a sensitive file (prior versions did `rm(path, { force: true })` unconditionally).
-export async function exportCsv(periods: PeriodExport[], outputPath: string): Promise<string> {
+export async function exportCsv(
+  periods: PeriodExport[],
+  outputPath: string,
+  accountConfig: Record<string, AccountConfig> = {},
+): Promise<string> {
   const thirtyDays = periods.find(p => p.label === '30 Days')
   const thirtyDayProjects = thirtyDays?.projects ?? periods[periods.length - 1]?.projects ?? []
 
@@ -324,6 +359,7 @@ export async function exportCsv(periods: PeriodExport[], outputPath: string): Pr
   await writeFile(join(folder, 'README.txt'), buildReadme(periods), 'utf-8')
   await writeFile(join(folder, 'summary.csv'), rowsToCsv(buildSummaryRows(periods)), 'utf-8')
   await writeFile(join(folder, 'daily.csv'), rowsToCsv(dailyRows), 'utf-8')
+  await writeFile(join(folder, 'accounts.csv'), rowsToCsv(buildAccountRows(thirtyDayProjects, accountConfig)), 'utf-8')
   await writeFile(join(folder, 'activity.csv'), rowsToCsv(activityRows), 'utf-8')
   await writeFile(join(folder, 'models.csv'), rowsToCsv(modelRows), 'utf-8')
   await writeFile(join(folder, 'projects.csv'), rowsToCsv(buildProjectRows(thirtyDayProjects)), 'utf-8')
@@ -334,7 +370,11 @@ export async function exportCsv(periods: PeriodExport[], outputPath: string): Pr
   return folder
 }
 
-export async function exportJson(periods: PeriodExport[], outputPath: string): Promise<string> {
+export async function exportJson(
+  periods: PeriodExport[],
+  outputPath: string,
+  accountConfig: Record<string, AccountConfig> = {},
+): Promise<string> {
   const thirtyDays = periods.find(p => p.label === '30 Days')
   const thirtyDayProjects = thirtyDays?.projects ?? periods[periods.length - 1]?.projects ?? []
   const { code, rate, symbol } = getCurrency()
@@ -347,9 +387,11 @@ export async function exportJson(periods: PeriodExport[], outputPath: string): P
     periods: periods.map(p => ({
       label: p.label,
       daily: buildDailyRows(p.projects, p.label),
+      accounts: buildAccountRows(p.projects, accountConfig),
       activity: buildActivityRows(p.projects, p.label),
       models: buildModelRows(p.projects, p.label),
     })),
+    accounts: buildAccountRows(thirtyDayProjects, accountConfig),
     projects: buildProjectRows(thirtyDayProjects),
     sessions: buildSessionRows(thirtyDayProjects),
     tools: buildToolRows(thirtyDayProjects),

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,9 @@ import { installMenubarApp } from './menubar-installer.js'
 import { exportCsv, exportJson, type PeriodExport } from './export.js'
 import { loadPricing, setModelAliases } from './models.js'
 import { parseAllSessions, filterProjectsByName, filterProjectsByDateRange, clearSessionCache } from './parser.js'
+import { buildAccountReport, filterProjectsByAccount, projectAccount, type AccountReport } from './accounts.js'
 import { convertCost } from './currency.js'
-import { renderStatusBar } from './format.js'
+import { formatCost, renderStatusBar } from './format.js'
 import { type PeriodData, type ProviderCost } from './menubar-json.js'
 import { buildMenubarPayload } from './menubar-json.js'
 import { getDaysInRange, ensureCacheHydrated, loadDailyCache, emptyCache, BACKFILL_DAYS, toDateString, type DailyCache } from './daily-cache.js'
@@ -16,7 +17,7 @@ import { formatDateRangeLabel, parseDateRangeFlags, getDateRange, toPeriod, type
 import { runOptimize, scanAndDetect } from './optimize.js'
 import { renderCompare } from './compare.js'
 import { getAllProviders } from './providers/index.js'
-import { clearPlan, readConfig, readPlan, readPlans, saveConfig, savePlan, getConfigFilePath, type Plan, type PlanId, type PlanProvider } from './config.js'
+import { clearPlan, readConfig, readPlan, readPlans, saveConfig, savePlan, getConfigFilePath, type AccountConfig, type Plan, type PlanId, type PlanProvider } from './config.js'
 import { clampResetDay, getPlanUsageOrNull, getPlanUsages, type PlanUsage } from './plan-usage.js'
 import { getPresetPlan, isPlanId, isPlanProvider, PLAN_IDS, PLAN_PROVIDERS, planDisplayName } from './plans.js'
 import { createRequire } from 'node:module'
@@ -99,6 +100,36 @@ async function attachPlanSummaries<T extends object>(payload: T): Promise<T & { 
   return payload
 }
 
+type ProjectFilterOptions = {
+  project?: string[]
+  exclude?: string[]
+  account?: string[]
+}
+
+function applyProjectFilters(projects: ProjectSummary[], opts: ProjectFilterOptions): ProjectSummary[] {
+  return filterProjectsByAccount(
+    filterProjectsByName(projects, opts.project, opts.exclude),
+    opts.account,
+  )
+}
+
+function filterAccountConfig(
+  accountConfig: Record<string, AccountConfig> | undefined,
+  accountFilter?: string[],
+  projects?: ProjectSummary[],
+): Record<string, AccountConfig> | undefined {
+  if (!accountConfig) return undefined
+  const patterns = accountFilter?.map(s => s.trim().toLowerCase()).filter(Boolean) ?? []
+  if (patterns.length === 0) return accountConfig
+  const filteredAccounts = new Set(projects?.map(project => projectAccount(project).toLowerCase()) ?? [])
+  return Object.fromEntries(
+    Object.entries(accountConfig).filter(([account]) => {
+      const lower = account.toLowerCase()
+      return filteredAccounts.has(lower) || patterns.some(pattern => lower.includes(pattern))
+    }),
+  )
+}
+
 function planLabel(plan: Plan): string {
   const name = planDisplayName(plan.id)
   return plan.id === 'custom' ? `${name} (${plan.provider})` : name
@@ -129,11 +160,14 @@ function assertFormat(value: string, allowed: readonly string[], command: string
   }
 }
 
-async function runJsonReport(period: Period, provider: string, project: string[], exclude: string[]): Promise<void> {
+async function runJsonReport(period: Period, provider: string, filters: ProjectFilterOptions): Promise<void> {
   await loadPricing()
   const { range, label } = getDateRange(period)
-  const projects = filterProjectsByName(await parseAllSessions(range, provider), project, exclude)
-  const report: ReturnType<typeof buildJsonReport> & { plan?: JsonPlanSummary; plans?: JsonPlanSummaryMap } = await attachPlanSummaries(buildJsonReport(projects, label, period))
+  const config = await readConfig()
+  const projects = applyProjectFilters(await parseAllSessions(range, provider), filters)
+  const report: ReturnType<typeof buildJsonReport> & { plan?: JsonPlanSummary; plans?: JsonPlanSummaryMap } = await attachPlanSummaries(
+    buildJsonReport(projects, label, period, filterAccountConfig(config.accounts, filters.account, projects)),
+  )
   console.log(JSON.stringify(report, null, 2))
 }
 
@@ -163,9 +197,10 @@ program.hook('preAction', async (thisCommand) => {
   await loadCurrency()
 })
 
-function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: string) {
+function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: string, accountConfig: Record<string, AccountConfig> = {}) {
   const sessions = projects.flatMap(p => p.sessions)
   const { code } = getCurrency()
+  const accountReport = buildAccountReport(projects, accountConfig)
 
   const totalCostUSD = projects.reduce((s, p) => s + p.totalCostUSD, 0)
   const totalCalls = projects.reduce((s, p) => s + p.totalApiCalls, 0)
@@ -226,6 +261,8 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
   const projectList = projects.map(p => ({
     name: p.project,
     path: p.projectPath,
+    ...(p.account ? { account: p.account } : {}),
+    ...(p.accountPath ? { accountPath: p.accountPath } : {}),
     cost: convertCost(p.totalCostUSD),
     avgCostPerSession: p.sessions.length > 0
       ? convertCost(p.totalCostUSD / p.sessions.length)
@@ -305,7 +342,14 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
     Object.entries(m).sort(([, a], [, b]) => b - a).map(([name, calls]) => ({ name, calls }))
 
   const topSessions = projects
-    .flatMap(p => p.sessions.map(s => ({ project: p.project, sessionId: s.sessionId, date: s.firstTimestamp ? dateKey(s.firstTimestamp) : null, cost: convertCost(s.totalCostUSD), calls: s.apiCalls })))
+    .flatMap(p => p.sessions.map(s => ({
+      project: p.project,
+      ...(p.account ? { account: p.account } : {}),
+      sessionId: s.sessionId,
+      date: s.firstTimestamp ? dateKey(s.firstTimestamp) : null,
+      cost: convertCost(s.totalCostUSD),
+      calls: s.apiCalls,
+    })))
     .sort((a, b) => b.cost - a.cost)
     .slice(0, 5)
 
@@ -328,6 +372,26 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
     },
     daily,
     projects: projectList,
+    accounts: accountReport.accounts.map(account => ({
+      name: account.account,
+      ...(account.accountPath ? { accountPath: account.accountPath } : {}),
+      ...(account.configured?.plan ? { plan: account.configured.plan } : {}),
+      ...(account.configured?.monthlyUsd ? { monthlyUSD: account.configured.monthlyUsd } : {}),
+      ...(account.configured?.budgetUsd ? { budgetUSD: account.configured.budgetUsd } : {}),
+      cost: convertCost(account.totalCostUSD),
+      apiEquivalentUSD: Math.round(account.totalCostUSD * 100) / 100,
+      calls: account.totalApiCalls,
+      sessions: account.sessions,
+      projects: account.projects,
+      editTurns: account.editTurns,
+      costPerSession: account.costPerSessionUSD !== null ? convertCost(account.costPerSessionUSD) : null,
+      costPerEdit: account.costPerEditUSD !== null ? convertCost(account.costPerEditUSD) : null,
+      subscriptionUtilizationPercent: account.subscriptionUtilizationPercent,
+      budgetUtilizationPercent: account.budgetUtilizationPercent,
+      topModels: account.topModels.map(model => ({ name: model.name, calls: model.calls, cost: convertCost(model.costUSD) })),
+      topProjects: account.topProjects.map(project => ({ path: project.projectPath, sessions: project.sessions, cost: convertCost(project.costUSD) })),
+    })),
+    accountRisks: accountReport.risks,
     models,
     activities,
     tools: sortedMap(toolMap),
@@ -335,6 +399,95 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
     shellCommands: sortedMap(bashMap),
     topSessions,
   }
+}
+
+function accountReportToJson(report: AccountReport) {
+  const { code } = getCurrency()
+  return {
+    currency: code,
+    accounts: report.accounts.map(account => ({
+      name: account.account,
+      accountPath: account.accountPath ?? null,
+      plan: account.configured?.plan ?? null,
+      monthlyUSD: account.configured?.monthlyUsd ?? null,
+      budgetUSD: account.configured?.budgetUsd ?? null,
+      cost: convertCost(account.totalCostUSD),
+      apiEquivalentUSD: Math.round(account.totalCostUSD * 100) / 100,
+      calls: account.totalApiCalls,
+      sessions: account.sessions,
+      projects: account.projects,
+      editTurns: account.editTurns,
+      costPerSession: account.costPerSessionUSD !== null ? convertCost(account.costPerSessionUSD) : null,
+      costPerEdit: account.costPerEditUSD !== null ? convertCost(account.costPerEditUSD) : null,
+      subscriptionCostPerSessionUSD: account.subscriptionCostPerSessionUSD,
+      subscriptionCostPerEditUSD: account.subscriptionCostPerEditUSD,
+      subscriptionUtilizationPercent: account.subscriptionUtilizationPercent,
+      budgetUtilizationPercent: account.budgetUtilizationPercent,
+      topModels: account.topModels.map(model => ({ name: model.name, calls: model.calls, cost: convertCost(model.costUSD) })),
+      topProjects: account.topProjects.map(project => ({ path: project.projectPath, sessions: project.sessions, cost: convertCost(project.costUSD) })),
+    })),
+    risks: report.risks,
+  }
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null) return '-'
+  return `${value.toFixed(1)}%`
+}
+
+function formatUSD(value: number): string {
+  const decimals = value > 0 && Math.abs(value) < 1 ? 3 : 2
+  return `USD ${value.toFixed(decimals)}`
+}
+
+function printAccountReport(report: AccountReport, label: string): void {
+  console.log(`\n  Accounts (${label})`)
+  if (report.accounts.length === 0) {
+    console.log('  No account-labelled usage found for this filter.')
+    console.log(`  Config: ${getConfigFilePath()}\n`)
+    return
+  }
+
+  console.log('  Account              Cost      Sessions  Projects  Calls   Plan/Budget')
+  for (const account of report.accounts) {
+    const plan = account.configured?.plan
+      ? `${account.configured.plan}${account.configured.monthlyUsd ? ` ${formatUSD(account.configured.monthlyUsd)}/mo` : ''}`
+      : ''
+    const budget = account.configured?.budgetUsd
+      ? `budget ${formatPercent(account.budgetUtilizationPercent)}`
+      : ''
+    const right = [plan, budget].filter(Boolean).join(', ') || '-'
+    console.log(
+      `  ${account.account.padEnd(20)} ` +
+      `${formatCost(account.totalCostUSD).padStart(9)} ` +
+      `${String(account.sessions).padStart(9)} ` +
+      `${String(account.projects).padStart(8)} ` +
+      `${String(account.totalApiCalls).padStart(6)}   ` +
+      right,
+    )
+  }
+
+  const configured = report.accounts.filter(a => a.configured?.monthlyUsd || a.configured?.budgetUsd)
+  if (configured.length > 0) {
+    console.log('\n  Subscription efficiency')
+    for (const account of configured) {
+      const subSession = account.subscriptionCostPerSessionUSD !== null
+        ? `${formatUSD(account.subscriptionCostPerSessionUSD)}/session`
+        : '-'
+      const subEdit = account.subscriptionCostPerEditUSD !== null
+        ? `${formatUSD(account.subscriptionCostPerEditUSD)}/edit`
+        : '-'
+      console.log(`  ${account.account.padEnd(20)} api-equivalent ${formatPercent(account.subscriptionUtilizationPercent).padStart(7)}   ${subSession.padStart(14)}   ${subEdit.padStart(12)}`)
+    }
+  }
+
+  if (report.risks.length > 0) {
+    console.log('\n  Signals')
+    for (const risk of report.risks.slice(0, 8)) {
+      console.log(`  - ${risk.message}`)
+    }
+  }
+  console.log(`\n  Config: ${getConfigFilePath()}\n`)
 }
 
 program
@@ -347,6 +500,7 @@ program
   .option('--format <format>', 'Output format: tui, json', 'tui')
   .option('--project <name>', 'Show only projects matching name (repeatable)', collect, [])
   .option('--exclude <name>', 'Exclude projects matching name (repeatable)', collect, [])
+  .option('--account <name>', 'Show only accounts matching label/path (repeatable)', collect, [])
   .option('--refresh <seconds>', 'Auto-refresh interval in seconds (0 to disable)', parseInteger, 30)
   .action(async (opts) => {
     assertFormat(opts.format, ['tui', 'json'], 'report')
@@ -364,19 +518,16 @@ program
       await loadPricing()
       if (customRange) {
         const label = formatDateRangeLabel(opts.from, opts.to)
-        const projects = filterProjectsByName(
-          await parseAllSessions(customRange, opts.provider),
-          opts.project,
-          opts.exclude,
-        )
-        console.log(JSON.stringify(await attachPlanSummaries(buildJsonReport(projects, label, 'custom')), null, 2))
+        const config = await readConfig()
+        const projects = applyProjectFilters(await parseAllSessions(customRange, opts.provider), opts)
+        console.log(JSON.stringify(await attachPlanSummaries(buildJsonReport(projects, label, 'custom', filterAccountConfig(config.accounts, opts.account, projects))), null, 2))
       } else {
-        await runJsonReport(period, opts.provider, opts.project, opts.exclude)
+        await runJsonReport(period, opts.provider, opts)
       }
       return
     }
     const customRangeLabel = customRange ? formatDateRangeLabel(opts.from, opts.to) : undefined
-    await renderDashboard(period, opts.provider, opts.refresh, opts.project, opts.exclude, customRange, customRangeLabel)
+    await renderDashboard(period, opts.provider, opts.refresh, opts.project, opts.exclude, customRange, customRangeLabel, opts.account)
   })
 
 function buildPeriodData(label: string, projects: ProjectSummary[]): PeriodData {
@@ -426,13 +577,14 @@ program
   .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
   .option('--project <name>', 'Show only projects matching name (repeatable)', collect, [])
   .option('--exclude <name>', 'Exclude projects matching name (repeatable)', collect, [])
+  .option('--account <name>', 'Show only accounts matching label/path (repeatable)', collect, [])
   .option('--period <period>', 'Primary period for menubar-json: today, week, 30days, month, all', 'today')
   .option('--no-optimize', 'Skip optimize findings (menubar-json only, faster)')
   .action(async (opts) => {
     assertFormat(opts.format, ['terminal', 'menubar-json', 'json'], 'status')
     await loadPricing()
     const pf = opts.provider
-    const fp = (p: ProjectSummary[]) => filterProjectsByName(p, opts.project, opts.exclude)
+    const fp = (p: ProjectSummary[]) => applyProjectFilters(p, opts)
     if (opts.format === 'menubar-json') {
       const periodInfo = getDateRange(opts.period)
       const now = new Date()
@@ -672,14 +824,15 @@ program
   .option('--format <format>', 'Output format: tui, json', 'tui')
   .option('--project <name>', 'Show only projects matching name (repeatable)', collect, [])
   .option('--exclude <name>', 'Exclude projects matching name (repeatable)', collect, [])
+  .option('--account <name>', 'Show only accounts matching label/path (repeatable)', collect, [])
   .option('--refresh <seconds>', 'Auto-refresh interval in seconds (0 to disable)', parseInteger, 30)
   .action(async (opts) => {
     assertFormat(opts.format, ['tui', 'json'], 'today')
     if (opts.format === 'json') {
-      await runJsonReport('today', opts.provider, opts.project, opts.exclude)
+      await runJsonReport('today', opts.provider, opts)
       return
     }
-    await renderDashboard('today', opts.provider, opts.refresh, opts.project, opts.exclude)
+    await renderDashboard('today', opts.provider, opts.refresh, opts.project, opts.exclude, null, undefined, opts.account)
   })
 
 program
@@ -689,14 +842,15 @@ program
   .option('--format <format>', 'Output format: tui, json', 'tui')
   .option('--project <name>', 'Show only projects matching name (repeatable)', collect, [])
   .option('--exclude <name>', 'Exclude projects matching name (repeatable)', collect, [])
+  .option('--account <name>', 'Show only accounts matching label/path (repeatable)', collect, [])
   .option('--refresh <seconds>', 'Auto-refresh interval in seconds (0 to disable)', parseInteger, 30)
   .action(async (opts) => {
     assertFormat(opts.format, ['tui', 'json'], 'month')
     if (opts.format === 'json') {
-      await runJsonReport('month', opts.provider, opts.project, opts.exclude)
+      await runJsonReport('month', opts.provider, opts)
       return
     }
-    await renderDashboard('month', opts.provider, opts.refresh, opts.project, opts.exclude)
+    await renderDashboard('month', opts.provider, opts.refresh, opts.project, opts.exclude, null, undefined, opts.account)
   })
 
 program
@@ -709,11 +863,12 @@ program
   .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
   .option('--project <name>', 'Show only projects matching name (repeatable)', collect, [])
   .option('--exclude <name>', 'Exclude projects matching name (repeatable)', collect, [])
+  .option('--account <name>', 'Show only accounts matching label/path (repeatable)', collect, [])
   .action(async (opts) => {
     assertFormat(opts.format, ['csv', 'json'], 'export')
     await loadPricing()
     const pf = opts.provider
-    const fp = (p: ProjectSummary[]) => filterProjectsByName(p, opts.project, opts.exclude)
+    const fp = (p: ProjectSummary[]) => applyProjectFilters(p, opts)
     let customRange: DateRange | null = null
     try {
       customRange = parseDateRangeFlags(opts.from, opts.to)
@@ -744,13 +899,19 @@ program
 
     const defaultName = `codeburn-${toDateString(new Date())}`
     const outputPath = opts.output ?? `${defaultName}.${opts.format}`
+    const config = await readConfig()
+    const accountConfig = filterAccountConfig(
+      config.accounts,
+      opts.account,
+      periods.flatMap(p => p.projects),
+    ) ?? {}
 
     let savedPath: string
     try {
       if (opts.format === 'json') {
-        savedPath = await exportJson(periods, outputPath)
+        savedPath = await exportJson(periods, outputPath, accountConfig)
       } else {
-        savedPath = await exportCsv(periods, outputPath)
+        savedPath = await exportCsv(periods, outputPath, accountConfig)
       }
     } catch (err) {
       // Protection guards in export.ts (symlink refusal, non-codeburn folder refusal, etc.)
@@ -829,6 +990,159 @@ program
     console.log(`  Symbol: ${symbol}`)
     console.log(`  Rate: 1 USD = ${rate} ${upperCode}`)
     console.log(`  Config saved to ${getConfigFilePath()}\n`)
+  })
+
+program
+  .command('accounts [action] [account]')
+  .description('Inspect and configure per-account usage, budgets, and subscriptions')
+  .option('--format <format>', 'Output format: text or json', 'text')
+  .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all', 'month')
+  .option('--from <date>', 'Start date (YYYY-MM-DD). Overrides --period when set')
+  .option('--to <date>', 'End date (YYYY-MM-DD). Overrides --period when set')
+  .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
+  .option('--project <name>', 'Show only projects matching name (repeatable)', collect, [])
+  .option('--exclude <name>', 'Exclude projects matching name (repeatable)', collect, [])
+  .option('--account <name>', 'Show only accounts matching label/path (repeatable)', collect, [])
+  .option('--plan <name>', 'Subscription/plan label for accounts set')
+  .option('--monthly-usd <n>', 'Monthly subscription cost in USD', parseNumber)
+  .option('--budget-usd <n>', 'Monthly budget/allowance in USD', parseNumber)
+  .option('--reset-day <n>', 'Day of month account budget resets (1-28)', parseInteger)
+  .action(async (
+    action?: string,
+    target?: string,
+    opts?: {
+      format?: string
+      period?: string
+      from?: string
+      to?: string
+      provider?: string
+      project?: string[]
+      exclude?: string[]
+      account?: string[]
+      plan?: string
+      monthlyUsd?: number
+      budgetUsd?: number
+      resetDay?: number
+    },
+  ) => {
+    assertFormat(opts?.format ?? 'text', ['text', 'json'], 'accounts')
+    let mode = action ?? 'show'
+    let accountFilter = opts?.account
+
+    if (!['show', 'list', 'set', 'reset'].includes(mode)) {
+      if (target) {
+        console.error('\n  Usage: codeburn accounts [show | set <account> | reset <account>]\n')
+        process.exitCode = 1
+        return
+      }
+      accountFilter = [mode, ...(accountFilter ?? [])]
+      mode = 'show'
+    }
+
+    if (mode === 'set') {
+      if (!target) {
+        console.error('\n  Usage: codeburn accounts set <account> [--plan name] [--monthly-usd n] [--budget-usd n]\n')
+        process.exitCode = 1
+        return
+      }
+      const account = target.trim().toLowerCase()
+      if (!account) {
+        console.error('\n  Account name cannot be empty.\n')
+        process.exitCode = 1
+        return
+      }
+      if (opts?.monthlyUsd !== undefined && opts.monthlyUsd < 0) {
+        console.error('\n  --monthly-usd must be >= 0.\n')
+        process.exitCode = 1
+        return
+      }
+      if (opts?.budgetUsd !== undefined && opts.budgetUsd < 0) {
+        console.error('\n  --budget-usd must be >= 0.\n')
+        process.exitCode = 1
+        return
+      }
+      if (opts?.resetDay !== undefined && (opts.resetDay < 1 || opts.resetDay > 28)) {
+        console.error('\n  --reset-day must be between 1 and 28.\n')
+        process.exitCode = 1
+        return
+      }
+
+      const config = await readConfig()
+      const existing = config.accounts?.[account] ?? {}
+      const updated: AccountConfig = {
+        ...existing,
+        ...(opts?.plan ? { plan: opts.plan } : {}),
+        ...(opts?.monthlyUsd !== undefined ? { monthlyUsd: opts.monthlyUsd } : {}),
+        ...(opts?.budgetUsd !== undefined ? { budgetUsd: opts.budgetUsd } : {}),
+        ...(opts?.resetDay !== undefined ? { resetDay: opts.resetDay } : {}),
+        setAt: new Date().toISOString(),
+      }
+      config.accounts = { ...(config.accounts ?? {}), [account]: updated }
+      await saveConfig(config)
+      console.log(`\n  Account saved: ${account}`)
+      if (updated.plan) console.log(`  Plan: ${updated.plan}`)
+      if (updated.monthlyUsd) console.log(`  Subscription: ${formatUSD(updated.monthlyUsd)}/month`)
+      if (updated.budgetUsd) console.log(`  Budget: ${formatUSD(updated.budgetUsd)}/month`)
+      console.log(`  Config: ${getConfigFilePath()}\n`)
+      return
+    }
+
+    if (mode === 'reset') {
+      if (!target) {
+        console.error('\n  Usage: codeburn accounts reset <account>\n')
+        process.exitCode = 1
+        return
+      }
+      const account = target.trim().toLowerCase()
+      if (!account) {
+        console.error('\n  Account name cannot be empty.\n')
+        process.exitCode = 1
+        return
+      }
+      const config = await readConfig()
+      if (config.accounts) {
+        delete config.accounts[account]
+        if (account !== target.trim()) delete config.accounts[target.trim()]
+        if (Object.keys(config.accounts).length === 0) delete config.accounts
+        await saveConfig(config)
+      }
+      console.log(`\n  Account config reset: ${account}\n`)
+      return
+    }
+
+    if (mode !== 'show' && mode !== 'list') {
+      console.error('\n  Usage: codeburn accounts [show | set <account> | reset <account>]\n')
+      process.exitCode = 1
+      return
+    }
+
+    let customRange: DateRange | null = null
+    try {
+      customRange = parseDateRangeFlags(opts?.from, opts?.to)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`\n  Error: ${message}\n`)
+      process.exit(1)
+    }
+
+    await loadPricing()
+    const period = toPeriod(opts?.period ?? 'month')
+    const { range, label } = customRange
+      ? { range: customRange, label: formatDateRangeLabel(opts?.from, opts?.to) }
+      : getDateRange(period)
+    const config = await readConfig()
+    const projects = applyProjectFilters(
+      await parseAllSessions(range, opts?.provider ?? 'all'),
+      { project: opts?.project, exclude: opts?.exclude, account: accountFilter },
+    )
+    const report = buildAccountReport(projects, filterAccountConfig(config.accounts, accountFilter, projects) ?? {})
+
+    if (opts?.format === 'json') {
+      console.log(JSON.stringify({ generated: new Date().toISOString(), period: label, ...accountReportToJson(report) }, null, 2))
+      return
+    }
+
+    printAccountReport(report, label)
   })
 
 program
@@ -1029,10 +1343,11 @@ program
   .description('Find token waste and get exact fixes')
   .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all', '30days')
   .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
+  .option('--account <name>', 'Show only accounts matching label/path (repeatable)', collect, [])
   .action(async (opts) => {
     await loadPricing()
     const { range, label } = getDateRange(opts.period)
-    const projects = await parseAllSessions(range, opts.provider)
+    const projects = filterProjectsByAccount(await parseAllSessions(range, opts.provider), opts.account)
     await runOptimize(projects, label, range)
   })
 
@@ -1041,10 +1356,11 @@ program
   .description('Compare two AI models side-by-side')
   .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all', 'all')
   .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
+  .option('--account <name>', 'Show only accounts matching label/path (repeatable)', collect, [])
   .action(async (opts) => {
     await loadPricing()
     const { range } = getDateRange(opts.period)
-    await renderCompare(range, opts.provider)
+    await renderCompare(range, opts.provider, opts.account)
   })
 
 program

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1830,7 +1830,8 @@ async function parseProviderSources(
 
   const projectMap = new Map<string, { project: string; projectPath?: string; source: ProviderSourceRef; sessions: SessionSummary[] }>()
   for (const [key, { project, projectPath, source, turns }] of sessionMap) {
-    const sessionId = key.split('\0')[0]!.split(':')[1] ?? key
+    const sessionKey = key.split('\0').pop() ?? key
+    const sessionId = sessionKey.split(':')[1] ?? sessionKey
     const session = buildSessionSummary(sessionId, project, turns, undefined, source)
     if (session.apiCalls > 0) {
       const mapKey = projectKey(project, source)
@@ -1903,7 +1904,8 @@ export function filterProjectsByName(
       const account = (p.account ?? '').toLowerCase()
       const accountPath = (p.accountPath ?? '').toLowerCase()
       const accountProject = account ? `${account}:${name}` : name
-      return patterns.some(pat => name.includes(pat) || path.includes(pat) || account.includes(pat) || accountPath.includes(pat) || accountProject.includes(pat))
+      const accountPathProject = account ? `${account}:${path}` : path
+      return patterns.some(pat => name.includes(pat) || path.includes(pat) || account.includes(pat) || accountPath.includes(pat) || accountProject.includes(pat) || accountPathProject.includes(pat))
     })
   }
   if (exclude && exclude.length > 0) {
@@ -1914,7 +1916,8 @@ export function filterProjectsByName(
       const account = (p.account ?? '').toLowerCase()
       const accountPath = (p.accountPath ?? '').toLowerCase()
       const accountProject = account ? `${account}:${name}` : name
-      return !patterns.some(pat => name.includes(pat) || path.includes(pat) || account.includes(pat) || accountPath.includes(pat) || accountProject.includes(pat))
+      const accountPathProject = account ? `${account}:${path}` : path
+      return !patterns.some(pat => name.includes(pat) || path.includes(pat) || account.includes(pat) || accountPath.includes(pat) || accountProject.includes(pat) || accountPathProject.includes(pat))
     })
   }
   return result

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -45,6 +45,34 @@ function normalizeProjectPathKey(projectPath: string): string {
   return (normalized.replace(/\/+$/, '') || normalized).toLowerCase()
 }
 
+type SourceAttribution = {
+  account?: string
+  accountPath?: string
+}
+
+type ClaudeProjectDir = {
+  path: string
+  name: string
+  account?: string
+  accountPath?: string
+}
+
+type ProviderSourceRef = {
+  path: string
+  project: string
+  account?: string
+  accountPath?: string
+}
+
+function projectKey(project: string, attribution?: SourceAttribution): string {
+  const accountKey = attribution?.accountPath ?? attribution?.account ?? ''
+  return accountKey ? `${accountKey}\0${project}` : project
+}
+
+function projectSummaryKey(project: ProjectSummary): string {
+  return projectKey(project.project, project)
+}
+
 const LARGE_JSONL_LINE_BYTES = 32 * 1024
 
 export function parseJsonlLine(line: string | Buffer): JournalEntry | null {
@@ -1138,6 +1166,7 @@ function buildSessionSummary(
   project: string,
   turns: ClassifiedTurn[],
   mcpInventory?: string[],
+  attribution?: SourceAttribution,
 ): SessionSummary {
   const modelBreakdown: SessionSummary['modelBreakdown'] = Object.create(null)
   const toolBreakdown: SessionSummary['toolBreakdown'] = Object.create(null)
@@ -1227,6 +1256,8 @@ function buildSessionSummary(
   return {
     sessionId,
     project,
+    ...(attribution?.account ? { account: attribution.account } : {}),
+    ...(attribution?.accountPath ? { accountPath: attribution.accountPath } : {}),
     firstTimestamp: firstTs || turns[0]?.timestamp || '',
     lastTimestamp: lastTs || turns[turns.length - 1]?.timestamp || '',
     totalCostUSD: totalCost,
@@ -1251,6 +1282,7 @@ async function parseSessionFile(
   project: string,
   seenMsgIds: Set<string>,
   dateRange?: DateRange,
+  attribution?: SourceAttribution,
 ): Promise<{ session: SessionSummary; canonicalCwd?: string } | null> {
   // Skip files whose mtime is older than the range start. A session file
   // can only contain entries up to its last-modified time; if that predates
@@ -1314,7 +1346,7 @@ async function parseSessionFile(
   const canonicalCwd = extractCanonicalCwd(entries)
 
   return {
-    session: buildSessionSummary(sessionId, project, classified, mcpInventory),
+    session: buildSessionSummary(sessionId, project, classified, mcpInventory, attribution),
     ...(canonicalCwd ? { canonicalCwd } : {}),
   }
 }
@@ -1336,7 +1368,7 @@ async function collectJsonlFiles(dirPath: string): Promise<string[]> {
 }
 
 async function scanProjectDirs(
-  dirs: Array<{ path: string; name: string }>,
+  dirs: ClaudeProjectDir[],
   seenMsgIds: Set<string>,
   diskCache: SessionCache,
   dateRange?: DateRange,
@@ -1344,11 +1376,23 @@ async function scanProjectDirs(
   const section = getOrCreateProviderSection(diskCache, 'claude')
   const allDiscoveredFiles = new Set<string>()
 
-  type FileInfo = { dirName: string; fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>> }
-  const unchangedFiles: Array<{ filePath: string; dirName: string; cached: CachedFile }> = []
+  type FileInfo = {
+    dirName: string
+    dirPath: string
+    attribution: SourceAttribution
+    fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>>
+  }
+  const unchangedFiles: Array<{
+    filePath: string
+    dirName: string
+    dirPath: string
+    attribution: SourceAttribution
+    cached: CachedFile
+  }> = []
   const changedFiles: Array<{ filePath: string; info: FileInfo }> = []
 
-  for (const { path: dirPath, name: dirName } of dirs) {
+  for (const { path: dirPath, name: dirName, account, accountPath } of dirs) {
+    const attribution: SourceAttribution = { account, accountPath }
     const jsonlFiles = await collectJsonlFiles(dirPath)
     for (const filePath of jsonlFiles) {
       allDiscoveredFiles.add(filePath)
@@ -1357,9 +1401,9 @@ async function scanProjectDirs(
 
       const action = reconcileFile(fp, section.files[filePath])
       if (action.action === 'unchanged') {
-        unchangedFiles.push({ filePath, dirName, cached: section.files[filePath]! })
+        unchangedFiles.push({ filePath, dirName, dirPath, attribution, cached: section.files[filePath]! })
       } else {
-        changedFiles.push({ filePath, info: { dirName, fp } })
+        changedFiles.push({ filePath, info: { dirName, dirPath, attribution, fp } })
       }
     }
   }
@@ -1400,14 +1444,14 @@ async function scanProjectDirs(
     }
   }
 
-  const projectMap = new Map<string, { project: string; projectPath: string; sessions: SessionSummary[] }>()
+  const projectMap = new Map<string, { project: string; projectPath: string; sourcePath: string; attribution: SourceAttribution; sessions: SessionSummary[] }>()
 
   const allFiles = [
-    ...unchangedFiles.map(f => ({ filePath: f.filePath, dirName: f.dirName })),
-    ...changedFiles.map(f => ({ filePath: f.filePath, dirName: f.info.dirName })),
+    ...unchangedFiles.map(f => ({ filePath: f.filePath, dirName: f.dirName, dirPath: f.dirPath, attribution: f.attribution })),
+    ...changedFiles.map(f => ({ filePath: f.filePath, dirName: f.info.dirName, dirPath: f.info.dirPath, attribution: f.info.attribution })),
   ]
 
-  for (const { filePath, dirName } of allFiles) {
+  for (const { filePath, dirName, dirPath, attribution } of allFiles) {
     const cachedFile = section.files[filePath]
     if (!cachedFile || cachedFile.turns.length === 0) continue
 
@@ -1428,17 +1472,18 @@ async function scanProjectDirs(
     const sessionId = basename(filePath, '.jsonl')
     const projectPath = cachedFile.canonicalCwd ?? unsanitizePath(dirName)
     const mcpInv = cachedFile.mcpInventory.length > 0 ? cachedFile.mcpInventory : undefined
-    const session = buildSessionSummary(sessionId, dirName, classifiedTurns, mcpInv)
+    const session = buildSessionSummary(sessionId, dirName, classifiedTurns, mcpInv, attribution)
 
     if (session.apiCalls > 0) {
-      const projectKey = cachedFile.canonicalCwd
+      const baseProjectKey = cachedFile.canonicalCwd
         ? normalizeProjectPathKey(cachedFile.canonicalCwd)
         : `slug:${dirName}`
-      const existing = projectMap.get(projectKey)
+      const mapKey = projectKey(baseProjectKey, attribution)
+      const existing = projectMap.get(mapKey)
       if (existing) {
         existing.sessions.push(session)
       } else {
-        projectMap.set(projectKey, { project: dirName, projectPath, sessions: [session] })
+        projectMap.set(mapKey, { project: dirName, projectPath, sourcePath: dirPath, attribution, sessions: [session] })
       }
     }
   }
@@ -1446,13 +1491,14 @@ async function scanProjectDirs(
   // Fold slug-keyed entries into cwd-keyed entries
   const cwdKeyByDirName = new Map<string, string>()
   for (const [key, entry] of projectMap) {
-    if (!key.startsWith('slug:') && !cwdKeyByDirName.has(entry.project)) {
-      cwdKeyByDirName.set(entry.project, key)
+    const dirAccountKey = projectKey(entry.project, entry.attribution)
+    if (!key.includes('slug:') && !cwdKeyByDirName.has(dirAccountKey)) {
+      cwdKeyByDirName.set(dirAccountKey, key)
     }
   }
   for (const [key, entry] of [...projectMap]) {
-    if (!key.startsWith('slug:')) continue
-    const cwdKey = cwdKeyByDirName.get(entry.project)
+    if (!key.includes('slug:')) continue
+    const cwdKey = cwdKeyByDirName.get(projectKey(entry.project, entry.attribution))
     if (!cwdKey) continue
     const target = projectMap.get(cwdKey)!
     target.sessions.push(...entry.sessions)
@@ -1460,10 +1506,13 @@ async function scanProjectDirs(
   }
 
   const projects: ProjectSummary[] = []
-  for (const { project, projectPath, sessions } of projectMap.values()) {
+  for (const { project, projectPath, sourcePath, attribution, sessions } of projectMap.values()) {
     projects.push({
       project,
       projectPath,
+      sourcePath,
+      ...(attribution.account ? { account: attribution.account } : {}),
+      ...(attribution.accountPath ? { accountPath: attribution.accountPath } : {}),
       sessions,
       totalCostUSD: sessions.reduce((s, sess) => s + sess.totalCostUSD, 0),
       totalApiCalls: sessions.reduce((s, sess) => s + sess.apiCalls, 0),
@@ -1654,7 +1703,7 @@ function warnProviderReadFailureOnce(providerName: string, err: unknown): void {
 
 async function parseProviderSources(
   providerName: string,
-  sources: Array<{ path: string; project: string }>,
+  sources: ProviderSourceRef[],
   seenKeys: Set<string>,
   diskCache: SessionCache,
   dateRange?: DateRange,
@@ -1665,8 +1714,8 @@ async function parseProviderSources(
   const section = getOrCreateProviderSection(diskCache, providerName)
   const allDiscoveredFiles = new Set<string>()
 
-  type SourceInfo = { source: { path: string; project: string }; fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>> }
-  const unchangedSources: Array<{ source: { path: string; project: string }; cached: CachedFile }> = []
+  type SourceInfo = { source: ProviderSourceRef; fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>> }
+  const unchangedSources: Array<{ source: ProviderSourceRef; cached: CachedFile }> = []
   const changedSources: SourceInfo[] = []
 
   for (const source of sources) {
@@ -1705,7 +1754,7 @@ async function parseProviderSources(
       delete section.files[source.path]
 
       const parser = provider.createSessionParser(
-        { path: source.path, project: source.project, provider: providerName },
+        { path: source.path, project: source.project, provider: providerName, ...(source.account ? { account: source.account, accountPath: source.accountPath } : {}) },
         parserDedup,
       )
 
@@ -1744,7 +1793,7 @@ async function parseProviderSources(
 
   // Query-time: derive SessionSummary from all cached turns.
   // Uses seenKeys (shared across providers) for cross-provider dedup.
-  const sessionMap = new Map<string, { project: string; projectPath?: string; turns: ClassifiedTurn[] }>()
+  const sessionMap = new Map<string, { project: string; projectPath?: string; source: ProviderSourceRef; turns: ClassifiedTurn[] }>()
 
   for (const source of sources) {
     const cachedFile = section.files[source.path]
@@ -1765,7 +1814,7 @@ async function parseProviderSources(
 
       const classified = cachedTurnToClassified(turn)
       const project = turn.calls[0]?.project ?? source.project
-      const key = `${providerName}:${turn.sessionId}:${project}`
+      const key = projectKey(`${providerName}:${turn.sessionId}:${project}`, source)
 
       const existing = sessionMap.get(key)
       if (existing) {
@@ -1774,31 +1823,34 @@ async function parseProviderSources(
           existing.projectPath = turn.calls[0]!.projectPath
         }
       } else {
-        sessionMap.set(key, { project, projectPath: turn.calls[0]?.projectPath, turns: [classified] })
+        sessionMap.set(key, { project, projectPath: turn.calls[0]?.projectPath, source, turns: [classified] })
       }
     }
   }
 
-  const projectMap = new Map<string, { projectPath?: string; sessions: SessionSummary[] }>()
-  for (const [key, { project, projectPath, turns }] of sessionMap) {
-    const sessionId = key.split(':')[1] ?? key
-    const session = buildSessionSummary(sessionId, project, turns)
+  const projectMap = new Map<string, { project: string; projectPath?: string; source: ProviderSourceRef; sessions: SessionSummary[] }>()
+  for (const [key, { project, projectPath, source, turns }] of sessionMap) {
+    const sessionId = key.split('\0')[0]!.split(':')[1] ?? key
+    const session = buildSessionSummary(sessionId, project, turns, undefined, source)
     if (session.apiCalls > 0) {
-      const existing = projectMap.get(project)
+      const mapKey = projectKey(project, source)
+      const existing = projectMap.get(mapKey)
       if (existing) {
         existing.sessions.push(session)
         if (!existing.projectPath && projectPath) existing.projectPath = projectPath
       } else {
-        projectMap.set(project, { projectPath, sessions: [session] })
+        projectMap.set(mapKey, { project, projectPath, source, sessions: [session] })
       }
     }
   }
 
   const projects: ProjectSummary[] = []
-  for (const [dirName, { projectPath, sessions }] of projectMap) {
+  for (const { project: dirName, projectPath, source, sessions } of projectMap.values()) {
     projects.push({
       project: dirName,
       projectPath: projectPath ?? unsanitizePath(dirName),
+      sourcePath: source.path,
+      ...(source.account ? { account: source.account, accountPath: source.accountPath } : {}),
       sessions,
       totalCostUSD: sessions.reduce((s, sess) => s + sess.totalCostUSD, 0),
       totalApiCalls: sessions.reduce((s, sess) => s + sess.apiCalls, 0),
@@ -1848,7 +1900,10 @@ export function filterProjectsByName(
     result = result.filter(p => {
       const name = p.project.toLowerCase()
       const path = p.projectPath.toLowerCase()
-      return patterns.some(pat => name.includes(pat) || path.includes(pat))
+      const account = (p.account ?? '').toLowerCase()
+      const accountPath = (p.accountPath ?? '').toLowerCase()
+      const accountProject = account ? `${account}:${name}` : name
+      return patterns.some(pat => name.includes(pat) || path.includes(pat) || account.includes(pat) || accountPath.includes(pat) || accountProject.includes(pat))
     })
   }
   if (exclude && exclude.length > 0) {
@@ -1856,7 +1911,10 @@ export function filterProjectsByName(
     result = result.filter(p => {
       const name = p.project.toLowerCase()
       const path = p.projectPath.toLowerCase()
-      return !patterns.some(pat => name.includes(pat) || path.includes(pat))
+      const account = (p.account ?? '').toLowerCase()
+      const accountPath = (p.accountPath ?? '').toLowerCase()
+      const accountProject = account ? `${account}:${name}` : name
+      return !patterns.some(pat => name.includes(pat) || path.includes(pat) || account.includes(pat) || accountPath.includes(pat) || accountProject.includes(pat))
     })
   }
   return result
@@ -1877,12 +1935,15 @@ export function filterProjectsByDateRange(projects: ProjectSummary[], dateRange:
     for (const session of project.sessions) {
       const turns = session.turns.filter(turn => turnIsInDateRange(turn, dateRange))
       if (turns.length === 0) continue
-      sessions.push(buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory))
+      sessions.push(buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory, project))
     }
     if (sessions.length === 0) continue
     filtered.push({
       project: project.project,
       projectPath: project.projectPath,
+      ...(project.account ? { account: project.account } : {}),
+      ...(project.accountPath ? { accountPath: project.accountPath } : {}),
+      ...(project.sourcePath ? { sourcePath: project.sourcePath } : {}),
       sessions,
       totalCostUSD: sessions.reduce((s, sess) => s + sess.totalCostUSD, 0),
       totalApiCalls: sessions.reduce((s, sess) => s + sess.apiCalls, 0),
@@ -1906,13 +1967,13 @@ export async function parseAllSessions(dateRange?: DateRange, providerFilter?: s
   const claudeSources = allSources.filter(s => s.provider === 'claude')
   const nonClaudeSources = allSources.filter(s => s.provider !== 'claude')
 
-  const claudeDirs = claudeSources.map(s => ({ path: s.path, name: s.project }))
+  const claudeDirs = claudeSources.map(s => ({ path: s.path, name: s.project, account: s.account, accountPath: s.accountPath }))
   const claudeProjects = await scanProjectDirs(claudeDirs, seenMsgIds, diskCache, dateRange)
 
-  const providerGroups = new Map<string, Array<{ path: string; project: string }>>()
+  const providerGroups = new Map<string, ProviderSourceRef[]>()
   for (const source of nonClaudeSources) {
     const existing = providerGroups.get(source.provider) ?? []
-    existing.push({ path: source.path, project: source.project })
+    existing.push({ path: source.path, project: source.project, account: source.account, accountPath: source.accountPath })
     providerGroups.set(source.provider, existing)
   }
 
@@ -1928,13 +1989,14 @@ export async function parseAllSessions(dateRange?: DateRange, providerFilter?: s
 
   const mergedMap = new Map<string, ProjectSummary>()
   for (const p of [...claudeProjects, ...otherProjects]) {
-    const existing = mergedMap.get(p.project)
+    const key = projectSummaryKey(p)
+    const existing = mergedMap.get(key)
     if (existing) {
       existing.sessions.push(...p.sessions)
       existing.totalCostUSD += p.totalCostUSD
       existing.totalApiCalls += p.totalApiCalls
     } else {
-      mergedMap.set(p.project, { ...p })
+      mergedMap.set(key, { ...p })
     }
   }
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -19,42 +19,73 @@ const shortNames: Record<string, string> = {
   'claude-3-5-haiku': 'Haiku 3.5',
 }
 
+type ClaudeRoot = {
+  path: string
+  account?: string
+  accountPath?: string
+}
+
 function expandHome(p: string): string {
   if (p === '~') return homedir()
   if (p.startsWith('~/') || p.startsWith('~\\')) return join(homedir(), p.slice(2))
   return p
 }
 
-/// Returns every Claude config dir to scan, in priority order with duplicates
-/// removed (resolved-path equality). Precedence: `CLAUDE_CONFIG_DIRS` (a
-/// `path.delimiter`-separated list, ":" on POSIX, ";" on Windows), then
-/// `CLAUDE_CONFIG_DIR` (single dir), then `~/.claude`. Sessions from every
-/// returned dir are merged into one ProjectSummary per project name in
-/// `src/parser.ts:scanProjectDirs`, so two dirs holding the same sanitized
-/// project slug naturally aggregate (issue #208 option 1).
-function getClaudeConfigDirs(): string[] {
+function normalizeDirs(dirs: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const dir of dirs) {
+    const trimmed = dir.trim()
+    if (!trimmed) continue
+    const resolved = resolve(expandHome(trimmed))
+    if (seen.has(resolved)) continue
+    seen.add(resolved)
+    out.push(resolved)
+  }
+  return out
+}
+
+function accountLabelForClaudeDir(dir: string): string {
+  const raw = basename(dir).replace(/^\.+/, '')
+  let label = /^claude$/i.test(raw) ? 'default' : raw.replace(/^claude[-_.]/i, '')
+  if (!label) label = 'default'
+  return label.toLowerCase()
+}
+
+function withClaudeAccounts(dirs: string[], forceLabel = false): ClaudeRoot[] {
+  const shouldLabel = forceLabel || dirs.length > 1
+  const assigned = new Set<string>()
+  return dirs.map(dir => {
+    if (!shouldLabel) return { path: dir }
+    const baseLabel = accountLabelForClaudeDir(dir)
+    let account = baseLabel
+    let suffix = 2
+    while (assigned.has(account)) {
+      account = `${baseLabel}-${suffix}`
+      suffix++
+    }
+    assigned.add(account)
+    return { path: dir, account, accountPath: dir }
+  })
+}
+
+/// Returns every Claude config root to scan, in priority order with duplicates
+/// removed (resolved-path equality). Precedence: explicit test override,
+/// `CLAUDE_CONFIG_DIRS`, `CLAUDE_CONFIG_DIR`, then `~/.claude`.
+function getClaudeRoots(overrideDirs?: string | string[]): ClaudeRoot[] {
+  if (overrideDirs !== undefined) {
+    return withClaudeAccounts(normalizeDirs(Array.isArray(overrideDirs) ? overrideDirs : [overrideDirs]))
+  }
+
   const multi = process.env['CLAUDE_CONFIG_DIRS']
   if (multi !== undefined && multi !== '') {
-    const dirs = multi
-      .split(pathDelimiter)
-      .map(s => s.trim())
-      .filter(s => s.length > 0)
-      .map(s => resolve(expandHome(s)))
-    if (dirs.length > 0) {
-      const seen = new Set<string>()
-      const out: string[] = []
-      for (const d of dirs) {
-        if (!seen.has(d)) {
-          seen.add(d)
-          out.push(d)
-        }
-      }
-      return out
-    }
+    const dirs = normalizeDirs(multi.split(pathDelimiter))
+    if (dirs.length > 0) return withClaudeAccounts(dirs, true)
   }
+
   const single = process.env['CLAUDE_CONFIG_DIR']
-  if (single !== undefined && single !== '') return [resolve(expandHome(single))]
-  return [join(homedir(), '.claude')]
+  if (single !== undefined && single !== '') return withClaudeAccounts(normalizeDirs([single]))
+  return withClaudeAccounts(normalizeDirs([join(homedir(), '.claude')]))
 }
 
 function getDesktopSessionsDir(): string {
@@ -89,84 +120,97 @@ async function findDesktopProjectDirs(base: string): Promise<string[]> {
   return results
 }
 
-export const claude: Provider = {
-  name: 'claude',
-  displayName: 'Claude',
+export function createClaudeProvider(claudeDirs?: string | string[], desktopSessionsDir?: string): Provider {
+  return {
+    name: 'claude',
+    displayName: 'Claude',
 
-  modelDisplayName(model: string): string {
-    const canonical = model.replace(/@.*$/, '').replace(/-\d{8}$/, '')
-    for (const [key, name] of Object.entries(shortNames)) {
-      if (canonical.startsWith(key)) return name
-    }
-    return canonical
-  },
-
-  toolDisplayName(rawTool: string): string {
-    return rawTool
-  },
-
-  async discoverSessions(): Promise<SessionSource[]> {
-    const sources: SessionSource[] = []
-    const seenProjectDirs = new Set<string>()
-    const configDirs = getClaudeConfigDirs()
-    let anyDirReadable = false
-
-    for (const claudeDir of configDirs) {
-      const projectsDir = join(claudeDir, 'projects')
-      let entries: string[]
-      try {
-        entries = await readdir(projectsDir)
-        anyDirReadable = true
-      } catch {
-        // Missing or unreadable dir is not fatal: a user can configure both
-        // a real and a stale path in CLAUDE_CONFIG_DIRS without breaking.
-        continue
+    modelDisplayName(model: string): string {
+      const canonical = model.replace(/@.*$/, '').replace(/-\d{8}$/, '')
+      for (const [key, name] of Object.entries(shortNames)) {
+        if (canonical.startsWith(key)) return name
       }
-      for (const dirName of entries) {
-        const dirPath = join(projectsDir, dirName)
-        // Resolve before deduping so two CLAUDE_CONFIG_DIRS entries that
-        // reach the same projects/<slug> directory (via symlinks or
-        // overlapping configs) emit only one SessionSource.
+      return canonical
+    },
+
+    toolDisplayName(rawTool: string): string {
+      return rawTool
+    },
+
+    async discoverSessions(): Promise<SessionSource[]> {
+      const sources: SessionSource[] = []
+      const seenProjectDirs = new Set<string>()
+      const roots = getClaudeRoots(claudeDirs)
+      let anyDirReadable = false
+      const shouldLabelDesktop = roots.some(root => root.account)
+
+      for (const root of roots) {
+        const projectsDir = join(root.path, 'projects')
+        let entries: string[]
+        try {
+          entries = await readdir(projectsDir)
+          anyDirReadable = true
+        } catch {
+          // Missing or unreadable dir is not fatal: a user can configure both
+          // a real and a stale path in CLAUDE_CONFIG_DIRS without breaking.
+          continue
+        }
+        for (const dirName of entries) {
+          const dirPath = join(projectsDir, dirName)
+          // Resolve before deduping so two CLAUDE_CONFIG_DIRS entries that
+          // reach the same projects/<slug> directory (via symlinks or
+          // overlapping configs) emit only one SessionSource.
+          const resolved = resolve(dirPath)
+          if (seenProjectDirs.has(resolved)) continue
+          const dirStat = await stat(dirPath).catch(() => null)
+          if (!dirStat?.isDirectory()) continue
+          seenProjectDirs.add(resolved)
+          sources.push({
+            path: dirPath,
+            project: dirName,
+            provider: 'claude',
+            ...(root.account ? { account: root.account, accountPath: root.accountPath } : {}),
+          })
+        }
+      }
+
+      // If the user explicitly set CLAUDE_CONFIG_DIRS and every entry was
+      // unreadable, emit a one-line stderr hint. Catches the most common
+      // misconfiguration: a Windows user typing `:` (POSIX delimiter) when
+      // the platform expects `;`, which produces a single bogus path that
+      // silently resolves to nothing on disk.
+      const explicitMulti = process.env['CLAUDE_CONFIG_DIRS']
+      if (!anyDirReadable && explicitMulti !== undefined && explicitMulti !== '' && roots.length > 0) {
+        process.stderr.write(
+          `codeburn: CLAUDE_CONFIG_DIRS was set but no listed directory could be read. ` +
+          `Tried: ${roots.map(root => root.path).join(', ')}. ` +
+          `Use "${pathDelimiter}" as the separator on this platform.\n`,
+        )
+      }
+
+      const desktopRoot = desktopSessionsDir ?? getDesktopSessionsDir()
+      const desktopDirs = await findDesktopProjectDirs(desktopRoot)
+      for (const dirPath of desktopDirs) {
         const resolved = resolve(dirPath)
         if (seenProjectDirs.has(resolved)) continue
-        const dirStat = await stat(dirPath).catch(() => null)
-        if (!dirStat?.isDirectory()) continue
         seenProjectDirs.add(resolved)
-        // `project: dirName` is identical across config dirs for the same
-        // sanitized slug, which is exactly what makes the parser merge
-        // their sessions into a single ProjectSummary.
-        sources.push({ path: dirPath, project: dirName, provider: 'claude' })
+        sources.push({
+          path: dirPath,
+          project: basename(dirPath),
+          provider: 'claude',
+          ...(shouldLabelDesktop ? { account: 'desktop', accountPath: desktopRoot } : {}),
+        })
       }
-    }
 
-    // If the user explicitly set CLAUDE_CONFIG_DIRS and every entry was
-    // unreadable, emit a one-line stderr hint. Catches the most common
-    // misconfiguration: a Windows user typing `:` (POSIX delimiter) when
-    // the platform expects `;`, which produces a single bogus path that
-    // silently resolves to nothing on disk.
-    const explicitMulti = process.env['CLAUDE_CONFIG_DIRS']
-    if (!anyDirReadable && explicitMulti !== undefined && explicitMulti !== '' && configDirs.length > 0) {
-      process.stderr.write(
-        `codeburn: CLAUDE_CONFIG_DIRS was set but no listed directory could be read. ` +
-        `Tried: ${configDirs.join(', ')}. ` +
-        `Use "${pathDelimiter}" as the separator on this platform.\n`,
-      )
-    }
+      return sources
+    },
 
-    const desktopDirs = await findDesktopProjectDirs(getDesktopSessionsDir())
-    for (const dirPath of desktopDirs) {
-      const resolved = resolve(dirPath)
-      if (seenProjectDirs.has(resolved)) continue
-      seenProjectDirs.add(resolved)
-      sources.push({ path: dirPath, project: basename(dirPath), provider: 'claude' })
-    }
-
-    return sources
-  },
-
-  createSessionParser(): SessionParser {
-    return {
-      async *parse() {},
-    }
-  },
+    createSessionParser(): SessionParser {
+      return {
+        async *parse() {},
+      }
+    },
+  }
 }
+
+export const claude = createClaudeProvider()

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -2,6 +2,8 @@ export type SessionSource = {
   path: string
   project: string
   provider: string
+  account?: string
+  accountPath?: string
 }
 
 export type SessionParser = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,8 @@ export type ClassifiedTurn = ParsedTurn & {
 export type SessionSummary = {
   sessionId: string
   project: string
+  account?: string
+  accountPath?: string
   firstTimestamp: string
   lastTimestamp: string
   totalCostUSD: number
@@ -137,6 +139,9 @@ export type SessionSummary = {
 export type ProjectSummary = {
   project: string
   projectPath: string
+  account?: string
+  accountPath?: string
+  sourcePath?: string
   sessions: SessionSummary[]
   totalCostUSD: number
   totalApiCalls: number

--- a/tests/accounts.test.ts
+++ b/tests/accounts.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildAccountReport, filterProjectsByAccount } from '../src/accounts.js'
+import type { ProjectSummary, SessionSummary, TaskCategory } from '../src/types.js'
+
+const categories: TaskCategory[] = [
+  'coding',
+  'debugging',
+  'feature',
+  'refactoring',
+  'testing',
+  'exploration',
+  'planning',
+  'delegation',
+  'git',
+  'build/deploy',
+  'conversation',
+  'brainstorming',
+  'general',
+]
+
+function makeSession(project: string, sessionId: string, costUSD: number, model = 'claude-sonnet-4-5'): SessionSummary {
+  return {
+    sessionId,
+    project,
+    firstTimestamp: '2099-04-20T10:00:00.000Z',
+    lastTimestamp: '2099-04-20T10:01:00.000Z',
+    totalCostUSD: costUSD,
+    totalInputTokens: 100,
+    totalOutputTokens: 50,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    apiCalls: 1,
+    turns: [],
+    modelBreakdown: {
+      [model]: {
+        calls: 1,
+        costUSD,
+        tokens: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          cachedInputTokens: 0,
+          reasoningTokens: 0,
+          webSearchRequests: 0,
+        },
+      },
+    },
+    toolBreakdown: {},
+    mcpBreakdown: {},
+    bashBreakdown: {},
+    categoryBreakdown: Object.fromEntries(categories.map(category => [
+      category,
+      { turns: category === 'feature' ? 1 : 0, costUSD: category === 'feature' ? costUSD : 0, retries: 0, editTurns: category === 'feature' ? 1 : 0, oneShotTurns: category === 'feature' ? 1 : 0 },
+    ])) as SessionSummary['categoryBreakdown'],
+    skillBreakdown: {},
+  }
+}
+
+function makeProject(account: string | undefined, projectPath: string, costUSD: number): ProjectSummary {
+  const project = projectPath.split('/').pop() ?? projectPath
+  return {
+    project,
+    projectPath,
+    ...(account ? { account, accountPath: `/tmp/claude-${account}` } : {}),
+    sessions: [makeSession(project, `${account ?? 'default'}-${project}`, costUSD)],
+    totalCostUSD: costUSD,
+    totalApiCalls: 1,
+  }
+}
+
+describe('account reporting', () => {
+  it('aggregates spend by account with subscription and budget signals', () => {
+    const report = buildAccountReport([
+      makeProject('work', '/Users/alice/work/app', 12),
+      makeProject('personal', '/Users/alice/work/app', 1),
+    ], {
+      work: { plan: 'Claude Max', monthlyUsd: 100, budgetUsd: 10 },
+      personal: { plan: 'Claude Pro', monthlyUsd: 20 },
+    })
+
+    expect(report.accounts.map(a => a.account)).toEqual(['work', 'personal'])
+    expect(report.accounts[0]).toMatchObject({
+      account: 'work',
+      totalCostUSD: 12,
+      sessions: 1,
+      projects: 1,
+      subscriptionUtilizationPercent: 12,
+      budgetUtilizationPercent: 120,
+    })
+    expect(report.risks.map(r => r.type)).toContain('duplicate-project')
+    expect(report.risks.map(r => r.type)).toContain('path-account-mismatch')
+    expect(report.risks.map(r => r.type)).toContain('over-budget')
+    expect(report.risks.map(r => r.type)).toContain('underused-subscription')
+  })
+
+  it('keeps configured but unused subscriptions visible', () => {
+    const report = buildAccountReport([], {
+      idle: { plan: 'Claude Pro', monthlyUsd: 20 },
+    })
+
+    expect(report.accounts).toHaveLength(1)
+    expect(report.accounts[0]).toMatchObject({
+      account: 'idle',
+      totalCostUSD: 0,
+      sessions: 0,
+      subscriptionUtilizationPercent: 0,
+    })
+    expect(report.risks).toContainEqual(expect.objectContaining({
+      type: 'underused-subscription',
+      account: 'idle',
+    }))
+  })
+
+  it('matches configured accounts case-insensitively', () => {
+    const report = buildAccountReport([
+      makeProject('work', '/Users/alice/work/app', 12),
+    ], {
+      Work: { plan: 'Claude Max', monthlyUsd: 100 },
+    })
+
+    expect(report.accounts).toHaveLength(1)
+    expect(report.accounts[0]).toMatchObject({
+      account: 'work',
+      configured: { plan: 'Claude Max' },
+      subscriptionUtilizationPercent: 12,
+    })
+  })
+
+  it('does not warn when an account-labelled project also has unlabelled provider usage', () => {
+    const report = buildAccountReport([
+      makeProject('work', '/Users/alice/work/app', 12),
+      makeProject(undefined, '/Users/alice/work/app', 3),
+    ])
+
+    expect(report.accounts.map(a => a.account)).toEqual(['work', 'unlabelled'])
+    expect(report.risks.map(r => r.type)).not.toContain('duplicate-project')
+  })
+
+  it('uses account-label tokens for wrong-account warnings', () => {
+    const report = buildAccountReport([
+      makeProject('homework', '/Users/alice/work/app', 1),
+      makeProject('personal-home', '/Users/alice/work/app', 1),
+    ])
+
+    const mismatches = report.risks.filter(r => r.type === 'path-account-mismatch')
+    expect(mismatches.map(r => r.account)).toEqual(['personal-home'])
+  })
+
+  it('filters projects by account label, path, and account-prefixed project', () => {
+    const projects = [
+      makeProject('work', '/Users/alice/work/app', 12),
+      makeProject('personal', '/Users/alice/work/app', 1),
+    ]
+
+    expect(filterProjectsByAccount(projects, ['work']).map(p => p.account)).toEqual(['work'])
+    expect(filterProjectsByAccount(projects, ['claude-personal']).map(p => p.account)).toEqual(['personal'])
+    expect(filterProjectsByAccount(projects, ['work:/users/alice/work']).map(p => p.account)).toEqual(['work'])
+  })
+})

--- a/tests/cli-accounts.test.ts
+++ b/tests/cli-accounts.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, mkdir, readFile, rm, utimes, writeFile } from 'node:fs/promises'
+import { spawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+async function createClaudeSession(configDir: string, project: string, sessionId: string, timestamp: string): Promise<void> {
+  const projectDir = join(configDir, 'projects', project)
+  await mkdir(projectDir, { recursive: true })
+  const filePath = join(projectDir, `${sessionId}.jsonl`)
+  await writeFile(filePath, JSON.stringify({
+    type: 'assistant',
+    sessionId,
+    timestamp,
+    cwd: project.replace(/-/g, '/'),
+    message: {
+      id: `msg-${sessionId}`,
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+      },
+    },
+  }) + '\n')
+  const mtime = new Date(timestamp)
+  await utimes(filePath, mtime, mtime)
+}
+
+function runCli(args: string[], home: string, extraEnv: Record<string, string> = {}) {
+  return spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOME: home,
+      CLAUDE_CONFIG_DIR: '',
+      ...extraEnv,
+    },
+    encoding: 'utf-8',
+  })
+}
+
+describe('codeburn accounts command', () => {
+  it('configures subscription metadata and reports filtered account rollups', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-accounts-'))
+    const workDir = join(home, 'claude-work')
+    const personalDir = join(home, 'claude-personal')
+
+    try {
+      await createClaudeSession(workDir, '-Users-alice-work-app', 'work-session', '2099-04-20T10:00:00.000Z')
+      await createClaudeSession(personalDir, '-Users-alice-work-app', 'personal-session', '2099-04-20T11:00:00.000Z')
+
+      const setResult = runCli(['accounts', 'set', 'Work', '--plan', 'Claude Max', '--monthly-usd', '100', '--budget-usd', '0.001'], home)
+      expect(setResult.status).toBe(0)
+      expect(setResult.stdout).toContain('Budget: USD 0.001/month')
+
+      const config = JSON.parse(await readFile(join(home, '.config', 'codeburn', 'config.json'), 'utf-8')) as {
+        accounts?: Record<string, { plan?: string; monthlyUsd?: number; budgetUsd?: number }>
+      }
+      expect(config.accounts?.work).toMatchObject({ plan: 'Claude Max', monthlyUsd: 100, budgetUsd: 0.001 })
+
+      const result = runCli([
+        'accounts',
+        'work',
+        '--format',
+        'json',
+        '--provider',
+        'claude',
+        '--account',
+        'claude-work',
+        '--from',
+        '2099-04-20',
+        '--to',
+        '2099-04-20',
+      ], home, {
+        CLAUDE_CONFIG_DIRS: `${workDir}:${personalDir}`,
+      })
+
+      expect(result.status).toBe(0)
+      const payload = JSON.parse(result.stdout) as {
+        accounts: Array<{ name: string; plan?: string; sessions: number; budgetUtilizationPercent?: number | null }>
+        risks: Array<{ type: string }>
+      }
+      expect(payload.accounts.map(a => a.name)).toEqual(['work'])
+      expect(payload.accounts[0]).toMatchObject({ name: 'work', plan: 'Claude Max', sessions: 1 })
+      expect(payload.accounts[0]!.budgetUtilizationPercent).toBeGreaterThan(100)
+      expect(payload.risks.map(r => r.type)).toContain('over-budget')
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  }, 15_000)
+})

--- a/tests/cli-export-date-range.test.ts
+++ b/tests/cli-export-date-range.test.ts
@@ -5,7 +5,7 @@ import { spawnSync } from 'node:child_process'
 
 import { describe, expect, it } from 'vitest'
 
-function runCli(args: string[], home: string) {
+function runCli(args: string[], home: string, extraEnv: Record<string, string> = {}) {
   return spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], {
     cwd: process.cwd(),
     env: {
@@ -13,6 +13,7 @@ function runCli(args: string[], home: string) {
       CLAUDE_CONFIG_DIR: join(home, '.claude'),
       HOME: home,
       TZ: 'UTC',
+      ...extraEnv,
     },
     encoding: 'utf-8',
   })
@@ -47,12 +48,23 @@ function assistantLine(sessionId: string, timestamp: string, messageId: string):
 }
 
 describe('codeburn export custom date range', () => {
-  it('exports a single custom period filtered by --from/--to', async () => {
+  it('exports a single custom period filtered by --from/--to and --account', async () => {
     const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-export-'))
 
     try {
-      const projectDir = join(home, '.claude', 'projects', 'app')
+      const workDir = join(home, 'claude-work')
+      const personalDir = join(home, 'claude-personal')
+      const configDir = join(home, '.config', 'codeburn')
+      const projectDir = join(workDir, 'projects', 'app')
+      const personalProjectDir = join(personalDir, 'projects', 'app')
       await mkdir(projectDir, { recursive: true })
+      await mkdir(personalProjectDir, { recursive: true })
+      await mkdir(configDir, { recursive: true })
+      await writeFile(join(configDir, 'config.json'), JSON.stringify({
+        accounts: {
+          work: { plan: 'Claude Max', monthlyUsd: 100, budgetUsd: 50 },
+        },
+      }))
       await writeFile(
         join(projectDir, 'in-range.jsonl'),
         [
@@ -67,6 +79,13 @@ describe('codeburn export custom date range', () => {
           assistantLine('out-of-range', '2026-04-11T09:01:00Z', 'msg-out-of-range'),
         ].join('\n'),
       )
+      await writeFile(
+        join(personalProjectDir, 'personal-in-range.jsonl'),
+        [
+          userLine('personal-in-range', '2026-04-10T10:00:00Z'),
+          assistantLine('personal-in-range', '2026-04-10T10:01:00Z', 'msg-personal-in-range'),
+        ].join('\n'),
+      )
 
       const outputPath = join(home, 'custom-export.json')
       const result = runCli([
@@ -75,20 +94,27 @@ describe('codeburn export custom date range', () => {
         '--from', '2026-04-10',
         '--to', '2026-04-10',
         '--provider', 'claude',
+        '--account', 'claude-work',
         '--output', outputPath,
-      ], home)
+      ], home, {
+        CLAUDE_CONFIG_DIR: '',
+        CLAUDE_CONFIG_DIRS: `${workDir}:${personalDir}`,
+      })
 
       expect(result.status).toBe(0)
       expect(result.stdout).toContain('Exported (2026-04-10 to 2026-04-10)')
 
       const exported = JSON.parse(await readFile(outputPath, 'utf-8')) as {
         summary: Array<{ Period: string; Sessions: number }>
-        sessions: Array<{ 'Session ID': string }>
+        accounts: Array<{ Account: string; Plan?: string; 'Monthly USD'?: number }>
+        sessions: Array<{ 'Session ID': string; Account?: string }>
       }
       expect(exported.summary).toHaveLength(1)
       expect(exported.summary[0]?.Period).toBe('2026-04-10 to 2026-04-10')
       expect(exported.summary[0]?.Sessions).toBe(1)
+      expect(exported.accounts[0]).toMatchObject({ Account: 'work', Plan: 'Claude Max', 'Monthly USD': 100 })
       expect(exported.sessions.map(s => s['Session ID'])).toEqual(['in-range'])
+      expect(exported.sessions[0]?.Account).toBe('work')
     } finally {
       await rm(home, { recursive: true, force: true })
     }

--- a/tests/cli-json.test.ts
+++ b/tests/cli-json.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, mkdir, writeFile, rm, utimes } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+import { describe, it, expect } from 'vitest'
+
+async function createClaudeSession(configDir: string, project: string, sessionId: string, timestamp: string): Promise<void> {
+  const projectDir = join(configDir, 'projects', project)
+  await mkdir(projectDir, { recursive: true })
+  const filePath = join(projectDir, `${sessionId}.jsonl`)
+  await writeFile(filePath, JSON.stringify({
+    type: 'assistant',
+    sessionId,
+    timestamp,
+    message: {
+      id: `msg-${sessionId}`,
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+      },
+    },
+  }) + '\n')
+  const mtime = new Date(timestamp)
+  await utimes(filePath, mtime, mtime)
+}
+
+describe('codeburn report --format json', () => {
+  it('includes Claude account labels on projects and top sessions', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-json-'))
+    const workDir = join(home, 'claude-work')
+
+    try {
+      await createClaudeSession(workDir, '-Users-alice-app', 'sess-001', '2099-04-20T10:00:00.000Z')
+      const result = spawnSync(process.execPath, [
+        '--import',
+        'tsx',
+        'src/cli.ts',
+        'report',
+        '--format',
+        'json',
+        '--provider',
+        'claude',
+        '--from',
+        '2099-04-20',
+        '--to',
+        '2099-04-20',
+      ], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          HOME: home,
+          CLAUDE_CONFIG_DIRS: workDir,
+          CLAUDE_CONFIG_DIR: '',
+        },
+        encoding: 'utf-8',
+      })
+
+      expect(result.status).toBe(0)
+      const report = JSON.parse(result.stdout) as {
+        projects: Array<{ account?: string; accountPath?: string }>
+        topSessions: Array<{ account?: string }>
+      }
+      expect(report.projects).toHaveLength(1)
+      expect(report.projects[0]).toMatchObject({ account: 'work', accountPath: workDir })
+      expect(report.topSessions[0]).toMatchObject({ account: 'work' })
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/cli-json.test.ts
+++ b/tests/cli-json.test.ts
@@ -30,12 +30,14 @@ async function createClaudeSession(configDir: string, project: string, sessionId
 }
 
 describe('codeburn report --format json', () => {
-  it('includes Claude account labels on projects and top sessions', async () => {
+  it('includes and filters Claude account labels on projects and top sessions', async () => {
     const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-json-'))
     const workDir = join(home, 'claude-work')
+    const personalDir = join(home, 'claude-personal')
 
     try {
       await createClaudeSession(workDir, '-Users-alice-app', 'sess-001', '2099-04-20T10:00:00.000Z')
+      await createClaudeSession(personalDir, '-Users-alice-personal-app', 'sess-002', '2099-04-20T11:00:00.000Z')
       const result = spawnSync(process.execPath, [
         '--import',
         'tsx',
@@ -49,12 +51,14 @@ describe('codeburn report --format json', () => {
         '2099-04-20',
         '--to',
         '2099-04-20',
+        '--account',
+        'claude-work',
       ], {
         cwd: process.cwd(),
         env: {
           ...process.env,
           HOME: home,
-          CLAUDE_CONFIG_DIRS: workDir,
+          CLAUDE_CONFIG_DIRS: `${workDir}:${personalDir}`,
           CLAUDE_CONFIG_DIR: '',
         },
         encoding: 'utf-8',
@@ -63,11 +67,12 @@ describe('codeburn report --format json', () => {
       expect(result.status).toBe(0)
       const report = JSON.parse(result.stdout) as {
         projects: Array<{ account?: string; accountPath?: string }>
-        topSessions: Array<{ account?: string }>
+        topSessions: Array<{ account?: string; sessionId?: string }>
       }
       expect(report.projects).toHaveLength(1)
       expect(report.projects[0]).toMatchObject({ account: 'work', accountPath: workDir })
       expect(report.topSessions[0]).toMatchObject({ account: 'work' })
+      expect(report.topSessions.map(s => s.sessionId)).toEqual(['sess-001'])
     } finally {
       await rm(home, { recursive: true, force: true })
     }

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -193,4 +193,32 @@ describe('exportCsv', () => {
     expect(readme).toContain('selected detail period')
     expect(readme).not.toContain('30-day window')
   })
+
+  it('keeps account CSV columns even when the first row is unlabelled', async () => {
+    const unlabelled = makeProject('unlabelled')
+    unlabelled.totalCostUSD = 2
+    unlabelled.sessions[0]!.totalCostUSD = 2
+    const labelled = makeProject('labelled')
+    labelled.account = 'work'
+    labelled.accountPath = '/tmp/claude-work'
+
+    const periods: PeriodExport[] = [
+      {
+        label: '30 Days',
+        projects: [unlabelled, labelled],
+      },
+    ]
+
+    const outputPath = join(tmpDir, 'accounts-columns.csv')
+    const folder = await exportCsv(periods, outputPath)
+    const projects = await readFile(join(folder, 'projects.csv'), 'utf-8')
+    const sessions = await readFile(join(folder, 'sessions.csv'), 'utf-8')
+
+    expect(projects.split('\n')[0]).toMatch(/^Account,Account Path,Project,/)
+    expect(projects).toContain('\n,,unlabelled,')
+    expect(projects).toContain('\nwork,/tmp/claude-work,labelled,')
+    expect(sessions.split('\n')[0]).toMatch(/^Account,Account Path,Project,/)
+    expect(sessions).toContain('\n,,unlabelled,')
+    expect(sessions).toContain('\nwork,/tmp/claude-work,labelled,')
+  })
 })

--- a/tests/parser-filter.test.ts
+++ b/tests/parser-filter.test.ts
@@ -3,10 +3,12 @@ import { describe, it, expect } from 'vitest'
 import { filterProjectsByName } from '../src/parser.js'
 import type { ProjectSummary } from '../src/types.js'
 
-function makeProject(project: string, projectPath = project): ProjectSummary {
+function makeProject(project: string, projectPath = project, account?: string, accountPath?: string): ProjectSummary {
   return {
     project,
     projectPath,
+    ...(account ? { account } : {}),
+    ...(accountPath ? { accountPath } : {}),
     sessions: [],
     totalCostUSD: 0,
     totalApiCalls: 0,
@@ -42,6 +44,24 @@ describe('filterProjectsByName', () => {
     expect(result.map(p => p.project)).toEqual(['AgentSeal'])
   })
 
+  it('include can target a Claude account label', () => {
+    const accountProjects = [
+      makeProject('-Users-alice-app', '/Users/alice/app', 'work', '/Users/alice/.claude-work'),
+      makeProject('-Users-alice-app', '/Users/alice/app', 'personal', '/Users/alice/.claude-personal'),
+    ]
+    const result = filterProjectsByName(accountProjects, ['work:/users/alice/app'])
+    expect(result.map(p => p.account)).toEqual(['work'])
+  })
+
+  it('include can match a bare Claude account label', () => {
+    const accountProjects = [
+      makeProject('-Users-alice-app', '/Users/alice/app', 'work', '/Users/alice/.claude-work'),
+      makeProject('-Users-alice-app', '/Users/alice/app', 'personal', '/Users/alice/.claude-personal'),
+    ]
+    const result = filterProjectsByName(accountProjects, ['work'])
+    expect(result.map(p => p.account)).toEqual(['work'])
+  })
+
   it('include uses OR semantics across patterns', () => {
     const result = filterProjectsByName(projects, ['codeburn', 'sandbox'])
     expect(result.map(p => p.project).sort()).toEqual(['codeburn', 'sandbox'])
@@ -55,6 +75,15 @@ describe('filterProjectsByName', () => {
   it('exclude matches path substring', () => {
     const result = filterProjectsByName(projects, undefined, ['/tmp'])
     expect(result.map(p => p.project)).not.toContain('sandbox')
+  })
+
+  it('exclude can target a Claude account label', () => {
+    const accountProjects = [
+      makeProject('-Users-alice-app', '/Users/alice/app', 'work', '/Users/alice/.claude-work'),
+      makeProject('-Users-alice-app', '/Users/alice/app', 'personal', '/Users/alice/.claude-personal'),
+    ]
+    const result = filterProjectsByName(accountProjects, undefined, ['personal'])
+    expect(result.map(p => p.account)).toEqual(['work'])
   })
 
   it('exclude is applied after include', () => {

--- a/tests/providers/claude.test.ts
+++ b/tests/providers/claude.test.ts
@@ -10,11 +10,13 @@ import type { DateRange } from '../../src/types.js'
 let tmpDir: string
 let originalConfigDir: string | undefined
 let originalConfigDirs: string | undefined
+let originalHome: string | undefined
 
 beforeEach(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), 'claude-provider-test-'))
   originalConfigDir = process.env['CLAUDE_CONFIG_DIR']
   originalConfigDirs = process.env['CLAUDE_CONFIG_DIRS']
+  originalHome = process.env['HOME']
 })
 
 afterEach(async () => {
@@ -27,6 +29,11 @@ afterEach(async () => {
     delete process.env['CLAUDE_CONFIG_DIRS']
   } else {
     process.env['CLAUDE_CONFIG_DIRS'] = originalConfigDirs
+  }
+  if (originalHome === undefined) {
+    delete process.env['HOME']
+  } else {
+    process.env['HOME'] = originalHome
   }
   await rm(tmpDir, { recursive: true, force: true })
 })
@@ -73,10 +80,87 @@ describe('claude provider', () => {
 
     expect(sessions.map(s => s.provider)).toEqual(['claude', 'claude'])
     expect(sessions.map(s => s.project).sort()).toEqual(['-Users-test-personal', '-Users-test-work'])
+    expect(sessions.map(s => s.account).sort()).toEqual(['personal', 'work'])
+    expect(sessions.map(s => s.accountPath).sort()).toEqual([personalDir, workDir].sort())
     expect(sessions.map(s => s.path).sort()).toEqual([
       join(personalDir, 'projects', '-Users-test-personal'),
       join(workDir, 'projects', '-Users-test-work'),
     ].sort())
+  })
+
+  it('expands ~/ in Claude config directories', async () => {
+    process.env['HOME'] = tmpDir
+    const workDir = join(tmpDir, 'claude-work')
+    await createProjectDir(workDir, '-Users-test-work')
+
+    const provider = createClaudeProvider('~/claude-work', join(tmpDir, 'missing-desktop'))
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]).toMatchObject({
+      path: join(workDir, 'projects', '-Users-test-work'),
+      project: '-Users-test-work',
+      provider: 'claude',
+    })
+  })
+
+  it('labels a single directory supplied through CLAUDE_CONFIG_DIRS', async () => {
+    const workDir = join(tmpDir, 'claude-work')
+    await createProjectDir(workDir, '-Users-test-work')
+    process.env['CLAUDE_CONFIG_DIRS'] = workDir
+
+    const provider = createClaudeProvider(undefined, join(tmpDir, 'missing-desktop'))
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]).toMatchObject({
+      account: 'work',
+      accountPath: workDir,
+      project: '-Users-test-work',
+    })
+  })
+
+  it('deduplicates account labels after Claude prefix stripping', async () => {
+    const workDir = join(tmpDir, 'claude-work')
+    const explicitWork2Dir = join(tmpDir, 'claude-work-2')
+    const duplicateWorkDir = join(tmpDir, '.claude-work')
+    await createProjectDir(workDir, '-Users-test-work')
+    await createProjectDir(explicitWork2Dir, '-Users-test-work-2')
+    await createProjectDir(duplicateWorkDir, '-Users-test-work-3')
+
+    const provider = createClaudeProvider([workDir, explicitWork2Dir, duplicateWorkDir], join(tmpDir, 'missing-desktop'))
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions.map(s => s.account).sort()).toEqual(['work', 'work-2', 'work-3'])
+  })
+
+  it('does not strip claude when it is not a separated prefix', async () => {
+    const claudiaDir = join(tmpDir, 'claudia')
+    const workDir = join(tmpDir, 'claude-work')
+    await createProjectDir(claudiaDir, '-Users-test-claudia')
+    await createProjectDir(workDir, '-Users-test-work')
+
+    const provider = createClaudeProvider([claudiaDir, workDir], join(tmpDir, 'missing-desktop'))
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions.map(s => s.account).sort()).toEqual(['claudia', 'work'])
+  })
+
+  it('expands ~/ in CLAUDE_CONFIG_DIR without adding an account label', async () => {
+    process.env['HOME'] = tmpDir
+    process.env['CLAUDE_CONFIG_DIR'] = '~/claude-work'
+    const workDir = join(tmpDir, 'claude-work')
+    await createProjectDir(workDir, '-Users-test-work')
+
+    const provider = createClaudeProvider(undefined, join(tmpDir, 'missing-desktop'))
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]).toMatchObject({
+      path: join(workDir, 'projects', '-Users-test-work'),
+      project: '-Users-test-work',
+    })
+    expect(sessions[0]!.account).toBeUndefined()
   })
 
   it('tracks Claude sessions from CLAUDE_CONFIG_DIRS', async () => {
@@ -98,6 +182,33 @@ describe('claude provider', () => {
     const projects = await parseAllSessions(range, 'claude')
 
     expect(projects.map(p => p.project).sort()).toEqual(['-Users-test-personal', '-Users-test-work'])
+    expect(projects.map(p => p.account).sort()).toEqual(['personal', 'work'])
     expect(projects.reduce((sum, project) => sum + project.totalApiCalls, 0)).toBe(2)
+  })
+
+  it('keeps the same Claude project separate across accounts', async () => {
+    const workDir = join(tmpDir, 'claude-work')
+    const personalDir = join(tmpDir, 'claude-personal')
+    const project = '-Users-test-app'
+
+    await createSession(workDir, project, 'work-session', '2099-04-15T10:00:00.000Z')
+    await createSession(personalDir, project, 'personal-session', '2099-04-15T11:00:00.000Z')
+
+    process.env['CLAUDE_CONFIG_DIRS'] = [workDir, personalDir].join(delimiter)
+
+    const range: DateRange = {
+      start: new Date('2099-04-15T00:00:00.000Z'),
+      end: new Date('2099-04-15T23:59:59.999Z'),
+    }
+    const projects = await parseAllSessions(range, 'claude')
+
+    expect(projects).toHaveLength(2)
+    expect(projects.map(p => `${p.account}:${p.project}`).sort()).toEqual([
+      `personal:${project}`,
+      `work:${project}`,
+    ])
+    expect(projects.every(p => p.projectPath === '/Users/test/app')).toBe(true)
+    expect(projects.map(p => p.totalApiCalls).sort()).toEqual([1, 1])
+    expect(projects.flatMap(p => p.sessions.map(s => s.account)).sort()).toEqual(['personal', 'work'])
   })
 })

--- a/tests/providers/claude.test.ts
+++ b/tests/providers/claude.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm, utimes } from 'fs/promises'
+import { delimiter, join } from 'path'
+import { tmpdir } from 'os'
+
+import { parseAllSessions } from '../../src/parser.js'
+import { createClaudeProvider } from '../../src/providers/claude.js'
+import type { DateRange } from '../../src/types.js'
+
+let tmpDir: string
+let originalConfigDir: string | undefined
+let originalConfigDirs: string | undefined
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'claude-provider-test-'))
+  originalConfigDir = process.env['CLAUDE_CONFIG_DIR']
+  originalConfigDirs = process.env['CLAUDE_CONFIG_DIRS']
+})
+
+afterEach(async () => {
+  if (originalConfigDir === undefined) {
+    delete process.env['CLAUDE_CONFIG_DIR']
+  } else {
+    process.env['CLAUDE_CONFIG_DIR'] = originalConfigDir
+  }
+  if (originalConfigDirs === undefined) {
+    delete process.env['CLAUDE_CONFIG_DIRS']
+  } else {
+    process.env['CLAUDE_CONFIG_DIRS'] = originalConfigDirs
+  }
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+async function createProjectDir(configDir: string, project: string): Promise<string> {
+  const projectDir = join(configDir, 'projects', project)
+  await mkdir(projectDir, { recursive: true })
+  return projectDir
+}
+
+async function createSession(configDir: string, project: string, sessionId: string, timestamp: string): Promise<void> {
+  const projectDir = await createProjectDir(configDir, project)
+  const filePath = join(projectDir, `${sessionId}.jsonl`)
+  await writeFile(filePath, JSON.stringify({
+    type: 'assistant',
+    sessionId,
+    timestamp,
+    message: {
+      id: `msg-${sessionId}`,
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+      },
+    },
+  }) + '\n')
+
+  const mtime = new Date(timestamp)
+  await utimes(filePath, mtime, mtime)
+}
+
+describe('claude provider', () => {
+  it('discovers projects across multiple Claude config directories', async () => {
+    const workDir = join(tmpDir, 'claude-work')
+    const personalDir = join(tmpDir, 'claude-personal')
+    await createProjectDir(workDir, '-Users-test-work')
+    await createProjectDir(personalDir, '-Users-test-personal')
+
+    const provider = createClaudeProvider([workDir, personalDir], join(tmpDir, 'missing-desktop'))
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions.map(s => s.provider)).toEqual(['claude', 'claude'])
+    expect(sessions.map(s => s.project).sort()).toEqual(['-Users-test-personal', '-Users-test-work'])
+    expect(sessions.map(s => s.path).sort()).toEqual([
+      join(personalDir, 'projects', '-Users-test-personal'),
+      join(workDir, 'projects', '-Users-test-work'),
+    ].sort())
+  })
+
+  it('tracks Claude sessions from CLAUDE_CONFIG_DIRS', async () => {
+    const workDir = join(tmpDir, 'claude-work')
+    const personalDir = join(tmpDir, 'claude-personal')
+    const ignoredDir = join(tmpDir, 'claude-ignored')
+
+    await createSession(workDir, '-Users-test-work', 'work-session', '2099-04-14T10:00:00.000Z')
+    await createSession(personalDir, '-Users-test-personal', 'personal-session', '2099-04-14T11:00:00.000Z')
+    await createSession(ignoredDir, '-Users-test-ignored', 'ignored-session', '2099-04-14T12:00:00.000Z')
+
+    process.env['CLAUDE_CONFIG_DIRS'] = [workDir, personalDir].join(delimiter)
+    process.env['CLAUDE_CONFIG_DIR'] = ignoredDir
+
+    const range: DateRange = {
+      start: new Date('2099-04-14T00:00:00.000Z'),
+      end: new Date('2099-04-14T23:59:59.999Z'),
+    }
+    const projects = await parseAllSessions(range, 'claude')
+
+    expect(projects.map(p => p.project).sort()).toEqual(['-Users-test-personal', '-Users-test-work'])
+    expect(projects.reduce((sum, project) => sum + project.totalApiCalls, 0)).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary

Rebases and updates the Account Control Center on current `main` while preserving the current CLI split: `src/cli.ts` remains the Node-version-safe launcher, and the account workflow lives in `src/main.ts`.

This PR builds on the multiple Claude config directory work and turns it into a user-facing attribution workflow for people who run work, personal, desktop, or client Claude accounts side by side.

It answers questions that aggregate cost views cannot answer:

- Which account generated this spend?
- Which projects and sessions drove it?
- Did a work/client project run on the wrong account?
- Is a configured subscription underused or over budget?
- Can usage be exported per account for reimbursement or accountability?

## What changed

- Claude discovery carries account metadata from `CLAUDE_CONFIG_DIRS` through project/session parsing.
- Parser and cache paths preserve `account`, `accountPath`, and `sourcePath`, so the same project path under two Claude accounts does not merge into one summary.
- New `codeburn accounts` command with text and JSON output.
- Account config stored in CodeBurn config:
  - `plan`
  - `monthlyUsd`
  - `budgetUsd`
  - `resetDay`
- `--account` filtering added to:
  - `report`
  - `today`
  - `month`
  - `status`
  - `export`
  - `accounts`
  - `optimize`
  - `compare`
- JSON reports include account rollups and account risks.
- CSV/JSON exports include account rows and account metadata.
- Dashboard and compare paths respect account filters while keeping current custom range and multi-plan behavior.

## Examples

```bash
codeburn accounts
codeburn accounts work
codeburn accounts set work --plan "Claude Max" --monthly-usd 100 --budget-usd 300
codeburn report --account work --format json
codeburn export --account client-a -f csv
```

A project present under both `work` and `personal` account roots is now reported separately instead of being silently merged. Unlabelled provider usage remains grouped as `unlabelled`, but it does not create duplicate-project noise against labelled Claude accounts.

## Account Signals

The account report surfaces:

- total cost and calls,
- sessions and project count,
- edit turns and one-shot turns,
- cost per session and cost per edit,
- top models and top projects,
- subscription utilization vs configured monthly price,
- budget utilization vs configured budget.

Risk signals include:

- duplicate project path across labelled accounts,
- work/client-looking paths on personal accounts,
- personal-looking paths on work/client accounts,
- underused subscription,
- over-budget account.

## Review Fixes

Pre-push review found and fixed these issues before the branch was updated:

- Account-scoped project/session keys now prevent same-path projects from merging across accounts.
- Account config matching is case-insensitive, so `Work` and `work` do not become separate configured rows.
- Wrong-account heuristics tokenize account labels, so names like `homework` do not trip the `work` marker.
- Tiny budget values such as `0.001` render as `USD 0.001`, not `USD 0`.
- CSV exports always include deterministic `Account` and `Account Path` columns even when the first sorted row is unlabelled.
- Provider-source session IDs are extracted from the actual session-key suffix even if a future provider source includes account metadata.
- The CLI account integration test has an explicit timeout because it launches multiple Node/tsx subprocesses.

## Validation

- [x] `npx vitest run tests/accounts.test.ts tests/cli-accounts.test.ts tests/parser-filter.test.ts tests/export.test.ts tests/cli-json.test.ts tests/providers/claude.test.ts tests/cli-export-date-range.test.ts` — 37/37 passed.
- [x] `npx tsc --noEmit --pretty false` — passed.
- [x] `npm run build` — passed.
- [x] `git diff --check` — passed.
- [x] Argus-style local review — PASS.
- [x] Claude Opus 4.7 effort max review — PASS.
- [x] Gemini 3.1 Pro Preview review — PASS after fixing the required issues above.
- [x] GitHub checks `check`, `semgrep`, and `assess` — passed.

## Security / Privacy

This is local aggregation and local config only. It does not add shell execution, network calls, remote writes, or secret handling. CSV export continues to use the existing spreadsheet-injection escaping path.

No local account names, project names, prompts, session IDs, real paths, costs, usage values, or private product details are included in this PR description.
