### PR TITLE
Fix Gemini and Vibe one-shot rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@
   model aliases to priced Kimi K2 entries.
 
 ### Fixed (CLI)
+- **Gemini and Mistral Vibe one-shot rates use provider turn grouping.**
+  Provider calls that belong to the same user turn are cached together, so
+  retry detection can see multi-message `Edit -> Bash -> Edit` flows instead
+  of counting each assistant message as an independent one-shot turn. Mistral
+  Vibe now splits assistant-message tool calls into turn-grouped calls while
+  preserving cumulative session token totals, and it prefers
+  `meta.json.stats.session_cost` over price-derived estimates when available
+  because current Vibe logs do not expose cache token fields. Session cache is
+  bumped to v2 so existing Gemini/Vibe cache entries are re-derived. Closes
+  #351.
 - **OpenCode child sessions are attributed to their root session.** The
   OpenCode parser now walks the unarchived `session.parent_id` subtree so
   child and grandchild agent sessions contribute token and tool usage under

--- a/docs/providers/mistral-vibe.md
+++ b/docs/providers/mistral-vibe.md
@@ -21,7 +21,11 @@ Subagent traces are stored under a parent session's `agents/` folder with the sa
 
 ## Caching
 
-None.
+Current Vibe local logs do not expose cache-read/cache-write token fields, so
+CodeBurn reports cache token counts as `0`. When `meta.json.stats.session_cost`
+is present, CodeBurn uses that session total instead of re-estimating from
+prompt/completion token prices because it is the best cache-aware cost signal
+available in the local log shape.
 
 ## Deduplication
 
@@ -29,8 +33,8 @@ Per `mistral-vibe:<session_id>`.
 
 ## Quirks
 
