### PR TITLE
Fix menubar blocking system sleep and sync refresh timing

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -59,8 +59,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         ProcessInfo.processInfo.automaticTerminationSupportEnabled = false
         ProcessInfo.processInfo.disableSuddenTermination()
         backgroundActivity = ProcessInfo.processInfo.beginActivity(
-            options: [.userInitiated, .automaticTerminationDisabled, .suddenTerminationDisabled],
-            reason: "CodeBurn menubar polls AI coding cost every 30 seconds while idle in the background."
+            options: [.automaticTerminationDisabled, .suddenTerminationDisabled],
+            reason: "CodeBurn menubar background refresh"
         )
 
         restorePersistedCurrency()
@@ -271,9 +271,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 let sinceLast = Date().timeIntervalSince(self.lastRefreshTime)
                 if sinceLast >= 5 {
                     if self.store.selectedPeriod != .today || self.store.selectedProvider != .all {
-                        await self.store.refreshQuietly(period: .today)
+                        async let quiet: Void = self.store.refreshQuietly(period: .today)
+                        async let main: Void = self.store.refresh(includeOptimize: false, force: true)
+                        _ = await (quiet, main)
+                    } else {
+                        await self.store.refresh(includeOptimize: false, force: true)
                     }
-                    await self.store.refresh(includeOptimize: false, force: true)
                     self.lastRefreshTime = Date()
                     self.refreshStatusButton()
                 }


### PR DESCRIPTION
## Summary
- Drop `.userInitiated` from the process activity so macOS can enter deep sleep while the menubar runs. The wake observer already re-syncs on resume.
- Run all-provider and per-provider refreshes in parallel in the loop tick so tab strip costs and the detail view update together instead of the detail view lagging behind.

## Test plan
- [ ] Verify `pmset -g assertions` no longer shows `PreventUserIdleSystemSleep` for CodeBurnMenubar
- [ ] Switch to a provider tab, confirm tab strip costs and detail view update at the same time on each 30s tick
- [ ] Close lid, reopen, confirm data refreshes on wake