### PR TITLE
fix(cursor): stop misattributing undated usage to 'Today'

### DIFF
--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -49,6 +49,11 @@ type AgentKvRow = {
 type AgentKvContent = {
   type?: string
   text?: string
+  timestamp?: string | number
+  createdAt?: string | number
+  time?: string | number
+  timeCreated?: string | number
+  time_created?: string | number
   providerOptions?: {
     cursor?: {
       modelName?: string
@@ -275,6 +280,39 @@ function extractTextLength(content: AgentKvContent[]): number {
   return total
 }
 
+function normalizeTimestampCandidate(raw: unknown): string | null {
+  if (raw === null || raw === undefined) return null
+  if (typeof raw === 'number') {
+    const ms = raw < 1e12 ? raw * 1000 : raw
+    const date = new Date(ms)
+    return Number.isNaN(date.getTime()) ? null : date.toISOString()
+  }
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  if (/^\d+$/.test(trimmed)) {
+    const num = Number(trimmed)
+    if (!Number.isNaN(num)) {
+      const ms = num < 1e12 ? num * 1000 : num
+      const date = new Date(ms)
+      return Number.isNaN(date.getTime()) ? null : date.toISOString()
+    }
+  }
+  const parsed = new Date(trimmed)
+  if (Number.isNaN(parsed.getTime())) return null
+  return parsed.toISOString()
+}
+
+function extractTimestampFromAgentContent(content: AgentKvContent[]): string | null {
+  for (const block of content) {
+    const timestamp = normalizeTimestampCandidate(
+      block.timestamp ?? block.createdAt ?? block.time ?? block.timeCreated ?? block.time_created
+    )
+    if (timestamp) return timestamp
+  }
+  return null
+}
+
 function parseAgentKv(db: SqliteDatabase, seenKeys: Set<string>): { calls: ParsedProviderCall[] } {
   const results: ParsedProviderCall[] = []
 
@@ -285,7 +323,7 @@ function parseAgentKv(db: SqliteDatabase, seenKeys: Set<string>): { calls: Parse
     return { calls: results }
   }
 
-  const sessions: Map<string, { inputChars: number; outputChars: number; model: string | null; userText: string }> = new Map()
+  const sessions: Map<string, { inputChars: number; outputChars: number; model: string | null; userText: string; content: AgentKvContent[] }> = new Map()
   let currentRequestId = 'unknown'
   let turnIndex = 0
 
@@ -317,8 +355,9 @@ function parseAgentKv(db: SqliteDatabase, seenKeys: Set<string>): { calls: Parse
     const model = extractModelFromContent(content)
 
     if (row.role === 'user') {
-      const existing = sessions.get(requestId) ?? { inputChars: 0, outputChars: 0, model: null, userText: '' }
+      const existing = sessions.get(requestId) ?? { inputChars: 0, outputChars: 0, model: null, userText: '', content: [] }
       existing.inputChars += textLength
+      existing.content.push(...content)
       if (!existing.userText) {
         const text = content[0]?.text ?? row.content
         const queryMatch = text.match(/<user_query>([\s\S]*?)<\/user_query>/)
@@ -326,19 +365,23 @@ function parseAgentKv(db: SqliteDatabase, seenKeys: Set<string>): { calls: Parse
       }
       sessions.set(requestId, existing)
     } else if (row.role === 'assistant') {
-      const existing = sessions.get(requestId) ?? { inputChars: 0, outputChars: 0, model: null, userText: '' }
+      const existing = sessions.get(requestId) ?? { inputChars: 0, outputChars: 0, model: null, userText: '', content: [] }
       existing.outputChars += textLength
+      existing.content.push(...content)
       if (model) existing.model = model
       sessions.set(requestId, existing)
     } else if (row.role === 'tool' || row.role === 'system') {
-      const existing = sessions.get(requestId) ?? { inputChars: 0, outputChars: 0, model: null, userText: '' }
+      const existing = sessions.get(requestId) ?? { inputChars: 0, outputChars: 0, model: null, userText: '', content: [] }
       existing.inputChars += textLength
+      existing.content.push(...content)
       sessions.set(requestId, existing)
     }
   }
 
   for (const [requestId, session] of sessions) {
     if (session.inputChars === 0 && session.outputChars === 0) continue
+    const timestamp = extractTimestampFromAgentContent(session.content)
+    if (!timestamp) continue
 
     const inputTokens = Math.ceil(session.inputChars / CHARS_PER_TOKEN)
     const outputTokens = Math.ceil(session.outputChars / CHARS_PER_TOKEN)
@@ -364,7 +407,7 @@ function parseAgentKv(db: SqliteDatabase, seenKeys: Set<string>): { calls: Parse
       costUSD,
       tools: [],
       bashCommands: [],
-      timestamp: new Date().toISOString(),
+      timestamp,
       speed: 'standard',
       deduplicationKey: dedupKey,
       userMessage: session.userText,

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -139,7 +139,8 @@ const USER_MESSAGES_QUERY = `
 `
 
 const BUBBLE_QUERY_SINCE = BUBBLE_QUERY_BASE + `
-    AND (json_extract(value, '$.createdAt') > ? OR json_extract(value, '$.createdAt') IS NULL)
+    AND json_extract(value, '$.createdAt') IS NOT NULL
+    AND json_extract(value, '$.createdAt') > ?
   ORDER BY ROWID ASC
 `
 
@@ -203,6 +204,7 @@ function parseBubbles(db: SqliteDatabase, seenKeys: Set<string>): { calls: Parse
       }
 
       const createdAt = row.created_at ?? ''
+      if (!createdAt) continue
       const conversationId = row.conversation_id ?? 'unknown'
       const dedupKey = `cursor:${conversationId}:${createdAt}:${inputTokens}:${outputTokens}`
 
@@ -214,7 +216,7 @@ function parseBubbles(db: SqliteDatabase, seenKeys: Set<string>): { calls: Parse
 
       const costUSD = calculateCost(pricingModel, inputTokens, outputTokens, 0, 0, 0)
 
-      const timestamp = createdAt || new Date().toISOString()
+      const timestamp = createdAt
       const convMessages = userMessages.get(conversationId) ?? []
       const userQuestion = convMessages.length > 0 ? convMessages.shift()! : ''
       const assistantText = row.user_text ?? ''

--- a/tests/providers/cursor.test.ts
+++ b/tests/providers/cursor.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import { mkdtemp, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
 import { getAllProviders } from '../../src/providers/index.js'
 import type { Provider } from '../../src/providers/types.js'
+import { isSqliteAvailable } from '../../src/sqlite.js'
+import { createCursorProvider } from '../../src/providers/cursor.js'
 
 describe('cursor provider', () => {
   let cursorProvider: Provider
@@ -73,5 +78,59 @@ describe('cursor cache', () => {
     const { readCachedResults } = await import('../../src/cursor-cache.js')
     const result = await readCachedResults('/nonexistent/path.db')
     expect(result).toBeNull()
+  })
+})
+
+const skipUnlessSqlite = isSqliteAvailable() ? describe : describe.skip
+
+skipUnlessSqlite('cursor provider timestamps', () => {
+  it('does not emit calls for rows missing createdAt', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'codeburn-cursor-test-'))
+    const dbPath = join(tempDir, 'state.vscdb')
+    try {
+      const { DatabaseSync: Database } = require('node:sqlite')
+      const db = new Database(dbPath)
+      db.prepare(`
+        CREATE TABLE cursorDiskKV (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        )
+      `).run()
+
+      const createdAt = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+      const withTimestamp = JSON.stringify({
+        tokenCount: { inputTokens: 10, outputTokens: 20 },
+        modelInfo: { modelName: 'default' },
+        createdAt,
+        conversationId: 'conv-a',
+        text: 'assistant reply',
+        type: 2,
+        codeBlocks: [],
+      })
+      const missingTimestamp = JSON.stringify({
+        tokenCount: { inputTokens: 99, outputTokens: 199 },
+        modelInfo: { modelName: 'default' },
+        conversationId: 'conv-b',
+        text: 'missing time',
+        type: 2,
+        codeBlocks: [],
+      })
+      db.prepare(`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`).run('bubbleId:conv-a:b1', withTimestamp)
+      db.prepare(`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`).run('bubbleId:conv-b:b2', missingTimestamp)
+      db.close()
+
+      const provider = createCursorProvider(dbPath)
+      const [source] = await provider.discoverSessions()
+      const calls = []
+      for await (const call of provider.createSessionParser(source!, new Set()).parse()) {
+        calls.push(call)
+      }
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]!.timestamp).toBe(createdAt)
+      expect(calls[0]!.sessionId).toBe('conv-a')
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/providers/cursor.test.ts
+++ b/tests/providers/cursor.test.ts
@@ -133,4 +133,75 @@ skipUnlessSqlite('cursor provider timestamps', () => {
       await rm(tempDir, { recursive: true, force: true })
     }
   })
+
+  it('skips agentKv sessions when no timestamp exists in content', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'codeburn-cursor-test-'))
+    const dbPath = join(tempDir, 'state.vscdb')
+    try {
+      const { DatabaseSync: Database } = require('node:sqlite')
+      const db = new Database(dbPath)
+      db.prepare(`
+        CREATE TABLE cursorDiskKV (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        )
+      `).run()
+
+      const agentKvNoTimestamp = JSON.stringify({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'no timestamp here' }],
+        providerOptions: { cursor: { requestId: 'req-no-ts' } },
+      })
+      db.prepare(`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`).run('agentKv:blob:no-ts', agentKvNoTimestamp)
+      db.close()
+
+      const provider = createCursorProvider(dbPath)
+      const [source] = await provider.discoverSessions()
+      const calls = []
+      for await (const call of provider.createSessionParser(source!, new Set()).parse()) {
+        calls.push(call)
+      }
+
+      expect(calls).toHaveLength(0)
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('uses timestamp from agentKv content when available', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'codeburn-cursor-test-'))
+    const dbPath = join(tempDir, 'state.vscdb')
+    try {
+      const { DatabaseSync: Database } = require('node:sqlite')
+      const db = new Database(dbPath)
+      db.prepare(`
+        CREATE TABLE cursorDiskKV (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        )
+      `).run()
+
+      const ts = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString()
+      const agentKvWithTimestamp = JSON.stringify({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'has timestamp', timestamp: ts, providerOptions: { cursor: { modelName: 'default' } } }],
+        providerOptions: { cursor: { requestId: 'req-ts' } },
+      })
+      db.prepare(`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`).run('agentKv:blob:with-ts', agentKvWithTimestamp)
+      db.close()
+
+      const provider = createCursorProvider(dbPath)
+      const [source] = await provider.discoverSessions()
+      const calls = []
+      for await (const call of provider.createSessionParser(source!, new Set()).parse()) {
+        calls.push(call)
+      }
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0]!.timestamp).toBe(ts)
+      expect(calls[0]!.sessionId).toBe('req-ts')
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
## What this fixes
Codeburn was misreporting Cursor usage by assigning undated records to the current day. In practice this made **Today** look artificially high, and the day with the highest usage appeared to "move" depending on when you ran the report/menubar refresh.

## Root cause
Two Cursor parsing paths were manufacturing timestamps when source data was missing/undated:
- Bubble rows: missing `createdAt` fell back to `new Date().toISOString()`
- `agentKv` sessions: timestamp was also defaulted to current time

This re-bucketed historical/undated usage into the runtime date rather than preserving day accuracy.

## Why this matters
- Daily charts and "most active day" become unreliable
- Menubar "Today" can spike incorrectly
- Trend analysis/regression tracking is misleading for users managing token spend

## Solution
- Require real `createdAt` for Cursor bubble bucketing (skip undated bubbles)
- Stop defaulting `agentKv` session timestamps to "now"
- Extract timestamp candidates from `agentKv` content when available; skip undated sessions
- Preserve existing dedup behavior and parser flow

## Tests
- Added/updated regression tests in `tests/providers/cursor.test.ts` to verify:
  - bubbles without `createdAt` are excluded from dated buckets
  - `agentKv` sessions without timestamps are skipped
  - `agentKv` sessions with timestamp metadata are retained with that timestamp

## Verification run
- `npm test -- tests/providers/cursor.test.ts`
- `npm run build`