-- **Usage is cumulative per session.** Vibe does not write per-assistant-message token usage into `messages.jsonl`; token counts come from `meta.json.stats.session_prompt_tokens` and `session_completion_tokens`. CodeBurn emits one usage record per Vibe session.
-- **Cost prefers Vibe's own model prices.** `meta.json.stats.input_price_per_million` and `output_price_per_million` are used first, with the active model config as a fallback. LiteLLM pricing is only used when Vibe provides no price data.
+- **Usage is cumulative per session.** Vibe does not write per-assistant-message token usage into `messages.jsonl`; token counts come from `meta.json.stats.session_prompt_tokens` and `session_completion_tokens`. CodeBurn splits assistant-message tools into their user turns for classification and distributes the cumulative token/cost totals across those assistant calls so session totals remain unchanged.
+- **Cost prefers Vibe's own session total.** `meta.json.stats.session_cost` is used first. If it is missing, `meta.json.stats.input_price_per_million` and `output_price_per_million` are used with the active model config as a fallback. LiteLLM pricing is only used when Vibe provides no price data.
 - **Project names come from metadata.** Discovery uses `meta.json.environment.working_directory` and falls back to the session directory name if that field is missing.
 - **Tool calls come from messages.** Assistant `tool_calls[*].function.name` is normalized to the standard CodeBurn names (`bash` to `Bash`, `search_replace` to `Edit`, etc.). Bash commands are extracted from `function.arguments.command`.
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1517,6 +1517,32 @@ function providerCallToTurn(call: ParsedProviderCall): ParsedTurn {
 
 // ── Cache Conversion ───────────────────────────────────────────────────
 
+function providerCallToCachedCall(call: ParsedProviderCall): CachedCall {
+  return {
+    provider: call.provider,
+    model: call.model,
+    usage: {
+      inputTokens: call.inputTokens,
+      outputTokens: call.outputTokens,
+      cacheCreationInputTokens: call.cacheCreationInputTokens,
+      cacheReadInputTokens: call.cacheReadInputTokens,
+      cachedInputTokens: call.cachedInputTokens,
+      reasoningTokens: call.reasoningTokens,
+      webSearchRequests: call.webSearchRequests,
+      cacheCreationOneHourTokens: 0,
+    },
+    costUSD: call.provider === 'mistral-vibe' ? call.costUSD : undefined,
+    speed: call.speed,
+    timestamp: call.timestamp,
+    tools: call.tools,
+    bashCommands: call.bashCommands,
+    skills: [],
+    deduplicationKey: call.deduplicationKey,
+    project: call.project,
+    projectPath: call.projectPath,
+  }
+}
+
 function apiCallToCachedCall(call: ParsedApiCall): CachedCall {
   return {
     provider: call.provider,
@@ -1545,29 +1571,36 @@ function providerCallToCachedTurn(call: ParsedProviderCall): CachedTurn {
     timestamp: call.timestamp,
     sessionId: call.sessionId,
     userMessage: call.userMessage.slice(0, 2000),
-    calls: [{
-      provider: call.provider,
-      model: call.model,
-      usage: {
-        inputTokens: call.inputTokens,
-        outputTokens: call.outputTokens,
-        cacheCreationInputTokens: call.cacheCreationInputTokens,
-        cacheReadInputTokens: call.cacheReadInputTokens,
-        cachedInputTokens: call.cachedInputTokens,
-        reasoningTokens: call.reasoningTokens,
-        webSearchRequests: call.webSearchRequests,
-        cacheCreationOneHourTokens: 0,
-      },
-      speed: call.speed,
-      timestamp: call.timestamp,
-      tools: call.tools,
-      bashCommands: call.bashCommands,
-      skills: [],
-      deduplicationKey: call.deduplicationKey,
-      project: call.project,
-      projectPath: call.projectPath,
-    }],
+    calls: [providerCallToCachedCall(call)],
   }
+}
+
+function providerCallsToCachedTurns(calls: ParsedProviderCall[]): CachedTurn[] {
+  const turns: CachedTurn[] = []
+  const grouped = new Map<string, CachedTurn>()
+
+  for (const call of calls) {
+    if (!call.turnId) {
+      turns.push(providerCallToCachedTurn(call))
+      continue
+    }
+
+    const key = `${call.sessionId}\0${call.turnId}`
+    let turn = grouped.get(key)
+    if (!turn) {
+      turn = {
+        timestamp: call.timestamp,
+        sessionId: call.sessionId,
+        userMessage: call.userMessage.slice(0, 2000),
+        calls: [],
+      }
+      grouped.set(key, turn)
+      turns.push(turn)
+    }
+    turn.calls.push(providerCallToCachedCall(call))
+  }
+
+  return turns
 }
 
 function cachedCallToApiCall(call: CachedCall): ParsedApiCall {
@@ -1592,7 +1625,7 @@ function cachedCallToApiCall(call: CachedCall): ParsedApiCall {
       reasoningTokens: u.reasoningTokens,
       webSearchRequests: u.webSearchRequests,
     },
-    costUSD,
+    costUSD: call.costUSD ?? costUSD,
     tools: call.tools,
     mcpTools: extractMcpTools(call.tools),
     skills: call.skills,
@@ -1725,10 +1758,11 @@ async function parseProviderSources(
       )
 
       try {
-        const turns: CachedTurn[] = []
+        const calls: ParsedProviderCall[] = []
         for await (const call of parser.parse()) {
-          turns.push(providerCallToCachedTurn(call))
+          calls.push(call)
         }
+        const turns = providerCallsToCachedTurns(calls)
         section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns }
         didParse = true
         ;(diskCache as { _dirty?: boolean })._dirty = true

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -67,6 +67,8 @@ function parseSession(data: GeminiSession, seenKeys: Set<string>): ParsedProvide
   const results: ParsedProviderCall[] = []
 
   let lastUserMessage = ''
+  let turnOrdinal = 0
+  let currentTurnId = `${data.sessionId}:prelude`
   let geminiOrdinal = 0
 
   for (const msg of data.messages) {
@@ -76,6 +78,7 @@ function parseSession(data: GeminiSession, seenKeys: Set<string>): ParsedProvide
       } else if (typeof msg.content === 'string') {
         lastUserMessage = msg.content.slice(0, 500)
       }
+      currentTurnId = `${data.sessionId}:turn-${turnOrdinal++}`
       continue
     }
 
@@ -136,6 +139,7 @@ function parseSession(data: GeminiSession, seenKeys: Set<string>): ParsedProvide
       timestamp: tsDate.toISOString(),
       speed: 'standard',
       deduplicationKey: dedupKey,
+      turnId: currentTurnId,
       userMessage: lastUserMessage,
       sessionId: data.sessionId,
     })

