### PR TITLE
Fix mangled project paths in By Project and Top Sessions panels

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -247,16 +247,17 @@ function DailyActivity({ projects, days = 14, pw, bw }: { projects: ProjectSumma
   )
 }
 
-const _homeEncoded = homedir().replace(/\//g, '-')
-
-function shortProject(encoded: string): string {
-  let path = encoded.replace(/^-/, '')
-  if (path.startsWith(_homeEncoded.replace(/^-/, ''))) {
-    path = path.slice(_homeEncoded.replace(/^-/, '').length).replace(/^-/, '')
-  }
-  path = path.replace(/^private-tmp-[^-]+-[^-]+-/, '').replace(/^private-tmp-/, '').replace(/^tmp-/, '')
+export function shortProject(absPath: string): string {
+  const home = homedir()
+  const homePrefix = home.endsWith('/') ? home : home + '/'
+  let path: string
+  if (absPath === home) path = ''
+  else if (absPath.startsWith(homePrefix)) path = absPath.slice(homePrefix.length)
+  else path = absPath
+  path = path.replace(/^\/+/, '')
+  path = path.replace(/^private\/tmp\/[^/]+\/[^/]+\//, '').replace(/^private\/tmp\//, '').replace(/^tmp\//, '')
   if (!path) return 'home'
-  const parts = path.split('-').filter(Boolean)
+  const parts = path.split('/').filter(Boolean)
   if (parts.length <= 3) return parts.join('/')
   return parts.slice(-3).join('/')
 }
@@ -282,7 +283,7 @@ function ProjectBreakdown({ projects, pw, bw, budgets }: { projects: ProjectSumm
         return (
           <Text key={`${project.project}-${i}`} wrap="truncate-end">
             <HBar value={project.totalCostUSD} max={maxCost} width={bw} />
-            <Text dimColor> {fit(shortProject(project.project), nw)}</Text>
+            <Text dimColor> {fit(shortProject(project.projectPath), nw)}</Text>
             <Text color={GOLD}>{formatCost(project.totalCostUSD).padStart(8)}</Text>
             <Text color={GOLD}>{avgCost.padStart(PROJECT_COL_AVG)}</Text>
             <Text>{String(project.sessions.length).padStart(6)}</Text>
@@ -442,7 +443,7 @@ const TOP_SESSIONS_CALLS_COL = 6
 
 function TopSessions({ projects, pw, bw }: { projects: ProjectSummary[]; pw: number; bw: number }) {
   const allSessions = projects.flatMap(p =>
-    p.sessions.map(s => ({ ...s, projectName: p.project }))
+    p.sessions.map(s => ({ ...s, projectPath: p.projectPath }))
   )
   const top = [...allSessions].sort((a, b) => b.totalCostUSD - a.totalCostUSD).slice(0, 5)
 
@@ -460,7 +461,7 @@ function TopSessions({ projects, pw, bw }: { projects: ProjectSummary[]; pw: num
         const date = session.firstTimestamp
           ? session.firstTimestamp.slice(0, TOP_SESSIONS_DATE_LEN)
           : '----------'
-        const label = `${date} ${shortProject(session.projectName)}`
+        const label = `${date} ${shortProject(session.projectPath)}`
         return (
           <Text key={`${session.sessionId}-${i}`} wrap="truncate-end">
             <HBar value={session.totalCostUSD} max={maxCost} width={bw} />

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -1,5 +1,8 @@
+import { homedir } from 'os'
+
 import { describe, it, expect } from 'vitest'
 
+import { shortProject } from '../src/dashboard.js'
 import { formatCost } from '../src/format.js'
 import type { ProjectSummary, SessionSummary } from '../src/types.js'
 
@@ -96,6 +99,36 @@ describe('TopSessions - top-5 selection', () => {
     const project = makeProject('proj', sessions)
     const top = getTopSessions([project])
     expect(top.map(s => s.sessionId)).toEqual(['s1', 's2', 's3'])
+  })
+})
+
+describe('shortProject - path shortening', () => {
+  const home = homedir()
+
+  it('preserves directory names containing dashes', () => {
+    expect(shortProject(`${home}/work/my-project`)).toBe('work/my-project')
+  })
+
+  it('preserves directory names containing dots', () => {
+    expect(shortProject(`${home}/work/my.app.io`)).toBe('work/my.app.io')
+  })
+
+  it('returns "home" for the home dir itself', () => {
+    expect(shortProject(home)).toBe('home')
+  })
+
+  it('does not strip a sibling whose name shares the home prefix', () => {
+    const sibling = `${home}-backup/proj`
+    expect(shortProject(sibling).endsWith('proj')).toBe(true)
+    expect(shortProject(sibling)).not.toMatch(/^-/)
+  })
+
+  it('keeps only the last 3 segments for deeply nested paths', () => {
+    expect(shortProject(`${home}/a/b/c/d/e/f`)).toBe('d/e/f')
+  })
+
+  it('handles paths outside the home dir', () => {
+    expect(shortProject('/opt/myproject')).toBe('opt/myproject')
   })
 })
 


### PR DESCRIPTION
## Summary

The `By Project` and `Top Sessions` panels in the dashboard displayed corrupted project names whenever a directory contained a dash or a dot. For example, `~/Projects/foo-bar` rendered as `Projects/foo/bar`, and `~/Projects/site.github.io` rendered as `Projects/site/github/io` with the `Projects/` prefix dropped entirely on deeper paths.

## Root cause

`shortProject()` in `src/dashboard.tsx` received Claude Code's encoded slug (e.g. `-home-user-Projects-foo-bar`) and tried to recover the original path by splitting on `-` and joining with `/`. This is intrinsically lossy: there's no way to distinguish dashes that came from path separators from dashes that were part of the original directory name.

## Fix

`ProjectSummary.projectPath` is already populated from the canonical `cwd` extracted by `parser.ts` (`extractCanonicalCwd`, with fallback to the legacy decode when no JSONL `cwd` is found). Other consumers (`export.ts`, `cli.ts`) already use it. The dashboard was the last holdout still re-decoding the slug.

This PR:
- Switches both the `By Project` and `Top Sessions` panels to consume `projectPath` (the real cwd).
- Rewrites `shortProject` to operate on an absolute path: split on `/`, keep the last 3 segments, strip the home prefix and any `private/tmp/...` macOS noise.
- Renames the in-flight `projectName` field to `projectPath` for semantic accuracy.
- Exports `shortProject` so it can be unit-tested.

## Test plan

- [x] `npm test` passes (added 6 cases for `shortProject` covering dashes, dots, the home dir itself, deep nesting, and paths outside home).
- [x] Manual: ran the dashboard against `~/.claude/projects/`; directories with dashes and dots now render verbatim instead of being split.