### PR TITLE
fix(menubar): make provider strip reachable and mouse-wheel scrollable

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
@@ -1,26 +1,111 @@
+import AppKit
 import SwiftUI
+
+/// Shared state read by the NSEvent local monitor closure. The closure
+/// snapshots its captured environment at install time, so SwiftUI @State
+/// can't be used directly — a reference-type holder keeps the latest hover
+/// status visible to the monitor across SwiftUI updates.
+@MainActor
+final class AgentTabStripScrollState {
+    static let shared = AgentTabStripScrollState()
+    var isStripHovered: Bool = false
+}
 
 struct AgentTabStrip: View {
     @Environment(AppStore.self) private var store
+    @State private var stripViewportWidth: CGFloat = 0
+    @State private var stripContentWidth: CGFloat = 0
+    @State private var scrollWheelMonitor: Any?
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 5) {
-                ForEach(visibleFilters) { filter in
-                    AgentTab(
-                        filter: filter,
-                        cost: cost(for: filter),
-                        isActive: store.selectedProvider == filter,
-                        quota: store.quotaSummary(for: filter)
-                    ) {
-                        store.switchTo(provider: filter)
+        GeometryReader { viewportGeo in
+            ScrollViewReader { proxy in
+                HStack(spacing: 4) {
+                    if isOverflowing {
+                        Button {
+                            selectAdjacentProvider(direction: -1, proxy: proxy)
+                        } label: {
+                            Image(systemName: "chevron.left")
+                                .font(.system(size: 10, weight: .semibold))
+                                .frame(width: 18, height: 18)
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(canMoveBackward ? Color.primary : Color.secondary.opacity(0.35))
+                        .disabled(!canMoveBackward)
+                        .help("Show previous providers")
+                    }
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 5) {
+                            ForEach(visibleFilters) { filter in
+                                AgentTab(
+                                    filter: filter,
+                                    cost: cost(for: filter),
+                                    isActive: store.selectedProvider == filter,
+                                    quota: store.quotaSummary(for: filter)
+                                ) {
+                                    store.switchTo(provider: filter)
+                                    withAnimation(.easeInOut(duration: 0.18)) {
+                                        proxy.scrollTo(filter.id, anchor: .center)
+                                    }
+                                }
+                                .id(filter.id)
+                            }
+                        }
+                        .background(
+                            GeometryReader { contentGeo in
+                                Color.clear
+                                    .onAppear {
+                                        stripContentWidth = contentGeo.size.width
+                                    }
+                                    .onChange(of: contentGeo.size.width) { _, newWidth in
+                                        stripContentWidth = newWidth
+                                    }
+                            }
+                        )
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
+                    .padding(.bottom, 4)
+                    .onHover { hovering in
+                        AgentTabStripScrollState.shared.isStripHovered = hovering
+                    }
+
+                    if isOverflowing {
+                        Button {
+                            selectAdjacentProvider(direction: 1, proxy: proxy)
+                        } label: {
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 10, weight: .semibold))
+                                .frame(width: 18, height: 18)
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(canMoveForward ? Color.primary : Color.secondary.opacity(0.35))
+                        .disabled(!canMoveForward)
+                        .help("Show next providers")
                     }
                 }
+                .onAppear {
+                    stripViewportWidth = viewportGeo.size.width
+                    installScrollWheelMonitorIfNeeded()
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        proxy.scrollTo(store.selectedProvider.id, anchor: .center)
+                    }
+                }
+                .onChange(of: viewportGeo.size.width) { _, newWidth in
+                    stripViewportWidth = newWidth
+                }
+                .onChange(of: store.selectedProvider) { _, newProvider in
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        proxy.scrollTo(newProvider.id, anchor: .center)
+                    }
+                }
+                .onDisappear {
+                    removeScrollWheelMonitorIfNeeded()
+                }
             }
-            .padding(.horizontal, 12)
-            .padding(.top, 8)
-            .padding(.bottom, 4)
         }
