### PR TITLE
fix: invalidate Cursor cache after missing-createdAt fix

### DIFF
--- a/src/cursor-cache.ts
+++ b/src/cursor-cache.ts
@@ -11,7 +11,9 @@ import type { ParsedProviderCall } from './providers/types.js'
 // router relies on those composer ids to bucket calls per project.
 // Version 2 caches contain `sessionId: 'unknown'` for every call and would
 // route everything to the orphan project, so we invalidate them.
-const CURSOR_CACHE_VERSION = 3
+// Bumped to 4 after skipping bubble rows without createdAt: version 3 caches
+// could contain historical Cursor bubbles timestamped with the parse time.
+const CURSOR_CACHE_VERSION = 4
 
 type ResultCache = {
   version?: number
@@ -23,7 +25,7 @@ type ResultCache = {
 const CACHE_FILE = 'cursor-results.json'
 
 function getCacheDir(): string {
-  return join(homedir(), '.cache', 'codeburn')
+  return process.env['CODEBURN_CACHE_DIR'] ?? join(homedir(), '.cache', 'codeburn')
 }
 
 function getCachePath(): string {

--- a/tests/cursor-cache.test.ts
+++ b/tests/cursor-cache.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { readCachedResults } from '../src/cursor-cache.js'
+
+let tmpDir: string
+let oldCacheDir: string | undefined
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'cursor-cache-'))
+  oldCacheDir = process.env['CODEBURN_CACHE_DIR']
+  process.env['CODEBURN_CACHE_DIR'] = join(tmpDir, 'cache')
+})
+
+afterEach(async () => {
+  if (oldCacheDir === undefined) {
+    delete process.env['CODEBURN_CACHE_DIR']
+  } else {
+    process.env['CODEBURN_CACHE_DIR'] = oldCacheDir
+  }
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+describe('cursor result cache', () => {
+  it('invalidates v3 caches written before the missing-createdAt fix', async () => {
+    const dbPath = join(tmpDir, 'state.vscdb')
+    await writeFile(dbPath, 'cursor db')
+    const fp = await stat(dbPath)
+
+    const cacheDir = process.env['CODEBURN_CACHE_DIR']!
+    await mkdir(cacheDir, { recursive: true })
+    await writeFile(
+      join(cacheDir, 'cursor-results.json'),
+      JSON.stringify({
+        version: 3,
+        dbMtimeMs: fp.mtimeMs,
+        dbSizeBytes: fp.size,
+        calls: [],
+      }),
+    )
+
+    await expect(readCachedResults(dbPath)).resolves.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Bump Cursor result cache version from 3 to 4 so stale v3 caches are invalidated.
- Respect `CODEBURN_CACHE_DIR` for Cursor result cache, matching docs and enabling isolated cache tests.
- Add a regression test for old v3 Cursor caches created before the missing-`createdAt` fix.

## Why

This follows up on `fe2e622` ("Skip Cursor bubble rows that lack a createdAt timestamp") from PR #321; it invalidates caches generated before that parser fix.

That parser fix made fresh parsing skip Cursor bubble rows without `createdAt`, but existing `~/.cache/codeburn/cursor-results.json` files could still contain v3 cached calls timestamped with parse time.

If the Cursor DB mtime/size did not change, CodeBurn would continue trusting that stale cache and still report phantom current-day usage.

## Testing

- `npm test -- tests/cursor-cache.test.ts tests/providers/cursor.test.ts tests/providers/cursor-bubble-dedup.test.ts tests/providers/cursor-workspace-breakdown.test.ts`
- `npx tsc --noEmit`

## Notes

This does not change Cursor parsing logic. It only invalidates previously poisoned Cursor result caches and adds coverage for that behavior.