### PR TITLE
Add MCP and skill reliability report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 ### Added (CLI)
+- **MCP and skill reliability report.** `codeburn optimize` now detects MCP
+  servers and skills whose edit turns are disproportionately retry-heavy,
+  using turn-level MCP/Skill call evidence and a shared-turn token estimate so
+  one retry-heavy turn is not double-counted across multiple capabilities.
 - **Agent and subagent tracking coverage.** Gemini sessions now emit one
   provider call per assistant message with token usage instead of one aggregate
   call per session, preserving per-message tools, bash commands, timestamps,

--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -99,6 +99,15 @@ const WORTH_IT_LOW_MAX_CANDIDATES = 2
 const WORTH_IT_LOW_MAX_TOTAL_COST_USD = 10
 const WORTH_IT_HIGH_MIN_CANDIDATES = 10
 const WORTH_IT_HIGH_TOTAL_COST_USD = 50
+const CAPABILITY_RELIABILITY_MIN_EDIT_TURNS = 5
+const CAPABILITY_RELIABILITY_MIN_RETRY_TURNS = 3
+const CAPABILITY_RELIABILITY_MIN_RETRY_RATE = 0.50
+const CAPABILITY_RELIABILITY_RECOVERY_FRACTION = 0.50
+const CAPABILITY_RELIABILITY_PREVIEW = 5
+const CAPABILITY_RELIABILITY_LOW_MAX_CANDIDATES = 1
+const CAPABILITY_RELIABILITY_LOW_MAX_TOKENS = 50_000
+const CAPABILITY_RELIABILITY_HIGH_MIN_CANDIDATES = 5
+const CAPABILITY_RELIABILITY_HIGH_IMPACT_TOKENS = 200_000
 
 // ============================================================================
 // Scoring constants