+        .frame(height: 38)
     }
 
     private var todayAll: MenubarPayload {
@@ -53,6 +138,60 @@ struct AgentTabStrip: View {
         )
         return filter.providerKeys.reduce(0.0) { sum, key in
             sum + (providers[key] ?? 0)
+        }
+    }
+
+    private var currentFilterIndex: Int {
+        visibleFilters.firstIndex(of: store.selectedProvider) ?? 0
+    }
+
+    private var canMoveBackward: Bool { currentFilterIndex > 0 }
+    private var canMoveForward: Bool { currentFilterIndex < visibleFilters.count - 1 }
+    private var isOverflowing: Bool { stripContentWidth > (stripViewportWidth - 30) }
+
+    private func selectAdjacentProvider(direction: Int, proxy: ScrollViewProxy) {
+        guard !visibleFilters.isEmpty else { return }
+        let targetIndex = min(max(currentFilterIndex + direction, 0), visibleFilters.count - 1)
+        let target = visibleFilters[targetIndex]
+        store.switchTo(provider: target)
+        withAnimation(.easeInOut(duration: 0.18)) {
+            proxy.scrollTo(target.id, anchor: .center)
+        }
+    }
+
+    /// Standard mouse wheels emit vertical-only scroll deltas, which a horizontal
+    /// `ScrollView` ignores. While the cursor is over the strip we transpose
+    /// vertical-axis scroll fields onto the horizontal axis so the underlying
+    /// NSScrollView receives a real horizontal delta. Trackpad events (precise
+    /// deltas, with native horizontal component) are passed through untouched
+    /// so vertical scrolling elsewhere in the popover is unaffected.
+    private func installScrollWheelMonitorIfNeeded() {
+        guard scrollWheelMonitor == nil else { return }
+        scrollWheelMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
+            guard AgentTabStripScrollState.shared.isStripHovered,
+                  !event.hasPreciseScrollingDeltas,
+                  abs(event.scrollingDeltaX) < 0.001,
+                  abs(event.scrollingDeltaY) > 0,
+                  let cg = event.cgEvent?.copy() else {
+                return event
+            }
+            let lineDeltaY = cg.getIntegerValueField(.scrollWheelEventDeltaAxis1)
+            let pointDeltaY = cg.getDoubleValueField(.scrollWheelEventPointDeltaAxis1)
+            let fixedDeltaY = cg.getDoubleValueField(.scrollWheelEventFixedPtDeltaAxis1)
+            cg.setIntegerValueField(.scrollWheelEventDeltaAxis1, value: 0)
+            cg.setDoubleValueField(.scrollWheelEventPointDeltaAxis1, value: 0)
+            cg.setDoubleValueField(.scrollWheelEventFixedPtDeltaAxis1, value: 0)
+            cg.setIntegerValueField(.scrollWheelEventDeltaAxis2, value: lineDeltaY)
+            cg.setDoubleValueField(.scrollWheelEventPointDeltaAxis2, value: pointDeltaY)
+            cg.setDoubleValueField(.scrollWheelEventFixedPtDeltaAxis2, value: fixedDeltaY)
+            return NSEvent(cgEvent: cg) ?? event
+        }
+    }
+
+    private func removeScrollWheelMonitorIfNeeded() {
+        if let monitor = scrollWheelMonitor {
+            NSEvent.removeMonitor(monitor)
+            scrollWheelMonitor = nil
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add overflow-aware left/right chevron nav buttons to `AgentTabStrip` so off-screen providers are reachable when chips don't all fit in the popover.
- Translate vertical-only mouse-wheel scroll events into horizontal deltas while the cursor is over the strip so standard mice can scroll it.

## Why

The strip already lays out provider chips inside a horizontal `ScrollView`, which on macOS:

1. Does not scroll from click-drag, so when chips overflow the viewport at the default 360pt popover width (~7+ providers), the off-screen chips are completely unreachable.
2. Ignores vertical-only `NSEvent`s. Standard mouse wheels emit `hasPreciseScrollingDeltas == false` with a non-zero `deltaY` and zero `deltaX`, so a horizontal `ScrollView` silently drops the event. Trackpads, which produce precise deltas with native horizontal components, already worked.

Either bug alone is annoying; together they make some providers unselectable on a mouse-only setup.

## Implementation notes

- Wrap the strip in `ScrollViewReader`. Add left/right chevron buttons that programmatically scroll to the next/previous visible provider via `proxy.scrollTo(target.id, anchor: .center)` and switch the selected provider via the existing `store.switchTo(provider:)`. Buttons are only rendered when `stripContentWidth > stripViewportWidth - 30`, and they disable at the strip's ends.
- Install an `NSEvent.addLocalMonitorForEvents(matching: .scrollWheel)` in `.onAppear` (removed in `.onDisappear`). Track strip hover via `.onHover` into a `@MainActor` singleton `AgentTabStripScrollState` so the monitor closure can read the latest hover state without capturing stale SwiftUI `@State`.
- In the monitor, gate the rewrite on:
  - cursor is currently over the strip
  - `!event.hasPreciseScrollingDeltas` (mouse wheel, not trackpad)
  - `|deltaX| < 0.001` and `|deltaY| > 0` (vertical-only delta)
  When all hold, copy the `CGEvent` and transpose `scrollWheelEventDeltaAxis1` / `PointDeltaAxis1` / `FixedPtDeltaAxis1` onto axis 2, then return the rewritten event so the underlying NSScrollView receives a real horizontal delta. All other events (trackpad, vertical scroll outside the strip, etc.) are passed through untouched, so vertical scrolling of the main popover content is unaffected.

## Test plan

- [x] Run the menubar app with 7+ detected providers at the default popover width. The provider strip shows left/right chevrons.
- [x] Click the chevrons. Hidden providers become visible and selectable; chevrons disable at the strip ends.
- [x] With a standard mouse wheel, hover the strip and scroll. The strip scrolls horizontally.
- [x] With a trackpad, two-finger horizontal swipe over the strip still scrolls it.
- [x] With a standard mouse wheel, hover the main popover content (outside the strip) and scroll. Vertical scrolling of the main content still works as before.
- [x] Open the popover on a configuration where providers fit without overflow. Chevrons do not appear.

Fixes #333. Related to #332.

Made with [Cursor](https://cursor.com)