### PR TITLE
Release 0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.9.7 - 2026-05-07
+
 ### Added (CLI)
 - **MCP tool coverage detector.** New `optimize` finding flags MCP servers
   whose tool inventory is largely unused. Inventory is observed from the
@@ -28,13 +30,23 @@
   Sessions flagged here take priority and are excluded from both the
   context-bloat and cost-outlier findings so the same session is not listed
   more than once.
+- **Per-model efficiency metrics.** JSON report includes edit turns, one-shot rate, retries per edit, and cost per edit for each model.
+- **Custom date range export.** `codeburn export --from --to` exports a single custom period.
+- **Live Claude quota bar.** Menubar shows real-time quota usage inside the agent tab strip with OAuth refresh gate.
 
 ### Fixed (CLI)
+- **Invalid `--format` silently accepted.** All commands now reject unknown format values with a clear error and exit 1 instead of silently falling back to the default.
+- **Invalid `--period` silently accepted.** `getDateRange()` no longer falls back to "week" on unknown periods. All period-accepting commands reject invalid values.
+- **`status` help text.** Description said "today + week + month" but only today and month were shown. Fixed to match actual output.
 - **Windows Claude project paths.** Claude Code project rollups now prefer
   the canonical `cwd` stored in session JSONL files instead of reconstructing
   paths from lossy directory slugs, and group case/slash variants together.
   Closes #217.
 - **`all` period semantics unified between CLI and dashboard.** The dashboard treated `--period all` as all-time (epoch start) while the CLI bounded it to the last 6 months. Both now consistently mean "Last 6 months". Period helpers (`Period`, `PERIODS`, `PERIOD_LABELS`, `toPeriod`, `getDateRange`) consolidated into `cli-date.ts`. Use `--from` / `--to` for unbounded historical ranges.
+- **Popover anchor, tab strip flicker, and stale-data refresh.** Batch of UI regressions from the menubar hardening round.
+- **Validator hardenings.** Batch of edge-case fixes from the multi-agent bug hunt.
+- **Command injection in yield.** `yield` now uses `execFileSync` instead of `execSync` to prevent shell injection via crafted branch names.
+- **SHA-256 checksum verification.** Menubar installer verifies download integrity before replacing the running app.
 
 ### Fixed (macOS menubar)
 - **Stuck loading spinner.** The menubar ran `--optimize` on every 30-second background refresh. As sessions accumulated, optimize exceeded the 45-second timeout, and the loading overlay stayed forever with no fallback. Optimize is now stripped from all menubar fetches (use `codeburn optimize` in the CLI instead). On fetch failure with empty cache, the app retries without optimize so the spinner always clears.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeburn",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeburn",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeburn",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "See where your AI coding tokens go - by task, tool, model, and project",
   "type": "module",
   "main": "./dist/cli.js",


### PR DESCRIPTION
## Summary
- Version bump to 0.9.7
- Changelog updated with all changes since 0.9.6

## What's new
- 3 new optimize detectors (MCP coverage, session outliers, context bloat, worth-it score)
- Per-model efficiency metrics in JSON reports
- Custom date range export
- Live Claude quota bar in menubar
- Input validation on all --format and --period flags
- Batch of menubar stability fixes (spinner, sleep, refresh, update button)
- Security fixes (command injection in yield, checksum verification)