### PR TITLE
Expose per-day one-shot data in daily JSON output (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   is yellow, provider name is dim. Inspired by tokscale's per-model table
   and ccusage's responsive cli-table3 layout, ported to plain Node with
   no new runtime dependency.
+- **Per-day one-shot data in `--format json`.** Each entry of `daily[]` now
+  carries `turns`, `editTurns`, `oneShotTurns`, and `oneShotRate` (0-100,
+  one decimal, `null` when no edit turns). Counts match the existing
+  period-level `activities[]` rollup so a consumer can sum across days and
+  reconcile. Closes #279.
 
 ### Changed (CLI)
 - **`optimize` suggestions now declare their destination.** Every paste-style

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -138,12 +138,23 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
   const cacheHitDenom = totalInput + totalCacheRead
   const cacheHitPercent = cacheHitDenom > 0 ? Math.round((totalCacheRead / cacheHitDenom) * 1000) / 10 : 0
 
-  const dailyMap: Record<string, { cost: number; calls: number }> = {}
+  // Per-day rollup. Mirrors parser.ts categoryBreakdown semantics so a
+  // consumer summing daily[].editTurns over a period gets the same total as
+  // sum(activities[].editTurns) for that period: every turn counts once for
+  // `turns`, edit turns count for `editTurns`, edit turns with zero retries
+  // count for `oneShotTurns`. Issue #279 — daily-resolution efficiency
+  // dashboards need this without re-deriving from activity-level rollups.
+  const dailyMap: Record<string, { cost: number; calls: number; turns: number; editTurns: number; oneShotTurns: number }> = {}
   for (const sess of sessions) {
     for (const turn of sess.turns) {
       if (!turn.timestamp) { continue }
       const day = dateKey(turn.timestamp)
-      if (!dailyMap[day]) { dailyMap[day] = { cost: 0, calls: 0 } }
+      if (!dailyMap[day]) { dailyMap[day] = { cost: 0, calls: 0, turns: 0, editTurns: 0, oneShotTurns: 0 } }
+      dailyMap[day].turns += 1
+      if (turn.hasEdits) {
+        dailyMap[day].editTurns += 1
+        if (turn.retries === 0) dailyMap[day].oneShotTurns += 1
+      }
       for (const call of turn.assistantCalls) {
         dailyMap[day].cost += call.costUSD
         dailyMap[day].calls += 1
@@ -154,6 +165,15 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
     date,
     cost: convertCost(d.cost),
     calls: d.calls,
+    turns: d.turns,
+    editTurns: d.editTurns,
+    oneShotTurns: d.oneShotTurns,
+    // Pre-computed convenience for dashboards that don't want to do the math.
+    // null when there are no edit turns (the rate is undefined, not zero —
+    // a day where the user only had Q&A turns shouldn't read as 0% one-shot).
+    oneShotRate: d.editTurns > 0
+      ? Math.round((d.oneShotTurns / d.editTurns) * 1000) / 10
+      : null,
   }))
 
   const projectList = projects.map(p => ({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,8 +147,14 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
   const dailyMap: Record<string, { cost: number; calls: number; turns: number; editTurns: number; oneShotTurns: number }> = {}
   for (const sess of sessions) {
     for (const turn of sess.turns) {
-      if (!turn.timestamp) { continue }
-      const day = dateKey(turn.timestamp)
+      // Prefer the user-message timestamp on the turn; fall back to the first
+      // assistant-call timestamp when the user line is missing (continuation
+      // sessions where the JSONL begins mid-conversation). Previously these
+      // turns dropped from daily but stayed in activities, breaking the
+      // sum(daily[].editTurns) === sum(activities[].editTurns) invariant.
+      const ts = turn.timestamp || turn.assistantCalls[0]?.timestamp
+      if (!ts) { continue }
+      const day = dateKey(ts)
       if (!dailyMap[day]) { dailyMap[day] = { cost: 0, calls: 0, turns: 0, editTurns: 0, oneShotTurns: 0 } }
       dailyMap[day].turns += 1
       if (turn.hasEdits) {

--- a/tests/cli-json-daily.test.ts
+++ b/tests/cli-json-daily.test.ts
@@ -1,0 +1,172 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+import { describe, expect, it } from 'vitest'
+
+function runCli(args: string[], home: string) {
+  return spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      CLAUDE_CONFIG_DIR: join(home, '.claude'),
+      HOME: home,
+      TZ: 'UTC',
+    },
+    encoding: 'utf-8',
+  })
+}
+
+function userLine(sessionId: string, timestamp: string): string {
+  return JSON.stringify({
+    type: 'user',
+    sessionId,
+    timestamp,
+    message: { role: 'user', content: 'do the thing' },
+  })
+}
+
+function assistantEditLine(sessionId: string, timestamp: string, messageId: string): string {
+  // Includes a tool_use of `Edit` so the parser flags this turn as hasEdits=true.
+  // Single edit-turn with no retry (one assistant message in the turn) → counts
+  // as one oneShotTurn.
+  return JSON.stringify({
+    type: 'assistant',
+    sessionId,
+    timestamp,
+    message: {
+      id: messageId,
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [
+        { type: 'text', text: 'editing' },
+        { type: 'tool_use', id: 'tu-1', name: 'Edit', input: { file_path: '/tmp/x', old_string: 'a', new_string: 'b' } },
+      ],
+      usage: { input_tokens: 1000, output_tokens: 100 },
+    },
+  })
+}
+
+function assistantNoEditLine(sessionId: string, timestamp: string, messageId: string): string {
+  // No edit tool — this turn does not count toward editTurns/oneShotTurns,
+  // but does count toward `turns` and `calls`.
+  return JSON.stringify({
+    type: 'assistant',
+    sessionId,
+    timestamp,
+    message: {
+      id: messageId,
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [{ type: 'text', text: 'just chatting' }],
+      usage: { input_tokens: 200, output_tokens: 30 },
+    },
+  })
+}
+
+describe('codeburn report --format json daily[] one-shot fields (issue #279)', () => {
+  it('exposes per-day turns / editTurns / oneShotTurns / oneShotRate', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-json-daily-'))
+
+    try {
+      const projectDir = join(home, '.claude', 'projects', 'app')
+      await mkdir(projectDir, { recursive: true })
+
+      // Day 1 (2026-04-10): one edit-turn (one-shot), one chat-turn
+      // Day 2 (2026-04-11): one edit-turn (one-shot)
+      await writeFile(
+        join(projectDir, 'session.jsonl'),
+        [
+          userLine('s1', '2026-04-10T09:00:00Z'),
+          assistantEditLine('s1', '2026-04-10T09:01:00Z', 'm-d1-edit'),
+          userLine('s1', '2026-04-10T10:00:00Z'),
+          assistantNoEditLine('s1', '2026-04-10T10:01:00Z', 'm-d1-chat'),
+          userLine('s1', '2026-04-11T09:00:00Z'),
+          assistantEditLine('s1', '2026-04-11T09:01:00Z', 'm-d2-edit'),
+        ].join('\n'),
+      )
+
+      const result = runCli([
+        '--format', 'json',
+        '--from', '2026-04-10',
+        '--to', '2026-04-11',
+        '--provider', 'claude',
+      ], home)
+
+      expect(result.status).toBe(0)
+
+      const report = JSON.parse(result.stdout) as {
+        daily: Array<{
+          date: string
+          cost: number
+          calls: number
+          turns: number
+          editTurns: number
+          oneShotTurns: number
+          oneShotRate: number | null
+        }>
+      }
+
+      expect(report.daily).toHaveLength(2)
+
+      const day1 = report.daily.find(d => d.date === '2026-04-10')
+      expect(day1).toBeDefined()
+      expect(day1!.turns).toBe(2)
+      expect(day1!.editTurns).toBe(1)
+      expect(day1!.oneShotTurns).toBe(1)
+      expect(day1!.oneShotRate).toBe(100)
+
+      const day2 = report.daily.find(d => d.date === '2026-04-11')
+      expect(day2).toBeDefined()
+      expect(day2!.turns).toBe(1)
+      expect(day2!.editTurns).toBe(1)
+      expect(day2!.oneShotTurns).toBe(1)
+      expect(day2!.oneShotRate).toBe(100)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('reports null oneShotRate when the day has no edit turns', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-json-daily-'))
+
+    try {
+      const projectDir = join(home, '.claude', 'projects', 'app')
+      await mkdir(projectDir, { recursive: true })
+
+      await writeFile(
+        join(projectDir, 'chat-only.jsonl'),
+        [
+          userLine('s2', '2026-04-10T09:00:00Z'),
+          assistantNoEditLine('s2', '2026-04-10T09:01:00Z', 'm-chat-1'),
+          userLine('s2', '2026-04-10T09:30:00Z'),
+          assistantNoEditLine('s2', '2026-04-10T09:31:00Z', 'm-chat-2'),
+        ].join('\n'),
+      )
+
+      const result = runCli([
+        '--format', 'json',
+        '--from', '2026-04-10',
+        '--to', '2026-04-10',
+        '--provider', 'claude',
+      ], home)
+
+      expect(result.status).toBe(0)
+      const report = JSON.parse(result.stdout) as {
+        daily: Array<{ date: string; turns: number; editTurns: number; oneShotTurns: number; oneShotRate: number | null }>
+      }
+      const day = report.daily.find(d => d.date === '2026-04-10')!
+      expect(day.turns).toBe(2)
+      expect(day.editTurns).toBe(0)
+      expect(day.oneShotTurns).toBe(0)
+      // null, not 0 — the rate is undefined when no edits happened, and a
+      // chat-only day would otherwise read as 0% one-shot which is misleading.
+      expect(day.oneShotRate).toBeNull()
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
Closes #279.

Adds `turns`, `editTurns`, `oneShotTurns`, `oneShotRate` to each entry of `daily[]` in `codeburn report --format json`. The data was already computed internally for the period-level `activities[]` rollup; this just buckets it by date so consumers can build daily-resolution efficiency dashboards without re-deriving the rate.

## Schema

```json
{
  "date": "2026-05-08",
  "cost": 241.27,
  "calls": 2480,
  "turns": 2234,
  "editTurns": 150,
  "oneShotTurns": 146,
  "oneShotRate": 97.3
}
```

- `turns` — every classified turn that day
- `editTurns` — turns that triggered file edits (Edit / Write / MultiEdit / etc.)
- `oneShotTurns` — edit turns that succeeded on the first attempt (no retries)
- `oneShotRate` — `Math.round((oneShotTurns / editTurns) * 1000) / 10`, `null` when `editTurns === 0` (chat-only days)

## Counting matches `activities[]`

For the same period, `sum(daily[].editTurns) === sum(activities[].editTurns)`. Verified empirically on real data:

| Period | metric | daily sum | activities sum | match |
|---|---|---|---|---|
| week | turns | 18357 | 18357 | ✓ |
| week | editTurns | 940 | 940 | ✓ |
| week | oneShotTurns | 856 | 856 | ✓ |
| today | turns | 2241 | 2241 | ✓ |
| today | editTurns | 150 | 150 | ✓ |
| today | oneShotTurns | 146 | 146 | ✓ |

## Tests

`tests/cli-json-daily.test.ts` — two integration tests via spawn that produce real Claude JSONL fixtures, run the CLI, and verify the new fields. Covers:
- multi-day session with edit + chat turns
- chat-only day producing `oneShotRate: null` (not 0)

## Defensive fix

`turn.timestamp` is the user-message timestamp. Continuation sessions starting mid-conversation have no leading user line and could leave `turn.timestamp` empty — those turns would drop from `daily[]` but stay in `activities[]`, violating the reconciliation invariant. Falls back to `turn.assistantCalls[0]?.timestamp` (matching `day-aggregator.ts` behavior) before dropping.

## Test plan

- [x] `npm test` — 557/557
- [x] `npx tsc --noEmit` — zero errors
- [x] Live smoke against the developer's session data — fields match formula
- [x] Daily/activities cross-check — invariant holds exactly across week and today

Reporter: [@eugene-eee-hongkyu](https://github.com/eugene-eee-hongkyu) — please pull this branch and validate against your `ai-usage-tracker` consumer before we merge. Once you confirm the schema works for your dashboard we'll merge and ship in the next release.

```bash
git fetch origin feat/json-daily-oneshot
git checkout feat/json-daily-oneshot
npm install && npm run build
node dist/cli.js --format json --period 7days | jq '.daily[0]'
```