### PR TITLE
Wait for old menubar process to exit before launching new one

### DIFF
--- a/src/menubar-installer.ts
+++ b/src/menubar-installer.ts
@@ -142,6 +142,10 @@ async function killRunningApp(): Promise<void> {
     proc.on('close', () => resolve())
     proc.on('error', () => resolve())
   })
+  for (let i = 0; i < 10; i++) {
+    if (!(await isAppRunning())) return
+    await new Promise(r => setTimeout(r, 500))
+  }
 }
 
 export async function installMenubarApp(options: { force?: boolean } = {}): Promise<InstallResult> {


### PR DESCRIPTION
## Summary

- `killRunningApp()` sent SIGTERM but returned immediately
- The `open` call raced the dying process, failing with error -600 on `--force` reinstalls
- Now polls `isAppRunning()` up to 5 seconds after SIGTERM before proceeding