### PR TITLE
fix: handle # compound-path separator in fingerprintFile

### DIFF
--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -239,6 +239,21 @@ export async function fingerprintFile(filePath: string): Promise<FileFingerprint
     const s = await stat(filePath)
     return { dev: s.dev, ino: s.ino, mtimeMs: s.mtimeMs, sizeBytes: s.size }
   } catch {
+    // Providers encode extra context into source paths using virtual suffixes:
+    // - Cursor: `<dbPath>#cursor-ws=<workspace>` (workspace-aware routing)
+    // - OpenCode: `<dbPath>:<sessionId>` (session scoping)
+    // These compound paths don't exist on disk; strip the suffix to stat the
+    // underlying file. Try `#` first (rare in real paths), then `:` (must use
+    // lastIndexOf to tolerate Windows drive letters like C:\...).
+    const hashIdx = filePath.indexOf('#')
+    if (hashIdx > 0) {
+      try {
+        const s = await stat(filePath.slice(0, hashIdx))
+        return { dev: s.dev, ino: s.ino, mtimeMs: s.mtimeMs, sizeBytes: s.size }
+      } catch {
+        // fall through to colon check
+      }
+    }
     const colonIdx = filePath.lastIndexOf(':')
     if (colonIdx > 0) {
       try {

--- a/tests/session-cache.test.ts
+++ b/tests/session-cache.test.ts
@@ -185,6 +185,42 @@ describe('fingerprintFile', () => {
     const fp = await fingerprintFile('/no/such/file')
     expect(fp).toBeNull()
   })
+
+  it('resolves compound path with # separator (Cursor workspace)', async () => {
+    await mkdir(TMP_DIR, { recursive: true })
+    const filePath = join(TMP_DIR, 'state.vscdb')
+    await writeFile(filePath, 'cursor-data')
+
+    const fp = await fingerprintFile(`${filePath}#cursor-ws=__orphan__`)
+    expect(fp).not.toBeNull()
+    expect(fp!.sizeBytes).toBe(11)
+  })
+
+  it('resolves compound path with : separator (OpenCode session)', async () => {
+    await mkdir(TMP_DIR, { recursive: true })
+    const filePath = join(TMP_DIR, 'opencode.db')
+    await writeFile(filePath, 'opencode-data')
+
+    const fp = await fingerprintFile(`${filePath}:ses_abc123`)
+    expect(fp).not.toBeNull()
+    expect(fp!.sizeBytes).toBe(13)
+  })
+
+  it('returns null when base file does not exist for compound path', async () => {
+    const fp = await fingerprintFile('/no/such/file.db#cursor-ws=workspace')
+    expect(fp).toBeNull()
+  })
+
+  it('prefers # separator over : when both present', async () => {
+    await mkdir(TMP_DIR, { recursive: true })
+    const filePath = join(TMP_DIR, 'state.vscdb')
+    await writeFile(filePath, 'both-seps')
+
+    // Path has both # and : — should strip at # first and find the base file
+    const fp = await fingerprintFile(`${filePath}#cursor-ws=ws:extra-colon`)
+    expect(fp).not.toBeNull()
+    expect(fp!.sizeBytes).toBe(9)
+  })
 })
 
 // ── reconcileFile ──────────────────────────────────────────────────────


### PR DESCRIPTION
# Problem

The Cursor provider encodes workspace context into source paths as
`<dbPath>#cursor-ws=<workspace>` (introduced for workspace-aware routing).
`fingerprintFile` in `session-cache.ts` only has a fallback for the `:`
separator (used by OpenCode's `<dbPath>:<sessionId>` encoding).
On macOS/Linux, paths contain no colons, so `lastIndexOf(':')` returns -1
and Cursor sources silently return `null` — causing them to be skipped
entirely in `parseProviderSources`.

## Fix
Add a `#` fallback before the existing `:` check in `fingerprintFile`.
The first `stat()` on the full path still succeeds for real files that
legitimately contain `#`, so there is no regression.

## Tests
4 new test cases in `tests/session-cache.test.ts`:
- Resolves `#cursor-ws=` compound path to base file
- Resolves `:session_id` compound path to base file  
- Returns null when base file doesn't exist
- Prefers `#` separator over `:` when both are present

All 884 existing tests continue to pass.