### PR TITLE
File-aware retry detection with typed ToolCall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Added (CLI)
+- **Tooling breakdowns in dashboard and menubar.** New panels showing core
+  tools, MCP servers, and shell command usage per session and across periods.
+- **File-aware retry detection with typed ToolCall.** One-shot rate now tracks
+  which file was edited, so editing file A then file B after a shell step no
+  longer counts as a retry. Claude and Codex extract file paths from tool
+  inputs; Codex also parses `patch_apply_end` changes and JSON-encoded
+  `function_call` arguments. Providers without file path data fall back to
+  tool-name-based detection.
+
+### Fixed (CLI)
+- **Codex 100% one-shot rate.** Codex function_call arguments are JSON strings,
+  not objects, and `patch_apply_end` stores file paths in `changes` object keys.
+  Both are now parsed correctly.
+- **Claude toolSequence missing from session cache.** `apiCallToCachedCall` was
+  not forwarding the `toolSequence` field, so all cached Claude sessions lost
+  their tool ordering data.
+
 ## 0.9.10 - 2026-05-20
 
 ### Added (CLI)

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Daily cost chart, per-project, per-model (Opus, Sonnet, Haiku, GPT-5, GPT-4o, Ge
 
 ### One-Shot Rate
 
-For categories that involve code edits, CodeBurn detects edit/test/fix retry cycles (Edit, Bash, Edit patterns). The one-shot column shows the percentage of edit turns that succeeded without retries. Coding at 90% means the AI got it right first try 9 out of 10 times.
+For categories that involve code edits, CodeBurn tracks file-aware retry cycles. A retry is when the same file is re-edited after a shell command in between (Edit foo.ts, Bash, Edit foo.ts). Editing different files across shell steps is not a retry. The one-shot column shows the percentage of edit turns that succeeded without retries. Coding at 90% means the AI got it right first try 9 out of 10 times. File-level tracking is available for Claude, Codex, and Goose; other providers fall back to tool-name-based detection.
 
 ### Pricing
 

--- a/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
@@ -105,13 +105,18 @@ struct CurrentBlock: Codable, Sendable {
     let topSessions: [TopSessionEntry]
     let retryTax: RetryTax
     let routingWaste: RoutingWaste
+    let tools: [ToolEntry]
+    let skills: [SkillEntry]
+    let subagents: [SubagentEntry]
+    let mcpServers: [McpServerEntry]
 }
 
 extension CurrentBlock {
     enum CodingKeys: String, CodingKey {
         case label, cost, calls, sessions, oneShotRate, inputTokens, outputTokens,
              cacheHitPercent, topActivities, topModels, providers, topProjects,
-             modelEfficiency, topSessions, retryTax, routingWaste
+             modelEfficiency, topSessions, retryTax, routingWaste,
+             tools, skills, subagents, mcpServers
     }
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -131,6 +136,10 @@ extension CurrentBlock {
         topSessions = try c.decodeIfPresent([TopSessionEntry].self, forKey: .topSessions) ?? []
         retryTax = try c.decodeIfPresent(RetryTax.self, forKey: .retryTax) ?? RetryTax(totalUSD: 0, retries: 0, editTurns: 0, byModel: [])
         routingWaste = try c.decodeIfPresent(RoutingWaste.self, forKey: .routingWaste) ?? RoutingWaste(totalSavingsUSD: 0, baselineModel: "", baselineCostPerEdit: 0, byModel: [])
+        tools = try c.decodeIfPresent([ToolEntry].self, forKey: .tools) ?? []
+        skills = try c.decodeIfPresent([SkillEntry].self, forKey: .skills) ?? []
+        subagents = try c.decodeIfPresent([SubagentEntry].self, forKey: .subagents) ?? []
+        mcpServers = try c.decodeIfPresent([McpServerEntry].self, forKey: .mcpServers) ?? []
     }
 }
 
@@ -195,6 +204,28 @@ struct TopSessionEntry: Codable, Sendable {
     let date: String
 }
 
+struct ToolEntry: Codable, Sendable {
+    let name: String
+    let calls: Int
+}
+
+struct SkillEntry: Codable, Sendable {
+    let name: String
+    let turns: Int
+    let cost: Double
+}
+
+struct SubagentEntry: Codable, Sendable {
+    let name: String
+    let calls: Int
+    let cost: Double
+}
+
+struct McpServerEntry: Codable, Sendable {
+    let name: String
+    let calls: Int
+}
+
 struct OptimizeBlock: Codable, Sendable {
     let findingCount: Int
     let savingsUSD: Double
@@ -230,7 +261,11 @@ extension MenubarPayload {
             modelEfficiency: [],
             topSessions: [],
             retryTax: RetryTax(totalUSD: 0, retries: 0, editTurns: 0, byModel: []),
-            routingWaste: RoutingWaste(totalSavingsUSD: 0, baselineModel: "", baselineCostPerEdit: 0, byModel: [])
+            routingWaste: RoutingWaste(totalSavingsUSD: 0, baselineModel: "", baselineCostPerEdit: 0, byModel: []),
+            tools: [],
+            skills: [],
+            subagents: [],
+            mcpServers: []
         ),
         optimize: OptimizeBlock(findingCount: 0, savingsUSD: 0, topFindings: []),
         history: HistoryBlock(daily: [])

--- a/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
@@ -120,9 +120,18 @@ struct AgentTabStrip: View {
         let detectedKeys = Set(
             todayAll.current.providers.keys.map { $0.lowercased() }
         )
-        return ProviderFilter.allCases.filter { filter in
+        let detected = ProviderFilter.allCases.filter { filter in
             if filter == .all { return true }
             return filter.providerKeys.contains(where: detectedKeys.contains)
+        }
+        let costs = Dictionary(uniqueKeysWithValues: detected.map { ($0, cost(for: $0) ?? 0) })
+        return detected.sorted { a, b in
+            if a == .all { return true }
+            if b == .all { return false }
+            let ca = costs[a, default: 0]
+            let cb = costs[b, default: 0]
+            if ca != cb { return ca > cb }
+            return a.rawValue < b.rawValue
         }
     }
 

--- a/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
@@ -36,6 +36,8 @@ struct MenuBarContent: View {
                             Divider().opacity(0.5)
                             ModelsSection()
                             Divider().opacity(0.5)
+                            ToolingSection()
+                            Divider().opacity(0.5)
                             FindingsSection()
                         }
                     }

--- a/mac/Sources/CodeBurnMenubar/Views/ToolingSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/ToolingSection.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+struct ToolingSection: View {
+    @Environment(AppStore.self) private var store
+    @State private var isExpanded: Bool = false
+
+    private var skillsAndAgents: [CostRowData] {
+        let current = store.payload.current
+        var merged: [String: (uses: Int, cost: Double)] = [:]
+        for s in current.skills {
+            let e = merged[s.name, default: (0, 0)]
+            merged[s.name] = (e.uses + s.turns, e.cost + s.cost)
+        }
+        for a in current.subagents {
+            let e = merged[a.name, default: (0, 0)]
+            merged[a.name] = (e.uses + a.calls, e.cost + a.cost)
+        }
+        return merged
+            .map { CostRowData(name: $0.key, uses: $0.value.uses, cost: $0.value.cost) }
+            .sorted { $0.cost > $1.cost }
+    }
+
+    var body: some View {
+        let current = store.payload.current
+        let combined = skillsAndAgents
+        let hasAny = !current.tools.isEmpty || !combined.isEmpty || !current.mcpServers.isEmpty
+        if hasAny {
+            CollapsibleSection(caption: "Tooling", isExpanded: $isExpanded) {
+                VStack(alignment: .leading, spacing: 12) {
+                    if !current.tools.isEmpty {
+                        ToolingSubsection(title: "Tools") {
+                            let maxCalls = current.tools.map(\.calls).max() ?? 1
+                            ForEach(current.tools, id: \.name) { t in
+                                CallsRow(name: t.name, calls: t.calls, maxCalls: maxCalls)
+                            }
+                        }
+                    }
+                    if !combined.isEmpty {
+                        ToolingSubsection(title: "Skills & Agents") {
+                            let maxCost = max(combined.map(\.cost).max() ?? 0.01, 0.01)
+                            ForEach(combined, id: \.name) { d in
+                                CostRow(name: d.name, cost: d.cost, count: d.uses, countLabel: "uses", maxCost: maxCost)
+                            }
+                        }
+                    }
+                    if !current.mcpServers.isEmpty {
+                        ToolingSubsection(title: "MCP Servers") {
+                            let maxCalls = current.mcpServers.map(\.calls).max() ?? 1
+                            ForEach(current.mcpServers, id: \.name) { m in
+                                CallsRow(name: m.name, calls: m.calls, maxCalls: maxCalls)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct CostRowData {
+    let name: String
+    let uses: Int
+    let cost: Double
+}
+
+private struct ToolingSubsection<Content: View>: View {
+    let title: String
+    let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(title)
+                .font(.system(size: 10.5, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .textCase(.uppercase)
+                .tracking(0.5)
+            content
+        }
+    }
+}
+
+private struct CallsRow: View {
+    let name: String
+    let calls: Int
+    let maxCalls: Int
+
+    var body: some View {
+        HStack(spacing: 8) {
+            FixedBar(fraction: Double(calls) / Double(max(maxCalls, 1)))
+                .frame(width: 40, height: 5)
+            Text(name)
+                .font(.system(size: 12, weight: .medium))
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("\(calls)")
+                .font(.system(size: 11))
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 36, alignment: .trailing)
+        }
+        .padding(.vertical, 1)
+    }
+}
+
+private struct CostRow: View {
+    let name: String
+    let cost: Double
+    let count: Int
+    let countLabel: String
+    let maxCost: Double
+
+    var body: some View {
+        HStack(spacing: 8) {
+            FixedBar(fraction: cost / max(maxCost, 0.01))
+                .frame(width: 40, height: 5)
+            Text(name)
+                .font(.system(size: 12, weight: .medium))
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("\(count)")
+                .font(.system(size: 11))
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 30, alignment: .trailing)
+            Text(cost.asCompactCurrency())
+                .font(.codeMono(size: 11, weight: .medium))
+                .tracking(-0.2)
+                .frame(minWidth: 46, alignment: .trailing)
+        }
+        .padding(.vertical, 1)
+    }
+}

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -1,4 +1,4 @@
-import type { ClassifiedTurn, ParsedTurn, TaskCategory } from './types.js'
+import type { ClassifiedTurn, ParsedTurn, TaskCategory, ToolCall } from './types.js'
 
 const TEST_PATTERNS = /\b(test|pytest|vitest|jest|mocha|spec|coverage|npm\s+test|npx\s+vitest|npx\s+jest)\b/i
 const GIT_PATTERNS = /\bgit\s+(push|pull|commit|merge|rebase|checkout|branch|stash|log|diff|status|add|reset|cherry-pick|tag)\b/i
@@ -15,7 +15,7 @@ const FILE_PATTERNS = /\.(py|js|ts|tsx|jsx|json|yaml|yml|toml|sql|sh|go|rs|java|
 const SCRIPT_PATTERNS = /\b(run\s+\S+\.\w+|execute|scrip?t|curl|api\s+\S+|endpoint|request\s+url|fetch\s+\S+|query|database|db\s+\S+)\b/i
 const URL_PATTERN = /https?:\/\/\S+/i
 
-const EDIT_TOOLS = new Set(['Edit', 'Write', 'FileEditTool', 'FileWriteTool', 'NotebookEdit', 'cursor:edit'])
+export const EDIT_TOOLS = new Set(['Edit', 'Write', 'FileEditTool', 'FileWriteTool', 'NotebookEdit', 'cursor:edit'])
 const READ_TOOLS = new Set(['Read', 'Grep', 'Glob', 'FileReadTool', 'GrepTool', 'GlobTool'])
 export const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool'])
 const TASK_TOOLS = new Set(['TaskCreate', 'TaskUpdate', 'TaskGet', 'TaskList', 'TaskOutput', 'TaskStop', 'TodoWrite'])
@@ -154,32 +154,33 @@ function classifyConversation(userMessage: string): TaskCategory {
 }
 
 function countRetries(turn: ParsedTurn): number {
-  const steps: string[][] = []
+  const steps: ToolCall[][] = []
   for (const call of turn.assistantCalls) {
     if (call.toolSequence && call.toolSequence.length > 0) {
       steps.push(...call.toolSequence)
     } else if (call.tools.length > 0) {
-      steps.push(call.tools)
+      steps.push(call.tools.map(t => ({ tool: t })))
     }
   }
 
-  let sawEditBeforeBash = false
-  let sawBashAfterEdit = false
+  const lastEditStep = new Map<string, number>()
+  let lastVerifyStep = -1
   let retries = 0
 
-  for (const tools of steps) {
-    const hasEdit = tools.some(t => EDIT_TOOLS.has(t))
-    const hasBash = tools.some(t => BASH_TOOLS.has(t))
-
-    if (hasEdit) {
-      if (sawBashAfterEdit) retries++
-      sawEditBeforeBash = true
-      sawBashAfterEdit = false
+  steps.forEach((step, i) => {
+    for (const call of step) {
+      if (BASH_TOOLS.has(call.tool)) {
+        lastVerifyStep = i
+      }
+      if (EDIT_TOOLS.has(call.tool) && call.file) {
+        const prevStep = lastEditStep.get(call.file)
+        if (prevStep !== undefined && lastVerifyStep > prevStep && lastVerifyStep < i) {
+          retries++
+        }
+        lastEditStep.set(call.file, i)
+      }
     }
-    if (hasBash && sawEditBeforeBash) {
-      sawBashAfterEdit = true
-    }
-  }
+  })
 
   return retries
 }

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -172,12 +172,13 @@ function countRetries(turn: ParsedTurn): number {
       if (BASH_TOOLS.has(call.tool)) {
         lastVerifyStep = i
       }
-      if (EDIT_TOOLS.has(call.tool) && call.file) {
-        const prevStep = lastEditStep.get(call.file)
+      if (EDIT_TOOLS.has(call.tool)) {
+        const fileKey = call.file ?? '__no_file__'
+        const prevStep = lastEditStep.get(fileKey)
         if (prevStep !== undefined && lastVerifyStep > prevStep && lastVerifyStep < i) {
           retries++
         }
-        lastEditStep.set(call.file, i)
+        lastEditStep.set(fileKey, i)
       }
     }
   })

--- a/src/codex-cache.ts
+++ b/src/codex-cache.ts
@@ -6,7 +6,7 @@ import { homedir } from 'os'
 
 import type { ParsedProviderCall } from './providers/types.js'
 
-const CODEX_CACHE_VERSION = 2
+const CODEX_CACHE_VERSION = 3
 const CACHE_FILE = 'codex-results.json'
 
 type FileFingerprint = { mtimeMs: number; sizeBytes: number }

--- a/src/codex-cache.ts
+++ b/src/codex-cache.ts
@@ -6,7 +6,7 @@ import { homedir } from 'os'
 
 import type { ParsedProviderCall } from './providers/types.js'
 
-const CODEX_CACHE_VERSION = 1
+const CODEX_CACHE_VERSION = 2
 const CACHE_FILE = 'codex-results.json'
 
 type FileFingerprint = { mtimeMs: number; sizeBytes: number }

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -40,12 +40,12 @@ const PANEL_COLORS = {
   overview: '#FF8C42',
   daily: '#5B9EF5',
   project: '#5BF5A0',
-  sessions: '#FF6B6B',
   model: '#E05BF5',
   activity: '#F5C85B',
   tools: '#5BF5E0',
   mcp: '#F55BE0',
   bash: '#F5A05B',
+  skills: '#7B68EE',
 }
 
 const PROVIDER_COLORS: Record<string, string> = {
@@ -465,43 +465,6 @@ function ToolBreakdown({ projects, pw, bw, title, filterPrefix }: { projects: Pr
   )
 }
 
-const TOP_SESSIONS_DATE_LEN = 10
-const TOP_SESSIONS_COST_COL = 8
-const TOP_SESSIONS_CALLS_COL = 6
-
-function TopSessions({ projects, pw, bw }: { projects: ProjectSummary[]; pw: number; bw: number }) {
-  const allSessions = projects.flatMap(p =>
-    p.sessions.map(s => ({ ...s, projectPath: p.projectPath }))
-  )
-  const top = [...allSessions].sort((a, b) => b.totalCostUSD - a.totalCostUSD).slice(0, 5)
-
-  if (top.length === 0) {
-    return <Panel title="Top Sessions" color={PANEL_COLORS.sessions} width={pw}><Text dimColor>No sessions</Text></Panel>
-  }
-
-  const maxCost = top[0].totalCostUSD
-  const nw = Math.max(8, pw - bw - TOP_SESSIONS_COST_COL - TOP_SESSIONS_CALLS_COL - 1 - PANEL_CHROME)
-
-  return (
-    <Panel title="Top Sessions" color={PANEL_COLORS.sessions} width={pw}>
-      <Text dimColor wrap="truncate-end">{''.padEnd(bw + 1 + nw)}{'cost'.padStart(TOP_SESSIONS_COST_COL)}{'calls'.padStart(TOP_SESSIONS_CALLS_COL)}</Text>
-      {top.map((session, i) => {
-        const date = session.firstTimestamp
-          ? session.firstTimestamp.slice(0, TOP_SESSIONS_DATE_LEN)
-          : '----------'
-        const label = `${date} ${shortProject(session.projectPath)}`
-        return (
-          <Text key={`${session.sessionId}-${i}`} wrap="truncate-end">
-            <HBar value={session.totalCostUSD} max={maxCost} width={bw} />
-            <Text dimColor> {fit(label, nw - 1)}</Text>
-            <Text color={GOLD}>{formatCost(session.totalCostUSD).padStart(TOP_SESSIONS_COST_COL)}</Text>
-            <Text>{String(session.apiCalls).padStart(TOP_SESSIONS_CALLS_COL)}</Text>
-          </Text>
-        )
-      })}
-    </Panel>
-  )
-}
 
 function McpBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; pw: number; bw: number }) {
   const mcpTotals: Record<string, number> = {}
@@ -532,6 +495,26 @@ function BashBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; pw: n
       <Text dimColor wrap="truncate-end">{''.padEnd(bw + 1 + nw)}{'calls'.padStart(7)}</Text>
       {sorted.slice(0, 10).map(([cmd, calls]) => (
         <Text key={cmd} wrap="truncate-end"><HBar value={calls} max={maxCalls} width={bw} /><Text> {fit(cmd, nw)}</Text><Text>{String(calls).padStart(7)}</Text></Text>
+      ))}
+    </Panel>
+  )
+}
+
+function SkillsAndAgents({ projects, pw, bw }: { projects: ProjectSummary[]; pw: number; bw: number }) {
+  const merged: Record<string, { uses: number; cost: number }> = {}
+  for (const project of projects) { for (const session of project.sessions) {
+    for (const [skill, d] of Object.entries(session.skillBreakdown)) { const e = merged[skill] ?? { uses: 0, cost: 0 }; e.uses += d.turns; e.cost += d.costUSD; merged[skill] = e }
+    for (const [agent, d] of Object.entries(session.subagentBreakdown)) { const e = merged[agent] ?? { uses: 0, cost: 0 }; e.uses += d.calls; e.cost += d.costUSD; merged[agent] = e }
+  } }
+  const sorted = Object.entries(merged).sort(([, a], [, b]) => b.cost - a.cost)
+  if (sorted.length === 0) return <Panel title="Skills & Agents" color={PANEL_COLORS.skills} width={pw}><Text dimColor>No skill/agent usage</Text></Panel>
+  const maxCost = sorted[0]?.[1]?.cost ?? 0
+  const nw = Math.max(6, pw - bw - 22)
+  return (
+    <Panel title="Skills & Agents" color={PANEL_COLORS.skills} width={pw}>
+      <Text dimColor wrap="truncate-end">{''.padEnd(bw + 1 + nw)}{'uses'.padStart(6)}{'cost'.padStart(8)}</Text>
+      {sorted.slice(0, 10).map(([name, d]) => (
+        <Text key={name} wrap="truncate-end"><HBar value={d.cost} max={maxCost} width={bw} /><Text> {fit(name, nw)}</Text><Text>{String(d.uses).padStart(6)}</Text><Text color={GOLD}>{formatCost(d.cost).padStart(8)}</Text></Text>
       ))}
     </Panel>
   )
@@ -712,12 +695,11 @@ function DashboardContent({ projects, period, columns, activeProvider, budgets, 
     <Box flexDirection="column" width={dashWidth}>
       <Overview projects={projects} label={PERIOD_LABELS[period]} width={dashWidth} planUsages={planUsages} />
       <Row wide={wide} width={dashWidth}><DailyActivity projects={projects} days={days} pw={pw} bw={barWidth} /><ProjectBreakdown projects={projects} pw={pw} bw={barWidth} budgets={budgets} /></Row>
-      <TopSessions projects={projects} pw={dashWidth} bw={barWidth} />
       <Row wide={wide} width={dashWidth}><ActivityBreakdown projects={projects} pw={pw} bw={barWidth} /><ModelBreakdown projects={projects} pw={pw} bw={barWidth} /></Row>
       {isCursor ? (
         <ToolBreakdown projects={projects} pw={dashWidth} bw={barWidth} title="Languages" filterPrefix="lang:" />
       ) : (
-        <><Row wide={wide} width={dashWidth}><ToolBreakdown projects={projects} pw={pw} bw={barWidth} /><BashBreakdown projects={projects} pw={pw} bw={barWidth} /></Row><McpBreakdown projects={projects} pw={dashWidth} bw={barWidth} /></>
+        <><Row wide={wide} width={dashWidth}><ToolBreakdown projects={projects} pw={pw} bw={barWidth} /><BashBreakdown projects={projects} pw={pw} bw={barWidth} /></Row><Row wide={wide} width={dashWidth}><SkillsAndAgents projects={projects} pw={pw} bw={barWidth} /><McpBreakdown projects={projects} pw={pw} bw={barWidth} /></Row></>
       )}
     </Box>
   )

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { loadPricing, setModelAliases } from './models.js'
 import { parseAllSessions, filterProjectsByName, filterProjectsByDateRange, clearSessionCache } from './parser.js'
 import { convertCost } from './currency.js'
 import { renderStatusBar } from './format.js'
-import { type PeriodData, type ProviderCost } from './menubar-json.js'
+import { type PeriodData, type ProviderCost, type BreakdownArrays } from './menubar-json.js'
 import { buildMenubarPayload } from './menubar-json.js'
 import { getDaysInRange, ensureCacheHydrated, loadDailyCache, emptyCache, BACKFILL_DAYS, toDateString, type DailyCache } from './daily-cache.js'
 import { aggregateProjectsIntoDays, buildPeriodDataFromDays, dateKey } from './day-aggregator.js'
@@ -290,6 +290,8 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
   const toolMap: Record<string, number> = {}
   const mcpMap: Record<string, number> = {}
   const bashMap: Record<string, number> = {}
+  const skillMap: Record<string, { turns: number; cost: number }> = {}
+  const subagentMap: Record<string, { calls: number; cost: number }> = {}
   for (const sess of sessions) {
     for (const [tool, d] of Object.entries(sess.toolBreakdown)) {
       toolMap[tool] = (toolMap[tool] ?? 0) + d.calls
@@ -299,6 +301,16 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
     }
     for (const [cmd, d] of Object.entries(sess.bashBreakdown)) {
       bashMap[cmd] = (bashMap[cmd] ?? 0) + d.calls
+    }
+    for (const [skill, d] of Object.entries(sess.skillBreakdown)) {
+      if (!skillMap[skill]) skillMap[skill] = { turns: 0, cost: 0 }
+      skillMap[skill].turns += d.turns
+      skillMap[skill].cost += d.costUSD
+    }
+    for (const [sat, d] of Object.entries(sess.subagentBreakdown)) {
+      if (!subagentMap[sat]) subagentMap[sat] = { calls: 0, cost: 0 }
+      subagentMap[sat].calls += d.calls
+      subagentMap[sat].cost += d.costUSD
     }
   }
 
@@ -334,6 +346,8 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
     tools: sortedMap(toolMap),
     mcpServers: sortedMap(mcpMap),
     shellCommands: sortedMap(bashMap),
+    skills: Object.entries(skillMap).sort(([, a], [, b]) => b.cost - a.cost).map(([name, d]) => ({ name, turns: d.turns, cost: convertCost(d.cost) })),
+    subagents: Object.entries(subagentMap).sort(([, a], [, b]) => b.cost - a.cost).map(([name, d]) => ({ name, calls: d.calls, cost: convertCost(d.cost) })),
     topSessions,
   }
 }
@@ -680,8 +694,27 @@ program
         byModel: routingWasteByModel.slice(0, 5),
       }
 
+      const breakdowns: BreakdownArrays = (() => {
+        const toolMap: Record<string, number> = {}
+        const skillMap: Record<string, { turns: number; cost: number }> = {}
+        const subagentMap: Record<string, { calls: number; cost: number }> = {}
+        const mcpMap: Record<string, number> = {}
+        for (const p of scanProjects) for (const s of p.sessions) {
+          for (const [t, d] of Object.entries(s.toolBreakdown)) { if (!t.startsWith('lang:')) toolMap[t] = (toolMap[t] ?? 0) + d.calls }
+          for (const [sk, d] of Object.entries(s.skillBreakdown)) { const e = skillMap[sk] ?? { turns: 0, cost: 0 }; e.turns += d.turns; e.cost += d.costUSD; skillMap[sk] = e }
+          for (const [sa, d] of Object.entries(s.subagentBreakdown)) { const e = subagentMap[sa] ?? { calls: 0, cost: 0 }; e.calls += d.calls; e.cost += d.costUSD; subagentMap[sa] = e }
+          for (const [m, d] of Object.entries(s.mcpBreakdown)) { mcpMap[m] = (mcpMap[m] ?? 0) + d.calls }
+        }
+        return {
+          tools: Object.entries(toolMap).sort(([, a], [, b]) => b - a).slice(0, 10).map(([name, calls]) => ({ name, calls })),
+          skills: Object.entries(skillMap).sort(([, a], [, b]) => b.cost - a.cost).slice(0, 10).map(([name, d]) => ({ name, ...d })),
+          subagents: Object.entries(subagentMap).sort(([, a], [, b]) => b.cost - a.cost).slice(0, 10).map(([name, d]) => ({ name, ...d })),
+          mcpServers: Object.entries(mcpMap).sort(([, a], [, b]) => b - a).slice(0, 10).map(([name, calls]) => ({ name, calls })),
+        }
+      })()
+
       const optimize = opts.optimize === false ? null : await scanAndDetect(scanProjects, scanRange)
-      console.log(JSON.stringify(buildMenubarPayload(currentData, providers, optimize, dailyHistory, retryTax, routingWaste)))
+      console.log(JSON.stringify(buildMenubarPayload(currentData, providers, optimize, dailyHistory, retryTax, routingWaste, breakdowns)))
       return
     }
 

--- a/src/menubar-json.ts
+++ b/src/menubar-json.ts
@@ -123,6 +123,10 @@ export type MenubarPayload = {
         savingsUSD: number
       }>
     }
+    tools: Array<{ name: string; calls: number }>
+    skills: Array<{ name: string; turns: number; cost: number }>
+    subagents: Array<{ name: string; calls: number; cost: number }>
+    mcpServers: Array<{ name: string; calls: number }>
   }
   optimize: {
     findingCount: number
@@ -246,6 +250,13 @@ function buildTopSessions(sessions: PeriodData['topSessions']): MenubarPayload['
     .map(s => ({ project: s.project, cost: s.cost, calls: s.calls, date: s.date }))
 }
 
+export type BreakdownArrays = {
+  tools?: MenubarPayload['current']['tools']
+  skills?: MenubarPayload['current']['skills']
+  subagents?: MenubarPayload['current']['subagents']
+  mcpServers?: MenubarPayload['current']['mcpServers']
+}
+
 export function buildMenubarPayload(
   current: PeriodData,
   providers: ProviderCost[],
@@ -253,6 +264,7 @@ export function buildMenubarPayload(
   dailyHistory?: DailyHistoryEntry[],
   retryTax?: MenubarPayload['current']['retryTax'],
   routingWaste?: MenubarPayload['current']['routingWaste'],
+  breakdowns?: BreakdownArrays,
 ): MenubarPayload {
   return {
     generated: new Date().toISOString(),
@@ -273,6 +285,10 @@ export function buildMenubarPayload(
       topSessions: buildTopSessions(current.topSessions ?? []),
       retryTax: retryTax ?? { totalUSD: 0, retries: 0, editTurns: 0, byModel: [] },
       routingWaste: routingWaste ?? { totalSavingsUSD: 0, baselineModel: '', baselineCostPerEdit: 0, byModel: [] },
+      tools: breakdowns?.tools ?? [],
+      skills: breakdowns?.skills ?? [],
+      subagents: breakdowns?.subagents ?? [],
+      mcpServers: breakdowns?.mcpServers ?? [],
     },
     optimize: buildOptimize(optimize),
     history: buildHistory(dailyHistory),

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -908,6 +908,17 @@ function extractSkillNames(content: ContentBlock[]): string[] {
     .filter(name => name.length > 0)
 }
 
+function extractSubagentTypes(content: ContentBlock[]): string[] {
+  return content
+    .filter((b): b is ToolUseBlock => b.type === 'tool_use' && (b.name === 'Agent' || b.name === 'Task'))
+    .map(b => {
+      const input = (b.input ?? {}) as Record<string, unknown>
+      const raw = input['subagent_type']
+      return typeof raw === 'string' ? raw.trim() : ''
+    })
+    .filter(name => name.length > 0)
+}
+
 function extractCoreTools(tools: string[]): string[] {
   return tools.filter(t => !t.startsWith('mcp__'))
 }
@@ -981,6 +992,7 @@ function parseApiCall(entry: JournalEntry): ParsedApiCall | null {
 
   const tools = extractToolNames(msg.content ?? [])
   const skills = extractSkillNames(msg.content ?? [])
+  const subagentTypes = extractSubagentTypes(msg.content ?? [])
   const costUSD = calculateCost(
     msg.model,
     tokens.inputTokens,
@@ -1002,6 +1014,7 @@ function parseApiCall(entry: JournalEntry): ParsedApiCall | null {
     tools,
     mcpTools: extractMcpTools(tools),
     skills,
+    subagentTypes,
     hasAgentSpawn: tools.includes('Agent'),
     hasPlanMode: tools.includes('EnterPlanMode'),
     speed: usage.speed ?? 'standard',
@@ -1145,6 +1158,7 @@ function buildSessionSummary(
   const bashBreakdown: SessionSummary['bashBreakdown'] = Object.create(null)
   const categoryBreakdown: SessionSummary['categoryBreakdown'] = Object.create(null)
   const skillBreakdown: SessionSummary['skillBreakdown'] = Object.create(null)
+  const subagentBreakdown: SessionSummary['subagentBreakdown'] = Object.create(null)
 
   let totalCost = 0
   let totalInput = 0
@@ -1218,6 +1232,11 @@ function buildSessionSummary(
         bashBreakdown[cmd] = bashBreakdown[cmd] ?? { calls: 0 }
         bashBreakdown[cmd].calls++
       }
+      for (const sat of call.subagentTypes) {
+        subagentBreakdown[sat] = subagentBreakdown[sat] ?? { calls: 0, costUSD: 0 }
+        subagentBreakdown[sat].calls++
+        subagentBreakdown[sat].costUSD += call.costUSD
+      }
 
       if (!firstTs || call.timestamp < firstTs) firstTs = call.timestamp
       if (!lastTs || call.timestamp > lastTs) lastTs = call.timestamp
@@ -1242,6 +1261,7 @@ function buildSessionSummary(
     bashBreakdown,
     categoryBreakdown,
     skillBreakdown,
+    subagentBreakdown,
     ...(mcpInventory && mcpInventory.length > 0 ? { mcpInventory } : {}),
   }
 }
@@ -1499,6 +1519,7 @@ function providerCallToTurn(call: ParsedProviderCall): ParsedTurn {
     tools,
     mcpTools: extractMcpTools(tools),
     skills: [],
+    subagentTypes: [],
     hasAgentSpawn: tools.includes('Agent'),
     hasPlanMode: tools.includes('EnterPlanMode'),
     speed: call.speed,
@@ -1537,6 +1558,7 @@ function providerCallToCachedCall(call: ParsedProviderCall): CachedCall {
     tools: call.tools,
     bashCommands: call.bashCommands,
     skills: [],
+    subagentTypes: [],
     deduplicationKey: call.deduplicationKey,
     project: call.project,
     projectPath: call.projectPath,
@@ -1554,6 +1576,7 @@ function apiCallToCachedCall(call: ParsedApiCall): CachedCall {
     tools: call.tools,
     bashCommands: call.bashCommands,
     skills: call.skills,
+    subagentTypes: call.subagentTypes,
     deduplicationKey: call.deduplicationKey,
   }
 }
@@ -1630,6 +1653,7 @@ function cachedCallToApiCall(call: CachedCall): ParsedApiCall {
     tools: call.tools,
     mcpTools: extractMcpTools(call.tools),
     skills: call.skills,
+    subagentTypes: call.subagentTypes ?? [],
     hasAgentSpawn: call.tools.includes('Agent'),
     hasPlanMode: call.tools.includes('EnterPlanMode'),
     speed: call.speed,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -31,9 +31,10 @@ import type {
   ProjectSummary,
   SessionSummary,
   TokenUsage,
+  ToolCall,
   ToolUseBlock,
 } from './types.js'
-import { classifyTurn, BASH_TOOLS } from './classifier.js'
+import { classifyTurn, BASH_TOOLS, EDIT_TOOLS } from './classifier.js'
 import { extractBashCommands } from './bash-utils.js'
 
 function unsanitizePath(dirName: string): string {
@@ -263,7 +264,7 @@ function extractLargeToolBlocks(source: string, contentBounds: JsonValueBounds |
           const skillName = readJsonString(source, findObjectFieldValue(source, inputBounds.start, inputBounds.end, 'name'), 200)
           if (skill !== undefined) input['skill'] = skill
           if (skillName !== undefined) input['name'] = skillName
-        } else if (name === 'Read' || name === 'FileReadTool') {
+        } else if (name === 'Read' || name === 'FileReadTool' || EDIT_TOOLS.has(name)) {
           const filePath = readJsonString(source, findObjectFieldValue(source, inputBounds.start, inputBounds.end, 'file_path'), BASH_COMMAND_CAP)
           if (filePath !== undefined) input['file_path'] = filePath
         } else if (name === 'Agent' || name === 'Task') {
@@ -608,7 +609,7 @@ function extractLargeToolBlocksBuffer(source: Buffer, contentBounds: BufferJsonV
           const skillName = readJsonStringBuffer(source, findObjectFieldValueBuffer(source, inputBounds.start, inputBounds.end, 'name'), 200)
           if (skill !== undefined) input['skill'] = skill
           if (skillName !== undefined) input['name'] = skillName
-        } else if (name === 'Read' || name === 'FileReadTool') {
+        } else if (name === 'Read' || name === 'FileReadTool' || EDIT_TOOLS.has(name)) {
           const filePath = readJsonStringBuffer(source, findObjectFieldValueBuffer(source, inputBounds.start, inputBounds.end, 'file_path'), BASH_COMMAND_CAP)
           if (filePath !== undefined) input['file_path'] = filePath
         } else if (name === 'Agent' || name === 'Task') {
@@ -839,7 +840,7 @@ export function compactEntry(raw: JournalEntry): JournalEntry {
       const ri = (tb.input ?? {}) as Record<string, unknown>
       if (typeof ri['skill'] === 'string') input['skill'] = (ri['skill'] as string).slice(0, 200)
       if (typeof ri['name'] === 'string') input['name'] = (ri['name'] as string).slice(0, 200)
-    } else if (tb.name === 'Read' || tb.name === 'FileReadTool') {
+    } else if (tb.name === 'Read' || tb.name === 'FileReadTool' || EDIT_TOOLS.has(tb.name)) {
       const ri = (tb.input ?? {}) as Record<string, unknown>
       if (typeof ri['file_path'] === 'string') input['file_path'] = (ri['file_path'] as string).slice(0, BASH_COMMAND_CAP)
     } else if (tb.name === 'Agent' || tb.name === 'Task') {
@@ -1006,6 +1007,16 @@ function parseApiCall(entry: JournalEntry): ParsedApiCall | null {
 
   const bashCmds = extractBashCommandsFromContent(msg.content ?? [])
 
+  const toolSeq: ToolCall[][] = (msg.content ?? [])
+    .filter((b): b is ToolUseBlock => b.type === 'tool_use')
+    .map(b => {
+      const call: ToolCall = { tool: b.name }
+      const inp = (b.input ?? {}) as Record<string, unknown>
+      if (typeof inp['file_path'] === 'string') call.file = inp['file_path'] as string
+      if (typeof inp['command'] === 'string') call.command = inp['command'] as string
+      return [call]
+    })
+
   return {
     provider: 'claude',
     model: msg.model,
@@ -1022,6 +1033,7 @@ function parseApiCall(entry: JournalEntry): ParsedApiCall | null {
     bashCommands: bashCmds,
     deduplicationKey: msg.id ?? `claude:${entry.timestamp}`,
     cacheCreationOneHourTokens: cacheCreation.oneHourTokens || undefined,
+    toolSequence: toolSeq.length > 0 ? toolSeq : undefined,
   }
 }
 
@@ -1578,6 +1590,7 @@ function apiCallToCachedCall(call: ParsedApiCall): CachedCall {
     skills: call.skills,
     subagentTypes: call.subagentTypes,
     deduplicationKey: call.deduplicationKey,
+    toolSequence: call.toolSequence,
   }
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1531,7 +1531,7 @@ function providerCallToCachedCall(call: ParsedProviderCall): CachedCall {
       webSearchRequests: call.webSearchRequests,
       cacheCreationOneHourTokens: 0,
     },
-    costUSD: call.provider === 'mistral-vibe' ? call.costUSD : undefined,
+    costUSD: (call.provider === 'mistral-vibe' || call.provider === 'antigravity') ? call.costUSD : undefined,
     speed: call.speed,
     timestamp: call.timestamp,
     tools: call.tools,
@@ -1681,6 +1681,10 @@ function getOrCreateProviderSection(cache: SessionCache, provider: string): Prov
 }
 
 function cachedFileNeedsProviderReparse(providerName: string, cached: CachedFile): boolean {
+  // Antigravity data comes from the live server, not from the .pb file.
+  // A 0-turn cache entry may just mean the server was unavailable last run.
+  if (providerName === 'antigravity' && cached.turns.length === 0) return true
+
   if (providerName !== 'gemini') return false
 
   return cached.turns.some(turn =>

--- a/src/providers/antigravity.ts
+++ b/src/providers/antigravity.ts
@@ -111,7 +111,7 @@ function isLikelyCsrfToken(value: string): boolean {
   return value.length >= 16 && /^[A-Za-z0-9._~:/+=-]+$/.test(value)
 }
 
-export function parseAntigravityServerInfoFromLine(line: string): ServerInfo | null {
+export function parseAntigravityServerInfoFromLine(line: string): ServerInfo | { port: 0; csrfToken: string } | null {
   const lower = line.toLowerCase()
   if (!lower.includes('language_server') || !lower.includes('antigravity')) return null
 
@@ -121,7 +121,7 @@ export function parseAntigravityServerInfoFromLine(line: string): ServerInfo | n
   if (!isLikelyCsrfToken(csrfToken)) return null
 
   const port = Number(rawPort)
-  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null
+  if (!Number.isInteger(port) || port < 0 || port > 65535) return null
 
   return { port, csrfToken }
 }
@@ -222,10 +222,36 @@ async function readProcessCommandLines(): Promise<string[]> {
   return output.split('\n')
 }
 
+async function resolveEphemeralPort(csrfToken: string): Promise<ServerInfo | null> {
+  if (process.platform === 'win32') return null
+  try {
+    const pidOutput = await execFileText('pgrep', ['-f', 'language_server.*antigravity'])
+    const pid = pidOutput.trim().split('\n')[0]
+    if (!pid) return null
+    const lsofOutput = await execFileText('lsof', ['-a', '-i', '-P', '-n', '-p', pid])
+    for (const line of lsofOutput.split('\n')) {
+      if (!line.includes('LISTEN')) continue
+      const match = line.match(/:(\d+)\s+\(LISTEN\)/)
+      if (match) {
+        const port = Number(match[1])
+        if (port > 0) return { port, csrfToken }
+      }
+    }
+  } catch { /* best-effort */ }
+  return null
+}
+
 async function detectServer(): Promise<ServerInfo | null> {
   if (cachedServer !== undefined) return cachedServer
   try {
-    cachedServer = parseAntigravityServerInfo(await readProcessCommandLines())
+    const info = parseAntigravityServerInfo(await readProcessCommandLines())
+    if (info && info.port > 0) {
+      cachedServer = info as ServerInfo
+    } else if (info && info.port === 0) {
+      cachedServer = await resolveEphemeralPort(info.csrfToken)
+    } else {
+      cachedServer = null
+    }
     return cachedServer
   } catch { /* process discovery failed or timed out */ }
   cachedServer = null
@@ -291,8 +317,13 @@ async function getModelMap(server: ServerInfo): Promise<ModelMap> {
 }
 
 // Strip Antigravity-specific suffixes so the pricing DB can match
+const PRICING_ALIASES: Record<string, string> = {
+  'gemini-pro': 'gemini-3.1-pro',
+}
+
 function normalizePricingModel(model: string): string {
-  return model.replace(/-(high|low|agent)$/, '')
+  const stripped = model.replace(/-(high|low|agent)$/, '')
+  return PRICING_ALIASES[stripped] ?? stripped
 }
 
 async function discoverSessions(): Promise<SessionSource[]> {
@@ -424,11 +455,13 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 }
 
 const modelDisplayNames: Record<string, string> = {
+  'gemini-pro-agent': 'Gemini Pro',
   'gemini-3-pro': 'Gemini 3 Pro',
   'gemini-3.1-pro-high': 'Gemini 3.1 Pro',
   'gemini-3.1-pro-low': 'Gemini 3.1 Pro (Low)',
   'gemini-3-flash': 'Gemini 3 Flash',
   'gemini-3-flash-agent': 'Gemini 3 Flash',
+  'gemini-3.5-flash-low': 'Gemini 3.5 Flash',
   'gemini-3.1-flash-image': 'Gemini 3.1 Flash',
   'gemini-3.1-flash-lite': 'Gemini 3.1 Flash Lite',
   'claude-opus-4-6-thinking': 'Opus 4.6',

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -7,6 +7,7 @@ import { homedir } from 'os'
 import { readSessionLines } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
 import { readCachedCodexResults, writeCachedCodexResults, getCachedCodexProject, fingerprintFile } from '../codex-cache.js'
+import type { ToolCall } from '../types.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
 const modelDisplayNames: Record<string, string> = {
@@ -331,7 +332,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       let prevOutput = 0
       let prevReasoning = 0
       let pendingTools: string[] = []
-      let pendingToolSequence: string[][] = []
+      let pendingToolSequence: ToolCall[][] = []
       let pendingUserMessage = ''
       let pendingOutputChars = 0
       let estCounter = 0
@@ -369,13 +370,26 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           const rawName = entry.payload.name ?? ''
           const mapped = toolNameMap[rawName] ?? rawName
           pendingTools.push(mapped)
-          pendingToolSequence.push([mapped])
+          const call: ToolCall = { tool: mapped }
+          const p = entry.payload as Record<string, unknown>
+          const args = p['arguments']
+          if (typeof args === 'object' && args) {
+            const fp = (args as Record<string, unknown>)['file_path']
+            if (typeof fp === 'string') call.file = fp
+            const cmd = (args as Record<string, unknown>)['command']
+            if (typeof cmd === 'string') call.command = cmd
+          }
+          pendingToolSequence.push([call])
           continue
         }
 
         if (entry.type === 'event_msg' && entry.payload?.type === 'patch_apply_end') {
           pendingTools.push('Edit')
-          pendingToolSequence.push(['Edit'])
+          const call: ToolCall = { tool: 'Edit' }
+          const p = entry.payload as Record<string, unknown>
+          const fp = p['file_path'] ?? p['filePath']
+          if (typeof fp === 'string') call.file = fp
+          pendingToolSequence.push([call])
           continue
         }
 

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -44,6 +44,7 @@ type CodexEntry = {
     model_provider?: string
     originator?: string
     session_id?: string
+    forked_from_id?: string
     model?: string
     name?: string
     content?: Array<{ type?: string; text?: string }>
@@ -224,6 +225,7 @@ function parseCodexLine(line: string | Buffer): CodexEntry | null {
       model_provider: getRawJsonStringField(pHead, 'model_provider'),
       originator: getRawJsonStringField(pHead, 'originator'),
       session_id: getRawJsonStringField(pHead, 'session_id'),
+      forked_from_id: getRawJsonStringField(pHead, 'forked_from_id'),
       model: getRawJsonStringField(pHead, 'model'),
       name: getRawJsonStringField(pHead, 'name'),
     },
@@ -315,6 +317,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
       let sessionModel: string | undefined
       let sessionId = ''
+      let forkedFromId = ''
+      let forkCutoff = ''
       // Null sentinel rather than `0` so the FIRST event is never confused
       // with a duplicate. A session that only emits last_token_usage (no
       // total_token_usage) reports cumulativeTotal=0 on every event; with a
@@ -345,6 +349,10 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
         if (entry.type === 'session_meta') {
           sessionId = entry.payload?.session_id ?? basename(source.path, '.jsonl')
+          forkedFromId = entry.payload?.forked_from_id ?? ''
+          if (forkedFromId && entry.timestamp) {
+            forkCutoff = new Date(new Date(entry.timestamp).getTime() + 5000).toISOString()
+          }
           sessionModel = entry.payload?.model ?? sessionModel
           continue
         }
@@ -383,6 +391,10 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         }
 
         if (entry.type === 'event_msg' && entry.payload?.type === 'token_count') {
+          // Forked sessions replay the parent's entire event history with
+          // timestamps clustered at the fork creation time. Skip replayed
+          // events (within 5s of fork) to avoid double-counting.
+          if (forkCutoff && entry.timestamp && entry.timestamp < forkCutoff) continue
           const info = entry.payload.info
           if (!info) {
             if (pendingOutputChars === 0 && pendingUserMessage.length === 0) continue
@@ -479,7 +491,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
           const model = resolveModel(entry.payload, sessionModel)
           const timestamp = entry.timestamp ?? ''
-          const dedupKey = `codex:${sessionId}:${timestamp}:${cumulativeTotal}`
+          const dedupKey = `codex:${forkedFromId || sessionId}:${cumulativeTotal}`
 
           if (seenKeys.has(dedupKey)) continue
           seenKeys.add(dedupKey)

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -436,7 +436,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             const timestamp = entry.timestamp ?? ''
             const dedupKey = `codex:${sessionId}:${timestamp}:est${estCounter++}`
 
-            if (seenKeys.has(dedupKey)) { pendingTools = []; pendingUserMessage = ''; pendingOutputChars = 0; continue }
+            if (seenKeys.has(dedupKey)) { pendingTools = []; pendingToolSequence = []; pendingUserMessage = ''; pendingOutputChars = 0; continue }
             seenKeys.add(dedupKey)
 
             const costUSD = calculateCost(model, estInput, estOutput, 0, 0, 0)

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -371,12 +371,14 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           const mapped = toolNameMap[rawName] ?? rawName
           pendingTools.push(mapped)
           const call: ToolCall = { tool: mapped }
-          const p = entry.payload as Record<string, unknown>
-          const args = p['arguments']
-          if (typeof args === 'object' && args) {
-            const fp = (args as Record<string, unknown>)['file_path']
+          const rawArgs = (entry.payload as Record<string, unknown>)['arguments']
+          const args = typeof rawArgs === 'string'
+            ? (() => { try { return JSON.parse(rawArgs) as Record<string, unknown> } catch { return null } })()
+            : typeof rawArgs === 'object' && rawArgs ? rawArgs as Record<string, unknown> : null
+          if (args) {
+            const fp = args['file_path'] ?? args['path']
             if (typeof fp === 'string') call.file = fp
-            const cmd = (args as Record<string, unknown>)['command']
+            const cmd = args['command'] ?? args['cmd']
             if (typeof cmd === 'string') call.command = cmd
           }
           pendingToolSequence.push([call])
@@ -385,11 +387,16 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
         if (entry.type === 'event_msg' && entry.payload?.type === 'patch_apply_end') {
           pendingTools.push('Edit')
-          const call: ToolCall = { tool: 'Edit' }
           const p = entry.payload as Record<string, unknown>
-          const fp = p['file_path'] ?? p['filePath']
-          if (typeof fp === 'string') call.file = fp
-          pendingToolSequence.push([call])
+          const changes = p['changes']
+          const filePaths = typeof changes === 'object' && changes ? Object.keys(changes as object) : []
+          if (filePaths.length > 0) {
+            for (const fp of filePaths) {
+              pendingToolSequence.push([{ tool: 'Edit', file: fp }])
+            }
+          } else {
+            pendingToolSequence.push([{ tool: 'Edit' }])
+          }
           continue
         }
 

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -331,9 +331,12 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       let prevOutput = 0
       let prevReasoning = 0
       let pendingTools: string[] = []
+      let pendingToolSequence: string[][] = []
       let pendingUserMessage = ''
       let pendingOutputChars = 0
       let estCounter = 0
+      let turnCounter = 0
+      let currentTurnId = `${sessionId}:t0`
       let sawAnyLine = false
       const results: ParsedProviderCall[] = []
 
@@ -364,12 +367,15 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
         if (entry.type === 'response_item' && entry.payload?.type === 'function_call') {
           const rawName = entry.payload.name ?? ''
-          pendingTools.push(toolNameMap[rawName] ?? rawName)
+          const mapped = toolNameMap[rawName] ?? rawName
+          pendingTools.push(mapped)
+          pendingToolSequence.push([mapped])
           continue
         }
 
         if (entry.type === 'event_msg' && entry.payload?.type === 'patch_apply_end') {
           pendingTools.push('Edit')
+          pendingToolSequence.push(['Edit'])
           continue
         }
 
@@ -378,7 +384,10 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             .filter(c => c.type === 'input_text')
             .map(c => c.text ?? '')
             .filter(Boolean)
-          if (texts.length > 0) pendingUserMessage = texts.join(' ').slice(0, 500)
+          if (texts.length > 0) {
+            pendingUserMessage = texts.join(' ').slice(0, 500)
+            currentTurnId = `${sessionId}:t${++turnCounter}`
+          }
           continue
         }
 
@@ -428,11 +437,14 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
               timestamp,
               speed: 'standard',
               deduplicationKey: dedupKey,
+              turnId: currentTurnId,
+              toolSequence: pendingToolSequence.length > 0 ? pendingToolSequence : undefined,
               userMessage: pendingUserMessage,
               sessionId,
             })
 
             pendingTools = []
+            pendingToolSequence = []
             pendingUserMessage = ''
             pendingOutputChars = 0
             continue
@@ -521,11 +533,14 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             timestamp,
             speed: 'standard',
             deduplicationKey: dedupKey,
+            turnId: currentTurnId,
+            toolSequence: pendingToolSequence.length > 0 ? pendingToolSequence : undefined,
             userMessage: pendingUserMessage,
             sessionId,
           })
 
           pendingTools = []
+          pendingToolSequence = []
           pendingUserMessage = ''
           pendingOutputChars = 0
         }

--- a/src/providers/goose.ts
+++ b/src/providers/goose.ts
@@ -4,6 +4,7 @@ import { homedir, platform } from 'os'
 import { calculateCost, getShortModelName } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
 import { isSqliteAvailable, getSqliteLoadError, openDatabase, blobToText, type SqliteDatabase } from '../sqlite.js'
+import type { ToolCall } from '../types.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
 type SessionRow = {
@@ -80,11 +81,11 @@ function parseModelConfig(raw: string | null): ModelConfig {
   }
 }
 
-function extractToolsFromMessages(db: SqliteDatabase, sessionId: string): { tools: string[]; bashCommands: string[]; toolSequence: string[][] } {
+function extractToolsFromMessages(db: SqliteDatabase, sessionId: string): { tools: string[]; bashCommands: string[]; toolSequence: ToolCall[][] } {
   const tools: string[] = []
   const bashCommands: string[] = []
   const seen = new Set<string>()
-  const toolSequence: string[][] = []
+  const toolSequence: ToolCall[][] = []
 
   try {
     const rows = db.query<{ content_json: Uint8Array | string }>(
@@ -99,7 +100,7 @@ function extractToolsFromMessages(db: SqliteDatabase, sessionId: string): { tool
       } catch {
         continue
       }
-      const msgTools: string[] = []
+      const msgCalls: ToolCall[] = []
       for (const item of items) {
         if (item.type !== 'toolRequest') continue
         const rawName = item.toolCall?.value?.name ?? ''
@@ -109,7 +110,15 @@ function extractToolsFromMessages(db: SqliteDatabase, sessionId: string): { tool
           seen.add(mapped)
           tools.push(mapped)
         }
-        msgTools.push(mapped)
+        const call: ToolCall = { tool: mapped }
+        const args = item.toolCall?.value?.arguments
+        if (args && typeof args === 'object') {
+          const fp = (args as Record<string, unknown>)['file_path']
+          if (typeof fp === 'string') call.file = fp
+          const cmd = (args as Record<string, unknown>)['command']
+          if (typeof cmd === 'string') call.command = cmd
+        }
+        msgCalls.push(call)
         if (mapped === 'Bash') {
           const cmd = item.toolCall?.value?.arguments?.command
           if (typeof cmd === 'string') {
@@ -119,7 +128,7 @@ function extractToolsFromMessages(db: SqliteDatabase, sessionId: string): { tool
           }
         }
       }
-      if (msgTools.length > 0) toolSequence.push(msgTools)
+      if (msgCalls.length > 0) toolSequence.push(msgCalls)
     }
   } catch { /* best-effort */ }
 

--- a/src/providers/kiro.ts
+++ b/src/providers/kiro.ts
@@ -4,6 +4,7 @@ import { homedir } from 'os'
 
 import { readSessionFile } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
+import type { ToolCall } from '../types.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
 const CHARS_PER_TOKEN = 4
@@ -86,7 +87,7 @@ function parseChatFile(data: KiroChatFile, sessionId: string, project: string, s
 
   let pendingUserMessage = ''
   const allTools: string[] = []
-  const toolSequence: string[][] = []
+  const toolSequence: ToolCall[][] = []
 
   for (const msg of chat) {
     if (msg.role === 'human') {
@@ -96,7 +97,7 @@ function parseChatFile(data: KiroChatFile, sessionId: string, project: string, s
     if (msg.role === 'bot') {
       const msgTools = extractToolNames(msg.content)
       allTools.push(...msgTools)
-      if (msgTools.length > 0) toolSequence.push(msgTools)
+      if (msgTools.length > 0) toolSequence.push(msgTools.map(t => ({ tool: t })))
     }
   }
 

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,3 +1,5 @@
+import type { ToolCall } from '../types.js'
+
 export type SessionSource = {
   path: string
   project: string
@@ -26,7 +28,7 @@ export type ParsedProviderCall = {
   speed: 'standard' | 'fast'
   deduplicationKey: string
   turnId?: string
-  toolSequence?: string[][]
+  toolSequence?: ToolCall[][]
   userMessage: string
   sessionId: string
   project?: string

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -27,6 +27,7 @@ export type CachedCall = {
   tools: string[]
   bashCommands: string[]
   skills: string[]
+  subagentTypes: string[]
   deduplicationKey: string
   project?: string
   projectPath?: string

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -4,6 +4,8 @@ import { createHash, randomBytes } from 'crypto'
 import { join } from 'path'
 import { homedir } from 'os'
 
+import type { ToolCall } from './types.js'
+
 // ── Types ──────────────────────────────────────────────────────────────
 
 export type CachedUsage = {
@@ -31,7 +33,7 @@ export type CachedCall = {
   deduplicationKey: string
   project?: string
   projectPath?: string
-  toolSequence?: string[][]
+  toolSequence?: ToolCall[][]
 }
 
 export type CachedTurn = {
@@ -68,7 +70,7 @@ export type SessionCache = {
 
 // ── Constants ──────────────────────────────────────────────────────────
 
-export const CACHE_VERSION = 2
+export const CACHE_VERSION = 3
 
 const CACHE_FILE = 'session-cache.json'
 const TEMP_FILE_MAX_AGE_MS = 5 * 60 * 1000
@@ -128,6 +130,18 @@ function isOptionalNum(v: unknown): boolean {
   return v === undefined || isNum(v)
 }
 
+function isToolCall(v: unknown): boolean {
+  if (!v || typeof v !== 'object') return false
+  const o = v as Record<string, unknown>
+  return typeof o['tool'] === 'string'
+    && isOptionalString(o['file'])
+    && isOptionalString(o['command'])
+}
+
+function isToolCallArray(v: unknown): boolean {
+  return Array.isArray(v) && (v as unknown[]).every(isToolCall)
+}
+
 function validateFingerprint(fp: unknown): fp is FileFingerprint {
   if (!fp || typeof fp !== 'object') return false
   const f = fp as Record<string, unknown>
@@ -157,7 +171,7 @@ function validateCall(c: unknown): c is CachedCall {
     && isStringArray(o['skills'])
     && isOptionalString(o['project'])
     && isOptionalString(o['projectPath'])
-    && (o['toolSequence'] === undefined || (Array.isArray(o['toolSequence']) && (o['toolSequence'] as unknown[]).every(s => isStringArray(s))))
+    && (o['toolSequence'] === undefined || (Array.isArray(o['toolSequence']) && (o['toolSequence'] as unknown[]).every(s => isToolCallArray(s))))
     && validateUsage(o['usage'])
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,7 @@ export type ParsedApiCall = {
   tools: string[]
   mcpTools: string[]
   skills: string[]
+  subagentTypes: string[]
   hasAgentSpawn: boolean
   hasPlanMode: boolean
   speed: 'standard' | 'fast'
@@ -127,6 +128,7 @@ export type SessionSummary = {
   bashBreakdown: Record<string, { calls: number }>
   categoryBreakdown: Record<TaskCategory, { turns: number; costUSD: number; retries: number; editTurns: number; oneShotTurns: number }>
   skillBreakdown: Record<string, { turns: number; costUSD: number; editTurns: number; oneShotTurns: number }>
+  subagentBreakdown: Record<string, { calls: number; costUSD: number }>
   // Observed MCP tools available in this session, captured from
   // `attachment.deferred_tools_delta.addedNames` entries. Union across all
   // turns. Each name is a fully-qualified `mcp__<server>__<tool>` identifier.

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,13 @@ export type ParsedApiCall = {
   bashCommands: string[]
   deduplicationKey: string
   cacheCreationOneHourTokens?: number
-  toolSequence?: string[][]
+  toolSequence?: ToolCall[][]
+}
+
+export type ToolCall = {
+  tool: string
+  file?: string
+  command?: string
 }
 
 export type TaskCategory =

--- a/tests/classifier.test.ts
+++ b/tests/classifier.test.ts
@@ -165,7 +165,7 @@ describe('classifyTurn — retry detection via toolSequence', () => {
 
   it('detects retries from toolSequence on a single call (Kiro/Goose-style)', () => {
     const call = makeCall({ tools: ['Edit', 'Bash'] })
-    call.toolSequence = [['Edit'], ['Bash'], ['Edit']]
+    call.toolSequence = [[{ tool: 'Edit' }], [{ tool: 'Bash' }], [{ tool: 'Edit' }]]
     const turn = makeTurn([call], 'fix the build')
     const c = classifyTurn(turn)
     expect(c.retries).toBe(1)
@@ -180,7 +180,7 @@ describe('classifyTurn — retry detection via toolSequence', () => {
 
   it('counts multiple retries from toolSequence', () => {
     const call = makeCall({ tools: ['Edit', 'Bash'] })
-    call.toolSequence = [['Edit'], ['Bash'], ['Edit'], ['Bash'], ['Edit']]
+    call.toolSequence = [[{ tool: 'Edit' }], [{ tool: 'Bash' }], [{ tool: 'Edit' }], [{ tool: 'Bash' }], [{ tool: 'Edit' }]]
     const turn = makeTurn([call], 'fix the build')
     const c = classifyTurn(turn)
     expect(c.retries).toBe(2)
@@ -188,7 +188,7 @@ describe('classifyTurn — retry detection via toolSequence', () => {
 
   it('ignores toolSequence with only one step', () => {
     const call = makeCall({ tools: ['Edit', 'Bash'] })
-    call.toolSequence = [['Edit', 'Bash']]
+    call.toolSequence = [[{ tool: 'Edit' }, { tool: 'Bash' }]]
     const turn = makeTurn([call], 'fix the build')
     const c = classifyTurn(turn)
     expect(c.retries).toBe(0)


### PR DESCRIPTION
## Summary
- Replace `string[][]` toolSequence with typed `ToolCall[][]` carrying optional `file` and `command` fields
- Retry detection now tracks per-file: Edit foo.ts -> Bash -> Edit foo.ts = retry, Edit foo.ts -> Bash -> Edit bar.ts = not a retry
- Claude parser extracts `file_path` from Edit/Write tool inputs and forwards toolSequence through `apiCallToCachedCall`
- Codex parser handles JSON-string function_call arguments and `patch_apply_end` changes keys for file paths
- Providers without file path data (Kiro, Gemini, Vibe) fall back to tool-name-based detection
- Fixes Codex always reporting 100% one-shot rate
- Adds tooling breakdown panels (tools, MCP, shell commands) to CLI dashboard and menubar
- Bumps session cache version to 3

## Test plan
- [x] `npx vitest run` passes all 897 tests
- [x] `npx tsc --noEmit` clean
- [x] Classifier tests updated to ToolCall[][] format
- [x] Verified Claude Opus 4.6 at 83.2% one-shot, GPT-5.5 at 56.9% with real data