### PR TITLE
Refuse to load node:sqlite on known-buggy Node 22.x patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "developer-tools"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=22.20"
   },
   "author": "AgentSeal <hello@agentseal.org>",
   "license": "MIT",

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -23,6 +23,31 @@ let DatabaseSync: DatabaseSyncCtor | null = null
 let loadAttempted = false
 let loadError: string | null = null
 
+/// Minimum Node 22.x patch version that contains the node:sqlite UTF-8 fix.
+/// Older 22.x lines crash with `Check failed: (location_) != nullptr` when a
+/// SQLite TEXT column returns bytes that V8's String::NewFromUtf8 rejects —
+/// commonly the case for Cursor's text blobs (truncated multi-byte chars at
+/// streaming boundaries) and OpenCode message text (rich tooling output).
+/// Track of issue: https://github.com/getagentseal/codeburn/issues/264
+/// Track of upstream: https://github.com/nodejs/node — fix landed in 22.x via
+/// later patches; stable on Node 24+.
+const MIN_NODE_22_PATCH = 20
+
+function checkBuggyNodeVersion(): string | null {
+  const match = /^v(\d+)\.(\d+)\.(\d+)/.exec(process.version)
+  if (!match) return null
+  const major = parseInt(match[1]!, 10)
+  const minor = parseInt(match[2]!, 10)
+  if (major === 22 && minor < MIN_NODE_22_PATCH) {
+    return (
+      `codeburn: Node ${process.version} ships an older node:sqlite that crashes on ` +
+      `non-UTF-8 bytes in Cursor/OpenCode session text. Upgrade to Node 22.${MIN_NODE_22_PATCH}+ ` +
+      `or 24+ to avoid the V8 fatal error. (https://nodejs.org)`
+    )
+  }
+  return null
+}
+
 /// Lazily imports `node:sqlite`. On Node 22/23 it emits an ExperimentalWarning the first
 /// time the module is loaded; we silence that specific warning once so dashboards aren't
 /// preceded by a scary stderr line every run. Any other warnings (including future
@@ -30,6 +55,15 @@ let loadError: string | null = null
 function loadDriver(): boolean {
   if (loadAttempted) return DatabaseSync !== null
   loadAttempted = true
+
+  // Refuse to load on a Node version known to crash mid-query. Treating the
+  // SQLite providers as unavailable is much friendlier than letting the user
+  // hit a V8 CHECK abort that takes down the whole CLI.
+  const versionWarning = checkBuggyNodeVersion()
+  if (versionWarning !== null) {
+    loadError = versionWarning
+    return false
+  }
 
   const origEmit = process.emit.bind(process)
   let restored = false


### PR DESCRIPTION
Closes #264.

When SQLite returns a TEXT column whose bytes contain invalid UTF-8 (Cursor's `cursorDiskKV` value blobs hit this when streaming truncates a multi-byte char), Node 22.x prior to 22.20 crashes the whole process with:

```
# Fatal error in , line 0
# Check failed: (location_) != nullptr.
v8::String::NewFromUtf8(...)
node::sqlite::StatementSync::ColumnToValue(int)
```

The Node `node:sqlite` implementation didn't check the `MaybeLocal<String>` returned by `String::NewFromUtf8` before dereferencing. A `try`/`catch` in JS cannot recover — the abort runs in the C++ extension before the V8 exception handler.

This PR detects the situation at module-load time and refuses to use `node:sqlite` on those Node versions, falling back to a clean diagnostic via the existing `isSqliteAvailable()` / `loadError` plumbing. The CLI keeps running with all the file-based providers (Claude, Codex, Copilot, Gemini, …); only Cursor and OpenCode parsers are skipped.

## Changes
- `package.json`: `engines.node` bumped to `>=22.20` so npm warns at install time
- `src/sqlite.ts`: `checkBuggyNodeVersion()` returns a friendly upgrade message for Node 22.x < 22.20; `loadDriver()` routes through the existing `loadError` path

## Test plan
- [x] `npm test` — 555/555
- [x] `npm run build` — clean
- [x] Manual: smoke against real session data on Node 25 (no warning, all providers work)