### PR TITLE
Normalize Copilot MCP tool names

### DIFF
--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -52,6 +52,37 @@ const toolNameMap: Record<string, string> = {
   kill_terminal: 'Bash',
 }
 
+function normalizeMcpSegment(segment: string): string {
+  return segment
+    .replace(/[^a-zA-Z0-9_]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+}
+
+function normalizeCopilotMcpTool(rawTool: string): string | null {
+  const serverSeparator = rawTool.lastIndexOf('-')
+  if (serverSeparator <= 0 || serverSeparator >= rawTool.length - 1) return null
+
+  const server = normalizeMcpSegment(rawTool.slice(0, serverSeparator))
+  const tool = normalizeMcpSegment(rawTool.slice(serverSeparator + 1))
+  if (!server || !tool) return null
+
+  return `mcp__${server}__${tool}`
+}
+
+function normalizeToolName(rawTool?: unknown): string {
+  if (typeof rawTool !== 'string') return ''
+  if (!rawTool) return ''
+  if (rawTool.startsWith('mcp__')) return rawTool
+
+  const builtIn = toolNameMap[rawTool]
+  if (builtIn) return builtIn
+
+  // Copilot records MCP tools as `<server>-<tool>` instead of Claude's
+  // `mcp__server__tool`; built-ins are handled above before this heuristic.
+  return normalizeCopilotMcpTool(rawTool) ?? rawTool
+}
+
 const CHARS_PER_TOKEN = 4
 const COPILOT_OPENAI_AUTO = 'copilot-openai-auto'
 const COPILOT_ANTHROPIC_AUTO = 'copilot-anthropic-auto'
@@ -125,9 +156,8 @@ function parseLegacyEvents(content: string, sessionId: string, seenKeys: Set<str
       // that follows the bad event.
       const toolRequests = Array.isArray(rawToolRequests) ? rawToolRequests : []
       const tools = toolRequests
-        .map(t => t.name ?? '')
+        .map(t => normalizeToolName(t?.name))
         .filter(Boolean)
-        .map(n => toolNameMap[n] ?? n)
 
       const costUSD = calculateCost(currentModel, 0, outputTokens, 0, 0, 0)
 
@@ -259,9 +289,8 @@ function parseTranscriptEvents(content: string, sessionId: string, seenKeys: Set
       // sessions have shipped toolRequests as non-array values.
       const legacyToolRequests = Array.isArray(data.toolRequests) ? data.toolRequests : []
       const tools = legacyToolRequests
-        .map(t => t.name ?? '')
+        .map(t => normalizeToolName(t?.name))
         .filter(Boolean)
-        .map(n => toolNameMap[n] ?? n)
 
       const costUSD = calculateCost(model, inputTokens, outputTokens + reasoningTokens, 0, 0, 0)
 
@@ -456,7 +485,7 @@ export function createCopilotProvider(sessionStateDir?: string, workspaceStorage
     },
 
     toolDisplayName(rawTool: string): string {
-      return toolNameMap[rawTool] ?? rawTool
+      return normalizeToolName(rawTool)
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -94,6 +94,7 @@ const PROVIDER_ENV_VARS: Record<string, string[]> = {
 const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   claude: 'worktree-project-grouping-v1',
   cline: 'worktree-project-grouping-v1',
+  copilot: 'mcp-tool-normalization-v1',
   'ibm-bob': 'worktree-project-grouping-v1',
   'kilo-code': 'worktree-project-grouping-v1',
   'roo-code': 'worktree-project-grouping-v1',
@@ -373,3 +374,4 @@ export async function cleanupOrphanedTempFiles(): Promise<void> {
     }
   } catch {}
 }
+

--- a/tests/providers/copilot.test.ts
+++ b/tests/providers/copilot.test.ts
@@ -45,7 +45,7 @@ function transcriptUserMessage(content: string) {
   return JSON.stringify({ type: 'user.message', data: { content, attachments: [] } })
 }
 
-function transcriptAssistantMessage(opts: { messageId: string; content?: string; reasoningText?: string; toolCallIds?: string[] }) {
+function transcriptAssistantMessage(opts: { messageId: string; content?: string; reasoningText?: string; toolCallIds?: string[]; toolNames?: string[] }) {
   return JSON.stringify({
     type: 'assistant.message',
     data: {
@@ -54,7 +54,7 @@ function transcriptAssistantMessage(opts: { messageId: string; content?: string;
       reasoningText: opts.reasoningText ?? '',
       toolRequests: (opts.toolCallIds ?? []).map((id, i) => ({
         toolCallId: id,
-        name: i === 0 ? 'read_file' : 'run_in_terminal',
+        name: opts.toolNames?.[i] ?? (i === 0 ? 'read_file' : 'run_in_terminal'),
         type: 'function',
       })),
     },
@@ -126,6 +126,29 @@ describe('copilot provider - JSONL parsing', () => {
     expect(calls[0]!.tools).toEqual(['Bash', 'Read', 'Edit'])
   })
 
+  it('normalizes Copilot MCP tool names from toolRequests', async () => {
+    const eventsPath = await createSessionDir('sess-mcp-tools', [
+      modelChange('gpt-4.1'),
+      userMessage('list MCP-backed tasks and issues'),
+      assistantMessage({
+        messageId: 'msg-1',
+        outputTokens: 60,
+        tools: ['github-mcp-server-list_issues', 'cyberday-get_tasks', 'mempalace-mempalace_search', 'bash'],
+      }),
+    ])
+
+    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+
+    expect(calls[0]!.tools).toEqual([
+      'mcp__github_mcp_server__list_issues',
+      'mcp__cyberday__get_tasks',
+      'mcp__mempalace__mempalace_search',
+      'Bash',
+    ])
+  })
+
   it('does not crash on malformed toolRequests (string / null / missing)', async () => {
     // Regression guard: a corrupt session previously aborted the whole file's
     // parse loop because .map was called on a non-array. The fix coerces any
@@ -165,6 +188,31 @@ describe('copilot provider - JSONL parsing', () => {
     for (const c of corruptCalls) {
       expect(c.tools).toEqual([])
     }
+  })
+
+  it('ignores malformed non-string tool names', async () => {
+    const malformedToolName = JSON.stringify({
+      type: 'assistant.message',
+      timestamp: '2026-04-15T10:00:15Z',
+      data: {
+        messageId: 'malformed-tool-name',
+        outputTokens: 50,
+        toolRequests: [null, { name: 123, toolCallId: 'call-bad', type: 'function' }],
+      },
+    })
+    const eventsPath = await createSessionDir('sess-malformed-tool-name', [
+      modelChange('gpt-4.1'),
+      malformedToolName,
+      assistantMessage({ messageId: 'msg-after', outputTokens: 100, tools: ['github-mcp-server-list_issues'] }),
+    ])
+
+    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]!.tools).toEqual([])
+    expect(calls[1]!.tools).toEqual(['mcp__github_mcp_server__list_issues'])
   })
 
   it('skips assistant messages with zero outputTokens', async () => {
@@ -290,6 +338,26 @@ describe('copilot provider - JSONL parsing', () => {
     expect(calls).toHaveLength(3)
     expect(calls.every(c => c.model === 'copilot-openai-auto')).toBe(true)
   })
+
+  it('normalizes Copilot MCP tool names from VS Code transcripts', async () => {
+    const eventsPath = await createSessionDir('sess-tr-mcp-tools', [
+      transcriptSessionStart('sess-tr-mcp-tools'),
+      transcriptUserMessage('use GitHub MCP'),
+      transcriptAssistantMessage({
+        messageId: 'msg-1',
+        content: 'done',
+        toolCallIds: ['call_abc123', 'call_def456'],
+        toolNames: ['github-mcp-server-list_issues', 'read_file'],
+      }),
+    ])
+
+    const source = { path: eventsPath, project: 'test', provider: 'copilot' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.tools).toEqual(['mcp__github_mcp_server__list_issues', 'Read'])
+  })
 })
 
 describe('copilot provider - discoverSessions', () => {
@@ -378,6 +446,7 @@ describe('copilot provider - metadata', () => {
     expect(copilot.toolDisplayName('read_file')).toBe('Read')
     expect(copilot.toolDisplayName('write_file')).toBe('Edit')
     expect(copilot.toolDisplayName('web_search')).toBe('WebSearch')
+    expect(copilot.toolDisplayName('github-mcp-server-list_issues')).toBe('mcp__github_mcp_server__list_issues')
     expect(copilot.toolDisplayName('unknown_tool')).toBe('unknown_tool')
   })
 

--- a/tests/session-cache.test.ts
+++ b/tests/session-cache.test.ts
@@ -166,6 +166,7 @@ describe('computeEnvFingerprint', () => {
 
   it('includes parser versions in provider fingerprints', () => {
     expect(computeEnvFingerprint('claude')).not.toBe(computeEnvFingerprint('unknown-provider'))
+    expect(computeEnvFingerprint('copilot')).not.toBe(computeEnvFingerprint('unknown-provider'))
     expect(computeEnvFingerprint('warp')).not.toBe(computeEnvFingerprint('unknown-provider'))
   })
 })


### PR DESCRIPTION
## Summary

Closes #371 by making Copilot MCP tool calls show up in MCP server breakdowns instead of being counted as ordinary core tools.

## Root cause

CodeBurn's MCP aggregation expects tool names in the Claude-style `mcp__server__tool` format. Copilot records MCP calls as `<server>-<tool>` in `toolRequests`, for example `github-mcp-server-list_issues`, `cyberday-get_tasks`, and `mempalace-mempalace_search`. The Copilot provider only mapped built-in tools like `bash` and `read_file`, so those MCP calls stayed as raw strings and `extractMcpTools()` ignored them.

## What changed

- Normalize Copilot MCP tool names from `<server>-<tool>` to `mcp__server__tool` in both legacy session-state logs and VS Code transcript logs.
- Keep built-in Copilot tools mapped first, so `bash` still reports as `Bash` and does not get misclassified as MCP.
- Pass through already-normalized `mcp__...` names idempotently.
- Add Copilot-only parser cache invalidation so previously cached Copilot sessions are reparsed with the new normalization.
- Harden Copilot tool parsing against malformed `toolRequests` elements.

## Validation

I ran a concrete Copilot fixture through the actual CLI. The fixture contains this assistant `toolRequests` input:

```text
github-mcp-server-list_issues
cyberday-get_tasks
mempalace-mempalace_search
bash
```

`codeburn report --format json --provider copilot --from 2026-05-21 --to 2026-05-21` now reports the MCP tools as MCP servers and leaves only Bash in core tools:

```json
{
  "reportMcpServers": [
    { "name": "github_mcp_server", "calls": 1 },
    { "name": "cyberday", "calls": 1 },
    { "name": "mempalace", "calls": 1 }
  ],
  "reportCoreTools": [
    { "name": "Bash", "calls": 1 }
  ]
}
```

Additional checks:

```text
npm test -- --run tests/providers/copilot.test.ts tests/session-cache.test.ts
npm test -- --run
npm run build
git diff --check
Claude Opus 4.7 effort max review - PASS
Gemini 3.1 Pro Preview review - PASS
```
