### PR TITLE
Skip Cursor bubble rows without createdAt timestamp

### DIFF
--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -329,7 +329,8 @@ const USER_MESSAGES_QUERY = `
 // the whole template. The original combined string is preserved as
 // BUBBLE_QUERY_SINCE for any caller that doesn't want the cap.
 const BUBBLE_QUERY_SINCE_HEAD = BUBBLE_QUERY_BASE + `
-    AND (json_extract(value, '$.createdAt') > ? OR json_extract(value, '$.createdAt') IS NULL)`
+    AND json_extract(value, '$.createdAt') IS NOT NULL
+    AND json_extract(value, '$.createdAt') > ?`
 const BUBBLE_QUERY_SINCE_TAIL = `
   ORDER BY ROWID ASC
 `
@@ -458,6 +459,7 @@ function parseBubbles(db: SqliteDatabase, seenKeys: Set<string>): { calls: Parse
       }
 
       const createdAt = row.created_at ?? ''
+      if (!createdAt) continue
       // The JSON `conversationId` field on bubbles is empty in current
       // Cursor builds. The real composerId lives in the row key
       // `bubbleId:<composerId>:<bubbleUuid>`. Extract from the key so the
@@ -487,7 +489,7 @@ function parseBubbles(db: SqliteDatabase, seenKeys: Set<string>): { calls: Parse
 
       const costUSD = calculateCost(pricingModel, inputTokens, outputTokens, 0, 0, 0)
 
-      const timestamp = createdAt || new Date().toISOString()
+      const timestamp = createdAt
       const userQuestion = takeUserMessage(userMessages, conversationId)
       const assistantText = blobToText(row.user_text)
       const userText = (userQuestion + ' ' + assistantText).trim()


### PR DESCRIPTION
## Summary

- Skip Cursor bubble rows that lack a `createdAt` timestamp instead of defaulting to `new Date()`, which misattributed historical usage to Today
- Filter at both the SQL level (`IS NOT NULL`) and application level (`if (!createdAt) continue`)
- No change to agentKv handling (file mtime fallback is still the most reliable timestamp source for binary protobuf rows)

Based on the bubble-side fix from #262 by @darthrevanyunka.

Validated live against a real Cursor database (5,556 bubble rows, all with `createdAt`). No data loss, identical output before and after.

Closes #262