@@ -891,6 +900,245 @@ export function detectMcpToolCoverage(
         ? 'Remove the underused server, or trim its tools in your MCP config:'
         : 'Remove underused servers, or trim their tools in your MCP config:',
       text: removeCommands.join('\n'),
+    },
+  }
+}
+
+type CapabilityKind = 'mcp' | 'skill'
+
+type CapabilityRef = {
+  kind: CapabilityKind
+  name: string
+}
+
+type CapabilityReliabilityAccumulator = CapabilityRef & {
+  editTurns: number
+  retryTurns: number
+  oneShotTurns: number
+  retries: number
+  tokensTouched: number
+  projects: Set<string>
+  retryTurnSavings: Map<string, number>
+}
+
+export type CapabilityReliabilityCandidate = {
+  kind: CapabilityKind
+  name: string
+  editTurns: number
+  retryTurns: number
+  oneShotTurns: number
+  retries: number
+  retryRate: number
+  tokensTouched: number
+  tokensSaved: number
+  projects: string[]
+}
+
+function capabilityKey(ref: CapabilityRef): string {
+  return `${ref.kind}:${ref.name}`
+}
+
+function formatCapabilityKind(kind: CapabilityKind): string {
+  return kind === 'mcp' ? 'MCP server' : 'skill'
+}
+
+function mcpServerFromToolName(fqn: string): string | null {
+  const parts = fqn.split('__')
+  if (parts.length < 3 || parts[0] !== 'mcp') return null
+  return parts[1] || null
+}
+
+function collectReliabilityCapabilities(turn: ProjectSummary['sessions'][number]['turns'][number]): Map<string, CapabilityRef> {
+  const capabilities = new Map<string, CapabilityRef>()
+
+  for (const call of turn.assistantCalls) {
+    for (const fqn of call.mcpTools) {
+      const server = mcpServerFromToolName(fqn)
+      if (!server) continue
+      const ref: CapabilityRef = { kind: 'mcp', name: server }
+      capabilities.set(capabilityKey(ref), ref)
+    }
+    for (const rawSkill of call.skills ?? []) {
+      const skill = rawSkill.trim()
+      if (!skill) continue
+      const ref: CapabilityRef = { kind: 'skill', name: skill }
+      capabilities.set(capabilityKey(ref), ref)
+    }
+  }
+
+  return capabilities
+}
+
+function turnEffectiveTokenTotal(turn: ProjectSummary['sessions'][number]['turns'][number]): number {
+  return Math.round(turn.assistantCalls.reduce((sum, call) =>
+    sum
+    + call.usage.inputTokens
+    + call.usage.outputTokens
+    + call.usage.cacheCreationInputTokens * CACHE_WRITE_MULTIPLIER
+    + call.usage.cacheReadInputTokens * CACHE_READ_DISCOUNT,
+  0))
+}
+
+function reliabilityTurnKey(
+  project: ProjectSummary,
+  session: ProjectSummary['sessions'][number],
+  turn: ProjectSummary['sessions'][number]['turns'][number],
+  turnIndex: number,
+): string {
+  return `${project.projectPath || project.project}:${session.sessionId}:${turn.timestamp}:${turnIndex}`
+}
+
+function getReliabilityAccumulator(
+  stats: Map<string, CapabilityReliabilityAccumulator>,
+  ref: CapabilityRef,
+): CapabilityReliabilityAccumulator {
+  const key = capabilityKey(ref)
+  let acc = stats.get(key)
+  if (!acc) {
+    acc = {
+      ...ref,
+      editTurns: 0,
+      retryTurns: 0,
+      oneShotTurns: 0,
+      retries: 0,
+      tokensTouched: 0,
+      projects: new Set(),
+      retryTurnSavings: new Map(),
+    }
+    stats.set(key, acc)
+  }
+  return acc
+}
+
+function findCapabilityReliabilityCandidates(projects: ProjectSummary[]): CapabilityReliabilityCandidate[] {
+  const stats = new Map<string, CapabilityReliabilityAccumulator>()
+
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      for (let turnIndex = 0; turnIndex < session.turns.length; turnIndex++) {
+        const turn = session.turns[turnIndex]!
+        if (!turn.hasEdits) continue
+
+        const capabilities = collectReliabilityCapabilities(turn)
+        if (capabilities.size === 0) continue
+
+        const turnTokens = turnEffectiveTokenTotal(turn)
+        const turnKey = reliabilityTurnKey(project, session, turn, turnIndex)
+        const recoverableTokens = turn.retries > 0
+          ? Math.round(turnTokens * CAPABILITY_RELIABILITY_RECOVERY_FRACTION)
+          : 0
+
+        for (const ref of capabilities.values()) {
+          const acc = getReliabilityAccumulator(stats, ref)
+          acc.editTurns++
+          acc.tokensTouched += turnTokens
+          acc.projects.add(project.project)
+          if (turn.retries > 0) {
+            acc.retryTurns++
+            acc.retries += turn.retries
+            acc.retryTurnSavings.set(turnKey, recoverableTokens)
+          } else {
+            acc.oneShotTurns++
+          }
+        }
+      }
+    }
+  }
+
+  const candidates: CapabilityReliabilityCandidate[] = []
+  for (const acc of stats.values()) {
+    if (acc.editTurns < CAPABILITY_RELIABILITY_MIN_EDIT_TURNS) continue
+    if (acc.retryTurns < CAPABILITY_RELIABILITY_MIN_RETRY_TURNS) continue
+    const retryRate = acc.retryTurns / acc.editTurns
+    if (retryRate < CAPABILITY_RELIABILITY_MIN_RETRY_RATE) continue
+
+    candidates.push({
+      kind: acc.kind,
+      name: acc.name,
+      editTurns: acc.editTurns,
+      retryTurns: acc.retryTurns,
+      oneShotTurns: acc.oneShotTurns,
+      retries: acc.retries,
+      retryRate,
+      tokensTouched: acc.tokensTouched,
+      tokensSaved: Array.from(acc.retryTurnSavings.values()).reduce((sum, tokens) => sum + tokens, 0),
+      projects: Array.from(acc.projects).sort(),
+    })
+  }
+
+  candidates.sort((a, b) =>
+    b.retryRate - a.retryRate
+    || b.retries - a.retries
+    || b.tokensSaved - a.tokensSaved
+    || a.kind.localeCompare(b.kind)
+    || a.name.localeCompare(b.name)
+  )
+  return candidates
+}
+
+export function detectCapabilityReliability(projects: ProjectSummary[]): WasteFinding | null {
+  const candidates = findCapabilityReliabilityCandidates(projects)
+  if (candidates.length === 0) return null
+
+  const candidateKeys = new Set(candidates.map(c => capabilityKey(c)))
+  const uniqueRetryTurnSavings = new Map<string, number>()
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      for (let turnIndex = 0; turnIndex < session.turns.length; turnIndex++) {
+        const turn = session.turns[turnIndex]!
+        if (!turn.hasEdits || turn.retries <= 0) continue
+        const capabilities = collectReliabilityCapabilities(turn)
+        if (capabilities.size === 0) continue
+
+        const hasFlaggedCapability = Array.from(capabilities.keys()).some(key => candidateKeys.has(key))
+        if (!hasFlaggedCapability) continue
+
+        const key = reliabilityTurnKey(project, session, turn, turnIndex)
+        const tokens = Math.round(turnEffectiveTokenTotal(turn) * CAPABILITY_RELIABILITY_RECOVERY_FRACTION)
+        uniqueRetryTurnSavings.set(key, Math.max(uniqueRetryTurnSavings.get(key) ?? 0, tokens))
+      }
+    }
+  }
+
+  const tokensSaved = Array.from(uniqueRetryTurnSavings.values()).reduce((sum, tokens) => sum + tokens, 0)
+  const preview = candidates.slice(0, CAPABILITY_RELIABILITY_PREVIEW)
+  const list = preview.map(c => {
+    const percent = Math.round(c.retryRate * 100)
+    const projects = c.projects.length > 1 ? ` across ${c.projects.length} projects` : ` in ${c.projects[0] ?? 'one project'}`
+    return `${formatCapabilityKind(c.kind)} ${c.name}: ${c.retryTurns}/${c.editTurns} edit turns retried (${percent}%), ${c.retries} retries${projects}`
+  }).join('; ')
+  const extra = candidates.length > preview.length ? `; +${candidates.length - preview.length} more` : ''
+
+  const names = preview
+    .map(c => `${formatCapabilityKind(c.kind)} ${c.name}`)
+    .join(', ')
+
+  let impact: Impact
+  if (candidates.length >= CAPABILITY_RELIABILITY_HIGH_MIN_CANDIDATES || tokensSaved >= CAPABILITY_RELIABILITY_HIGH_IMPACT_TOKENS) {
+    impact = 'high'
+  } else if (candidates.length <= CAPABILITY_RELIABILITY_LOW_MAX_CANDIDATES && tokensSaved < CAPABILITY_RELIABILITY_LOW_MAX_TOKENS) {
+    impact = 'low'
+  } else {
+    impact = 'medium'
+  }
+
+  const kindSet = new Set(candidates.map(c => c.kind))
+  const noun = kindSet.size === 1
+    ? (kindSet.has('mcp') ? 'MCP server' : 'skill')
+    : 'MCP/skill capability'
+  const pluralNoun = noun === 'MCP/skill capability' ? 'MCP/skill capabilities' : `${noun}s`
+  const verb = candidates.length === 1 ? 'correlates' : 'correlate'
+
+  return {
+    title: `${candidates.length} ${candidates.length === 1 ? noun : pluralNoun} ${verb} with retry-heavy edits`,
+    explanation: `Edit turns using these capabilities are retry-heavy: ${list}${extra}. This is a correlation report, not proof of causation; compare the retry-heavy turns with one-shot turns before changing MCP scope or skill instructions.`,
+    impact,
+    tokensSaved,
+    fix: {
+      type: 'paste',
+      destination: 'prompt',
+      label: 'Ask Claude to audit the retry-heavy capability before changing config:',
+      text: `Investigate these retry-correlated capabilities: ${names}. Compare edit turns with retries against one-shot edit turns, identify whether the MCP server or skill actually caused rework, then propose a scoped MCP config or skill-instruction change with session evidence. Do not remove a capability solely because it appears in this report.`,
     },
   }
 }
