### PR TITLE
Fix OpenCode router calls with missing usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@
   child and grandchild agent sessions contribute token and tool usage under
   the discovered root session while still excluding child sessions from
   top-level discovery to avoid double counting.
+- **OpenCode router sessions with missing usage are still reported.**
+  Some OpenCode router/provider combinations can persist assistant messages
+  with text or tool activity but zero token and cost fields. The OpenCode
+  parser now keeps those turns as zero-cost calls instead of dropping the
+  session entirely. Closes #341.
 
 ## 0.9.9 - 2026-05-15
 

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -32,6 +32,9 @@ Per `<sessionId>:<messageId>`.
   token, and tool usage back to the root session.
 - Each message's `parts` are indexed; preserving the order matters for reasoning-token correctness.
 - Tokens are reported across `input`, `output`, `reasoning`, `cache.read`, and `cache.write`. Anthropic semantics.
+- Assistant messages with missing router usage are kept as zero-cost calls
+  when their parts contain non-empty text or tool activity. Empty zero-usage
+  assistant placeholders are still skipped.
 - External MCP tools are stored as `<server>_<tool>` names (for example
   `clickup_clickup_get_task`). The provider normalizes those to CodeBurn's
   canonical `mcp__<server>__<tool>` names before aggregation so shared MCP

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -264,16 +264,19 @@ function createParser(
             cacheWrite: data.tokens?.cache?.write ?? 0,
           }
 
+          const msgParts = partsByMsg.get(msg.id) ?? []
+          const toolParts = msgParts.filter((p) => p.type === 'tool' && normalizeToolName(p.tool))
+          const hasTextOutput = msgParts.some((p) => p.type === 'text' && typeof p.text === 'string' && p.text.trim().length > 0)
+          const hasActivity = hasTextOutput || toolParts.length > 0
+
           const allZero =
             tokens.input === 0 &&
             tokens.output === 0 &&
             tokens.reasoning === 0 &&
             tokens.cacheRead === 0 &&
             tokens.cacheWrite === 0
-          if (allZero && (data.cost ?? 0) === 0) continue
+          if (allZero && (data.cost ?? 0) === 0 && !hasActivity) continue
 
-          const msgParts = partsByMsg.get(msg.id) ?? []
-          const toolParts = msgParts.filter((p) => p.type === 'tool')
           const tools = toolParts
             .map((p) => normalizeToolName(p.tool))
             .filter(Boolean)

--- a/tests/providers/opencode.test.ts
+++ b/tests/providers/opencode.test.ts
@@ -469,6 +469,49 @@ skipUnlessSqlite('opencode provider - session parsing', () => {
     expect(calls).toHaveLength(0)
   })
 
