### PR TITLE
Fix cli-plan test failing on Windows

### DIFF
--- a/tests/cli-plan.test.ts
+++ b/tests/cli-plan.test.ts
@@ -11,6 +11,9 @@ function runCli(args: string[], home: string) {
     env: {
       ...process.env,
       HOME: home,
+      USERPROFILE: home, // os.homedir() uses USERPROFILE on Windows
+      HOMEPATH: home,
+      HOMEDRIVE: '',
     },
     encoding: 'utf-8',
   })


### PR DESCRIPTION
## Summary

`os.homedir()` on Windows reads `USERPROFILE`, not `HOME`. The test was only setting `HOME`, so the CLI wrote config to the real home directory instead of the temp dir, causing the assertion to fail.

**Fix:** also set `USERPROFILE`, `HOMEPATH`, and `HOMEDRIVE` in the test's spawned process environment, matching what Windows actually uses.

## Test plan
- Run `npx vitest run tests/cli-plan.test.ts` on Windows — should pass (was failing before this fix)