### PR TITLE
Fix uneven provider chip heights in menubar header

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
@@ -5,7 +5,14 @@ struct AgentTabStrip: View {
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 5) {
+            // Align chips to .top so the label baseline matches across all
+            // providers. Claude/Codex chips reserve a 6pt quota-bar slot
+            // (label + 3pt spacing + 3pt bar); chips without that slot
+            // (All / Cursor / Droid / Gemini / Copilot / etc.) are 6pt
+            // shorter, so a default .center alignment pushes their label
+            // ~3pt below the Claude/Codex labels. Top alignment makes every
+            // chip start at the same y, putting all labels on a shared line.
+            HStack(alignment: .top, spacing: 5) {
                 ForEach(visibleFilters) { filter in
                     Button {
                         store.switchTo(provider: filter)

--- a/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
@@ -100,17 +100,18 @@ private struct AgentTab: View {
                         .tracking(-0.2)
                 }
             }
-            // Reserve the bar slot only for providers whose quota source we
-            // implement (Claude, Codex). Providers that will never have a bar
-            // (All / Cursor / Droid / Gemini / Copilot) skip the slot entirely
-            // so the text centers naturally and the chip stays compact.
-            // Reserving the slot for Claude/Codex prevents the strip from
-            // jumping by 6pt the moment the user clicks Connect.
-            if Self.providerSupportsQuota(filter) {
-                AgentTabQuotaBar(quota: quota, isActive: isActive)
-                    .frame(height: 3)
-                    .opacity(quota == nil ? 0 : 1)
-            }
+            // Reserve the 6pt quota-bar slot (3pt spacing + 3pt bar) on every
+            // chip, not just Claude/Codex. Otherwise the strip mixes 28pt and
+            // 22pt chips, which looks fine when everything is inactive (the
+            // muted background blends in) but becomes obviously uneven the
+            // moment one chip turns orange-active. For providers without a
+            // live quota source we hide the bar with opacity 0; the slot
+            // height stays reserved so all chips share the same height.
+            // This also keeps the original "no 6pt jump on Connect" behavior
+            // for Claude/Codex.
+            AgentTabQuotaBar(quota: quota, isActive: isActive)
+                .frame(height: 3)
+                .opacity(Self.providerSupportsQuota(filter) && quota != nil ? 1 : 0)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 4)


### PR DESCRIPTION
## Summary

The provider chip strip in the menubar popover renders chips at two different heights:

- **Claude / Codex** reserve a 6pt quota-bar slot (3pt spacing + 3pt bar) under the label so the strip doesn't jump 6pt the moment the user signs in: **28pt tall**.
- **All / Cursor / Droid / Gemini / Copilot / etc.** skip that slot: **22pt tall**.

Measured at runtime with a temporary `GeometryReader`:

| Chip | active | size |
|---|---|---|
| All | ✓ | 84 × **22** |
| Gemini | – | 95 × **22** |
| Codex | – | 98.5 × **28** |
| Claude | – | 108.5 × **28** |

When every chip carries the muted `Color.secondary.opacity(0.08)` background the 6pt delta is barely visible. The moment one chip flips to the orange brand-accent active state, the inequality becomes obvious (see screenshots on #267): a Codex-active chip towers over a Gemini-inactive one, a Gemini-active chip looks stubby next to a Codex-inactive one, and label baselines drift across the row.

## Fix

Two complementary changes:

1. **`AgentTab` reserves the quota-bar slot on every chip**, not just `.claude` / `.codex`. Providers without a live quota source render the bar with `opacity(0)`; the 3pt frame still occupies space so every chip ends up at the same 28pt height. The original "don't jump 6pt on Connect" behavior for Claude/Codex still holds because their slot was already reserved unconditionally.
2. **`AgentTabStrip` aligns the outer `HStack` to `.top`** as a defensive measure so any future chip variant that ends up shorter still keeps its label on the shared baseline.

Net effect: every chip is the same height regardless of provider or active state, and labels sit on a shared horizontal line.

## Test plan

- [ ] `swift build` clean on Apple Silicon (Xcode 16 toolchain)
- [ ] Local install: confirmed via `GeometryReader` print that all chips report identical height; visual check confirms uniform chip strip with Codex / Gemini / Claude active in turn
- [ ] Reviewer: visual check on a build with at least one provider with a visible quota bar (Claude/Codex signed in) and one without (Gemini/Copilot) in the same row, both inactive and active states

Closes #267