### PR TITLE
Fix per-provider data loss, division-by-zero, and decode fragility

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
@@ -122,10 +122,10 @@ extension CurrentBlock {
         oneShotRate = try c.decodeIfPresent(Double.self, forKey: .oneShotRate)
         inputTokens = try c.decode(Int.self, forKey: .inputTokens)
         outputTokens = try c.decode(Int.self, forKey: .outputTokens)
-        cacheHitPercent = try c.decode(Double.self, forKey: .cacheHitPercent)
-        topActivities = try c.decode([ActivityEntry].self, forKey: .topActivities)
-        topModels = try c.decode([ModelEntry].self, forKey: .topModels)
-        providers = try c.decode([String: Double].self, forKey: .providers)
+        cacheHitPercent = try c.decodeIfPresent(Double.self, forKey: .cacheHitPercent) ?? 0
+        topActivities = try c.decodeIfPresent([ActivityEntry].self, forKey: .topActivities) ?? []
+        topModels = try c.decodeIfPresent([ModelEntry].self, forKey: .topModels) ?? []
+        providers = try c.decodeIfPresent([String: Double].self, forKey: .providers) ?? [:]
         topProjects = try c.decodeIfPresent([ProjectEntry].self, forKey: .topProjects) ?? []
         modelEfficiency = try c.decodeIfPresent([ModelEfficiencyEntry].self, forKey: .modelEfficiency) ?? []
         topSessions = try c.decodeIfPresent([TopSessionEntry].self, forKey: .topSessions) ?? []

--- a/mac/Sources/CodeBurnMenubar/Views/ActivitySection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/ActivitySection.swift
@@ -20,7 +20,7 @@ struct ActivitySection: View {
             }
         ) {
             VStack(alignment: .leading, spacing: 7) {
-                let maxCost = store.payload.current.topActivities.map(\.cost).max() ?? 1
+                let maxCost = max(store.payload.current.topActivities.map(\.cost).max() ?? 1, 0.01)
                 ForEach(store.payload.current.topActivities, id: \.name) { activity in
                     ActivityRow(activity: activity, maxCost: maxCost)
                 }

--- a/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
@@ -373,7 +373,7 @@ private struct BarTooltipCard: View {
 
             if !bar.topModels.isEmpty {
                 VStack(alignment: .leading, spacing: 3) {
-                    ForEach(Array(bar.topModels.prefix(4).enumerated()), id: \.element.name) { idx, m in
+                    ForEach(Array(bar.topModels.prefix(4).enumerated()), id: \.offset) { idx, m in
                         HStack(spacing: 6) {
                             RoundedRectangle(cornerRadius: 1)
                                 .fill(Theme.brandAccent.opacity(0.75 - Double(idx) * 0.12))

--- a/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
@@ -653,8 +653,10 @@ struct FooterBar: View {
             }
 
             let fresh = await FXRateCache.shared.rate(for: code)
-            store.currency = code
-            CurrencyState.shared.apply(code: code, rate: fresh ?? cached, symbol: symbol)
+            if let rate = fresh ?? cached {
+                store.currency = code
+                CurrencyState.shared.apply(code: code, rate: rate, symbol: symbol)
+            }
         }
 
         CLICurrencyConfig.persist(code: code)

--- a/mac/Sources/CodeBurnMenubar/Views/ModelsSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/ModelsSection.swift
@@ -19,7 +19,7 @@ struct ModelsSection: View {
             }
         ) {
             VStack(alignment: .leading, spacing: 7) {
-                let maxCost = store.payload.current.topModels.map(\.cost).max() ?? 1
+                let maxCost = max(store.payload.current.topModels.map(\.cost).max() ?? 1, 0.01)
                 ForEach(store.payload.current.topModels, id: \.name) { model in
                     ModelRow(model: model, maxCost: maxCost)
                 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -467,7 +467,6 @@ program
       let scanRange: DateRange
       let cache: DailyCache
       let todayProviderData: PeriodData | null = null
-      let usedPerProviderCachePath = false
 
       if (isAllProviders) {
         cache = await hydrateCache()
@@ -487,32 +486,11 @@ program
         }
       } else {
         cache = await loadDailyCache()
-        const cacheIsCurrent = cache.lastComputedDate !== null
-          && cache.lastComputedDate >= yesterdayStr
-        if (cacheIsCurrent && rangeStartStr < todayStr) {
-          const todayProviderProjects = fp(await parseAllSessions(todayRange, pf))
-          todayProviderData = buildPeriodData(periodInfo.label, todayProviderProjects)
-          const historicalDays = getDaysInRange(cache, rangeStartStr, yesterdayStr)
-          let histCost = 0, histCalls = 0
-          for (const d of historicalDays) {
-            const prov = d.providers[pf]
-            if (prov) { histCost += prov.cost; histCalls += prov.calls }
-          }
-          currentData = {
-            ...todayProviderData,
-            cost: todayProviderData.cost + histCost,
-            calls: todayProviderData.calls + histCalls,
-          }
-          scanProjects = todayProviderProjects
-          scanRange = todayRange
-          usedPerProviderCachePath = true
-        } else {
-          const fullProjects = fp(await parseAllSessions(periodInfo.range, pf))
-          todayProviderData = buildPeriodData(periodInfo.label, fullProjects)
-          currentData = todayProviderData
-          scanProjects = fullProjects
-          scanRange = periodInfo.range
-        }
+        const fullProjects = fp(await parseAllSessions(periodInfo.range, pf))
+        todayProviderData = buildPeriodData(periodInfo.label, fullProjects)
+        currentData = todayProviderData
+        scanProjects = fullProjects
+        scanRange = periodInfo.range
       }
 
       // PROVIDERS
@@ -579,51 +557,9 @@ program
             topModels,
           }
         })
-      } else if (usedPerProviderCachePath) {
-        const historyFromCache = allCacheDays.map(d => {
-          const prov = d.providers[pf] ?? { calls: 0, cost: 0 }
-          return {
-            date: d.date,
-            cost: prov.cost,
-            calls: prov.calls,
-            inputTokens: 0,
-            outputTokens: 0,
-            cacheReadTokens: 0,
-            cacheWriteTokens: 0,
-            topModels: [] as { name: string; cost: number; calls: number; inputTokens: number; outputTokens: number }[],
-          }
-        })
-        const todayCost = todayProviderData!.cost
-        const todayCalls = todayProviderData!.calls
-        if (todayCost > 0 || todayCalls > 0) {
-          historyFromCache.push({
-            date: todayStr,
-            cost: todayCost,
-            calls: todayCalls,
-            inputTokens: 0,
-            outputTokens: 0,
-            cacheReadTokens: 0,
-            cacheWriteTokens: 0,
-            topModels: [],
-          })
-        }
-        dailyHistory = historyFromCache
       } else {
-        const histFromCache = allCacheDays.map(d => {
-          const prov = d.providers[pf] ?? { calls: 0, cost: 0 }
-          return {
-            date: d.date,
-            cost: prov.cost,
-            calls: prov.calls,
-            inputTokens: 0,
-            outputTokens: 0,
-            cacheReadTokens: 0,
-            cacheWriteTokens: 0,
-            topModels: [] as { name: string; cost: number; calls: number; inputTokens: number; outputTokens: number }[],
-          }
-        })
         const fallbackDays = aggregateProjectsIntoDays(scanProjects)
-        const liveDays = fallbackDays.map(d => {
+        dailyHistory = fallbackDays.map(d => {
           const prov = d.providers[pf] ?? { calls: 0, cost: 0 }
           return {
             date: d.date,
@@ -636,7 +572,6 @@ program
             topModels: [] as { name: string; cost: number; calls: number; inputTokens: number; outputTokens: number }[],
           }
         })
-        dailyHistory = [...histFromCache, ...liveDays]
       }
 
       const home = homedir()

--- a/src/main.ts
+++ b/src/main.ts
@@ -558,8 +558,8 @@ program
           }
         })
       } else {
-        const fallbackDays = aggregateProjectsIntoDays(scanProjects)
-        dailyHistory = fallbackDays.map(d => {
+        const emptyModels = [] as { name: string; cost: number; calls: number; inputTokens: number; outputTokens: number }[]
+        const historyFromCache = allCacheDays.map(d => {
           const prov = d.providers[pf] ?? { calls: 0, cost: 0 }
           return {
             date: d.date,
@@ -569,9 +569,25 @@ program
             outputTokens: 0,
             cacheReadTokens: 0,
             cacheWriteTokens: 0,
-            topModels: [] as { name: string; cost: number; calls: number; inputTokens: number; outputTokens: number }[],
+            topModels: emptyModels,
           }
         })
+        const todayFromParse = aggregateProjectsIntoDays(scanProjects)
+          .filter(d => d.date === todayStr)
+          .map(d => {
+            const prov = d.providers[pf] ?? { calls: 0, cost: 0 }
+            return {
+              date: d.date,
+              cost: prov.cost,
+              calls: prov.calls,
+              inputTokens: 0,
+              outputTokens: 0,
+              cacheReadTokens: 0,
+              cacheWriteTokens: 0,
+              topModels: emptyModels,
+            }
+          })
+        dailyHistory = [...historyFromCache, ...todayFromParse]
       }
 
       const home = homedir()

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -370,7 +370,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             .filter(c => c.type === 'input_text')
             .map(c => c.text ?? '')
             .filter(Boolean)
-          if (texts.length > 0) pendingUserMessage = texts.join(' ')
+          if (texts.length > 0) pendingUserMessage = texts.join(' ').slice(0, 500)
           continue
         }
 

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -1,7 +1,8 @@
-import { readdir, readFile, stat } from 'fs/promises'
+import { readdir, stat } from 'fs/promises'
 import { join } from 'path'
 import { homedir } from 'os'
 
+import { readSessionFile } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
@@ -185,12 +186,8 @@ function parseJsonl(raw: string): GeminiSession | null {
 function createParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
   return {
     async *parse(): AsyncGenerator<ParsedProviderCall> {
-      let raw: string
-      try {
-        raw = await readFile(source.path, 'utf-8')
-      } catch {
-        return
-      }
+      const raw = await readSessionFile(source.path)
+      if (raw === null) return
 
       let data: GeminiSession | null = null
 


### PR DESCRIPTION
## Summary

Bug sweep found by automated agents auditing all changes since v0.9.9.

- **CRITICAL: Per-provider multi-day data loss** — switching to Claude/Codex tab on 7-day/30-day/month periods only showed today's categories, models, sessions, and tokens. The cache shortcut only merged cost/calls. Removed the broken shortcut; per-provider periods now always do a full parse.
- **Division by zero in ActivitySection & ModelsSection** — when all entries have zero cost, `maxCost` was 0, producing NaN bar widths. Now floors at 0.01.
- **ForEach ID collision in BarTooltipCard** — duplicate model names in trend bar tooltips caused SwiftUI row drops. Switched to offset-based ID.
- **Payload decode fragility** — `cacheHitPercent`, `topActivities`, `topModels`, `providers` used required decode, crashing on older CLI output. Now uses `decodeIfPresent` with defaults.
- **Currency rate/symbol desync** — switching currency while offline left stale FX rate with new symbol. Now skips the switch when no rate is available.
- **Gemini missing file size guard** — used raw `readFile` instead of `readSessionFile`, bypassing the 128MB cap.
- **Codex userMessage not truncated** — unlike all other providers, Codex stored full user messages instead of capping at 500 chars.
- **Per-provider daily history double-counting** — removed overlapping cache + live data merge that inflated chart values.

## Test plan

- [x] 879 CLI tests pass
- [x] Swift build passes
- [x] Per-provider multi-day verified: Claude 7-day shows 10,688 sessions, 12 activities, 5 models (was today-only before fix)
- [x] All-provider queries unaffected