+  it('keeps zero-usage assistant messages when router responses contain text', async () => {
+    const dbPath = createTestDb(tmpDir)
+    withTestDb(dbPath, (db) => {
+      insertSession(db, 'sess-1')
+      insertMessage(db, 'msg-u1', 'sess-1', 1700000000000, { role: 'user' })
+      insertPart(db, 'part-u1', 'msg-u1', 'sess-1', { type: 'text', text: 'use the configured router' })
+      insertMessage(db, 'msg-a1', 'sess-1', 1700000001000, {
+        role: 'assistant', modelID: 'edenai/router-model', cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      })
+      insertPart(db, 'part-a1', 'msg-a1', 'sess-1', { type: 'text', text: 'router response text' })
+    })
+
+    const calls = await collectCalls(createOpenCodeProvider(tmpDir), dbPath, 'sess-1')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.model).toBe('edenai/router-model')
+    expect(calls[0]!.inputTokens).toBe(0)
+    expect(calls[0]!.outputTokens).toBe(0)
+    expect(calls[0]!.costUSD).toBe(0)
+    expect(calls[0]!.userMessage).toBe('use the configured router')
+  })
+
+  it('keeps zero-usage assistant messages when router responses contain tool calls', async () => {
+    const dbPath = createTestDb(tmpDir)
+    withTestDb(dbPath, (db) => {
+      insertSession(db, 'sess-1')
+      insertMessage(db, 'msg-a1', 'sess-1', 1700000001000, {
+        role: 'assistant', modelID: 'edenai/router-model', cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      })
+      insertPart(db, 'part-a1', 'msg-a1', 'sess-1', {
+        type: 'tool', tool: 'bash',
+        state: { status: 'completed', input: { command: 'npm test' } },
+      })
+    })
+
+    const calls = await collectCalls(createOpenCodeProvider(tmpDir), dbPath, 'sess-1')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.tools).toEqual(['Bash'])
+    expect(calls[0]!.bashCommands).toEqual(['npm'])
+    expect(calls[0]!.costUSD).toBe(0)
+  })
+
   it('deduplicates messages across parses', async () => {
     const dbPath = createTestDb(tmpDir)
     withTestDb(dbPath, (db) => {


### PR DESCRIPTION
## Summary

Fixes #341 for OpenCode users whose router/provider writes assistant activity but does not persist token or cost usage metadata.

The reporter uses OpenCode through EdenAI as a router. In that kind of setup, OpenCode can still store the assistant response and tool activity in the `part` table while the assistant message usage fields remain all zero. CodeBurn treated those rows as empty placeholders and skipped them, which could make OpenCode look like it had no usage at all.

## Root Cause

The OpenCode parser reads two tables:

- `message`: assistant/user metadata, including `role`, `modelID`, `tokens`, and `cost`
- `part`: message content and tool calls

Before this PR, CodeBurn skipped every assistant message where all token fields and cost were zero:

```ts
if (allZero && (data.cost ?? 0) === 0) continue
```

That is safe for truly empty assistant placeholders, but too aggressive for router-backed sessions. A router can produce a real assistant turn like this:

```json
// message.data
{
  "role": "assistant",
  "modelID": "edenai/router-model",
  "cost": 0,
  "tokens": {
    "input": 0,
    "output": 0,
    "reasoning": 0,
    "cache": { "read": 0, "write": 0 }
  }
}
```

while still having real activity in `part`:

```json
// part.data, text response
{ "type": "text", "text": "router response text" }
```

or:

```json
// part.data, tool activity
{
  "type": "tool",
  "tool": "bash",
  "state": { "input": { "command": "npm test" } }
}
```

Previously both examples were dropped because usage was zero. That is why the provider could report no OpenCode usage even though OpenCode had real assistant turns.

## What Changed

The skip condition now distinguishes empty placeholders from zero-usage real activity:

- Keep the assistant call if usage is zero but `part` contains non-empty text.
- Keep the assistant call if usage is zero but `part` contains a valid tool call.
- Still skip assistant rows with zero usage and no text/tool activity.

The kept calls intentionally remain zero-token and zero-cost. This avoids inventing token totals or spend that OpenCode did not record, while still allowing CodeBurn to show the session/call/tool activity.

## Before / After

Before:

- OpenCode DB has assistant response text or tool parts.
- `message.data.tokens` and `message.data.cost` are all zero.
- CodeBurn drops the assistant message.
- If all assistant turns in the session look like that, CodeBurn reports no OpenCode usage.

After:

- OpenCode DB has assistant response text or tool parts.
- `message.data.tokens` and `message.data.cost` are all zero.
- CodeBurn keeps the assistant message as a zero-cost call.
- Tool names and shell command breakdowns still work when the `part` row contains tools.
- Empty zero-usage placeholders are still ignored.

## Tests Added

Added focused OpenCode SQLite fixtures for:

- zero-usage assistant message with text part -> counted as one zero-cost call
- zero-usage assistant message with tool part -> counted as one zero-cost call, with tool/bash extraction preserved
- existing zero-usage assistant message with no parts -> still skipped

## Validation

- [x] `npx vitest run tests/providers/opencode.test.ts tests/provider-registry.test.ts` - 49/49 tests passed.
- [x] `npx tsc --noEmit --pretty false` - passed.
- [x] `npm run build` - passed.
- [x] `git diff --check` - passed.
- [x] Argus-style review - PASS.
- [x] Claude Opus 4.7 effort max review - PASS.
- [x] Gemini 3.1 Pro Preview review - PASS.
- [x] GitHub checks: `check`, `assess`, `semgrep` - passed.

## Safety / Scope

This PR does not change OpenCode database discovery paths and does not add a new schema parser. It only relaxes the existing skip logic when the already-read `part` rows prove the assistant turn had real activity.

I did not validate against the reporter's local OpenCode database. The coverage uses synthetic SQLite fixtures matching the reported failure mode, so no local project names, prompts, paths, session IDs, usage values, or private product details are included.