--- a/src/providers/mistral-vibe.ts
+++ b/src/providers/mistral-vibe.ts
@@ -38,6 +38,7 @@ const toolNameMap: Record<string, string> = {
 type VibeStats = {
   session_prompt_tokens?: number
   session_completion_tokens?: number
+  session_cost?: number
   input_price_per_million?: number
   output_price_per_million?: number
   tokens_per_second?: number
@@ -75,6 +76,8 @@ type VibeToolCall = {
 type VibeMessage = {
   role?: string
   content?: unknown
+  message_id?: string
+  timestamp?: string
   tool_calls?: VibeToolCall[] | null
 }
 
@@ -179,6 +182,9 @@ function safeNumber(value: unknown): number {
 
 function calculateSessionCost(metadata: VibeMetadata, model: string, inputTokens: number, outputTokens: number): number {
   const stats = metadata.stats ?? {}
+  const sessionCost = safeNumber(stats.session_cost)
+  if (sessionCost > 0) return sessionCost
+
   const configured = activeModelConfig(metadata)
   const inputPrice = safeNumber(stats.input_price_per_million) || safeNumber(configured?.input_price)
   const outputPrice = safeNumber(stats.output_price_per_million) || safeNumber(configured?.output_price)
@@ -216,26 +222,41 @@ function parseToolArguments(raw: string | Record<string, unknown> | null | undef
   }
 }
 
+function extractMessageTools(message: VibeMessage): { tools: string[]; bashCommands: string[] } {
+  const tools: string[] = []
+  const bashCommands: string[] = []
+
+  if (message.role !== 'assistant') return { tools, bashCommands }
+
+  for (const toolCall of message.tool_calls ?? []) {
+    const rawName = toolCall.function?.name
+    if (!rawName) continue
+
+    const mappedName = toolNameMap[rawName] ?? rawName
+    tools.push(mappedName)
+
+    if (mappedName !== 'Bash') continue
+    const args = parseToolArguments(toolCall.function?.arguments)
+    const command = args['command']
+    if (typeof command === 'string') {
+      bashCommands.push(...extractBashCommands(command))
+    }
+  }
+
+  return {
+    tools: [...new Set(tools)],
+    bashCommands: [...new Set(bashCommands)],
+  }
+}
+
 function extractTools(messages: VibeMessage[]): { tools: string[]; bashCommands: string[] } {
   const tools: string[] = []
   const bashCommands: string[] = []
 
   for (const message of messages) {
-    if (message.role !== 'assistant') continue
-    for (const toolCall of message.tool_calls ?? []) {
-      const rawName = toolCall.function?.name
-      if (!rawName) continue
-
-      const mappedName = toolNameMap[rawName] ?? rawName
-      tools.push(mappedName)
-
-      if (mappedName !== 'Bash') continue
-      const args = parseToolArguments(toolCall.function?.arguments)
-      const command = args['command']
-      if (typeof command === 'string') {
-        bashCommands.push(...extractBashCommands(command))
-      }
-    }
+    const extracted = extractMessageTools(message)
+    tools.push(...extracted.tools)
+    bashCommands.push(...extracted.bashCommands)
   }
 
   return {
@@ -267,6 +288,17 @@ function firstUserMessage(messages: VibeMessage[], fallback?: string | null): st
   return (fallback ?? '').slice(0, 500)
 }
 
+function allocateInteger(total: number, index: number, count: number): number {
+  if (count <= 1) return total
+  const base = Math.floor(total / count)
+  const remainder = total % count
+  return base + (index < remainder ? 1 : 0)
+}
+
+function allocateCost(total: number, count: number): number {
+  return count <= 1 ? total : total / count
+}
+
 function createParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
   return {
     async *parse(): AsyncGenerator<ParsedProviderCall> {
@@ -281,33 +313,85 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       if (inputTokens === 0 && outputTokens === 0) return
 
       const sessionId = metadata.session_id || basename(source.path)
-      const deduplicationKey = `mistral-vibe:${sessionId}`
-      if (seenKeys.has(deduplicationKey)) return
-      seenKeys.add(deduplicationKey)
-
       const messages = await readMessages(messagesPath)
       const model = resolveModel(metadata)
-      const { tools, bashCommands } = extractTools(messages)
       const costUSD = calculateSessionCost(metadata, model, inputTokens, outputTokens)
+      const assistantMessages = messages.filter(message => message.role === 'assistant')
+      const fallbackTimestamp = metadata.end_time ?? metadata.start_time ?? ''
 
-      yield {
-        provider: 'mistral-vibe',
-        model,
-        inputTokens,
-        outputTokens,
-        cacheCreationInputTokens: 0,
-        cacheReadInputTokens: 0,
-        cachedInputTokens: 0,
-        reasoningTokens: 0,
-        webSearchRequests: 0,
-        costUSD,
-        tools,
-        bashCommands,
-        timestamp: metadata.end_time ?? metadata.start_time ?? '',
-        speed: 'standard',
-        deduplicationKey,
-        userMessage: firstUserMessage(messages, metadata.title),
-        sessionId,
+      if (assistantMessages.length === 0) {
+        const deduplicationKey = `mistral-vibe:${sessionId}`
+        if (seenKeys.has(deduplicationKey)) return
+        seenKeys.add(deduplicationKey)
+        const { tools, bashCommands } = extractTools(messages)
+
+        yield {
+          provider: 'mistral-vibe',
+          model,
+          inputTokens,
+          outputTokens,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          cachedInputTokens: 0,
+          reasoningTokens: 0,
+          webSearchRequests: 0,
+          costUSD,
+          tools,
+          bashCommands,
+          timestamp: fallbackTimestamp,
+          speed: 'standard',
+          deduplicationKey,
+          userMessage: firstUserMessage(messages, metadata.title),
+          sessionId,
+        }
+        return
+      }
+
+      let currentUserMessage = (metadata.title ?? '').slice(0, 500)
+      let turnOrdinal = 0
+      let currentTurnId = `${sessionId}:prelude`
+      let assistantOrdinal = 0
+
+      for (const message of messages) {
+        if (message.role === 'user') {
+          const text = normalizeContent(message.content).trim()
+          if (text) currentUserMessage = text.slice(0, 500)
+          currentTurnId = `${sessionId}:turn-${turnOrdinal++}`
+          continue
+        }
+
+        if (message.role !== 'assistant') continue
+
+        const messageKey = message.message_id || `idx-${assistantOrdinal}`
+        const deduplicationKey = `mistral-vibe:${sessionId}:${messageKey}`
+        const allocationIndex = assistantOrdinal
+        assistantOrdinal++
+
+        if (seenKeys.has(deduplicationKey)) continue
+        seenKeys.add(deduplicationKey)
+
+        const { tools, bashCommands } = extractMessageTools(message)
+
+        yield {
+          provider: 'mistral-vibe',
+          model,
+          inputTokens: allocateInteger(inputTokens, allocationIndex, assistantMessages.length),
+          outputTokens: allocateInteger(outputTokens, allocationIndex, assistantMessages.length),
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          cachedInputTokens: 0,
+          reasoningTokens: 0,
+          webSearchRequests: 0,
+          costUSD: allocateCost(costUSD, assistantMessages.length),
+          tools,
+          bashCommands,
+          timestamp: message.timestamp ?? fallbackTimestamp,
+          speed: 'standard',
+          deduplicationKey,
+          turnId: currentTurnId,
+          userMessage: currentUserMessage,
+          sessionId,
+        }
       }
     },
   }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -25,6 +25,7 @@ export type ParsedProviderCall = {
   timestamp: string
   speed: 'standard' | 'fast'
   deduplicationKey: string
+  turnId?: string
   userMessage: string
   sessionId: string
   project?: string

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -21,6 +21,7 @@ export type CachedCall = {
   provider: string
   model: string
   usage: CachedUsage
+  costUSD?: number
   speed: 'standard' | 'fast'
   timestamp: string
   tools: string[]
@@ -65,7 +66,7 @@ export type SessionCache = {
 
 // ── Constants ──────────────────────────────────────────────────────────
 
-export const CACHE_VERSION = 1
+export const CACHE_VERSION = 2
 
 const CACHE_FILE = 'session-cache.json'
 const TEMP_FILE_MAX_AGE_MS = 5 * 60 * 1000
@@ -147,6 +148,7 @@ function validateCall(c: unknown): c is CachedCall {
     && typeof o['deduplicationKey'] === 'string'
     && typeof o['timestamp'] === 'string'
     && (o['speed'] === 'standard' || o['speed'] === 'fast')
+    && isOptionalNum(o['costUSD'])
     && isStringArray(o['tools'])
     && isStringArray(o['bashCommands'])
     && isStringArray(o['skills'])
@@ -325,5 +327,3 @@ export async function cleanupOrphanedTempFiles(): Promise<void> {
     }
   } catch {}
 }
-
-

--- a/tests/provider-turn-grouping.test.ts
+++ b/tests/provider-turn-grouping.test.ts
@@ -1,0 +1,170 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DateRange } from '../src/types.js'
+
+let home: string
+let cacheDir: string
+let vibeHome: string
+let originalHome: string | undefined
+let originalCacheDir: string | undefined
+let originalVibeHome: string | undefined
+let clearParserCache: (() => void) | undefined
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), 'codeburn-turn-group-home-'))
+  cacheDir = await mkdtemp(join(tmpdir(), 'codeburn-turn-group-cache-'))
+  vibeHome = await mkdtemp(join(tmpdir(), 'codeburn-turn-group-vibe-'))
+  originalHome = process.env['HOME']
+  originalCacheDir = process.env['CODEBURN_CACHE_DIR']
+  originalVibeHome = process.env['VIBE_HOME']
+  process.env['HOME'] = home
+  process.env['CODEBURN_CACHE_DIR'] = cacheDir
+  process.env['VIBE_HOME'] = vibeHome
+})
+
+afterEach(async () => {
+  clearParserCache?.()
+  clearParserCache = undefined
+  vi.resetModules()
+  if (originalHome === undefined) delete process.env['HOME']
+  else process.env['HOME'] = originalHome
+  if (originalCacheDir === undefined) delete process.env['CODEBURN_CACHE_DIR']
+  else process.env['CODEBURN_CACHE_DIR'] = originalCacheDir
+  if (originalVibeHome === undefined) delete process.env['VIBE_HOME']
+  else process.env['VIBE_HOME'] = originalVibeHome
+  await rm(home, { recursive: true, force: true })
+  await rm(cacheDir, { recursive: true, force: true })
+  await rm(vibeHome, { recursive: true, force: true })
+})
+
+function dayRange(): DateRange {
+  return {
+    start: new Date('2026-05-16T00:00:00.000Z'),
+    end: new Date('2026-05-16T23:59:59.999Z'),
+  }
+}
+
+async function loadParser() {
+  vi.resetModules()
+  const parser = await import('../src/parser.js')
+  clearParserCache = parser.clearSessionCache
+  return parser.parseAllSessions
+}
+
+describe('provider turn grouping', () => {
+  it('groups Gemini assistant messages under their user turn so retries are counted', async () => {
+    const chatsDir = join(home, '.gemini', 'tmp', 'project-a', 'chats')
+    await mkdir(chatsDir, { recursive: true })
+    await writeFile(join(chatsDir, 'session-gemini.json'), JSON.stringify({
+      sessionId: 'gemini-session-1',
+      startTime: '2026-05-16T10:00:00.000Z',
+      messages: [
+        { id: 'u1', timestamp: '2026-05-16T10:00:00.000Z', type: 'user', content: 'implement parser update in src/parser.ts' },
+        {
+          id: 'g1',
+          timestamp: '2026-05-16T10:00:05.000Z',
+          type: 'gemini',
+          content: 'editing',
+          model: 'gemini-3.1-pro-preview',
+          tokens: { input: 100, output: 30 },
+          toolCalls: [{ id: 't1', name: 'edit_file', args: { path: 'src/parser.ts' } }],
+        },
+        {
+          id: 'g2',
+          timestamp: '2026-05-16T10:00:10.000Z',
+          type: 'gemini',
+          content: 'testing',
+          model: 'gemini-3.1-pro-preview',
+          tokens: { input: 80, output: 20 },
+          toolCalls: [{ id: 't2', name: 'run_command', args: { command: 'npm test' } }],
+        },
+        {
+          id: 'g3',
+          timestamp: '2026-05-16T10:00:15.000Z',
+          type: 'gemini',
+          content: 'fixing after test',
+          model: 'gemini-3.1-pro-preview',
+          tokens: { input: 90, output: 25 },
+          toolCalls: [{ id: 't3', name: 'edit_file', args: { path: 'src/parser.ts' } }],
+        },
+      ],
+    }))
+
+    const parseAllSessions = await loadParser()
+    const projects = await parseAllSessions(dayRange(), 'gemini')
+    const session = projects[0]!.sessions[0]!
+    const turn = session.turns[0]!
+
+    expect(session.turns).toHaveLength(1)
+    expect(turn.assistantCalls.map(call => call.deduplicationKey)).toEqual([
+      'gemini:gemini-session-1:g1',
+      'gemini:gemini-session-1:g2',
+      'gemini:gemini-session-1:g3',
+    ])
+    expect(turn.hasEdits).toBe(true)
+    expect(turn.retries).toBe(1)
+    expect(session.categoryBreakdown[turn.category].editTurns).toBe(1)
+    expect(session.categoryBreakdown[turn.category].oneShotTurns).toBe(0)
+  })
+
+  it('groups Mistral Vibe assistant messages and uses Vibe session_cost when present', async () => {
+    const sessionDir = join(vibeHome, 'logs', 'session', 'session_20260516_100000_vibe')
+    await mkdir(sessionDir, { recursive: true })
+    await writeFile(join(sessionDir, 'meta.json'), JSON.stringify({
+      session_id: 'vibe-session-1',
+      start_time: '2026-05-16T10:00:00.000Z',
+      end_time: '2026-05-16T10:01:00.000Z',
+      environment: { working_directory: '/Users/test/project-a' },
+      stats: {
+        session_prompt_tokens: 300,
+        session_completion_tokens: 90,
+        session_cost: 0.123456,
+        input_price_per_million: 100,
+        output_price_per_million: 100,
+      },
+      config: { active_model: 'mistral-medium-3.5', models: [] },
+      title: 'vibe parser update',
+    }))
+    await writeFile(join(sessionDir, 'messages.jsonl'), [
+      { role: 'user', content: 'implement parser update in src/providers/mistral-vibe.ts', message_id: 'u1' },
+      {
+        role: 'assistant',
+        content: 'editing',
+        message_id: 'a1',
+        tool_calls: [{ id: 't1', type: 'function', function: { name: 'search_replace', arguments: '{"file_path":"src/providers/mistral-vibe.ts"}' } }],
+      },
+      {
+        role: 'assistant',
+        content: 'testing',
+        message_id: 'a2',
+        tool_calls: [{ id: 't2', type: 'function', function: { name: 'bash', arguments: '{"command":"npm test"}' } }],
+      },
+      {
+        role: 'assistant',
+        content: 'fixing after test',
+        message_id: 'a3',
+        tool_calls: [{ id: 't3', type: 'function', function: { name: 'write_file', arguments: '{"path":"src/providers/mistral-vibe.ts"}' } }],
+      },
+    ].map(message => JSON.stringify(message)).join('\n') + '\n')
+
+    const parseAllSessions = await loadParser()
+    const projects = await parseAllSessions(dayRange(), 'mistral-vibe')
+    const session = projects[0]!.sessions[0]!
+    const turn = session.turns[0]!
+
+    expect(session.turns).toHaveLength(1)
+    expect(turn.assistantCalls.map(call => call.deduplicationKey)).toEqual([
+      'mistral-vibe:vibe-session-1:a1',
+      'mistral-vibe:vibe-session-1:a2',
+      'mistral-vibe:vibe-session-1:a3',
+    ])
+    expect(turn.retries).toBe(1)
+    expect(session.totalCostUSD).toBeCloseTo(0.123456, 8)
+    expect(session.totalInputTokens).toBe(300)
+    expect(session.totalOutputTokens).toBe(90)
+    expect(session.categoryBreakdown[turn.category].oneShotTurns).toBe(0)
+  })
+})

--- a/tests/providers/mistral-vibe.test.ts
+++ b/tests/providers/mistral-vibe.test.ts
@@ -29,6 +29,7 @@ function metadata(opts: {
   cwd?: string
   input?: number
   output?: number
+  sessionCost?: number
   inputPrice?: number
   outputPrice?: number
   activeModel?: string
@@ -49,6 +50,7 @@ function metadata(opts: {
     stats: {
       session_prompt_tokens: opts.input ?? 2000,
       session_completion_tokens: opts.output ?? 3000,
+      session_cost: opts.sessionCost,
       input_price_per_million: opts.inputPrice ?? 1.5,
       output_price_per_million: opts.outputPrice ?? 7.5,
       tokens_per_second: 42,
@@ -202,7 +204,22 @@ describe('mistral-vibe provider - parsing', () => {
     expect(call.timestamp).toBe('2026-05-11T10:05:00+00:00')
     expect(call.userMessage).toBe('track Mistral Vibe usage')
     expect(call.sessionId).toBe('session-abc123')
-    expect(call.deduplicationKey).toBe('mistral-vibe:session-abc123')
+    expect(call.deduplicationKey).toBe('mistral-vibe:session-abc123:msg-assistant-1')
+  })
+
+  it('prefers Vibe session_cost over price-derived estimates when present', async () => {
+    const sessionDir = await writeSession('session_20260511_100000_sessiona', metadata({
+      input: 364147,
+      output: 1731,
+      sessionCost: 0.381681,
+      inputPrice: 100,
+      outputPrice: 100,
+    }))
+
+    const calls = await collect(sessionDir, createMistralVibeProvider(tmpDir))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.costUSD).toBe(0.381681)
   })
 
   it('uses configured model prices when stats omit prices', async () => {


### PR DESCRIPTION
## Summary

Addresses #351 by fixing how non-Claude provider calls are cached for one-shot/retry classification.

The core issue was not cache hits. CodeBurn's one-shot rate is based on edit turns with zero detected retries/self-corrections. For Gemini and Mistral Vibe, the cached turn shape did not give the classifier enough structure to see retries inside a single user request.

This PR adds provider-level turn grouping so related assistant calls are cached under the same user turn. That lets the existing classifier see multi-message flows like `Edit -> Bash -> Edit` and count them as retries instead of reporting them as independent one-shot turns.

Closes #351.

## Root Cause

The classifier already knows how to detect retries when a turn contains multiple assistant calls:

```text
User: implement parser fix
Assistant call 1: Edit
Assistant call 2: Bash
Assistant call 3: Edit
```

That should be one edit turn with one retry, because the assistant edited, ran a command, then edited again.

Before this PR, provider calls emitted through `ParsedProviderCall` were converted into cached turns one call at a time. So Gemini assistant messages were cached like this:

```text
Turn 1: [Edit]  -> retries = 0, one-shot
Turn 2: [Bash]  -> no edit turn
Turn 3: [Edit]  -> retries = 0, one-shot
```

The classifier never saw the full `Edit -> Bash -> Edit` sequence in one turn, so the one-shot rate could look artificially perfect.

## Example: Gemini

Gemini already exposes per-assistant-message token/tool data, so no private user logs are needed to validate the fix.

Synthetic fixture shape:

```json
[
  { "type": "user", "content": "implement parser update in src/parser.ts" },
  { "type": "gemini", "id": "g1", "toolCalls": [{ "name": "edit_file" }] },
  { "type": "gemini", "id": "g2", "toolCalls": [{ "name": "run_command", "args": { "command": "npm test" } }] },
  { "type": "gemini", "id": "g3", "toolCalls": [{ "name": "edit_file" }] }
]
```

Before:

```text
3 cached turns, each with 1 assistant call
retry detector cannot see Edit -> Bash -> Edit
oneShotTurns can be inflated
```

After:

```text
1 cached turn, with assistant calls [g1, g2, g3]
retries = 1
oneShotTurns = 0
```

The new regression test asserts exactly that.

## Example: Mistral Vibe

Mistral Vibe's local logs are different from Gemini:

- `meta.json.stats` has cumulative session totals such as `session_prompt_tokens`, `session_completion_tokens`, and `session_cost`.
- `messages.jsonl` has user/assistant/tool message structure and assistant `tool_calls`.
- Current Vibe logs do not expose cache-read/cache-write token fields.

So this PR does not invent cache token counts. CodeBurn still reports Vibe cache token counts as `0` until Vibe persists those fields locally.

What this PR does instead:

1. Splits Vibe assistant messages into per-message provider calls so the classifier can see assistant message order.
2. Groups those calls under the current user turn via `turnId`.
3. Distributes cumulative session prompt/completion tokens across the assistant calls while preserving exact session totals.
4. Prefers `meta.json.stats.session_cost` when present, because that is the best local cost signal available and may already reflect Vibe-side accounting better than CodeBurn's price-derived estimate.
5. Preserves Vibe's provider-calculated cost through the session cache so `session_cost` is not lost during cached reads.

Synthetic Vibe fixture shape:

```json
// meta.json
{
  "stats": {
    "session_prompt_tokens": 300,
    "session_completion_tokens": 90,
    "session_cost": 0.123456
  }
}
```

```json
// messages.jsonl, simplified
{ "role": "user", "content": "implement parser update" }
{ "role": "assistant", "message_id": "a1", "tool_calls": [{ "function": { "name": "search_replace" } }] }
{ "role": "assistant", "message_id": "a2", "tool_calls": [{ "function": { "name": "bash", "arguments": "{\"command\":\"npm test\"}" } }] }
{ "role": "assistant", "message_id": "a3", "tool_calls": [{ "function": { "name": "write_file" } }] }
```

After parsing:

```text
1 cached turn, with assistant calls [a1, a2, a3]
retries = 1
oneShotTurns = 0
totalInputTokens = 300
totalOutputTokens = 90
totalCostUSD = 0.123456
```

## What Changed

- Add optional `ParsedProviderCall.turnId` so providers can mark calls that belong to the same user turn.
- Group parsed provider calls into cached turns by `(sessionId, turnId)` when `turnId` is present.
- Assign Gemini assistant calls to the current user turn.
- Split Mistral Vibe assistant messages into per-message calls grouped under the current user turn.
- Prefer `meta.json.stats.session_cost` for Mistral Vibe cost when present.
- Add optional cached `costUSD` for Vibe calls so provider-calculated Vibe cost survives cache round-trips.
- Bump session cache to v2 so existing cached Gemini/Vibe entries are re-derived with the new grouping.
- Document current Vibe cache limitations and the `session_cost` behavior.

## Validation

### Behavior proof

The main proof is `tests/provider-turn-grouping.test.ts`, which exercises the exact suspicious one-shot shape rather than only checking that the suite is green.

Gemini fixture:

```text
input:  user prompt + Gemini assistant messages [edit_file, run_command, edit_file]
output: one parsed CodeBurn session turn with assistant calls [g1, g2, g3]
asserts: retries = 1
asserts: category oneShotTurns = 0
```

This proves the classifier can now see the full `Edit -> Bash -> Edit` sequence for Gemini instead of treating each assistant message as a separate one-shot candidate.

Mistral Vibe fixture:

```text
input:  meta.json session totals + session_cost + messages [search_replace, bash, write_file]
output: one parsed CodeBurn session turn with assistant calls [a1, a2, a3]
asserts: retries = 1
asserts: category oneShotTurns = 0
asserts: totalInputTokens = 300
asserts: totalOutputTokens = 90
asserts: totalCostUSD = 0.123456
```

This proves both sides of the Vibe fix: retry detection sees the multi-message edit flow, and Vibe's own `session_cost` survives parser/cache round-trip instead of being replaced by a price-derived estimate.

`tests/providers/mistral-vibe.test.ts` also includes a direct cost regression where the fixture sets an intentionally large token price but `session_cost = 0.381681`; the provider returns exactly `0.381681`, proving `session_cost` takes precedence over estimated pricing.

### Command results

- [x] `./node_modules/.bin/tsc --noEmit --pretty false`
- [x] `npx vitest run tests/provider-turn-grouping.test.ts tests/providers/gemini.test.ts tests/providers/mistral-vibe.test.ts tests/parser-gemini-cache.test.ts tests/session-cache.test.ts` - 68 tests passed
- [x] `npm run build`
- [x] `npm test -- --run` - 63 files / 874 tests passed
- [x] `git diff --check`
- [x] Claude Opus 4.7 effort max review: PASS
- [x] Gemini 3.1 Pro Preview review: PASS
- [x] GitHub checks: `check`, `assess`, and `semgrep` pass

## Notes

Validation uses synthetic fixtures only. No private prompts, project names, session IDs, or local user logs were used.

This PR does not claim exact Vibe cache token accounting. Current Vibe local logs do not include cache token fields, so exact cache read/write token reporting requires an upstream Vibe logging change.