@@ -1800,6 +2048,7 @@ export async function scanAndDetect(
     () => detectDuplicateReads(toolCalls, dateRange),
     () => detectUnusedMcp(toolCalls, projects, projectCwds, mcpCoverage),
     () => detectMcpToolCoverage(projects, mcpCoverage),
+    () => detectCapabilityReliability(projects),
     () => detectLowWorthSessions(projects),
     () => detectContextBloat(projects, lowWorthSessionIds),
     () => detectSessionOutliers(projects, outlierExclusions),

--- a/tests/optimize.test.ts
+++ b/tests/optimize.test.ts
@@ -7,6 +7,7 @@ import {
   detectCacheBloat,
   detectBloatedClaudeMd,
   detectContextBloat,
+  detectCapabilityReliability,
   detectLowWorthSessions,
   detectSessionOutliers,
   computeHealth,
@@ -772,6 +773,156 @@ describe('detectLowWorthSessions', () => {
     )
     const finding = detectLowWorthSessions([project])
     expect(finding!.explanation).toContain('; +1 more')
+  })
+})
+
+type ReliabilityCall = LowWorthTurn['assistantCalls'][number]
+
+function reliabilityCall(overrides: Partial<ReliabilityCall> = {}): ReliabilityCall {
+  return {
+    provider: 'claude',
+    model: 'claude-sonnet-4-5',
+    usage: {
+      inputTokens: 1000,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      cachedInputTokens: 0,
+      reasoningTokens: 0,
+      webSearchRequests: 0,
+    },
+    costUSD: 0.01,
+    tools: ['Edit'],
+    mcpTools: [],
+    skills: [],
+    hasAgentSpawn: false,
+    hasPlanMode: false,
+    speed: 'standard',
+    timestamp: '2026-05-01T10:00:00Z',
+    bashCommands: [],
+    deduplicationKey: 'call',
+    ...overrides,
+  }
+}
+
+function reliabilityTurn(
+  i: number,
+  overrides: Partial<LowWorthTurn> & { call?: Partial<ReliabilityCall> } = {},
+): LowWorthTurn {
+  const { call: callOverrides, ...turnOverrides } = overrides
+  return lowWorthTurn({
+    userMessage: `turn ${i}`,
+    assistantCalls: [reliabilityCall({
+      timestamp: `2026-05-01T10:${String(i).padStart(2, '0')}:00Z`,
+      deduplicationKey: `call-${i}`,
+      ...callOverrides,
+    })],
+    timestamp: `2026-05-01T10:${String(i).padStart(2, '0')}:00Z`,
+    sessionId: 's1',
+    hasEdits: true,
+    retries: 0,
+    ...turnOverrides,
+  })
+}
+
+function projectWithReliabilityTurns(turns: LowWorthTurn[], project = 'app'): ProjectSummary {
+  return projectWithLowWorthSessions([
+    lowWorthSession(1, 0, {
+      turns,
+      totalInputTokens: turns.length * 1000,
+      totalOutputTokens: 0,
+      totalCacheReadTokens: 0,
+      totalCacheWriteTokens: 0,
+      apiCalls: turns.length,
+    }, project),
+  ], project)
+}
+
+describe('detectCapabilityReliability', () => {
+  it('flags retry-heavy skills from actual Skill call metadata', () => {
+    const turns = Array.from({ length: 5 }, (_, i) => reliabilityTurn(i, {
+      retries: i < 3 ? 1 : 0,
+      call: { tools: ['Edit', 'Skill'], skills: ['reviewer'] },
+    }))
+
+    const finding = detectCapabilityReliability([projectWithReliabilityTurns(turns)])
+
+    expect(finding).not.toBeNull()
+    expect(finding!.title).toContain('skill')
+    expect(finding!.explanation).toContain('skill reviewer')
+    expect(finding!.explanation).toContain('3/5 edit turns retried (60%)')
+    expect(finding!.explanation).toContain('correlation report')
+    expect(finding!.tokensSaved).toBe(1500)
+    expect(finding!.fix.type).toBe('paste')
+    if (finding!.fix.type === 'paste') expect(finding!.fix.destination).toBe('prompt')
+  })
+
+  it('flags retry-heavy MCP servers from invoked MCP tools', () => {
+    const turns = Array.from({ length: 5 }, (_, i) => reliabilityTurn(i, {
+      retries: i < 3 ? 1 : 0,
+      call: {
+        tools: ['Edit', 'mcp__ci__run'],
+        mcpTools: ['mcp__ci__run'],
+      },
+    }))
+
+    const finding = detectCapabilityReliability([projectWithReliabilityTurns(turns)])
+
+    expect(finding).not.toBeNull()
+    expect(finding!.title).toContain('MCP server')
+    expect(finding!.explanation).toContain('MCP server ci')
+    expect(finding!.explanation).toContain('3 retries')
+  })
+
+  it('does not flag healthy capabilities with mostly one-shot edit turns', () => {
+    const turns = Array.from({ length: 5 }, (_, i) => reliabilityTurn(i, {
+      retries: i === 0 ? 1 : 0,
+      call: { tools: ['Edit', 'Skill'], skills: ['healthy'] },
+    }))
+
+    expect(detectCapabilityReliability([projectWithReliabilityTurns(turns)])).toBeNull()
+  })
+
+  it('does not treat subCategory alone as skill evidence', () => {
+    const turns = Array.from({ length: 5 }, (_, i) => reliabilityTurn(i, {
+      retries: 1,
+      subCategory: 'legacy-skill-label',
+      call: { tools: ['Edit'], skills: [] },
+    }))
+
+    expect(detectCapabilityReliability([projectWithReliabilityTurns(turns)])).toBeNull()
+  })
+
+  it('does not double-count the same retry-heavy turn across MCP and skill candidates', () => {
+    const turns = Array.from({ length: 5 }, (_, i) => reliabilityTurn(i, {
+      retries: i < 3 ? 1 : 0,
+      call: {
+        tools: ['Edit', 'Skill', 'mcp__ci__run'],
+        mcpTools: ['mcp__ci__run'],
+        skills: ['reviewer'],
+      },
+    }))
+
+    const finding = detectCapabilityReliability([projectWithReliabilityTurns(turns)])
+
+    expect(finding).not.toBeNull()
+    expect(finding!.title).toContain('2 MCP/skill capabilities')
+    expect(finding!.explanation).toContain('MCP server ci')
+    expect(finding!.explanation).toContain('skill reviewer')
+    // Three retry-heavy turns at 1K effective tokens each, counted once at
+    // the 50% recoverable ceiling even though two flagged capabilities share
+    // every turn.
+    expect(finding!.tokensSaved).toBe(1500)
+  })
+
+  it('ignores read-only retry turns for capability reliability', () => {
+    const turns = Array.from({ length: 5 }, (_, i) => reliabilityTurn(i, {
+      hasEdits: false,
+      retries: 1,
+      call: { tools: ['Read', 'Skill'], skills: ['reader'] },
+    }))
+
+    expect(detectCapabilityReliability([projectWithReliabilityTurns(turns)])).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary
- Adds an MCP/skill reliability report to `codeburn optimize`.
- Flags MCP servers and skills whose edit turns are disproportionately retry-heavy.
- Uses turn-level capability evidence and shared-turn token accounting so one retry-heavy turn is not counted twice when both an MCP server and a skill appear together.

## Why
Existing optimize findings can show broad MCP waste, context bloat, and low-worth sessions, but they do not answer a capability-level reliability question:

> When a specific MCP server or skill is used during edit work, does that work repeatedly need retries?

This is useful for MCP and skill tuning because the right action is often not removal. A retry-heavy skill may need clearer instructions. A retry-heavy MCP server may need narrower project scope, a smaller tool set, or better usage guidance. The finding is intentionally framed as correlation, not causation, so users inspect the sessions before changing config.

For example:

- `Skill reviewer` appears in 5 edit turns, and 3 of those edit turns need retries.
- `mcp__ci__run` maps to MCP server `ci`, and the same 3/5 edit-turn retry pattern appears there.
- If both the skill and MCP server appear in the same retry-heavy turns, the savings estimate counts those turns once instead of reporting two independent piles of waste.

## What changed
- Adds `detectCapabilityReliability()` to `src/optimize.ts`.
- Aggregates per-capability edit reliability from existing parsed turn data:
  - MCP server evidence comes from `call.mcpTools`, normalized from names like `mcp__ci__run` to server `ci`
  - skill evidence comes from `call.skills`
  - `turn.subCategory` is deliberately not treated as skill evidence, avoiding legacy or classifier-derived false labels
- Emits a finding only when a capability has enough evidence:
  - at least 5 edit turns
  - at least 3 retry-heavy edit turns
  - at least 50% of edit turns are retry-heavy
- Ignores read-only turns so the report stays focused on edit reliability.
- Estimates recoverable tokens from retry-heavy edit turns with a 50% ceiling.
- De-duplicates shared retry-heavy turns across all flagged capabilities before computing `tokensSaved`.
- Adds focused regression coverage in `tests/optimize.test.ts`.

## Validation
I validated the behavior by running the real `detectCapabilityReliability()` export against controlled `ProjectSummary` fixtures via `npx tsx --eval`. This exercises the actual detector path and prints the expected edge cases.

```json
{
  "skill_retry_report": {
    "title": "1 skill correlates with retry-heavy edits",
    "tokensSaved": 1500,
    "expectedTokensSaved": 1500,
    "includesSkill": true,
    "proof": "5 edit turns using Skill reviewer; 3 retry-heavy turns at 1,000 effective tokens each; shared recovery ceiling is 50%, so 3*1000*0.5 = 1,500 tokens"
  },
  "mcp_retry_report": {
    "title": "1 MCP server correlates with retry-heavy edits",
    "tokensSaved": 1500,
    "expectedTokensSaved": 1500,
    "includesMcpServer": true,
    "proof": "same retry pattern attributed from mcp__ci__run to MCP server ci"
  },
  "shared_mcp_skill_turn_cap": {
    "title": "2 MCP/skill capabilities correlate with retry-heavy edits",
    "tokensSaved": 1500,
    "expectedTokensSaved": 1500,
    "includesBoth": true,
    "proof": "MCP server ci and Skill reviewer share the same 3 retry-heavy turns; tokensSaved stays 1,500 instead of doubling to 3,000"
  },
  "healthy_guard": {
    "finding": null,
    "proof": "1/5 retry-heavy edit turns is below the 50% retry-rate threshold"
  },
  "subcategory_guard": {
    "finding": null,
    "proof": "turn.subCategory without actual call.skills metadata does not create a skill reliability finding"
  },
  "readonly_guard": {
    "finding": null,
    "proof": "read-only retry turns are ignored because the detector is scoped to edit reliability"
  }
}
```

What this proves:
- A retry-heavy skill emits a skill reliability finding with the expected `1,500` token estimate.
- A retry-heavy MCP tool invocation is attributed to its MCP server namespace.
- A shared MCP+skill retry pattern reports both capabilities but keeps `tokensSaved` at `1,500`, not the inflated `3,000`.
- Healthy capabilities below the retry-rate threshold emit no finding.
- `turn.subCategory` alone does not create a skill finding.
- Read-only retry turns are ignored.

Supporting checks:
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `npx vitest run tests/optimize.test.ts` — 82 tests passed
- `npm run build`
- `npm test -- --run` — 62 files / 877 tests passed
- `git diff --check`
- Claude Opus 4.7, effort max review returned `PASS`
- Gemini 3.1 Pro Preview review returned `PASS`

## Notes
- The finding text explicitly says this is correlation, not proof of causation.
- The fix is a prompt to audit the retry-heavy capability, not an automatic MCP or skill config edit.
- This PR is independent of #354 and #356; it is based on current `main` and uses the existing parsed turn metadata.
