### PR TITLE
fix(classifier): feature verb wins over debug keyword (part of #196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@
   period-level `activities[]` rollup so a consumer can sum across days and
   reconcile. Closes #279.
 
+### Fixed (CLI)
+- **Activity classifier no longer mislabels feature work as debugging.**
+  Messages like "add error handling", "create an issue tracker", or
+  "implement the 404 page" used to land in the Debugging bucket because
+  the classifier checked the debug-keyword regex (which matches `error`,
+  `issue`, `404`) before the feature regex. Now the keyword that appears
+  earliest in the user message wins, so "add" beats "error", "create"
+  beats "issue", etc. A real bug report ("login is broken, traceback
+  below") still classifies as debugging because the debug word leads.
+  Fixes the activity-misattribution half of #196.
+
 ### Changed (CLI)
 - **`optimize` suggestions now declare their destination.** Every paste-style
   fix carries an explicit destination — `claude-md` (permanent project rule),

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -93,12 +93,38 @@ function classifyByToolPattern(turn: ParsedTurn): TaskCategory | null {
   return null
 }
 
+/// Picks the category whose keyword pattern matches earliest in the message.
+/// On a tie (same start index) the candidate listed first in `candidates` wins,
+/// so callers control tie-break priority by ordering. Returns null when no
+/// pattern matches. The first-match heuristic fixes the long-standing problem
+/// where "add error handling" was tagged Debugging because the DEBUG regex was
+/// checked before FEATURE; now FEATURE wins because "add" appears before
+/// "error". Issue #196.
+function firstMatchingCategory(
+  text: string,
+  candidates: ReadonlyArray<{ regex: RegExp; category: TaskCategory }>,
+): TaskCategory | null {
+  let best: { index: number; order: number; category: TaskCategory } | null = null
+  for (let i = 0; i < candidates.length; i++) {
+    const c = candidates[i]!
+    const m = c.regex.exec(text)
+    if (!m) continue
+    if (!best || m.index < best.index || (m.index === best.index && i < best.order)) {
+      best = { index: m.index, order: i, category: c.category }
+    }
+  }
+  return best?.category ?? null
+}
+
 function refineByKeywords(category: TaskCategory, userMessage: string): TaskCategory {
   if (category === 'coding') {
-    if (DEBUG_KEYWORDS.test(userMessage)) return 'debugging'
-    if (REFACTOR_KEYWORDS.test(userMessage)) return 'refactoring'
-    if (FEATURE_KEYWORDS.test(userMessage)) return 'feature'
-    return 'coding'
+    // Tie-break order (when two keywords match at the same index): refactoring
+    // first because its words are the most specific, then feature, then debug.
+    return firstMatchingCategory(userMessage, [
+      { regex: REFACTOR_KEYWORDS, category: 'refactoring' },
+      { regex: FEATURE_KEYWORDS, category: 'feature' },
+      { regex: DEBUG_KEYWORDS, category: 'debugging' },
+    ]) ?? 'coding'
   }
 
   if (category === 'exploration') {
@@ -113,8 +139,14 @@ function refineByKeywords(category: TaskCategory, userMessage: string): TaskCate
 function classifyConversation(userMessage: string): TaskCategory {
   if (BRAINSTORM_KEYWORDS.test(userMessage)) return 'brainstorming'
   if (RESEARCH_KEYWORDS.test(userMessage)) return 'exploration'
-  if (DEBUG_KEYWORDS.test(userMessage)) return 'debugging'
-  if (FEATURE_KEYWORDS.test(userMessage)) return 'feature'
+  // Same first-match-wins logic as refineByKeywords so a chat-only message
+  // starting with a feature verb does not flip to debugging because of an
+  // incidental "error" or "fix" word later in the same sentence.
+  const debugOrFeature = firstMatchingCategory(userMessage, [
+    { regex: FEATURE_KEYWORDS, category: 'feature' },
+    { regex: DEBUG_KEYWORDS, category: 'debugging' },
+  ])
+  if (debugOrFeature) return debugOrFeature
   if (FILE_PATTERNS.test(userMessage)) return 'coding'
   if (SCRIPT_PATTERNS.test(userMessage)) return 'coding'
   if (URL_PATTERN.test(userMessage)) return 'exploration'

--- a/tests/classifier.test.ts
+++ b/tests/classifier.test.ts
@@ -101,3 +101,53 @@ describe('classifyTurn — Skill subCategory', () => {
     expect(c.subCategory).toBeUndefined()
   })
 })
+
+// Regression coverage for issue #196: feature verbs that lead a message
+// were previously hijacked into 'debugging' just because the message contained
+// an incidental "error" / "fix" / "issue" word later in the same sentence.
+// Now whichever keyword pattern matches earliest wins.
+describe('classifyTurn — feature vs debugging precedence (#196)', () => {
+  function codingTurn(userMessage: string): ParsedTurn {
+    return makeTurn([makeCall({ tools: ['Edit'] })], userMessage)
+  }
+
+  it('classifies "add error handling" as feature, not debugging', () => {
+    const c = classifyTurn(codingTurn('add error handling to the auth module'))
+    expect(c.category).toBe('feature')
+  })
+
+  it('classifies "create an issue tracker" as feature, not debugging', () => {
+    const c = classifyTurn(codingTurn('create an issue tracker page in the dashboard'))
+    expect(c.category).toBe('feature')
+  })
+
+  it('classifies "implement the 404 page" as feature, not debugging', () => {
+    const c = classifyTurn(codingTurn('implement the 404 page with a friendly redirect'))
+    expect(c.category).toBe('feature')
+  })
+
+  it('still classifies "fix the layout for the new feature" as debugging', () => {
+    const c = classifyTurn(codingTurn('fix the layout for the new feature'))
+    expect(c.category).toBe('debugging')
+  })
+
+  it('still classifies a plain bug report as debugging', () => {
+    const c = classifyTurn(codingTurn('login is broken, traceback below'))
+    expect(c.category).toBe('debugging')
+  })
+
+  it('classifies "refactor the error handling" as refactoring', () => {
+    const c = classifyTurn(codingTurn('refactor the error handling so it is cleaner'))
+    expect(c.category).toBe('refactoring')
+  })
+
+  it('chat-only message starting with "add" stays feature even with "fix" later', () => {
+    const c = classifyTurn(makeTurn([], 'add a setting page; we will fix the styles after'))
+    expect(c.category).toBe('feature')
+  })
+
+  it('chat-only message starting with "fix" stays debugging even with "add" later', () => {
+    const c = classifyTurn(makeTurn([], 'fix the bug introduced when we added the new flag'))
+    expect(c.category).toBe('debugging')
+  })
+})


### PR DESCRIPTION
First of three PRs addressing the issues flagged in #196 and #159. Independent of the others; can land alone.

## The bug

Messages like \`add error handling\`, \`create an issue tracker\`, or \`implement the 404 page\` were landing in the **Debugging** bucket because the classifier checked the debug regex before the feature regex. Real users from #196 saw their feature work mislabeled.

\`\`\`ts
// Before: order of checks decided the result
if (DEBUG_KEYWORDS.test(userMessage)) return 'debugging'  // wins on "add error handling"
if (REFACTOR_KEYWORDS.test(userMessage)) return 'refactoring'
if (FEATURE_KEYWORDS.test(userMessage)) return 'feature'
\`\`\`

## The fix

Pick whichever keyword pattern matches **earliest** in the user message. The position of the leading verb is a much stronger intent signal than the order of the checks in code.

\`\`\`ts
// After: position decides
return firstMatchingCategory(userMessage, [
  { regex: REFACTOR_KEYWORDS, category: 'refactoring' },
  { regex: FEATURE_KEYWORDS,  category: 'feature' },
  { regex: DEBUG_KEYWORDS,    category: 'debugging' },
]) ?? 'coding'
\`\`\`

Tie-break (same start index) goes to the candidate listed first. Ordering is \`refactoring > feature > debugging\` so existing behavior for plain bug reports (\`login is broken, traceback below\`) is preserved — DEBUG word leads in those cases.

Same logic applied to \`classifyConversation\` for chat-only turns.

## Examples

| Message | Before | After |
|---|---|---|
| \`add error handling\` | debugging | **feature** |
| \`create an issue tracker\` | debugging | **feature** |
| \`implement the 404 page\` | debugging | **feature** |
| \`fix the layout for the new feature\` | debugging | **debugging** (unchanged) |
| \`login is broken, traceback below\` | debugging | **debugging** (unchanged) |
| \`refactor the error handling\` | refactoring | **refactoring** (unchanged) |

## Tests

8 new regression tests under \`describe('classifyTurn — feature vs debugging precedence (#196)')\`. Full suite: 45 files / 609 tests, all pass.

## Out of scope

- Cursor per-project breakdown (separate PR — addresses the other half of #196 and feeds into #159).
- Cursor model alias completeness (separate PR — addresses #159).