### PR TITLE
Fix timezone-unstable day-aggregator tests

### DIFF
--- a/tests/day-aggregator.test.ts
+++ b/tests/day-aggregator.test.ts
@@ -46,8 +46,8 @@ describe('aggregateProjectsIntoDays', () => {
         sessions: [{
           sessionId: 's1',
           project: 'p',
-          firstTimestamp: '2026-04-09T10:00:00Z',
-          lastTimestamp: '2026-04-10T08:00:00Z',
+          firstTimestamp: '2026-04-09T10:00:00',
+          lastTimestamp: '2026-04-10T08:00:00',
           totalCostUSD: 10,
           totalInputTokens: 0,
           totalOutputTokens: 0,
@@ -57,14 +57,14 @@ describe('aggregateProjectsIntoDays', () => {
           turns: [
             {
               userMessage: 'hi',
-              timestamp: '2026-04-09T10:00:00Z',
+              timestamp: '2026-04-09T10:00:00',
               sessionId: 's1',
               category: 'coding',
               retries: 0,
               hasEdits: true,
               assistantCalls: [
-                makeCall('2026-04-09T10:00:00Z', 4),
-                makeCall('2026-04-10T08:00:00Z', 6),
+                makeCall('2026-04-09T10:00:00', 4),
+                makeCall('2026-04-10T08:00:00', 6),
               ],
             },
           ],
@@ -92,8 +92,8 @@ describe('aggregateProjectsIntoDays', () => {
         sessions: [{
           sessionId: 's1',
           project: 'p',
-          firstTimestamp: '2026-04-09T10:00:00Z',
-          lastTimestamp: '2026-04-09T10:05:00Z',
+          firstTimestamp: '2026-04-09T10:00:00',
+          lastTimestamp: '2026-04-09T10:05:00',
           totalCostUSD: 3,
           totalInputTokens: 0,
           totalOutputTokens: 0,
@@ -103,12 +103,12 @@ describe('aggregateProjectsIntoDays', () => {
           turns: [
             {
               userMessage: 'hi',
-              timestamp: '2026-04-09T10:00:00Z',
+              timestamp: '2026-04-09T10:00:00',
               sessionId: 's1',
               category: 'coding',
               retries: 0,
               hasEdits: true,
-              assistantCalls: [makeCall('2026-04-09T10:00:00Z', 3)],
+              assistantCalls: [makeCall('2026-04-09T10:00:00', 3)],
             },
           ],
           modelBreakdown: {},
@@ -138,8 +138,8 @@ describe('aggregateProjectsIntoDays', () => {
         sessions: [{
           sessionId: 's1',
           project: 'p',
-          firstTimestamp: '2026-04-09T23:59:00Z',
-          lastTimestamp: '2026-04-10T00:10:00Z',
+          firstTimestamp: '2026-04-09T23:59:00',
+          lastTimestamp: '2026-04-10T00:10:00',
           totalCostUSD: 1,
           totalInputTokens: 0, totalOutputTokens: 0, totalCacheReadTokens: 0, totalCacheWriteTokens: 0,
           apiCalls: 0,
@@ -151,7 +151,7 @@ describe('aggregateProjectsIntoDays', () => {
       }),
     ]
     const days = aggregateProjectsIntoDays(projects)
-    const expectedDate = dateKey('2026-04-09T23:59:00Z')
+    const expectedDate = dateKey('2026-04-09T23:59:00')
     expect(days[0]!.date).toBe(expectedDate)
     expect(days[0]!.sessions).toBe(1)
   })
@@ -162,18 +162,18 @@ describe('aggregateProjectsIntoDays', () => {
         sessions: [{
           sessionId: 's1',
           project: 'p',
-          firstTimestamp: '2026-04-10T10:00:00Z',
-          lastTimestamp: '2026-04-10T10:00:00Z',
+          firstTimestamp: '2026-04-10T10:00:00',
+          lastTimestamp: '2026-04-10T10:00:00',
           totalCostUSD: 10,
           totalInputTokens: 0, totalOutputTokens: 0, totalCacheReadTokens: 0, totalCacheWriteTokens: 0,
           apiCalls: 2,
           turns: [
             {
-              userMessage: 'x', timestamp: '2026-04-10T10:00:00Z', sessionId: 's1',
+              userMessage: 'x', timestamp: '2026-04-10T10:00:00', sessionId: 's1',
               category: 'coding', retries: 0, hasEdits: false,
               assistantCalls: [
-                makeCall('2026-04-10T10:00:00Z', 7, 'Opus 4.7', 'claude'),
-                makeCall('2026-04-10T10:00:00Z', 3, 'gpt-5', 'codex'),
+                makeCall('2026-04-10T10:00:00', 7, 'Opus 4.7', 'claude'),
+                makeCall('2026-04-10T10:00:00', 3, 'gpt-5', 'codex'),
               ],
             },
           ],


### PR DESCRIPTION
## Summary

- Drop `Z` suffix from test timestamps in `tests/day-aggregator.test.ts` so date bucketing tests pass in all timezones
- Timestamps with `Z` are UTC, which shifts dates in non-UTC zones (e.g. `Apr 9 10:00Z` becomes `Apr 8 22:00` in UTC-12)
- Local timestamps without `Z` match how the aggregator actually interprets dates
- Verified passing in UTC+12, UTC-14, and default timezone

Based on #112 by @lfl1337, extended to cover all affected timestamps (the original PR only fixed 2 of 17).