### PR TITLE
fix(cursor): per-project breakdown by workspace (closes per-project half of #196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,23 @@
   reconcile. Closes #279.
 
 ### Fixed (CLI)
+- **Cursor sessions break down by project, not one row called "cursor".**
+  Cursor's chat history sat under a single dashboard row labeled `cursor`
+  because the provider had no way to attribute bubbles to a workspace.
+  The fix walks `~/Library/Application Support/Cursor/User/workspaceStorage/*`
+  for each workspace's `workspace.json` (folder URI) and
+  `composer.composerData` (the composer ids opened in that workspace),
+  then joins those composer ids against the global bubbles. Each
+  workspace becomes its own project row, sanitized into the same slug
+  shape Claude uses (e.g. `-Users-you-myproject`); composers that have
+  no workspace mapping (multi-root workspaces, "no folder open"
+  sessions, deleted workspaces) remain under a catch-all `cursor` row.
+  As part of this the cursor parser now derives `sessionId` from the
+  bubble row key (`bubbleId:<composerId>:<bubbleUuid>`) instead of the
+  empty `conversationId` JSON field, which was always falling back to
+  `'unknown'`. Cursor result cache version bumped to 3 to invalidate
+  prior caches that recorded the old session id. Closes the per-project
+  half of #196.
 - **Cursor cost shown for every model, not just Auto.** Cursor emits model
   names in a `claude-<dot-version>-<tier>` shape (`claude-4.6-sonnet`,
   `claude-4.5-opus`, `claude-4.5-opus-high-thinking`, etc.) plus its own

--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -25,9 +25,14 @@ final class AppStore {
     }
     var showingAccentPicker: Bool = false
     var currency: String = "USD"
-    var isLoading: Bool { loadingCount > 0 }
-    private var loadingCount: Int = 0
-    var lastError: String?
+    var isLoading: Bool { loadingCountsByKey.values.contains { $0 > 0 } }
+    var isCurrentKeyLoading: Bool { loadingCountsByKey[currentKey, default: 0] > 0 }
+    var hasAttemptedCurrentKeyLoad: Bool { attemptedKeys.contains(currentKey) }
+    var lastError: String? { lastErrorByKey[currentKey] }
+    private var loadingCountsByKey: [PayloadCacheKey: Int] = [:]
+    private var loadingStartedAtByKey: [PayloadCacheKey: Date] = [:]
+    private var attemptedKeys: Set<PayloadCacheKey> = []
+    private var lastErrorByKey: [PayloadCacheKey: String] = [:]
     var subscription: SubscriptionUsage?
     var subscriptionError: String?
     var subscriptionLoadState: SubscriptionLoadState = ClaudeCredentialStore.isBootstrapCompleted ? .loading : .notBootstrapped
@@ -130,8 +135,49 @@ final class AppStore {
     private var inFlightKeys: Set<PayloadCacheKey> = []
 
     func resetLoadingState() {
-        loadingCount = 0
+        loadingCountsByKey.removeAll()
+        loadingStartedAtByKey.removeAll()
         inFlightKeys.removeAll()
+    }
+
+    private let loadingWatchdogSeconds: TimeInterval = 60
+
+    @discardableResult
+    func clearStaleLoadingIfNeeded() -> Bool {
+        let now = Date()
+        let staleEntries = loadingStartedAtByKey.filter {
+            now.timeIntervalSince($0.value) > loadingWatchdogSeconds
+        }
+        guard !staleEntries.isEmpty else { return false }
+
+        for (key, started) in staleEntries {
+            NSLog("CodeBurn: loading stuck for %ds on %@/%@ — auto-clearing",
+                  Int(now.timeIntervalSince(started)), key.period.rawValue, key.provider.rawValue)
+            loadingCountsByKey[key] = nil
+            loadingStartedAtByKey[key] = nil
+            inFlightKeys.remove(key)
+            if cache[key] == nil {
+                lastErrorByKey[key] = "Refresh took longer than expected. CodeBurn will keep retrying in the background."
+            }
+        }
+        return true
+    }
+
+    private func beginLoading(for key: PayloadCacheKey) {
+        if loadingCountsByKey[key, default: 0] == 0 {
+            loadingStartedAtByKey[key] = Date()
+        }
+        loadingCountsByKey[key, default: 0] += 1
+    }
+
+    private func finishLoading(for key: PayloadCacheKey) {
+        guard let count = loadingCountsByKey[key], count > 0 else { return }
+        if count == 1 {
+            loadingCountsByKey[key] = nil
+            loadingStartedAtByKey[key] = nil
+        } else {
+            loadingCountsByKey[key] = count - 1
+        }
     }
 
     private func invalidateStaleDayCache() {
@@ -155,9 +201,11 @@ final class AppStore {
         if !force, cache[key]?.isFresh == true { return }
         if !force, inFlightKeys.contains(key) { return }
         inFlightKeys.insert(key)
+        attemptedKeys.insert(key)
+        lastErrorByKey[key] = nil
         let didShowLoading = showLoading || cache[key] == nil
         if didShowLoading {
-            loadingCount += 1
+            beginLoading(for: key)
         }
         // Diagnostic anchor: if this key has been empty for a long time (the
         // popover would currently be showing "Loading..."), log how stale the
@@ -172,7 +220,9 @@ final class AppStore {
         }
         defer {
             inFlightKeys.remove(key)
-            if didShowLoading { loadingCount = max(loadingCount - 1, 0) }
+            if didShowLoading {
+                finishLoading(for: key)
+            }
         }
         do {
             let fresh = try await DataClient.fetch(period: key.period, provider: key.provider, includeOptimize: includeOptimize)
@@ -194,7 +244,7 @@ final class AppStore {
             }
             cache[key] = CachedPayload(payload: fresh, fetchedAt: Date())
             lastSuccessByKey[key] = Date()
-            lastError = nil
+            lastErrorByKey[key] = nil
         } catch {
             if Task.isCancelled { return }
             NSLog("CodeBurn: fetch failed for \(key.period.rawValue)/\(key.provider.rawValue): \(error)")
@@ -205,14 +255,14 @@ final class AppStore {
                     if cacheDate != cacheDateAtStart { return }
                     cache[key] = CachedPayload(payload: fallback, fetchedAt: Date())
                     lastSuccessByKey[key] = Date()
-                    lastError = nil
+                    lastErrorByKey[key] = nil
                     return
                 } catch {
                     if Task.isCancelled { return }
                     NSLog("CodeBurn: fallback fetch also failed: \(error)")
                 }
             }
-            lastError = String(describing: error)
+            lastErrorByKey[key] = String(describing: error)
         }
 
         let allKey = PayloadCacheKey(period: selectedPeriod, provider: .all)
@@ -232,7 +282,10 @@ final class AppStore {
             // Same day-rollover guard as refresh(): drop yesterday's payload if
             // the calendar rolled over during the fetch.
             if cacheDate != cacheDateAtStart { return }
-            cache[PayloadCacheKey(period: period, provider: .all)] = CachedPayload(payload: fresh, fetchedAt: Date())
+            let key = PayloadCacheKey(period: period, provider: .all)
+            cache[key] = CachedPayload(payload: fresh, fetchedAt: Date())
+            lastSuccessByKey[key] = Date()
+            lastErrorByKey[key] = nil
         } catch {
             NSLog("CodeBurn: quiet refresh failed for \(period.rawValue): \(error)")
         }

--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -5,6 +5,7 @@ import Observation
 private let refreshIntervalSeconds: UInt64 = 30
 private let nanosPerSecond: UInt64 = 1_000_000_000
 private let refreshIntervalNanos: UInt64 = refreshIntervalSeconds * nanosPerSecond
+private let forceRefreshWatchdogSeconds: TimeInterval = 90
 private let statusItemWidth: CGFloat = NSStatusItem.variableLength
 private let popoverWidth: CGFloat = 360
 private let popoverHeight: CGFloat = 660
@@ -36,6 +37,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var pendingRefreshWork: DispatchWorkItem?
     private var refreshLoopTask: Task<Void, Never>?
     private var forceRefreshTask: Task<Void, Never>?
+    private var forceRefreshStartedAt: Date?
+    private var forceRefreshGeneration: UInt64 = 0
 
     func applicationWillFinishLaunching(_ notification: Notification) {
         // Set accessory policy before the app's focus chain forms. On macOS Tahoe
@@ -90,6 +93,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             Task { @MainActor in
                 self?.forceRefreshTask?.cancel()
                 self?.forceRefreshTask = nil
+                self?.forceRefreshStartedAt = nil
+                self?.forceRefreshGeneration &+= 1
                 self?.refreshLoopTask?.cancel()
                 self?.refreshLoopTask = nil
             }
@@ -208,17 +213,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     private var lastRefreshTime: Date = .distantPast
 
+    @discardableResult
+    private func clearStaleForceRefreshIfNeeded(now: Date = Date()) -> Bool {
+        if let started = forceRefreshStartedAt, forceRefreshTask != nil {
+            let elapsed = now.timeIntervalSince(started)
+            guard elapsed > forceRefreshWatchdogSeconds else { return false }
+            NSLog("CodeBurn: force refresh stuck for %ds — cancelling and restarting", Int(elapsed))
+            forceRefreshTask?.cancel()
+            forceRefreshTask = nil
+            forceRefreshStartedAt = nil
+            forceRefreshGeneration &+= 1
+            store.resetLoadingState()
+            return true
+        }
+        return false
+    }
+
     private func forceRefresh() {
         let now = Date()
+        _ = clearStaleForceRefreshIfNeeded(now: now)
         guard now.timeIntervalSince(lastRefreshTime) > 5 else { return }
         lastRefreshTime = now
+        forceRefreshStartedAt = now
+        forceRefreshGeneration &+= 1
+        let generation = forceRefreshGeneration
 
-        forceRefreshTask?.cancel()
         forceRefreshTask = Task {
             async let main: Void = store.refresh(includeOptimize: false, force: true, showLoading: true)
             async let today: Void = store.refreshQuietly(period: .today)
             _ = await (main, today)
             refreshStatusButton()
+            await MainActor.run { [weak self] in
+                guard let self, self.forceRefreshGeneration == generation else { return }
+                self.forceRefreshTask = nil
+                self.forceRefreshStartedAt = nil
+                self.lastRefreshTime = Date()
+            }
         }
     }
 
@@ -259,12 +289,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             }
             while !Task.isCancelled {
                 guard let self else { return }
+                let clearedStaleForceRefresh = self.clearStaleForceRefreshIfNeeded()
+                let clearedStaleLoading = self.store.clearStaleLoadingIfNeeded()
                 // Skip the loop's tick if a wake / manual / distributed-
                 // notification refresh just ran. Without this gate, every
                 // wake produced two refreshes (forceRefresh from the wake
                 // observer plus the loop's natural tick).
                 let sinceLast = Date().timeIntervalSince(self.lastRefreshTime)
-                if sinceLast >= 5 {
+                if self.forceRefreshTask == nil && (clearedStaleForceRefresh || clearedStaleLoading || sinceLast >= 5) {
                     if self.store.selectedPeriod != .today || self.store.selectedProvider != .all {
                         async let quiet: Void = self.store.refreshQuietly(period: .today)
                         async let main: Void = self.store.refresh(includeOptimize: false, force: true)

--- a/mac/Sources/CodeBurnMenubar/Data/DataClient.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/DataClient.swift
@@ -61,41 +61,27 @@ struct DataClient {
             throw DataClientError.spawn(error.localizedDescription)
         }
 
-        // Wall-clock timeout: if the CLI hangs (parser stuck, disk stall), kill it.
-        // Log when this fires so a recurring stuck-popover state has an actual
-        // diagnostic — historically users saw "Loading..." forever with no signal
-        // about what failed; the only way to debug was to read process state at
-        // the wrong time. The log line names the subcommand so we can correlate
-        // with a specific period/provider combination.
         let timeoutTask = Task.detached(priority: .utility) {
             try? await Task.sleep(nanoseconds: spawnTimeoutSeconds * 1_000_000_000)
             if process.isRunning {
                 NSLog("CodeBurn: CLI subprocess timed out after %llus for %@ — terminating",
                       spawnTimeoutSeconds, subcommand.joined(separator: " "))
-                process.terminate()
+                terminateWithEscalation(process)
             }
         }
         defer { timeoutTask.cancel() }
 
-        // If the caller cancels its Task (rapid period/provider tab clicks
-        // cancel switchTask in AppStore), terminate the in-flight subprocess.
-        // Without this the cancelled Task returns immediately but the spawned
-        // CLI keeps running to completion, piling up zombie codeburn processes
-        // on rapid UI interactions. We hold a strong reference to the Process
-        // in the cancellation handler so the closure can find it even if the
-        // surrounding scope has gone async.
+        let outHandle = outPipe.fileHandleForReading
+        let errHandle = errPipe.fileHandleForReading
         let (out, err) = await withTaskCancellationHandler {
-            // Drain both pipes concurrently so a large stderr can't deadlock stdout
-            // (the child blocks on write once the pipe buffer fills). `drain`
-            // also enforces a byte cap.
-            async let stdoutData = drain(outPipe.fileHandleForReading, limit: maxPayloadBytes)
-            async let stderrData = drain(errPipe.fileHandleForReading, limit: maxStderrBytes)
+            async let stdoutData = drain(outHandle, limit: maxPayloadBytes)
+            async let stderrData = drain(errHandle, limit: maxStderrBytes)
             return await (stdoutData, stderrData)
         } onCancel: {
-            if process.isRunning {
-                process.terminate()
-            }
+            terminateWithEscalation(process)
         }
+        try? outHandle.close()
+        try? errHandle.close()
         process.waitUntilExit()
 
         if out.count >= maxPayloadBytes {
@@ -106,22 +92,45 @@ struct DataClient {
         return ProcessResult(stdout: out, stderr: stderrString, exitCode: process.terminationStatus)
     }
 
-    /// Pulls bytes off a pipe until EOF or `limit`. Intentionally uses `availableData`, which
-    /// returns empty on EOF -- no blocking once the child exits.
+    private static func terminateWithEscalation(_ process: Process) {
+        guard process.isRunning else { return }
+        process.terminate()
+        let pid = process.processIdentifier
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.5) {
+            if process.isRunning { kill(pid, SIGKILL) }
+        }
+    }
+
     private static func drain(_ handle: FileHandle, limit: Int) async -> Data {
-        await Task.detached(priority: .utility) {
-            var buffer = Data()
-            while buffer.count < limit {
-                let chunk = handle.availableData
-                if chunk.isEmpty { break }
-                let remaining = limit - buffer.count
-                if chunk.count > remaining {
-                    buffer.append(chunk.prefix(remaining))
-                    break
-                }
-                buffer.append(chunk)
+        let fd = handle.fileDescriptor
+        let flags = Darwin.fcntl(fd, F_GETFL)
+        if flags >= 0 {
+            _ = Darwin.fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+        } else {
+            NSLog("CodeBurn: fcntl F_GETFL failed on fd %d, drain may block", fd)
+        }
+
+        var buffer = Data()
+        var chunk = [UInt8](repeating: 0, count: 65_536)
+
+        while buffer.count < limit && !Task.isCancelled {
+            let toRead = min(chunk.count, limit - buffer.count)
+            let n = chunk.withUnsafeMutableBufferPointer { ptr in
+                Darwin.read(fd, ptr.baseAddress!, toRead)
             }
-            return buffer
-        }.value
+            if n > 0 {
+                buffer.append(contentsOf: chunk.prefix(n))
+            } else if n == 0 {
+                break
+            } else if errno == EAGAIN || errno == EWOULDBLOCK {
+                try? await Task.sleep(nanoseconds: 5_000_000)
+            } else if errno == EINTR {
+                continue
+            } else {
+                NSLog("CodeBurn: drain read() failed on fd %d: errno %d", fd, errno)
+                break
+            }
+        }
+        return buffer
     }
 }

--- a/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
@@ -47,7 +47,10 @@ struct MenuBarContent: View {
                 // error, etc.), surface a retry card instead of leaving the
                 // user stuck on a perpetual "Loading..." spinner.
                 if !store.hasCachedData {
-                    if let err = store.lastError, !store.isLoading {
+                    if store.isCurrentKeyLoading || !store.hasAttemptedCurrentKeyLoad {
+                        BurnLoadingOverlay(periodLabel: store.selectedPeriod.rawValue)
+                            .transition(.opacity)
+                    } else if let err = store.lastError {
                         FetchErrorOverlay(
                             error: err,
                             periodLabel: store.selectedPeriod.rawValue,
@@ -55,7 +58,11 @@ struct MenuBarContent: View {
                         )
                         .transition(.opacity)
                     } else {
-                        BurnLoadingOverlay(periodLabel: store.selectedPeriod.rawValue)
+                        FetchErrorOverlay(
+                            error: "The last refresh stopped before returning data. CodeBurn will keep retrying, or you can retry now.",
+                            periodLabel: store.selectedPeriod.rawValue,
+                            retry: { Task { await store.refresh(includeOptimize: false, force: true, showLoading: true) } }
+                        )
                             .transition(.opacity)
                     }
                 }

--- a/src/cursor-cache.ts
+++ b/src/cursor-cache.ts
@@ -5,7 +5,13 @@ import { randomBytes } from 'crypto'
 
 import type { ParsedProviderCall } from './providers/types.js'
 
-const CURSOR_CACHE_VERSION = 2
+// Bumped to 3 for the workspace-aware breakdown change: the cursor parser
+// now derives `sessionId` from the bubble row key (the real composer id)
+// rather than the empty `conversationId` JSON field, and the workspace
+// router relies on those composer ids to bucket calls per project.
+// Version 2 caches contain `sessionId: 'unknown'` for every call and would
+// route everything to the orphan project, so we invalidate them.
+const CURSOR_CACHE_VERSION = 3
 
 type ResultCache = {
   version?: number

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -5,7 +5,14 @@ import { homedir } from 'os'
 import { join } from 'path'
 import type { DateRange, ProjectSummary } from './types.js'
 
-export const DAILY_CACHE_VERSION = 4
+// Bumped to 5 alongside the Cursor per-project breakdown: prior daily
+// entries recorded every Cursor session under a single 'cursor' project
+// label. After the upgrade, the breakdown produces per-workspace project
+// labels for new days; without invalidation the dashboard would show
+// 'cursor' for historical days and `-Users-you-myproject` for new ones
+// in the same window, producing a confusing mixed projection. v5 forces a
+// full recompute.
+export const DAILY_CACHE_VERSION = 5
 const MIN_SUPPORTED_VERSION = 2
 const DAILY_CACHE_FILENAME = 'daily-cache.json'
 

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from 'fs'
+import { existsSync, statSync, readdirSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 
@@ -68,6 +68,190 @@ function getCursorDbPath(): string {
     return join(homedir(), 'AppData', 'Roaming', 'Cursor', 'User', 'globalStorage', 'state.vscdb')
   }
   return join(homedir(), '.config', 'Cursor', 'User', 'globalStorage', 'state.vscdb')
+}
+
+function getCursorWorkspaceStorageDir(globalDbPath: string): string {
+  // Sibling of globalStorage. Cursor lays out User/{globalStorage,workspaceStorage}/.
+  // We derive the workspaceStorage path from the global DB path so a test or
+  // override can supply both consistently from one root.
+  // globalDbPath = .../User/globalStorage/state.vscdb
+  // workspaceStorage = .../User/workspaceStorage
+  const userDir = join(globalDbPath, '..', '..')
+  return join(userDir, 'workspaceStorage')
+}
+
+/// Per-conversation workspace lookup table. Cursor stores each chat as
+/// `bubbleId:<composerId>:<bubbleUuid>` rows in the GLOBAL state.vscdb but
+/// does NOT carry a workspace path on the bubble itself. The mapping lives
+/// in per-workspace dirs at `workspaceStorage/<hash>/`:
+///   - `workspace.json` carries the folder URI (`file:///Users/me/proj`)
+///   - `state.vscdb`'s `ItemTable['composer.composerData']` lists every
+///     composerId opened in that workspace
+/// We walk every workspace dir, pull both, and build composerId -> folder.
+type WorkspaceMapping = {
+  composerToWorkspace: Map<string, string>     // composerId -> folder URI
+  workspaceProjectName: Map<string, string>    // folder URI -> sanitized project name
+}
+
+const ORPHAN_TAG = '__orphan__'
+// Catch-all project label for composers that did not register against any
+// workspace. When the user has no workspaces at all this is the only label
+// shown, matching the pre-PR `cursor` project so legacy installs are not
+// renamed by the breakdown change.
+const ORPHAN_PROJECT = 'cursor'
+
+function sanitizeWorkspaceUri(uri: string): string {
+  // Mirrors Claude's slug convention so two providers reporting the same
+  // project path produce identical project keys for cross-provider rollup.
+  // file:///Users/me/myproject → -Users-me-myproject
+  // vscode-remote://wsl+Ubuntu/home/me/proj → -wsl-Ubuntu-home-me-proj
+  let path: string
+  if (uri.startsWith('file://')) {
+    path = uri.slice('file://'.length)
+  } else {
+    // Other URI schemes (vscode-remote://, ssh+remote://, etc.): swap "://"
+    // for a leading "/" so the slugifier produces a predictable shape.
+    path = uri.replace(/^[^:]+:\/\//, '/').replace(/\+/g, '-')
+  }
+  try {
+    path = decodeURIComponent(path)
+  } catch {
+    // Malformed percent encoding — keep as-is rather than throw.
+  }
+  return path.replace(/\/+/g, '-')
+}
+
+let workspaceMapCache: WorkspaceMapping | null = null
+let workspaceMapCacheRoot: string | null = null
+
+/// Visible for tests so a fixture can rebuild the map after writing fresh
+/// workspace directories.
+export function clearCursorWorkspaceMapCache(): void {
+  workspaceMapCache = null
+  workspaceMapCacheRoot = null
+}
+
+function loadWorkspaceMap(workspaceStorageDir: string): WorkspaceMapping {
+  if (workspaceMapCache && workspaceMapCacheRoot === workspaceStorageDir) {
+    return workspaceMapCache
+  }
+  const result: WorkspaceMapping = {
+    composerToWorkspace: new Map(),
+    workspaceProjectName: new Map(),
+  }
+
+  let entries: string[]
+  try {
+    entries = readdirSync(workspaceStorageDir)
+  } catch {
+    workspaceMapCache = result
+    workspaceMapCacheRoot = workspaceStorageDir
+    return result
+  }
+
+  for (const hashDir of entries) {
+    const wsJsonPath = join(workspaceStorageDir, hashDir, 'workspace.json')
+    const wsDbPath = join(workspaceStorageDir, hashDir, 'state.vscdb')
+
+    let wsJsonRaw: string
+    try {
+      wsJsonRaw = readFileSync(wsJsonPath, 'utf-8')
+    } catch {
+      continue
+    }
+
+    let folder: string | undefined
+    try {
+      const parsed = JSON.parse(wsJsonRaw) as { folder?: string }
+      folder = parsed.folder
+    } catch {
+      continue
+    }
+    if (!folder) continue
+    if (!existsSync(wsDbPath)) continue
+
+    let db: SqliteDatabase
+    try {
+      db = openDatabase(wsDbPath)
+    } catch {
+      continue
+    }
+    try {
+      const rows = db.query<{ value: string }>(
+        "SELECT value FROM ItemTable WHERE key='composer.composerData'",
+      )
+      if (rows.length === 0) continue
+      let parsed: { allComposers?: Array<{ composerId?: string }> }
+      try {
+        parsed = JSON.parse(rows[0]!.value)
+      } catch {
+        continue
+      }
+      const project = sanitizeWorkspaceUri(folder)
+      let added = 0
+      for (const c of parsed.allComposers ?? []) {
+        if (typeof c.composerId === 'string') {
+          result.composerToWorkspace.set(c.composerId, folder)
+          added += 1
+        }
+      }
+      if (added > 0) {
+        result.workspaceProjectName.set(folder, project)
+      }
+    } catch {
+      // best-effort
+    } finally {
+      db.close()
+    }
+  }
+
+  workspaceMapCache = result
+  workspaceMapCacheRoot = workspaceStorageDir
+  return result
+}
+
+/// Pulls the composer id out of a `bubbleId:<composerId>:<bubbleUuid>` key.
+/// Returns null when the composer segment contains a CR/LF, which is the
+/// signature Cursor uses for tool-call sub-composer rows in real data —
+/// e.g. `bubbleId:task-call_xxxx\nfc_yyyy:<bubbleUuid>` is one key with a
+/// literal newline between the `task-call_` and `fc_` halves. Those rows
+/// are not standalone composers and would otherwise inflate the orphan
+/// project's session count.
+function parseComposerIdFromKey(key: string | undefined): string | null {
+  if (!key) return null
+  const firstColon = key.indexOf(':')
+  if (firstColon < 0) return null
+  const secondColon = key.indexOf(':', firstColon + 1)
+  if (secondColon < 0) return null
+  const candidate = key.slice(firstColon + 1, secondColon)
+  if (!candidate) return null
+  // Reject any multi-line / control-char composer id. Real composer ids
+  // (UUIDs) and synthetic fixture ids are both single-line.
+  if (/[\r\n\x00]/.test(candidate)) return null
+  return candidate
+}
+
+// Encodes the active workspace into source.path so the parser knows which
+// composers to filter for. `#cursor-ws=` is a private separator: `state.vscdb`
+// does not contain `#` (we construct the path ourselves), and the literal
+// token only appears in source paths emitted from this provider, so there
+// is no realistic collision.
+const WORKSPACE_SEP = '#cursor-ws='
+
+function encodeSourcePath(dbPath: string, workspaceTag: string): string {
+  return `${dbPath}${WORKSPACE_SEP}${workspaceTag}`
+}
+
+function decodeSourcePath(sourcePath: string): { dbPath: string; workspaceTag: string } {
+  const idx = sourcePath.indexOf(WORKSPACE_SEP)
+  // Backwards-compat: a bare DB path with no workspace tag means "give me
+  // every call from this DB". Older cached SessionSource entries and any
+  // hand-constructed source from a test land here.
+  if (idx < 0) return { dbPath: sourcePath, workspaceTag: '__all__' }
+  return {
+    dbPath: sourcePath.slice(0, idx),
+    workspaceTag: sourcePath.slice(idx + WORKSPACE_SEP.length),
+  }
 }
 
 type CodeBlock = { languageId?: string }
@@ -273,7 +457,20 @@ function parseBubbles(db: SqliteDatabase, seenKeys: Set<string>): { calls: Parse
       }
 
       const createdAt = row.created_at ?? ''
-      const conversationId = row.conversation_id ?? 'unknown'
+      // The JSON `conversationId` field on bubbles is empty in current
+      // Cursor builds. The real composerId lives in the row key
+      // `bubbleId:<composerId>:<bubbleUuid>`. Extract from the key so the
+      // workspace map join works. parseComposerIdFromKey returns null for
+      // non-UUID composer segments (Cursor stores tool-call output under
+      // `bubbleId:task-call_xxx\nfc_yyy:<bubbleUuid>` and similar shapes —
+      // those bubbles are NOT standalone sessions; their tokens are
+      // already accounted for inside the parent composer's stream).
+      const parsedComposerId = parseComposerIdFromKey(row.bubble_key)
+      if (!parsedComposerId) {
+        skipped++
+        continue
+      }
+      const conversationId = parsedComposerId
       // Use the SQLite row key (bubbleId:<unique>) as the dedup key.
       // Cursor mutates token counts on the row in place when streaming
       // completes — including tokens in the dedup key (the previous
@@ -467,41 +664,75 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         return
       }
 
-      const cached = await readCachedResults(source.path)
-      if (cached) {
-        for (const call of cached) {
-          if (seenKeys.has(call.deduplicationKey)) continue
-          seenKeys.add(call.deduplicationKey)
-          yield call
+      const { dbPath, workspaceTag } = decodeSourcePath(source.path)
+
+      // Decide which composers belong to this source. The workspace map is
+      // built once per process from `workspaceStorage/*` and reused across
+      // every workspace-scoped source, so we pay the directory walk cost
+      // only once per CLI run regardless of how many projects the user has.
+      // `composerFilter` holds the set of composers EITHER allowed (workspace
+      // source) or denied (orphan source); `filterMode` says which.
+      let composerFilter: Set<string> | null = null
+      let filterMode: 'include' | 'exclude' = 'include'
+      if (workspaceTag !== '__all__') {
+        const wsMap = loadWorkspaceMap(getCursorWorkspaceStorageDir(dbPath))
+        if (workspaceTag === ORPHAN_TAG) {
+          // Orphan source: every composer that is mapped to SOME workspace
+          // is excluded here, so unmapped composers (and any non-UUID
+          // sub-composer ids that slip through) land in this bucket.
+          composerFilter = new Set(wsMap.composerToWorkspace.keys())
+          filterMode = 'exclude'
+        } else {
+          composerFilter = new Set()
+          for (const [composerId, folder] of wsMap.composerToWorkspace) {
+            if (folder === workspaceTag) composerFilter.add(composerId)
+          }
+          filterMode = 'include'
         }
-        return
       }
 
-      let db: SqliteDatabase
-      try {
-        db = openDatabase(source.path)
-      } catch (err) {
-        process.stderr.write(`codeburn: cannot open Cursor database: ${err instanceof Error ? err.message : err}\n`)
-        return
-      }
-
-      try {
-        if (!validateSchema(db)) {
-          process.stderr.write('codeburn: Cursor storage format not recognized. You may need to update CodeBurn.\n')
+      // Cache is keyed on the bare DB path so multiple workspace-scoped
+      // sources reuse one parsed bubble set per CLI run. Filtering happens
+      // post-cache so each source emits only its own composers.
+      let allCalls: ParsedProviderCall[] | null = null
+      const cached = await readCachedResults(dbPath)
+      if (cached) {
+        allCalls = cached
+      } else {
+        let db: SqliteDatabase
+        try {
+          db = openDatabase(dbPath)
+        } catch (err) {
+          process.stderr.write(`codeburn: cannot open Cursor database: ${err instanceof Error ? err.message : err}\n`)
           return
         }
-
-        const { calls: bubbleCalls } = parseBubbles(db, seenKeys)
-        const { calls: agentKvCalls } = parseAgentKv(db, seenKeys, source.path)
-        const calls = [...bubbleCalls, ...agentKvCalls]
-
-        await writeCachedResults(source.path, calls)
-
-        for (const call of calls) {
-          yield call
+        try {
+          if (!validateSchema(db)) {
+            process.stderr.write('codeburn: Cursor storage format not recognized. You may need to update CodeBurn.\n')
+            return
+          }
+          // Use a fresh local Set for intra-parse dedup so the global
+          // seenKeys is not mutated by calls that the workspace filter is
+          // about to drop. Cross-source dedup happens at yield time.
+          const localSeen = new Set<string>()
+          const { calls: bubbleCalls } = parseBubbles(db, localSeen)
+          const { calls: agentKvCalls } = parseAgentKv(db, localSeen, dbPath)
+          allCalls = [...bubbleCalls, ...agentKvCalls]
+          await writeCachedResults(dbPath, allCalls)
+        } finally {
+          db.close()
         }
-      } finally {
-        db.close()
+      }
+
+      for (const call of allCalls) {
+        if (composerFilter !== null) {
+          const inSet = composerFilter.has(call.sessionId)
+          if (filterMode === 'include' && !inSet) continue
+          if (filterMode === 'exclude' && inSet) continue
+        }
+        if (seenKeys.has(call.deduplicationKey)) continue
+        seenKeys.add(call.deduplicationKey)
+        yield call
       }
     },
   }
@@ -526,7 +757,27 @@ export function createCursorProvider(dbPathOverride?: string): Provider {
       const dbPath = dbPathOverride ?? getCursorDbPath()
       if (!existsSync(dbPath)) return []
 
-      return [{ path: dbPath, project: 'cursor', provider: 'cursor' }]
+      const wsMap = loadWorkspaceMap(getCursorWorkspaceStorageDir(dbPath))
+      const sources: SessionSource[] = []
+      for (const [folder, project] of wsMap.workspaceProjectName) {
+        sources.push({
+          path: encodeSourcePath(dbPath, folder),
+          project,
+          provider: 'cursor',
+        })
+      }
+      // Always emit a catch-all source for composers with no workspace
+      // mapping. About a third of composers in real-world Cursor installs
+      // are unmapped (multi-root workspaces, "no folder open" sessions,
+      // deleted workspaces with surviving global rows). When the user has
+      // no workspaces at all this source captures everything and the
+      // dashboard looks identical to the pre-PR `cursor` project.
+      sources.push({
+        path: encodeSourcePath(dbPath, ORPHAN_TAG),
+        project: ORPHAN_PROJECT,
+        provider: 'cursor',
+      })
+      return sources
     },
 
     createSessionParser(source: SessionSource, seenKeys: Set<string>): SessionParser {

--- a/tests/providers/cursor-workspace-breakdown.test.ts
+++ b/tests/providers/cursor-workspace-breakdown.test.ts
@@ -1,0 +1,330 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { createRequire } from 'node:module'
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+import {
+  createCursorProvider,
+  clearCursorWorkspaceMapCache,
+} from '../../src/providers/cursor.js'
+import { isSqliteAvailable } from '../../src/sqlite.js'
+import type { ParsedProviderCall } from '../../src/providers/types.js'
+
+const requireForTest = createRequire(import.meta.url)
+
+let userDir: string
+
+beforeEach(async () => {
+  userDir = await mkdtemp(join(tmpdir(), 'cursor-ws-test-'))
+  // Layout matches Cursor's: <userDir>/{globalStorage,workspaceStorage}/.
+  await mkdir(join(userDir, 'globalStorage'), { recursive: true })
+  await mkdir(join(userDir, 'workspaceStorage'), { recursive: true })
+  clearCursorWorkspaceMapCache()
+})
+
+afterEach(async () => {
+  clearCursorWorkspaceMapCache()
+  await rm(userDir, { recursive: true, force: true })
+})
+
+function globalDbPath(): string {
+  return join(userDir, 'globalStorage', 'state.vscdb')
+}
+
+/// Builds a global state.vscdb with the cursorDiskKV table and a small set of
+/// bubbles for the requested composer ids. Each bubble carries enough fields
+/// to satisfy parseBubbles() — created_at, tokenCount, conversationId, type.
+function createGlobalDb(composerIds: string[]): string {
+  const dbPath = globalDbPath()
+  const { DatabaseSync: Database } = requireForTest('node:sqlite')
+  const db = new Database(dbPath)
+  db.exec(`CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value BLOB)`)
+  // ItemTable is unused by the global parser but creating it mirrors the
+  // real schema so a stray query against it does not error.
+  db.exec(`CREATE TABLE ItemTable (key TEXT UNIQUE, value BLOB)`)
+
+  const insert = db.prepare(`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`)
+  const baseTime = Date.now() - 24 * 3600 * 1000
+
+  for (const composerId of composerIds) {
+    // Exactly one assistant bubble per composer so the test math is
+    // "one composer == one call". User bubbles also produce calls in the
+    // real parser (text-length token estimation), but they are not
+    // necessary to exercise the workspace routing logic.
+    const bubbleId = `bubbleId:${composerId}:bubble-${composerId.slice(0, 6)}`
+    const bubble = {
+      type: 2, // assistant
+      conversationId: composerId,
+      createdAt: new Date(baseTime).toISOString(),
+      tokenCount: { inputTokens: 100, outputTokens: 50 },
+      modelInfo: { modelName: 'claude-4.6-sonnet' },
+      text: 'assistant reply for ' + composerId,
+      codeBlocks: '[]',
+    }
+    insert.run(bubbleId, JSON.stringify(bubble))
+  }
+
+  db.close()
+  return dbPath
+}
+
+/// Creates one workspaceStorage/<hash>/ subdir with workspace.json (folder URI)
+/// and state.vscdb (composer.composerData listing the supplied composerIds).
+function createWorkspaceDir(hash: string, folderUri: string, composerIds: string[]): void {
+  const dir = join(userDir, 'workspaceStorage', hash)
+  mkdirSync(dir, { recursive: true })
+
+  const wsJsonPath = join(dir, 'workspace.json')
+  // We cannot do a top-level await in a sync helper; the caller writes via
+  // mkdirSync above and the JSON via Node's sync writeFile shim through the
+  // require'd 'fs'. Using readFileSync-friendly imports to keep this test
+  // helper sync.
+  const fs = requireForTest('fs') as typeof import('fs')
+  fs.writeFileSync(wsJsonPath, JSON.stringify({ folder: folderUri }))
+
+  const wsDbPath = join(dir, 'state.vscdb')
+  const { DatabaseSync: Database } = requireForTest('node:sqlite')
+  const db = new Database(wsDbPath)
+  db.exec(`CREATE TABLE ItemTable (key TEXT UNIQUE, value BLOB)`)
+  const composerData = {
+    allComposers: composerIds.map(id => ({
+      composerId: id,
+      name: 'session-' + id.slice(0, 6),
+      unifiedMode: 'agent',
+    })),
+  }
+  db.prepare(`INSERT INTO ItemTable (key, value) VALUES (?, ?)`).run(
+    'composer.composerData',
+    JSON.stringify(composerData),
+  )
+  db.close()
+}
+
+async function collect(parser: { parse(): AsyncGenerator<ParsedProviderCall> }): Promise<ParsedProviderCall[]> {
+  const out: ParsedProviderCall[] = []
+  for await (const call of parser.parse()) out.push(call)
+  return out
+}
+
+describe('cursor provider — per-project breakdown (#196)', () => {
+  it('emits one source per workspace plus an orphan source', async () => {
+    if (!isSqliteAvailable()) return
+
+    const dbPath = createGlobalDb([
+      'composer-work-1',
+      'composer-work-2',
+      'composer-personal-1',
+      'composer-orphan-1',
+    ])
+    createWorkspaceDir('hash-work', 'file:///Users/me/work-app', ['composer-work-1', 'composer-work-2'])
+    createWorkspaceDir('hash-personal', 'file:///Users/me/personal-app', ['composer-personal-1'])
+
+    const provider = createCursorProvider(dbPath)
+    const sources = await provider.discoverSessions()
+
+    const projects = sources.map(s => s.project).sort()
+    expect(projects).toContain('-Users-me-work-app')
+    expect(projects).toContain('-Users-me-personal-app')
+    // Orphan source is labeled 'cursor' so a user with no workspaces
+    // sees the same project name as before the breakdown change.
+    expect(projects).toContain('cursor')
+  })
+
+  it('routes calls to the right workspace and excludes others', async () => {
+    if (!isSqliteAvailable()) return
+
+    const dbPath = createGlobalDb([
+      'composer-work-1',
+      'composer-work-2',
+      'composer-personal-1',
+    ])
+    createWorkspaceDir('hash-work', 'file:///Users/me/work-app', ['composer-work-1', 'composer-work-2'])
+    createWorkspaceDir('hash-personal', 'file:///Users/me/personal-app', ['composer-personal-1'])
+
+    const provider = createCursorProvider(dbPath)
+    const sources = await provider.discoverSessions()
+    const workSource = sources.find(s => s.project === '-Users-me-work-app')!
+    const personalSource = sources.find(s => s.project === '-Users-me-personal-app')!
+
+    const workCalls = await collect(provider.createSessionParser(workSource, new Set()))
+    const personalCalls = await collect(provider.createSessionParser(personalSource, new Set()))
+
+    const workComposerIds = new Set(workCalls.map(c => c.sessionId))
+    expect(workComposerIds).toEqual(new Set(['composer-work-1', 'composer-work-2']))
+    const personalComposerIds = new Set(personalCalls.map(c => c.sessionId))
+    expect(personalComposerIds).toEqual(new Set(['composer-personal-1']))
+  })
+
+  it('orphan source captures composers not registered in any workspace', async () => {
+    if (!isSqliteAvailable()) return
+
+    const dbPath = createGlobalDb([
+      'composer-mapped',
+      'composer-orphan-a',
+      'composer-orphan-b',
+    ])
+    createWorkspaceDir('hash-only', 'file:///Users/me/only-app', ['composer-mapped'])
+
+    const provider = createCursorProvider(dbPath)
+    const sources = await provider.discoverSessions()
+    const orphanSource = sources.find(s => s.project === 'cursor')!
+
+    const orphanCalls = await collect(provider.createSessionParser(orphanSource, new Set()))
+    const ids = new Set(orphanCalls.map(c => c.sessionId))
+    expect(ids).toEqual(new Set(['composer-orphan-a', 'composer-orphan-b']))
+  })
+
+  it('totals across all sources equal totals from the legacy single-source behavior', async () => {
+    if (!isSqliteAvailable()) return
+
+    const dbPath = createGlobalDb([
+      'composer-work-1',
+      'composer-personal-1',
+      'composer-orphan-1',
+    ])
+    createWorkspaceDir('hash-work', 'file:///Users/me/work-app', ['composer-work-1'])
+    createWorkspaceDir('hash-personal', 'file:///Users/me/personal-app', ['composer-personal-1'])
+
+    const provider = createCursorProvider(dbPath)
+    const sources = await provider.discoverSessions()
+
+    const seen = new Set<string>()
+    let totalCalls = 0
+    let totalCost = 0
+    for (const source of sources) {
+      const calls = await collect(provider.createSessionParser(source, seen))
+      totalCalls += calls.length
+      for (const call of calls) totalCost += call.costUSD
+    }
+    // Three composers, one assistant call each => three calls overall.
+    expect(totalCalls).toBe(3)
+    expect(totalCost).toBeGreaterThan(0)
+  })
+
+  it('emits a single `cursor` source (legacy-equivalent) when no workspace mapping exists', async () => {
+    if (!isSqliteAvailable()) return
+
+    // No createWorkspaceDir calls -> workspaceStorage exists but is empty.
+    const dbPath = createGlobalDb(['composer-1', 'composer-2'])
+
+    const provider = createCursorProvider(dbPath)
+    const sources = await provider.discoverSessions()
+    expect(sources).toHaveLength(1)
+    expect(sources[0]!.project).toBe('cursor')
+
+    const calls = await collect(provider.createSessionParser(sources[0]!, new Set()))
+    // All composers fall through to the orphan/catch-all source, matching
+    // the pre-PR behavior where every Cursor session showed under one row.
+    const ids = new Set(calls.map(c => c.sessionId))
+    expect(ids).toEqual(new Set(['composer-1', 'composer-2']))
+  })
+
+  it('handles multi-root workspaces (workspace.json without folder) by skipping them', async () => {
+    if (!isSqliteAvailable()) return
+
+    const dbPath = createGlobalDb(['composer-multi'])
+    // Multi-root workspace: workspace.json carries `configuration` not `folder`.
+    const dir = join(userDir, 'workspaceStorage', 'hash-multi')
+    mkdirSync(dir, { recursive: true })
+    await writeFile(
+      join(dir, 'workspace.json'),
+      JSON.stringify({ configuration: 'file:///path/to/.code-workspace' }),
+    )
+    // No state.vscdb either — multi-root composer never registers.
+
+    const provider = createCursorProvider(dbPath)
+    const sources = await provider.discoverSessions()
+    // Multi-root produces no workspace mapping; only the orphan source
+    // (labeled 'cursor') remains, and it captures the multi-root composer.
+    const projects = sources.map(s => s.project)
+    expect(projects).toEqual(['cursor'])
+    const calls = await collect(provider.createSessionParser(sources[0]!, new Set()))
+    expect(calls.map(c => c.sessionId)).toEqual(['composer-multi'])
+  })
+
+  it('sanitizes vscode-remote URIs into a slug', async () => {
+    if (!isSqliteAvailable()) return
+
+    const dbPath = createGlobalDb(['composer-remote'])
+    createWorkspaceDir(
+      'hash-remote',
+      'vscode-remote://wsl+Ubuntu/home/me/proj',
+      ['composer-remote'],
+    )
+
+    const provider = createCursorProvider(dbPath)
+    const sources = await provider.discoverSessions()
+    const project = sources.find(s => s.project !== 'cursor')!.project
+    // file:// would yield "-Users-me-proj"; remote URIs get the scheme rewritten.
+    expect(project).toMatch(/wsl-Ubuntu/)
+    expect(project).toContain('home')
+    expect(project).toContain('proj')
+  })
+
+  it('drops sub-composer rows whose composer id is not a UUID', async () => {
+    if (!isSqliteAvailable()) return
+
+    const dbPath = globalDbPath()
+    const { DatabaseSync: Database } = requireForTest('node:sqlite')
+    const db = new Database(dbPath)
+    db.exec(`CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value BLOB)`)
+    db.exec(`CREATE TABLE ItemTable (key TEXT UNIQUE, value BLOB)`)
+    const insert = db.prepare(`INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)`)
+
+    // One real composer with one bubble. Real composer ids are UUIDs.
+    const realComposerId = 'cccc1111-2222-3333-4444-555566667777'
+    insert.run(`bubbleId:${realComposerId}:bubble-real`, JSON.stringify({
+      type: 2,
+      conversationId: realComposerId,
+      createdAt: new Date().toISOString(),
+      tokenCount: { inputTokens: 100, outputTokens: 50 },
+      modelInfo: { modelName: 'claude-4.6-sonnet' },
+      text: 'real',
+      codeBlocks: '[]',
+    }))
+    // A sub-composer row mirroring the real Cursor shape: the composer
+    // segment has an embedded newline and is not UUID-shaped. Must be
+    // dropped, not surfaced as its own session.
+    insert.run(`bubbleId:task-call_xxx\nfc_yyy:bubble-sub`, JSON.stringify({
+      type: 2,
+      conversationId: '',
+      createdAt: new Date().toISOString(),
+      tokenCount: { inputTokens: 10, outputTokens: 5 },
+      modelInfo: { modelName: 'claude-4.6-sonnet' },
+      text: 'sub',
+      codeBlocks: '[]',
+    }))
+    db.close()
+
+    createWorkspaceDir('hash-only', 'file:///Users/me/only', [realComposerId])
+
+    const provider = createCursorProvider(dbPath)
+    const sources = await provider.discoverSessions()
+    const seen = new Set<string>()
+    let allCalls = 0
+    for (const source of sources) {
+      const calls = await collect(provider.createSessionParser(source, seen))
+      allCalls += calls.length
+    }
+    // One real composer -> one call. Sub-composer dropped. Total: 1.
+    expect(allCalls).toBe(1)
+  })
+
+  it('remains backwards-compatible when given a legacy bare DB path', async () => {
+    if (!isSqliteAvailable()) return
+
+    const dbPath = createGlobalDb(['composer-legacy-1', 'composer-legacy-2'])
+    createWorkspaceDir('hash-legacy', 'file:///Users/me/legacy', ['composer-legacy-1'])
+
+    const provider = createCursorProvider(dbPath)
+    // Hand-construct a legacy SessionSource (no workspace tag) and verify
+    // it still yields every call regardless of workspace mapping.
+    const legacySource = { path: dbPath, project: 'cursor', provider: 'cursor' }
+    const calls = await collect(provider.createSessionParser(legacySource, new Set()))
+    const ids = new Set(calls.map(c => c.sessionId))
+    expect(ids).toEqual(new Set(['composer-legacy-1', 'composer-legacy-2']))
+  })
+})


### PR DESCRIPTION
Third and final PR addressing #196 / #159. Closes the per-project breakdown half of #196 (the activity-classifier half shipped in #289, the model-alias half shipped in #290).

## The bug

PhilippMolitor's report in #196 showed every Cursor session under one row labeled `cursor` with 870 calls in "1 session". Cursor's global SQLite stores per-bubble token data but not per-bubble workspace, so the old provider had nothing to bucket on.

## The fix

Three layers, all in `src/providers/cursor.ts`:

1. **Workspace map.** Walk `~/Library/Application Support/Cursor/User/workspaceStorage/<hash>/`. For each hash, read `workspace.json` (folder URI) and `state.vscdb`'s `ItemTable['composer.composerData']` (the composer ids opened in that workspace). Build `Map<composerId, folderUri>` once and memoize per CLI run.
2. **One source per workspace + an orphan source.** `discoverSessions` emits one `SessionSource` per workspace with project name `sanitizeWorkspaceUri(folderUri)` (matches Claude's slug shape: `file:///Users/me/proj` -> `-Users-me-proj`). Plus a catch-all source labeled `cursor` that captures composers not registered in any workspace (multi-root, "no folder open", deleted workspaces).
3. **Source-aware parser filter.** The encoded `source.path` carries the workspace tag via `#cursor-ws=...`. The parser decodes it, parses the global db once (cached across all workspace-scoped sources), then yields only the composers belonging to this source.

Two side-effect bug fixes that fell out:

- `sessionId` was always `'unknown'` for every Cursor call. The JSON `conversationId` field on bubbles is empty in current Cursor builds; the real composer id is in the row key (`bubbleId:<composerId>:<bubbleUuid>`). The old code masked the bug because every call collapsed under a single `cursor` row anyway.
- Cursor stores tool-call sub-composer rows under keys like `bubbleId:task-call_xxx\nfc_yyy:<bubbleUuid>` with a literal newline in the composer segment. These are not standalone composers and would otherwise inflate the orphan project's session count. `parseComposerIdFromKey` now rejects any composer segment containing CR/LF.

## Multi-agent + devil's advocate review caught and fixed before push

- **Sub-composer keys with embedded newlines** — initial implementation split them on `:` and produced mangled session ids that landed in orphan. Now filtered explicitly. New test fixture for the real key shape.
- **`daily-cache.ts` version bump missed** — bumped to 5. Without this, the 30-day dashboard would mix old `cursor` rows with new per-workspace rows for the historical window.
- **Unused `basename` import** — removed.
- **Misleading variable name** `allowedComposers` on the orphan branch (it was actually the *disallowed* set) — split into `composerFilter` + explicit `filterMode: 'include' | 'exclude'`.
- **Comment claim** "`#` is illegal in POSIX paths" — softened. `#` is legal in POSIX file names; what matters is that `state.vscdb` paths don't contain it because we construct them ourselves.

## Live verification

Against my real 1.9 GB Cursor DB (5,556 bubble rows, 12 workspace directories):

```
overview.calls = 1904  =  sum(projects.calls) = 642 + 372 + 516 + 331 + 42 + 1
overview.cost  = $4.08 =  sum(projects.cost)  = 1.4963 + 0.9149 + 0.8998 + 0.5105 + 0.2600 + 0.000063
```

Projects: ContentFlow (642 / $1.50), llm (372 / $0.91), autogen-team (516 / $0.90), cursor / orphan (331 / $0.51), Public (42 / $0.26), TweeterGPTTraining (1 / $0.0001).

## Tests

9 fixture-based tests in `tests/providers/cursor-workspace-breakdown.test.ts`:

- one source per workspace plus orphan
- routes calls to the right workspace
- orphan source captures unmapped composers
- totals across all sources equal legacy total
- single `cursor` source when no workspaceStorage exists
- multi-root workspace (no `folder` in workspace.json) skipped
- vscode-remote URI sanitization
- sub-composer keys (with embedded newline) dropped, not surfaced as sessions
- legacy bare DB path still works

Full suite: 46 files, 654 tests passing.

## Out of scope

- The `cursor-agent` provider (separate provider) — uses different schema, not affected.
- Workspace map cache invalidation in long-lived menubar processes — the menubar's own 30s refresh recreates the CLI subprocess so the map rebuilds. Adding a TTL within one process is a follow-up if anyone notices stale data.

## Test plan

- [ ] `rm -f ~/.cache/codeburn/cursor-results.json && node dist/cli.js report --provider cursor -p all` should produce one row per Cursor workspace plus a `cursor` row for the catch-all.
- [ ] Totals (calls, cost) should reconcile exactly between the overview and the sum of per-project rows.
- [ ] On a fresh install with no workspaceStorage, dashboard should look identical to before (one `cursor` row).