### PR TITLE
Add single-day review mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ codeburn today                  # today's usage
 codeburn month                  # this month's usage
 codeburn report -p 30days       # rolling 30-day window
 codeburn report -p all          # every recorded session
+codeburn report --day yesterday # review one calendar day
+codeburn status --format menubar-json --day yesterday # menubar payload for one day
 codeburn report --from 2026-04-01 --to 2026-04-10  # exact date range
 codeburn report --format json   # full dashboard data as JSON
 codeburn report --refresh 60    # auto-refresh every 60s (default: 30s)
@@ -91,7 +93,7 @@ codeburn models --task feature         # filter to feature-development work
 codeburn models --provider claude      # filter to one provider
 ```
 
-Arrow keys switch between Today, 7 Days, 30 Days, Month, and 6 Months (use `--from` / `--to` for an exact historical window). Press `q` to quit, `1` `2` `3` `4` `5` as shortcuts, `c` to open model comparison, `o` to open optimize. The dashboard auto-refreshes every 30 seconds by default (`--refresh 0` to disable). It also shows average cost per session and the five most expensive sessions across all projects.
+Arrow keys switch between Today, 7 Days, 30 Days, Month, and 6 Months (use `--from` / `--to` for an exact historical window). Press `d` to review yesterday as a single day, then use the arrow keys to move day by day. Press `q` to quit, `1` `2` `3` `4` `5` as shortcuts, `c` to open model comparison, `o` to open optimize. The dashboard auto-refreshes every 30 seconds by default (`--refresh 0` to disable). It also shows average cost per session and the five most expensive sessions across all projects.
 
 ## Supported Providers
 
@@ -313,9 +315,12 @@ Filter by provider, project name (case-insensitive substring), or exact date ran
 codeburn report --from 2026-04-01 --to 2026-04-10   # explicit window
 codeburn report --from 2026-04-01                    # this date through today
 codeburn report --to 2026-04-10                      # earliest data through this date
+codeburn report --day 2026-04-10                     # one calendar day
+codeburn report --day yesterday                      # previous local calendar day
+codeburn status --format menubar-json --day yesterday # menubar JSON for one calendar day
 ```
 
-Either flag alone is valid. Inverted or malformed dates exit with a clear error. In the TUI, the custom range sets the initial load only; pressing `1` through `5` switches back to predefined periods.
+Either `--from` / `--to` flag alone is valid. `--day` accepts `YYYY-MM-DD`, `today`, or `yesterday` and cannot be combined with `--from` / `--to` on `report`. Inverted or malformed dates exit with a clear error. In the TUI, `--day` starts in day mode; custom `--from` / `--to` ranges stay fixed. The menubar app uses the same `--day` path for its single-day popover view.
 
 ### JSON Output
 
@@ -345,7 +350,7 @@ codeburn menubar
 
 One command: downloads the latest `.app`, installs into `~/Applications`, and launches it. Re-run with `--force` to reinstall. Native Swift and SwiftUI app lives in `mac/` (see `mac/README.md` for build details).
 
-The menubar icon always shows today's spend (so $0 is normal if you have not used AI tools today). Click to open a popover with agent tabs, period switcher (Today, 7 Days, 30 Days, Month, All), Trend, Forecast, Pulse, Stats, and Plan insights, activity and model breakdowns, optimize findings, and CSV/JSON export. Refreshes every 30 seconds.
+The menubar icon always shows today's spend (so $0 is normal if you have not used AI tools today). Click to open a popover with agent tabs, period switcher (Today, 7 Days, 30 Days, Month, All), single-day date selector with a Today shortcut, Trend, Forecast, Pulse, Stats, and Plan insights, activity and model breakdowns, optimize findings, and CSV/JSON export. Refreshes every 30 seconds.
 
 **Compact mode** shrinks the menubar item to fit the text, dropping decimals (e.g. `$110` instead of `$110.20`):
 

--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -13,6 +13,11 @@ struct CachedPayload {
 struct PayloadCacheKey: Hashable {
     let period: Period
     let provider: ProviderFilter
+    let day: String?
+
+    var label: String {
+        day.map { "Day(\($0))" } ?? period.rawValue
+    }
 }
 
 @MainActor
@@ -20,6 +25,7 @@ struct PayloadCacheKey: Hashable {
 final class AppStore {
     var selectedProvider: ProviderFilter = .all
     var selectedPeriod: Period = .today
+    var selectedDay: String?
     var selectedInsight: InsightMode = .trend
     var accentPreset: AccentPreset = ThemeState.shared.preset {
         didSet { ThemeState.shared.preset = accentPreset }
@@ -66,17 +72,28 @@ final class AppStore {
     /// from "cache was wiped 10 minutes ago and we still haven't refilled".
     private var lastSuccessByKey: [PayloadCacheKey: Date] = [:]
 
+    private static let dayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = .current
+        return formatter
+    }()
+
+    static func dayString(from date: Date) -> String {
+        dayFormatter.string(from: date)
+    }
+
     private func staleSecondsForKey(_ key: PayloadCacheKey) -> TimeInterval {
         guard let last = lastSuccessByKey[key] else { return .infinity }
         return Date().timeIntervalSince(last)
     }
 
     private var todayAllKey: PayloadCacheKey {
-        PayloadCacheKey(period: .today, provider: .all)
+        PayloadCacheKey(period: .today, provider: .all, day: nil)
     }
 
     private var currentKey: PayloadCacheKey {
-        PayloadCacheKey(period: selectedPeriod, provider: selectedProvider)
+        PayloadCacheKey(period: selectedPeriod, provider: selectedProvider, day: selectedDay)
     }
 
     var payload: MenubarPayload {
@@ -101,7 +118,19 @@ final class AppStore {
     /// All-provider payload for the selected period. Used by the tab strip to show
     /// per-provider costs that match the active period, not just today.
     var periodAllPayload: MenubarPayload? {
-        cache[PayloadCacheKey(period: selectedPeriod, provider: .all)]?.payload
+        cache[PayloadCacheKey(period: selectedPeriod, provider: .all, day: selectedDay)]?.payload
+    }
+
+    var isDayMode: Bool {
+        selectedDay != nil
+    }
+
+    var selectionLabel: String {
+        selectedDay.map { "Day (\($0))" } ?? selectedPeriod.rawValue
+    }
+
+    var trendPeriod: Period {
+        isDayMode ? .today : selectedPeriod
     }
 
     var hasCachedData: Bool {
@@ -131,7 +160,7 @@ final class AppStore {
         let keys = Set([
             currentKey,
             todayAllKey,
-            PayloadCacheKey(period: selectedPeriod, provider: .all),
+            PayloadCacheKey(period: selectedPeriod, provider: .all, day: selectedDay),
         ])
         let staleAges = keys.compactMap { key -> TimeInterval? in
             guard let cached = cache[key] else { return nil }
@@ -142,7 +171,7 @@ final class AppStore {
     }
 
     var needsInteractivePayloadRefresh: Bool {
-        let periodAllKey = PayloadCacheKey(period: selectedPeriod, provider: .all)
+        let periodAllKey = PayloadCacheKey(period: selectedPeriod, provider: .all, day: selectedDay)
         return cache[currentKey]?.isFresh != true ||
             cache[todayAllKey]?.isFresh != true ||
             cache[periodAllKey]?.isFresh != true ||
@@ -158,8 +187,8 @@ final class AppStore {
     }
 
 #if DEBUG
-    func setCachedPayloadForTesting(_ payload: MenubarPayload, period: Period, provider: ProviderFilter, fetchedAt: Date) {
-        cache[PayloadCacheKey(period: period, provider: provider)] = CachedPayload(payload: payload, fetchedAt: fetchedAt)
+    func setCachedPayloadForTesting(_ payload: MenubarPayload, period: Period, provider: ProviderFilter, day: String? = nil, fetchedAt: Date) {
+        cache[PayloadCacheKey(period: period, provider: provider, day: day)] = CachedPayload(payload: payload, fetchedAt: fetchedAt)
     }
 #endif
 
@@ -171,7 +200,35 @@ final class AppStore {
     /// all-provider data in parallel so tab strip costs stay in sync with the hero.
     func switchTo(period: Period) {
         selectedPeriod = period
+        selectedDay = nil
         startInteractiveSelectionRefresh()
+    }
+
+    func switchToYesterday() {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date()
+        switchTo(day: yesterday)
+    }
+
+    func switchTo(day: Date) {
+        let clamped = min(Calendar.current.startOfDay(for: day), Calendar.current.startOfDay(for: Date()))
+        selectedDay = Self.dayString(from: clamped)
+        startInteractiveSelectionRefresh()
+    }
+
+    func shiftSelectedDay(by delta: Int) {
+        let base = selectedDayDate ?? Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date()
+        let shifted = Calendar.current.date(byAdding: .day, value: delta, to: base) ?? base
+        switchTo(day: shifted)
+    }
+
+    var selectedDayDate: Date? {
+        guard let selectedDay else { return nil }
+        return Self.dayFormatter.date(from: selectedDay)
+    }
+
+    var canShiftSelectedDayForward: Bool {
+        guard let selectedDayDate else { return false }
+        return Calendar.current.startOfDay(for: selectedDayDate) < Calendar.current.startOfDay(for: Date())
     }
 
     /// Switch to a provider filter. Cancels any in-flight switch so rapid tab tapping only
@@ -187,13 +244,15 @@ final class AppStore {
         resetLoadingState()
         let period = selectedPeriod
         let provider = selectedProvider
-        lastErrorByKey[PayloadCacheKey(period: period, provider: provider)] = nil
+        let day = selectedDay
+        let key = PayloadCacheKey(period: period, provider: provider, day: day)
+        lastErrorByKey[key] = nil
         switchTask = Task {
             if provider == .all {
-                await refresh(includeOptimize: false, force: true, showLoading: true)
+                await refresh(key: key, includeOptimize: false, force: true, showLoading: true)
             } else {
-                async let main: Void = refresh(includeOptimize: false, force: true, showLoading: true)
-                async let all: Void = refreshQuietly(period: period)
+                async let main: Void = refresh(key: key, includeOptimize: false, force: true, showLoading: true)
+                async let all: Void = refreshQuietly(period: period, day: day)
                 _ = await (main, all)
             }
         }
@@ -206,6 +265,7 @@ final class AppStore {
         loadingCountsByKey.removeAll()
         loadingStartedAtByKey.removeAll()
         inFlightKeys.removeAll()
+        attemptedKeys.removeAll()
     }
 
     func resetRefreshState(clearCache: Bool = false) {
@@ -232,7 +292,7 @@ final class AppStore {
         payloadRefreshGeneration &+= 1
         for (key, started) in staleEntries {
             NSLog("CodeBurn: loading stuck for %ds on %@/%@ — auto-clearing",
-                  Int(now.timeIntervalSince(started)), key.period.rawValue, key.provider.rawValue)
+                  Int(now.timeIntervalSince(started)), key.label, key.provider.rawValue)
             loadingCountsByKey[key] = nil
             loadingStartedAtByKey[key] = nil
             inFlightKeys.remove(key)
@@ -286,10 +346,14 @@ final class AppStore {
     }
 
     func refresh(includeOptimize: Bool, force: Bool = false, showLoading: Bool = false) async {
+        await refresh(key: currentKey, includeOptimize: includeOptimize, force: force, showLoading: showLoading)
+    }
+
+    private func refresh(key: PayloadCacheKey, includeOptimize: Bool, force: Bool = false, showLoading: Bool = false) async {
         invalidateStaleDayCache()
-        let key = currentKey
         let cacheDateAtStart = cacheDate
         let generationAtStart = payloadRefreshGeneration
+        if Task.isCancelled { return }
         if !force, cache[key]?.isFresh == true { return }
         if inFlightKeys.contains(key) { return }
         inFlightKeys.insert(key)
@@ -308,18 +372,22 @@ final class AppStore {
         // below filters .infinity) — that's just the cold path, not a bug.
         let staleSeconds = staleSecondsForKey(key)
         if staleSeconds.isFinite, staleSeconds > 120 {
-            NSLog("CodeBurn: refresh attempt for stale key \(key.period.rawValue)/\(key.provider.rawValue) — last success was \(Int(staleSeconds))s ago")
+            NSLog("CodeBurn: refresh attempt for stale key \(key.label)/\(key.provider.rawValue) — last success was \(Int(staleSeconds))s ago")
         }
         defer {
+            let abandonedAttempt = Task.isCancelled || generationAtStart != payloadRefreshGeneration
             inFlightKeys.remove(key)
             if didShowLoading {
                 finishLoading(for: key)
             }
+            if abandonedAttempt && cache[key] == nil && lastErrorByKey[key] == nil {
+                attemptedKeys.remove(key)
+            }
         }
         do {
-            let fresh = try await DataClient.fetch(period: key.period, provider: key.provider, includeOptimize: includeOptimize)
+            let fresh = try await DataClient.fetch(period: key.period, day: key.day, provider: key.provider, includeOptimize: includeOptimize)
             if generationAtStart != payloadRefreshGeneration {
-                NSLog("CodeBurn: dropping fetch result for \(key.period.rawValue)/\(key.provider.rawValue) — refresh pipeline reset mid-fetch")
+                NSLog("CodeBurn: dropping fetch result for \(key.label)/\(key.provider.rawValue) — refresh pipeline reset mid-fetch")
                 return
             }
             if Task.isCancelled {
@@ -327,7 +395,7 @@ final class AppStore {
                 // the silent-no-result path. Without this log, a cancelled
                 // fetch leaves cache empty + lastError nil and the user sees
                 // perpetual loading with nothing in the diagnostics.
-                NSLog("CodeBurn: fetch for \(key.period.rawValue)/\(key.provider.rawValue) cancelled before result was applied")
+                NSLog("CodeBurn: fetch for \(key.label)/\(key.provider.rawValue) cancelled before result was applied")
                 return
             }
             // Day-rollover race guard: if the calendar date changed during the
@@ -336,7 +404,7 @@ final class AppStore {
             // tick will refetch with today's data.
             if cacheDate != cacheDateAtStart || cacheDate != currentCacheDate() {
                 invalidateStaleDayCache()
-                NSLog("CodeBurn: dropping fetch result for \(key.period.rawValue)/\(key.provider.rawValue) — calendar rolled mid-fetch")
+                NSLog("CodeBurn: dropping fetch result for \(key.label)/\(key.provider.rawValue) — calendar rolled mid-fetch")
                 return
             }
             cache[key] = CachedPayload(payload: fresh, fetchedAt: Date())
@@ -344,10 +412,10 @@ final class AppStore {
             lastErrorByKey[key] = nil
         } catch {
             if Task.isCancelled { return }
-            NSLog("CodeBurn: fetch failed for \(key.period.rawValue)/\(key.provider.rawValue): \(error)")
+            NSLog("CodeBurn: fetch failed for \(key.label)/\(key.provider.rawValue): \(error)")
             if includeOptimize, cache[key] == nil {
                 do {
-                    let fallback = try await DataClient.fetch(period: key.period, provider: key.provider, includeOptimize: false)
+                    let fallback = try await DataClient.fetch(period: key.period, day: key.day, provider: key.provider, includeOptimize: false)
                     guard !Task.isCancelled else { return }
                     if generationAtStart != payloadRefreshGeneration { return }
                     if cacheDate != cacheDateAtStart || cacheDate != currentCacheDate() {
@@ -366,34 +434,34 @@ final class AppStore {
             lastErrorByKey[key] = String(describing: error)
         }
 
-        let allKey = PayloadCacheKey(period: selectedPeriod, provider: .all)
+        let allKey = PayloadCacheKey(period: key.period, provider: .all, day: key.day)
         if key != allKey, cache[allKey]?.isFresh != true {
-            await refreshQuietly(period: selectedPeriod)
+            await refreshQuietly(period: key.period, day: key.day)
         }
     }
 
     /// Background refresh for a period other than the visible one (e.g. keeping today fresh for the menubar badge).
     /// Does not toggle isLoading, so the popover's loading overlay is unaffected.
     /// Always uses the .all provider since the menubar badge shows total spend.
-    func refreshQuietly(period: Period, force: Bool = false) async {
+    func refreshQuietly(period: Period, day: String? = nil, force: Bool = false) async {
         invalidateStaleDayCache()
-        let key = PayloadCacheKey(period: period, provider: .all)
+        let key = PayloadCacheKey(period: period, provider: .all, day: day)
         if !force, cache[key]?.isFresh == true { return }
         if inFlightKeys.contains(key) { return }
         inFlightKeys.insert(key)
         attemptedKeys.insert(key)
         let cacheDateAtStart = cacheDate
         let generationAtStart = payloadRefreshGeneration
-        if period == .today, let age = todayPayloadAgeSeconds, age > 120 {
+        if day == nil && period == .today, let age = todayPayloadAgeSeconds, age > 120 {
             NSLog("CodeBurn: refreshing stale today status payload after %ds", age)
         }
         defer {
             inFlightKeys.remove(key)
         }
         do {
-            let fresh = try await DataClient.fetch(period: period, provider: .all, includeOptimize: false)
+            let fresh = try await DataClient.fetch(period: period, day: day, provider: .all, includeOptimize: false)
             if generationAtStart != payloadRefreshGeneration {
-                NSLog("CodeBurn: dropping quiet fetch result for \(period.rawValue) — refresh pipeline reset mid-fetch")
+                NSLog("CodeBurn: dropping quiet fetch result for \(key.label) — refresh pipeline reset mid-fetch")
                 return
             }
             // Same day-rollover guard as refresh(): drop yesterday's payload if
@@ -406,7 +474,7 @@ final class AppStore {
             lastSuccessByKey[key] = Date()
             lastErrorByKey[key] = nil
         } catch {
-            NSLog("CodeBurn: quiet refresh failed for \(period.rawValue): \(error)")
+            NSLog("CodeBurn: quiet refresh failed for \(key.label): \(error)")
         }
     }
 

--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -380,7 +380,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         forceRefreshTask = Task {
             async let main: Void = store.refresh(includeOptimize: false, force: true, showLoading: true)
             async let quotas: Bool = refreshLiveQuotaProgressIfDue(force: forceQuota)
-            if store.selectedPeriod != .today || store.selectedProvider != .all {
+            if store.selectedDay != nil || store.selectedPeriod != .today || store.selectedProvider != .all {
                 await store.refreshQuietly(period: .today)
             }
             _ = await main
@@ -580,7 +580,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             // "Refresh Now" should refresh the menubar payload AND every
             // connected provider's live quota. The user's intent is "make
             // this match reality right now."
-            let needsTodayTotal = self.store.selectedPeriod != .today || self.store.selectedProvider != .all
+            let needsTodayTotal = self.store.selectedDay != nil || self.store.selectedPeriod != .today || self.store.selectedProvider != .all
             async let payload: Void = self.store.refresh(includeOptimize: false, force: true, showLoading: true)
             async let quotas: Bool = self.refreshLiveQuotaProgressIfDue(force: true)
             if needsTodayTotal {

--- a/mac/Sources/CodeBurnMenubar/Data/DataClient.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/DataClient.swift
@@ -19,13 +19,17 @@ enum DataClientError: Error {
 /// Runs the CLI via argv (no shell interpretation). See `CodeburnCLI` for why we never route
 /// commands through `/bin/zsh -c` anymore.
 struct DataClient {
-    static func fetch(period: Period, provider: ProviderFilter, includeOptimize: Bool) async throws -> MenubarPayload {
+    static func fetch(period: Period, day: String?, provider: ProviderFilter, includeOptimize: Bool) async throws -> MenubarPayload {
         var subcommand = [
             "status",
             "--format", "menubar-json",
-            "--period", period.cliArg,
             "--provider", provider.cliArg,
         ]
+        if let day {
+            subcommand.append(contentsOf: ["--day", day])
+        } else {
+            subcommand.append(contentsOf: ["--period", period.cliArg])
+        }
         if !includeOptimize {
             subcommand.append("--no-optimize")
         }

--- a/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
@@ -79,7 +79,7 @@ struct HeatmapSection: View {
             } else {
                 PlanInsight(usage: store.subscription)
             }
-        case .trend: TrendInsight(days: store.payload.history.daily, period: store.selectedPeriod)
+        case .trend: TrendInsight(days: store.payload.history.daily, period: store.trendPeriod)
         case .forecast: ForecastInsight(days: store.payload.history.daily)
         case .pulse: PulseInsight(payload: store.payload)
         case .stats: StatsInsight(payload: store.payload)
@@ -1839,4 +1839,3 @@ private func relativeReset(_ date: Date) -> String {
     let days = Int(ceil(hours / 24))
     return "in \(days)d"
 }
-

--- a/mac/Sources/CodeBurnMenubar/Views/HeroSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeroSection.swift
@@ -53,7 +53,8 @@ struct HeroSection: View {
                 }
             }
 
-            if store.selectedPeriod == .today,
+            if !store.isDayMode,
+               store.selectedPeriod == .today,
                store.dailyBudget > 0,
                let todayCost = store.todayPayload?.current.cost,
                todayCost >= store.dailyBudget {
@@ -92,7 +93,7 @@ struct HeroSection: View {
 
     private var caption: String {
         let label = store.payload.current.label.isEmpty ? store.selectedPeriod.rawValue : store.payload.current.label
-        if store.selectedPeriod == .today {
+        if !store.isDayMode && store.selectedPeriod == .today {
             return "\(label) · \(todayDate)"
         }
         return label

--- a/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
@@ -24,7 +24,7 @@ struct MenuBarContent: View {
                         PeriodSegmentedControl()
                         Divider().opacity(0.5)
                         if isFilteredEmpty {
-                            EmptyProviderState(provider: store.selectedProvider, period: store.selectedPeriod)
+                            EmptyProviderState(provider: store.selectedProvider, periodLabel: store.selectionLabel)
                         } else {
                             HeatmapSection()
                                 .padding(.horizontal, 14)
@@ -49,22 +49,15 @@ struct MenuBarContent: View {
                 // error, etc.), surface a retry card instead of leaving the
                 // user stuck on a perpetual "Loading..." spinner.
                 if !store.hasCachedData {
-                    if store.isCurrentKeyLoading || !store.hasAttemptedCurrentKeyLoad {
-                        BurnLoadingOverlay(periodLabel: store.selectedPeriod.rawValue)
-                            .transition(.opacity)
-                    } else if let err = store.lastError {
+                    if let err = store.lastError {
                         FetchErrorOverlay(
                             error: err,
-                            periodLabel: store.selectedPeriod.rawValue,
+                            periodLabel: store.selectionLabel,
                             retry: { Task { await store.refresh(includeOptimize: false, force: true, showLoading: true) } }
                         )
                         .transition(.opacity)
                     } else {
-                        FetchErrorOverlay(
-                            error: "The last refresh stopped before returning data. CodeBurn will keep retrying, or you can retry now.",
-                            periodLabel: store.selectedPeriod.rawValue,
-                            retry: { Task { await store.refresh(includeOptimize: false, force: true, showLoading: true) } }
-                        )
+                        BurnLoadingOverlay(periodLabel: store.selectionLabel)
                             .transition(.opacity)
                     }
                 }
@@ -114,14 +107,14 @@ struct MenuBarContent: View {
 
 private struct EmptyProviderState: View {
     let provider: ProviderFilter
-    let period: Period
+    let periodLabel: String
 
     var body: some View {
         VStack(spacing: 10) {
             Image(systemName: "tray")
                 .font(.system(size: 26))
                 .foregroundStyle(.tertiary)
-            Text("No \(provider.rawValue) data for \(periodPhrase)")
+            Text("No \(provider.rawValue) data for \(periodLabel)")
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -130,15 +123,6 @@ private struct EmptyProviderState: View {
         .padding(.vertical, 60)
     }
 
-    private var periodPhrase: String {
-        switch period {
-        case .today: "today"
-        case .sevenDays: "the last 7 days"
-        case .thirtyDays: "the last 30 days"
-        case .month: "this month"
-        case .all: "the last 6 months"
-        }
-    }
 }
 
 /// Shown when a fetch failed and the cache is still empty for this key. The

--- a/mac/Sources/CodeBurnMenubar/Views/PeriodSegmentedControl.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/PeriodSegmentedControl.swift
@@ -2,35 +2,125 @@ import SwiftUI
 
 struct PeriodSegmentedControl: View {
     @Environment(AppStore.self) private var store
+    @State private var showingCalendar = false
 
     var body: some View {
-        HStack(spacing: 1) {
-            ForEach(Period.allCases) { period in
+        VStack(spacing: 6) {
+            HStack(spacing: 1) {
+                ForEach(Period.allCases) { period in
+                    let isActive = !store.isDayMode && store.selectedPeriod == period
+                    Button {
+                        store.switchTo(period: period)
+                    } label: {
+                        Text(period.rawValue)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(isActive ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 4)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .background(
+                        RoundedRectangle(cornerRadius: 5)
+                            .fill(isActive ? Color(NSColor.windowBackgroundColor).opacity(0.85) : .clear)
+                            .shadow(color: .black.opacity(isActive ? 0.06 : 0), radius: 1, y: 0.5)
+                    )
+                }
+            }
+            .padding(2)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(Color.secondary.opacity(0.08))
+            )
+
+            HStack(spacing: 8) {
                 Button {
-                    store.switchTo(period: period)
+                    showingCalendar.toggle()
                 } label: {
-                    Text(period.rawValue)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(store.selectedPeriod == period ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 4)
-                        .contentShape(Rectangle())
+                    HStack(spacing: 6) {
+                        Image(systemName: "calendar")
+                            .font(.system(size: 10.5, weight: .semibold))
+                            .foregroundStyle(store.isDayMode ? Theme.brandAccent : .secondary)
+                        Text(dayButtonTitle)
+                            .font(.system(size: 11.5, weight: .semibold))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.85)
+                            .foregroundStyle(.primary)
+                        Spacer(minLength: 0)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 28)
+                    .padding(.horizontal, 9)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .background(
-                    RoundedRectangle(cornerRadius: 5)
-                        .fill(store.selectedPeriod == period ? Color(NSColor.windowBackgroundColor).opacity(0.85) : .clear)
-                        .shadow(color: .black.opacity(store.selectedPeriod == period ? 0.06 : 0), radius: 1, y: 0.5)
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(store.isDayMode ? Color(NSColor.windowBackgroundColor).opacity(0.85) : Color.secondary.opacity(0.08))
+                        .shadow(color: .black.opacity(store.isDayMode ? 0.06 : 0), radius: 1, y: 0.5)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(store.isDayMode ? Theme.brandAccent.opacity(0.22) : Color.clear, lineWidth: 1)
+                )
+                .popover(isPresented: $showingCalendar, arrowEdge: .bottom) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Review day")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 10)
+                            .padding(.top, 8)
+                        DatePicker(
+                            "",
+                            selection: selectedDayBinding,
+                            in: Date.distantPast...Date(),
+                            displayedComponents: .date
+                        )
+                        .labelsHidden()
+                        .datePickerStyle(.graphical)
+                        .frame(width: 270)
+                        .padding(.horizontal, 8)
+                        .padding(.bottom, 8)
+                    }
+                }
+
+                Button("Today") {
+                    store.switchTo(day: Date())
+                }
+                .font(.system(size: 11, weight: .medium))
+                .buttonStyle(.plain)
+                .foregroundStyle(.primary)
+                .padding(.horizontal, 9)
+                .frame(width: 72, height: 28)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color.secondary.opacity(0.10))
                 )
             }
         }
-        .padding(2)
-        .background(
-            RoundedRectangle(cornerRadius: 7)
-                .fill(Color.secondary.opacity(0.08))
-        )
         .padding(.horizontal, 12)
         .padding(.top, 6)
         .padding(.bottom, 10)
+    }
+
+    private var selectedDayBinding: Binding<Date> {
+        Binding(
+            get: {
+                store.selectedDayDate ??
+                    Calendar.current.startOfDay(for: Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date())
+            },
+            set: {
+                store.switchTo(day: $0)
+                showingCalendar = false
+            }
+        )
+    }
+
+    private var dayButtonTitle: String {
+        let date = store.selectedDayDate ??
+            Calendar.current.startOfDay(for: Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date())
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, yyyy"
+        return formatter.string(from: date)
     }
 }

--- a/src/cli-date.ts
+++ b/src/cli-date.ts
@@ -58,6 +58,49 @@ function parseLocalDate(s: string): Date {
   return date
 }
 
+function endOfLocalDay(date: Date): Date {
+  return new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    END_OF_DAY_HOURS,
+    END_OF_DAY_MINUTES,
+    END_OF_DAY_SECONDS,
+    END_OF_DAY_MS,
+  )
+}
+
+export function dayRangeForDate(date: Date): DateRange {
+  const start = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  return { start, end: endOfLocalDay(start) }
+}
+
+export function formatDayRangeLabel(day: string): string {
+  return `Day (${day})`
+}
+
+export function shiftDay(day: string, delta: number): string {
+  const date = parseLocalDate(day)
+  return toDateString(new Date(date.getFullYear(), date.getMonth(), date.getDate() + delta))
+}
+
+export function parseDayFlag(day: string | undefined): { day: string; range: DateRange; label: string } | null {
+  if (day === undefined) return null
+
+  const now = new Date()
+  let date: Date
+  if (day === 'today') {
+    date = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  } else if (day === 'yesterday') {
+    date = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1)
+  } else {
+    date = parseLocalDate(day)
+  }
+
+  const resolvedDay = toDateString(date)
+  return { day: resolvedDay, range: dayRangeForDate(date), label: formatDayRangeLabel(resolvedDay) }
+}
+
 export function parseDateRangeFlags(from: string | undefined, to: string | undefined): DateRange | null {
   if (from === undefined && to === undefined) return null
 
@@ -72,15 +115,7 @@ export function parseDateRangeFlags(from: string | undefined, to: string | undef
     : new Date(now.getTime() - ALL_TIME_FALLBACK_MS)
 
   const endDate = to !== undefined ? parseLocalDate(to) : new Date(now.getFullYear(), now.getMonth(), now.getDate())
-  const end = new Date(
-    endDate.getFullYear(),
-    endDate.getMonth(),
-    endDate.getDate(),
-    END_OF_DAY_HOURS,
-    END_OF_DAY_MINUTES,
-    END_OF_DAY_SECONDS,
-    END_OF_DAY_MS,
-  )
+  const end = endOfLocalDay(endDate)
 
   if (start > end) {
     throw new Error(`--from must not be after --to (got ${from} > ${to})`)
@@ -113,12 +148,11 @@ export function getDateRange(period: string): { range: DateRange; label: string 
   switch (period) {
     case 'today': {
       const start = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-      return { range: { start, end }, label: `Today (${toDateString(start)})` }
+      return { range: dayRangeForDate(start), label: `Today (${toDateString(start)})` }
     }
     case 'yesterday': {
       const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1)
-      const yesterdayEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1, END_OF_DAY_HOURS, END_OF_DAY_MINUTES, END_OF_DAY_SECONDS, END_OF_DAY_MS)
-      return { range: { start, end: yesterdayEnd }, label: `Yesterday (${toDateString(start)})` }
+      return { range: dayRangeForDate(start), label: `Yesterday (${toDateString(start)})` }
     }
     case 'week': {
       const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7)

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -14,7 +14,7 @@ import { dateKey } from './day-aggregator.js'
 import { CompareView } from './compare.js'
 import { getPlanUsages, type PlanUsage } from './plan-usage.js'
 import { planDisplayName } from './plans.js'
-import { getDateRange, PERIODS, PERIOD_LABELS, type Period, formatDateRangeLabel } from './cli-date.js'
+import { formatDayRangeLabel, getDateRange, parseDayFlag, PERIODS, PERIOD_LABELS, shiftDay, type Period } from './cli-date.js'
 import { patchStdoutForWindows } from './ink-win.js'
 
 type View = 'dashboard' | 'optimize' | 'compare'
@@ -100,6 +100,10 @@ function gradientColor(pct: number): string {
 
 function getPeriodRange(period: Period): { start: Date; end: Date } {
   return getDateRange(period).range
+}
+
+function getDayRange(day: string): DateRange {
+  return parseDayFlag(day)!.range
 }
 
 function isHeavyPeriod(period: Period): boolean {
@@ -648,14 +652,16 @@ function OptimizeView({ findings, costRate, projects, label, width, healthScore,
   )
 }
 
-function StatusBar({ width, showProvider, view, findingCount, optimizeAvailable, compareAvailable, customRange }: { width: number; showProvider?: boolean; view?: View; findingCount?: number; optimizeAvailable?: boolean; compareAvailable?: boolean; customRange?: boolean }) {
+function StatusBar({ width, showProvider, view, findingCount, optimizeAvailable, compareAvailable, customRange, dayMode }: { width: number; showProvider?: boolean; view?: View; findingCount?: number; optimizeAvailable?: boolean; compareAvailable?: boolean; customRange?: boolean; dayMode?: boolean }) {
   const isOptimize = view === 'optimize'
   return (
     <Box borderStyle="round" borderColor={DIM} width={width} justifyContent="center" paddingX={1}>
       <Text>
         {isOptimize
           ? <><Text color={ORANGE} bold>b</Text><Text dimColor> back   </Text><Text color={ORANGE} bold>j</Text><Text dimColor>/</Text><Text color={ORANGE} bold>k</Text><Text dimColor> scroll   </Text></>
-          : !customRange
+          : dayMode
+            ? <><Text color={ORANGE} bold>{'<'}</Text><Text color={ORANGE}>{'>'}</Text><Text dimColor> day   </Text></>
+            : !customRange
             ? <><Text color={ORANGE} bold>{'<'}</Text><Text color={ORANGE}>{'>'}</Text><Text dimColor> switch   </Text></>
             : null}
         <Text color={ORANGE} bold>q</Text><Text dimColor> quit</Text>
@@ -666,6 +672,11 @@ function StatusBar({ width, showProvider, view, findingCount, optimizeAvailable,
             <Text color={ORANGE} bold>3</Text><Text dimColor> 30 days   </Text>
             <Text color={ORANGE} bold>4</Text><Text dimColor> month   </Text>
             <Text color={ORANGE} bold>5</Text><Text dimColor> 6 months</Text>
+          </>
+        )}
+        {!customRange && !isOptimize && (
+          <>
+            <Text dimColor>   </Text><Text color={ORANGE} bold>d</Text><Text dimColor>{dayMode ? ' exit day' : ' yesterday'}</Text>
           </>
         )}
         {!isOptimize && optimizeAvailable && (
@@ -685,15 +696,16 @@ function Row({ wide, width, children }: { wide: boolean; width: number; children
   return <>{children}</>
 }
 
-function DashboardContent({ projects, period, columns, activeProvider, budgets, planUsages }: { projects: ProjectSummary[]; period: Period; columns?: number; activeProvider?: string; budgets?: Map<string, ContextBudget>; planUsages?: PlanUsage[] }) {
+function DashboardContent({ projects, period, columns, activeProvider, budgets, planUsages, label, dayMode }: { projects: ProjectSummary[]; period: Period; columns?: number; activeProvider?: string; budgets?: Map<string, ContextBudget>; planUsages?: PlanUsage[]; label?: string; dayMode?: boolean }) {
   const { dashWidth, wide, halfWidth, barWidth } = getLayout(columns)
   const isCursor = activeProvider === 'cursor'
-  if (projects.length === 0) return <Panel title="CodeBurn" color={ORANGE} width={dashWidth}><Text dimColor>No usage data found for {PERIOD_LABELS[period]}.</Text></Panel>
+  const activeLabel = label ?? PERIOD_LABELS[period]
+  if (projects.length === 0) return <Panel title="CodeBurn" color={ORANGE} width={dashWidth}><Text dimColor>No usage data found for {activeLabel}.</Text></Panel>
   const pw = wide ? halfWidth : dashWidth
-  const days = period === 'all' ? undefined : (period === 'month' || period === '30days' ? 31 : 14)
+  const days = dayMode ? 1 : period === 'all' ? undefined : (period === 'month' || period === '30days' ? 31 : 14)
   return (
     <Box flexDirection="column" width={dashWidth}>
-      <Overview projects={projects} label={PERIOD_LABELS[period]} width={dashWidth} planUsages={planUsages} />
+      <Overview projects={projects} label={activeLabel} width={dashWidth} planUsages={planUsages} />
       <Row wide={wide} width={dashWidth}><DailyActivity projects={projects} days={days} pw={pw} bw={barWidth} /><ProjectBreakdown projects={projects} pw={pw} bw={barWidth} budgets={budgets} /></Row>
       <Row wide={wide} width={dashWidth}><ActivityBreakdown projects={projects} pw={pw} bw={barWidth} /><ModelBreakdown projects={projects} pw={pw} bw={barWidth} /></Row>
       {isCursor ? (
@@ -705,7 +717,7 @@ function DashboardContent({ projects, period, columns, activeProvider, budgets, 
   )
 }
 
-function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider, initialPlanUsages, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel }: {
+function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider, initialPlanUsages, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel, initialDay }: {
   initialProjects: ProjectSummary[]
   initialPeriod: Period
   initialProvider: string
@@ -715,6 +727,7 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
   excludeFilter?: string[]
   customRange?: DateRange | null
   customRangeLabel?: string
+  initialDay?: string
 }) {
   const { exit } = useApp()
   const [period, setPeriod] = useState<Period>(initialPeriod)
@@ -727,11 +740,13 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
   const [optimizeLoading, setOptimizeLoading] = useState(false)
   const [projectBudgets, setProjectBudgets] = useState<Map<string, ContextBudget>>(new Map())
   const [planUsages, setPlanUsages] = useState<PlanUsage[]>(initialPlanUsages ?? [])
+  const [dayDate, setDayDate] = useState<string | null>(initialDay ?? null)
   // Cursor for the OptimizeView's findings window. Reset whenever the user
   // leaves the optimize view OR the underlying findings change so a long
   // findings list never strands the user past the new array length.
   const [findingsCursor, setFindingsCursor] = useState(0)
-  const isCustomRange = customRange != null
+  const isDayMode = dayDate != null
+  const isCustomRange = customRange != null && !isDayMode
   const { columns } = useWindowSize()
   const { dashWidth } = getLayout(columns)
   const multipleProviders = detectedProviders.length > 1
@@ -743,8 +758,8 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const reloadGenerationRef = useRef(0)
   const reloadInFlightRef = useRef(false)
-  const currentReloadRef = useRef<{ period: Period; provider: string } | null>(null)
-  const pendingReloadRef = useRef<{ period: Period; provider: string } | null>(null)
+  const currentReloadRef = useRef<{ period: Period; provider: string; day: string | null } | null>(null)
+  const pendingReloadRef = useRef<{ period: Period; provider: string; day: string | null } | null>(null)
   const findingCount = optimizeResult?.findings.length ?? 0
 
   useEffect(() => {
@@ -773,31 +788,31 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
     return () => { cancelled = true }
   }, [projects])
 
-  const reloadData = useCallback(async (p: Period, prov: string) => {
+  const reloadData = useCallback(async (p: Period, prov: string, day: string | null = null) => {
     if (reloadInFlightRef.current) {
       const current = currentReloadRef.current
-      if (current?.period === p && current.provider === prov) {
+      if (current?.period === p && current.provider === prov && current.day === day) {
         pendingReloadRef.current = null
         return
       }
       reloadGenerationRef.current++
-      pendingReloadRef.current = { period: p, provider: prov }
+      pendingReloadRef.current = { period: p, provider: prov, day }
       return
     }
     reloadInFlightRef.current = true
-    currentReloadRef.current = { period: p, provider: prov }
+    currentReloadRef.current = { period: p, provider: prov, day }
     const generation = ++reloadGenerationRef.current
     setLoading(true)
     setOptimizeLoading(false)
     setOptimizeResult(null)
     try {
-      if (isHeavyPeriod(p)) {
+      if (!day && isHeavyPeriod(p)) {
         setProjects([])
         setProjectBudgets(new Map())
         await nextTick()
         if (reloadGenerationRef.current !== generation) return
       }
-      const range = getPeriodRange(p)
+      const range = day ? getDayRange(day) : getPeriodRange(p)
       const data = await parseAllSessions(range, prov)
       if (reloadGenerationRef.current !== generation) return
 
@@ -819,10 +834,14 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
       const pending = pendingReloadRef.current
       pendingReloadRef.current = null
       if (pending) {
-        void reloadData(pending.period, pending.provider)
+        void reloadData(pending.period, pending.provider, pending.day)
       }
     }
   }, [projectFilter, excludeFilter])
+
+  const currentRange = useCallback(() => {
+    return dayDate ? getDayRange(dayDate) : getPeriodRange(period)
+  }, [dayDate, period])
 
   const loadOptimizeResult = useCallback(async () => {
     if (!optimizeAvailable || projects.length === 0 || optimizeLoading) return
@@ -833,44 +852,63 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
     const generation = reloadGenerationRef.current
     setOptimizeLoading(true)
     try {
-      const result = await scanAndDetect(projects, getPeriodRange(period))
+      const result = await scanAndDetect(projects, currentRange())
       if (reloadGenerationRef.current === generation) setOptimizeResult(result)
     } catch (error) {
       console.error(error)
     } finally {
       if (reloadGenerationRef.current === generation) setOptimizeLoading(false)
     }
-  }, [optimizeAvailable, projects, period, optimizeLoading, optimizeResult])
+  }, [optimizeAvailable, projects, currentRange, optimizeLoading, optimizeResult])
 
   useEffect(() => {
     if (!refreshSeconds || refreshSeconds <= 0) return
-    if (isHeavyPeriod(period)) return
-    const id = setInterval(() => { reloadData(period, activeProvider) }, refreshSeconds * 1000)
+    if (!dayDate && isHeavyPeriod(period)) return
+    const id = setInterval(() => { reloadData(period, activeProvider, dayDate) }, refreshSeconds * 1000)
     return () => clearInterval(id)
-  }, [refreshSeconds, period, activeProvider, reloadData])
+  }, [refreshSeconds, period, activeProvider, dayDate, reloadData])
 
   const switchPeriod = useCallback((np: Period) => {
-    if (np === period) return
+    if (np === period && !dayDate) return
     // Clear projects + flip loading synchronously so the dashboard never
     // renders the new period label over the old period's numbers between
     // setPeriod() and the reloadData() promise resolving. Without this,
     // there's a frame-to-hundreds-of-ms window where users saw wrong
     // figures captioned with the new period.
     setPeriod(np)
+    setDayDate(null)
     setProjects([])
     setLoading(true)
     if (debounceRef.current) clearTimeout(debounceRef.current)
-    debounceRef.current = setTimeout(() => { reloadData(np, activeProvider) }, 600)
-  }, [period, activeProvider, reloadData])
+    debounceRef.current = setTimeout(() => { reloadData(np, activeProvider, null) }, 600)
+  }, [period, activeProvider, dayDate, reloadData])
 
   const switchPeriodImmediate = useCallback(async (np: Period) => {
-    if (np === period) return
+    if (np === period && !dayDate) return
     setPeriod(np)
+    setDayDate(null)
     setProjects([])
     setLoading(true)
     if (debounceRef.current) clearTimeout(debounceRef.current)
-    await reloadData(np, activeProvider)
-  }, [period, activeProvider, reloadData])
+    await reloadData(np, activeProvider, null)
+  }, [period, activeProvider, dayDate, reloadData])
+
+  const switchDay = useCallback(async (nextDay: string) => {
+    const today = parseDayFlag('today')!.day
+    const clampedDay = nextDay > today ? today : nextDay
+    if (clampedDay === dayDate) return
+    setDayDate(clampedDay)
+    setProjects([])
+    setLoading(true)
+    setView('dashboard')
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    await reloadData(period, activeProvider, clampedDay)
+  }, [period, activeProvider, dayDate, reloadData])
+
+  const enterYesterday = useCallback(async () => {
+    const yesterday = parseDayFlag('yesterday')!.day
+    await switchDay(yesterday)
+  }, [switchDay])
 
   useInput((input, key) => {
     if (input === 'q') { exit(); return }
@@ -881,6 +919,7 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
       const maxStart = Math.max(0, total - FINDINGS_WINDOW_SIZE)
       if (input === 'j' || key.downArrow) { setFindingsCursor(c => Math.min(c + 1, maxStart)); return }
       if (input === 'k' || key.upArrow)   { setFindingsCursor(c => Math.max(c - 1, 0)); return }
+      return
     }
     if (input === 'c' && compareAvailable && view === 'dashboard') { setView('compare'); return }
     if ((input === 'b' || key.escape) && view === 'compare') { setView('dashboard'); return }
@@ -888,18 +927,40 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
       const opts = ['all', ...detectedProviders]; const next = opts[(opts.indexOf(activeProvider) + 1) % opts.length]
       setActiveProvider(next); setView('dashboard')
       if (debounceRef.current) clearTimeout(debounceRef.current)
-      reloadData(period, next); return
+      reloadData(period, next, dayDate); return
     }
     // Period switches reload the underlying data. Disable them while the
     // compare view is mounted; the compare view re-aggregates from
     // `projects` and would visibly change underneath the user without any
     // affordance back to the dashboard. Press `b` or Esc to return first.
     if (view === 'compare') return
+    if (!customRange && input === 'd') {
+      if (dayDate) {
+        setDayDate(null)
+        setProjects([])
+        setLoading(true)
+        void reloadData(period, activeProvider, null)
+      } else {
+        void enterYesterday()
+      }
+      return
+    }
     // Also disable while a custom --from/--to range is in effect. Switching
     // period would silently abandon the user's explicit range and reload
     // standard period data; the period tab strip is hidden in this mode so
     // users have no expectation that 1-5 should do anything.
     if (isCustomRange) return
+    if (dayDate) {
+      if (key.leftArrow) { void switchDay(shiftDay(dayDate, -1)); return }
+      if (key.rightArrow || key.tab) { void switchDay(shiftDay(dayDate, 1)); return }
+      if (key.escape || input === 'b') {
+        setDayDate(null)
+        setProjects([])
+        setLoading(true)
+        void reloadData(period, activeProvider, null)
+        return
+      }
+    }
     const idx = PERIODS.indexOf(period)
     if (key.leftArrow) switchPeriod(PERIODS[(idx - 1 + PERIODS.length) % PERIODS.length]!)
     else if (key.rightArrow || key.tab) switchPeriod(PERIODS[(idx + 1) % PERIODS.length]!)
@@ -910,12 +971,13 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
     else if (input === '5') switchPeriodImmediate('all')
   })
 
-  const headerLabel = customRangeLabel ?? PERIOD_LABELS[period]
+  const headerLabel = dayDate ? formatDayRangeLabel(dayDate) : customRangeLabel ?? PERIOD_LABELS[period]
 
   if (loading || optimizeLoading) {
     return (
       <Box flexDirection="column" width={dashWidth}>
-        {!isCustomRange && <PeriodTabs active={period} providerName={activeProvider} showProvider={view !== 'compare' && multipleProviders} />}
+        {!isCustomRange && !isDayMode && <PeriodTabs active={period} providerName={activeProvider} showProvider={view !== 'compare' && multipleProviders} />}
+        {isDayMode && <DayBanner label={headerLabel} width={dashWidth} />}
         {isCustomRange && <CustomRangeBanner label={headerLabel} width={dashWidth} />}
         {view === 'compare'
           ? <Box flexDirection="column" paddingX={2} paddingY={1}>
@@ -928,21 +990,30 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
           : view === 'optimize'
             ? <Panel title="CodeBurn Optimize" color={ORANGE} width={dashWidth}><Text dimColor>Scanning {headerLabel}...</Text></Panel>
             : <Panel title="CodeBurn" color={ORANGE} width={dashWidth}><Text dimColor>Loading {headerLabel}...</Text></Panel>}
-        {view !== 'compare' && <StatusBar width={dashWidth} showProvider={multipleProviders} view={view} findingCount={0} optimizeAvailable={false} compareAvailable={false} customRange={isCustomRange} />}
+        {view !== 'compare' && <StatusBar width={dashWidth} showProvider={multipleProviders} view={view} findingCount={0} optimizeAvailable={false} compareAvailable={false} customRange={isCustomRange} dayMode={isDayMode} />}
       </Box>
     )
   }
 
   return (
     <Box flexDirection="column" width={dashWidth}>
-      {!isCustomRange && <PeriodTabs active={period} providerName={activeProvider} showProvider={multipleProviders && view !== 'compare'} />}
+      {!isCustomRange && !isDayMode && <PeriodTabs active={period} providerName={activeProvider} showProvider={multipleProviders && view !== 'compare'} />}
+      {isDayMode && <DayBanner label={headerLabel} width={dashWidth} />}
       {isCustomRange && <CustomRangeBanner label={headerLabel} width={dashWidth} />}
       {view === 'compare'
         ? <CompareView projects={projects} onBack={() => setView('dashboard')} />
         : view === 'optimize' && optimizeResult
           ? <OptimizeView findings={optimizeResult.findings} costRate={optimizeResult.costRate} projects={projects} label={headerLabel} width={dashWidth} healthScore={optimizeResult.healthScore} healthGrade={optimizeResult.healthGrade} cursor={findingsCursor} />
-          : <DashboardContent projects={projects} period={period} columns={columns} activeProvider={activeProvider} budgets={projectBudgets} planUsages={planUsages} />}
-      {view !== 'compare' && <StatusBar width={dashWidth} showProvider={multipleProviders} view={view} findingCount={findingCount} optimizeAvailable={optimizeAvailable} compareAvailable={compareAvailable} customRange={isCustomRange} />}
+          : <DashboardContent projects={projects} period={period} columns={columns} activeProvider={activeProvider} budgets={projectBudgets} planUsages={planUsages} label={headerLabel} dayMode={isDayMode} />}
+      {view !== 'compare' && <StatusBar width={dashWidth} showProvider={multipleProviders} view={view} findingCount={findingCount} optimizeAvailable={optimizeAvailable} compareAvailable={compareAvailable} customRange={isCustomRange} dayMode={isDayMode} />}
+    </Box>
+  )
+}
+
+function DayBanner({ label, width }: { label: string; width: number }) {
+  return (
+    <Box width={width} paddingX={1} marginBottom={1}>
+      <Text color={ORANGE} bold>{label}</Text>
     </Box>
   )
 }
@@ -956,31 +1027,33 @@ function CustomRangeBanner({ label, width }: { label: string; width: number }) {
   )
 }
 
-function StaticDashboard({ projects, period, activeProvider, planUsages }: { projects: ProjectSummary[]; period: Period; activeProvider?: string; planUsages?: PlanUsage[] }) {
+function StaticDashboard({ projects, period, activeProvider, planUsages, label, dayMode }: { projects: ProjectSummary[]; period: Period; activeProvider?: string; planUsages?: PlanUsage[]; label?: string; dayMode?: boolean }) {
   const { columns } = useWindowSize()
   const { dashWidth } = getLayout(columns)
   return (
     <Box flexDirection="column" width={dashWidth}>
-      <PeriodTabs active={period} />
-      <DashboardContent projects={projects} period={period} columns={columns} activeProvider={activeProvider} planUsages={planUsages} />
+      {dayMode ? <DayBanner label={label ?? PERIOD_LABELS[period]} width={dashWidth} /> : <PeriodTabs active={period} />}
+      <DashboardContent projects={projects} period={period} columns={columns} activeProvider={activeProvider} planUsages={planUsages} label={label} dayMode={dayMode} />
     </Box>
   )
 }
 
-export async function renderDashboard(period: Period = 'week', provider: string = 'all', refreshSeconds?: number, projectFilter?: string[], excludeFilter?: string[], customRange?: DateRange | null, customRangeLabel?: string): Promise<void> {
+export async function renderDashboard(period: Period = 'week', provider: string = 'all', refreshSeconds?: number, projectFilter?: string[], excludeFilter?: string[], customRange?: DateRange | null, customRangeLabel?: string, initialDay?: string): Promise<void> {
   await loadPricing()
-  const range = customRange ?? getPeriodRange(period)
+  const dayRange = initialDay ? getDayRange(initialDay) : null
+  const range = dayRange ?? customRange ?? getPeriodRange(period)
   const filteredProjects = filterProjectsByName(await parseAllSessions(range, provider), projectFilter, excludeFilter)
   const planUsages = await getPlanUsages()
   const isTTY = process.stdin.isTTY && process.stdout.isTTY
+  const label = initialDay ? formatDayRangeLabel(initialDay) : customRangeLabel
   patchStdoutForWindows()
   if (isTTY) {
     const { waitUntilExit } = render(
-      <InteractiveDashboard initialProjects={filteredProjects} initialPeriod={period} initialProvider={provider} initialPlanUsages={planUsages} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} />
+      <InteractiveDashboard initialProjects={filteredProjects} initialPeriod={period} initialProvider={provider} initialPlanUsages={planUsages} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} />
     )
     await waitUntilExit()
   } else {
-    const { unmount } = render(<StaticDashboard projects={filteredProjects} period={period} activeProvider={provider} planUsages={planUsages} />, { patchConsole: false })
+    const { unmount } = render(<StaticDashboard projects={filteredProjects} period={period} activeProvider={provider} planUsages={planUsages} label={label} dayMode={initialDay != null} />, { patchConsole: false })
     unmount()
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import { aggregateProjectsIntoDays, buildPeriodDataFromDays, dateKey } from './d
 import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory } from './types.js'
 import { aggregateModelEfficiency } from './model-efficiency.js'
 import { renderDashboard } from './dashboard.js'
-import { formatDateRangeLabel, parseDateRangeFlags, getDateRange, toPeriod, type Period } from './cli-date.js'
+import { formatDateRangeLabel, parseDateRangeFlags, parseDayFlag, getDateRange, toPeriod, type Period } from './cli-date.js'
 import { runOptimize, scanAndDetect } from './optimize.js'
 import { renderCompare } from './compare.js'
 import { getAllProviders } from './providers/index.js'
@@ -356,6 +356,7 @@ program
   .command('report', { isDefault: true })
   .description('Interactive usage dashboard')
   .option('-p, --period <period>', 'Starting period: today, week, 30days, month, all', 'week')
+  .option('--day <date>', 'Single day to review (YYYY-MM-DD, today, or yesterday). Overrides --period when set')
   .option('--from <date>', 'Start date (YYYY-MM-DD). Overrides --period when set')
   .option('--to <date>', 'End date (YYYY-MM-DD). Overrides --period when set')
   .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
@@ -366,7 +367,12 @@ program
   .action(async (opts) => {
     assertFormat(opts.format, ['tui', 'json'], 'report')
     let customRange: DateRange | null = null
+    let daySelection: ReturnType<typeof parseDayFlag> = null
     try {
+      if (opts.day && (opts.from || opts.to)) {
+        throw new Error('--day cannot be combined with --from or --to')
+      }
+      daySelection = parseDayFlag(opts.day)
       customRange = parseDateRangeFlags(opts.from, opts.to)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -377,21 +383,23 @@ program
     const period = toPeriod(opts.period)
     if (opts.format === 'json') {
       await loadPricing()
-      if (customRange) {
-        const label = formatDateRangeLabel(opts.from, opts.to)
+      if (daySelection || customRange) {
+        const range = daySelection?.range ?? customRange!
+        const label = daySelection?.label ?? formatDateRangeLabel(opts.from, opts.to)
+        const periodKey = daySelection ? 'day' : 'custom'
         const projects = filterProjectsByName(
-          await parseAllSessions(customRange, opts.provider),
+          await parseAllSessions(range, opts.provider),
           opts.project,
           opts.exclude,
         )
-        console.log(JSON.stringify(await attachPlanSummaries(buildJsonReport(projects, label, 'custom')), null, 2))
+        console.log(JSON.stringify(await attachPlanSummaries(buildJsonReport(projects, label, periodKey)), null, 2))
       } else {
         await runJsonReport(period, opts.provider, opts.project, opts.exclude)
       }
       return
     }
     const customRangeLabel = customRange ? formatDateRangeLabel(opts.from, opts.to) : undefined
-    await renderDashboard(period, opts.provider, opts.refresh, opts.project, opts.exclude, customRange, customRangeLabel)
+    await renderDashboard(period, opts.provider, opts.refresh, opts.project, opts.exclude, customRange, customRangeLabel, daySelection?.day)
   })
 
 function buildPeriodData(label: string, projects: ProjectSummary[]): PeriodData {
@@ -442,6 +450,7 @@ program
   .option('--project <name>', 'Show only projects matching name (repeatable)', collect, [])
   .option('--exclude <name>', 'Exclude projects matching name (repeatable)', collect, [])
   .option('--period <period>', 'Primary period for menubar-json: today, week, 30days, month, all', 'today')
+  .option('--day <date>', 'Single day for menubar-json (YYYY-MM-DD, today, or yesterday). Overrides --period when set')
   .option('--no-optimize', 'Skip optimize findings (menubar-json only, faster)')
   .action(async (opts) => {
     assertFormat(opts.format, ['terminal', 'menubar-json', 'json'], 'status')
@@ -449,7 +458,8 @@ program
     const pf = opts.provider
     const fp = (p: ProjectSummary[]) => filterProjectsByName(p, opts.project, opts.exclude)
     if (opts.format === 'menubar-json') {
-      const periodInfo = getDateRange(opts.period)
+      const daySelection = parseDayFlag(opts.day)
+      const periodInfo = daySelection ?? getDateRange(opts.period)
       const now = new Date()
       const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
       const todayRange: DateRange = { start: todayStart, end: now }
@@ -457,6 +467,7 @@ program
       const yesterdayStr = toDateString(new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1))
       const rangeStartStr = toDateString(periodInfo.range.start)
       const rangeEndStr = toDateString(periodInfo.range.end)
+      const historicalRangeEndStr = rangeEndStr < yesterdayStr ? rangeEndStr : yesterdayStr
       const isAllProviders = pf === 'all'
 
       let todayAllProjects: ProjectSummary[] | null = null
@@ -486,11 +497,13 @@ program
         cache = await hydrateCache()
         const todayProjects = await getTodayAllProjects()
         const todayDays = await getTodayAllDays()
-        const historicalDays = getDaysInRange(cache, rangeStartStr, yesterdayStr)
+        const historicalDays = rangeStartStr <= historicalRangeEndStr
+          ? getDaysInRange(cache, rangeStartStr, historicalRangeEndStr)
+          : []
         const todayInRange = todayDays.filter(d => d.date >= rangeStartStr && d.date <= rangeEndStr)
         const allDays = [...historicalDays, ...todayInRange].sort((a, b) => a.date.localeCompare(b.date))
         currentData = buildPeriodDataFromDays(allDays, periodInfo.label)
-        const isTodayOnly = opts.period === 'today'
+        const isTodayOnly = rangeStartStr === todayStr && rangeEndStr === todayStr
         if (isTodayOnly) {
           scanProjects = todayProjects
           scanRange = todayRange
@@ -506,6 +519,9 @@ program
         scanProjects = fullProjects
         scanRange = periodInfo.range
       }
+      if (isAllProviders) {
+        currentData = buildPeriodData(periodInfo.label, scanProjects)
+      }
 
       // PROVIDERS
       // For .all: enumerate every provider with cost across the period (from cache) + installed-but-zero.
@@ -515,8 +531,8 @@ program
       const providers: ProviderCost[] = []
       if (isAllProviders) {
         const allDaysForProviders = [
-          ...getDaysInRange(cache, rangeStartStr, yesterdayStr),
-          ...(await getTodayAllDays()).filter(d => d.date === todayStr),
+          ...(rangeStartStr <= historicalRangeEndStr ? getDaysInRange(cache, rangeStartStr, historicalRangeEndStr) : []),
+          ...(await getTodayAllDays()).filter(d => d.date >= rangeStartStr && d.date <= rangeEndStr),
         ]
         const providerTotals: Record<string, number> = {}
         for (const d of allDaysForProviders) {

--- a/tests/cli-json-daily.test.ts
+++ b/tests/cli-json-daily.test.ts
@@ -169,4 +169,69 @@ describe('codeburn report --format json daily[] one-shot fields (issue #279)', (
       await rm(home, { recursive: true, force: true })
     }
   })
+
+  it('filters a single review day with --day', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-json-day-'))
+
+    try {
+      const projectDir = join(home, '.claude', 'projects', 'app')
+      await mkdir(projectDir, { recursive: true })
+
+      // runCli pins TZ=UTC, so these exact boundaries exercise the inclusive
+      // start/end of the selected calendar day without local-offset drift.
+      await writeFile(
+        join(projectDir, 'day-selector.jsonl'),
+        [
+          userLine('day-before', '2026-04-09T23:59:00Z'),
+          assistantNoEditLine('day-before', '2026-04-09T23:59:30Z', 'm-before'),
+          userLine('day-selected', '2026-04-10T00:00:00Z'),
+          assistantEditLine('day-selected', '2026-04-10T23:59:59Z', 'm-selected'),
+          userLine('day-after', '2026-04-11T00:00:00Z'),
+          assistantNoEditLine('day-after', '2026-04-11T00:00:30Z', 'm-after'),
+        ].join('\n'),
+      )
+
+      const result = runCli([
+        '--format', 'json',
+        '--day', '2026-04-10',
+        '--provider', 'claude',
+      ], home)
+
+      expect(result.status).toBe(0)
+      const report = JSON.parse(result.stdout) as {
+        period: string
+        periodKey: string
+        daily: Array<{ date: string; calls: number; editTurns: number }>
+        projects: Array<{ sessions: number; calls: number }>
+      }
+
+      expect(report.period).toBe('Day (2026-04-10)')
+      expect(report.periodKey).toBe('day')
+      expect(report.daily.map(d => d.date)).toEqual(['2026-04-10'])
+      expect(report.daily[0]?.calls).toBe(1)
+      expect(report.daily[0]?.editTurns).toBe(1)
+      expect(report.projects[0]?.sessions).toBe(1)
+      expect(report.projects[0]?.calls).toBe(1)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects --day combined with --from/--to', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-json-day-'))
+
+    try {
+      const result = runCli([
+        '--format', 'json',
+        '--day', '2026-04-10',
+        '--from', '2026-04-10',
+        '--provider', 'claude',
+      ], home)
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('--day cannot be combined with --from or --to')
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
 })

--- a/tests/cli-status-menubar.test.ts
+++ b/tests/cli-status-menubar.test.ts
@@ -105,4 +105,53 @@ describe('codeburn status --format menubar-json', () => {
       await rm(home, { recursive: true, force: true })
     }
   })
+
+  it('filters menubar payloads to a selected review day with --day', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-menubar-day-'))
+
+    try {
+      const projectDir = join(home, '.claude', 'projects', 'myapp')
+      await mkdir(projectDir, { recursive: true })
+
+      await writeFile(
+        join(projectDir, 'session.jsonl'),
+        [
+          userLine('before', '2026-04-09T23:58:00Z'),
+          assistantLine('before', '2026-04-09T23:59:00Z', 'msg-before'),
+          userLine('selected', '2026-04-10T11:59:00Z'),
+          assistantLine('selected', '2026-04-10T12:00:00Z', 'msg-selected'),
+          userLine('after', '2026-04-11T00:00:00Z'),
+          assistantLine('after', '2026-04-11T00:01:00Z', 'msg-after'),
+        ].join('\n'),
+      )
+
+      const result = runCli([
+        'status',
+        '--format', 'menubar-json',
+        '--day', '2026-04-10',
+        '--provider', 'all',
+        '--no-optimize',
+      ], home)
+
+      expect(result.status, `stderr: ${result.stderr}`).toBe(0)
+
+      const payload = JSON.parse(result.stdout) as {
+        current: {
+          label: string
+          calls: number
+          sessions: number
+          topProjects: Array<{ sessions: number; sessionDetails: Array<{ date: string }> }>
+        }
+      }
+
+      expect(payload.current.label).toBe('Day (2026-04-10)')
+      expect(payload.current.calls).toBe(1)
+      expect(payload.current.sessions).toBe(1)
+      expect(payload.current.topProjects).toHaveLength(1)
+      expect(payload.current.topProjects[0]?.sessions).toBe(1)
+      expect(payload.current.topProjects[0]?.sessionDetails.map(s => s.date)).toEqual(['2026-04-10'])
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
 })

--- a/tests/date-range-filter.test.ts
+++ b/tests/date-range-filter.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest'
-import { formatDateRangeLabel, parseDateRangeFlags } from '../src/cli-date.js'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { formatDateRangeLabel, formatDayRangeLabel, parseDateRangeFlags, parseDayFlag, shiftDay } from '../src/cli-date.js'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 describe('parseDateRangeFlags', () => {
   it('returns null when neither flag is provided', () => {
@@ -85,5 +89,53 @@ describe('parseDateRangeFlags', () => {
     expect(formatDateRangeLabel('2026-04-07', '2026-04-10')).toBe('2026-04-07 to 2026-04-10')
     expect(formatDateRangeLabel(undefined, '2026-04-10')).toBe('all to 2026-04-10')
     expect(formatDateRangeLabel('2026-04-07', undefined)).toBe('2026-04-07 to today')
+  })
+})
+
+describe('parseDayFlag', () => {
+  it('returns null when no day is provided', () => {
+    expect(parseDayFlag(undefined)).toBeNull()
+  })
+
+  it('parses an explicit day as local midnight through end of day', () => {
+    const selected = parseDayFlag('2026-04-10')
+    expect(selected).not.toBeNull()
+    expect(selected!.day).toBe('2026-04-10')
+    expect(selected!.label).toBe('Day (2026-04-10)')
+    expect(selected!.range.start.getFullYear()).toBe(2026)
+    expect(selected!.range.start.getMonth()).toBe(3)
+    expect(selected!.range.start.getDate()).toBe(10)
+    expect(selected!.range.start.getHours()).toBe(0)
+    expect(selected!.range.end.getDate()).toBe(10)
+    expect(selected!.range.end.getHours()).toBe(23)
+    expect(selected!.range.end.getMinutes()).toBe(59)
+    expect(selected!.range.end.getSeconds()).toBe(59)
+  })
+
+  it('resolves yesterday as the previous local calendar day after midnight', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 4, 23, 0, 5, 0))
+
+    const selected = parseDayFlag('yesterday')
+
+    expect(selected!.day).toBe('2026-05-22')
+    expect(selected!.range.start.getDate()).toBe(22)
+    expect(selected!.range.end.getDate()).toBe(22)
+  })
+
+  it('supports today and day shifting', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 4, 23, 12, 0, 0))
+
+    expect(parseDayFlag('today')!.day).toBe('2026-05-23')
+    expect(formatDayRangeLabel('2026-05-22')).toBe('Day (2026-05-22)')
+    expect(shiftDay('2026-05-22', -1)).toBe('2026-05-21')
+    expect(shiftDay('2026-05-22', 1)).toBe('2026-05-23')
+  })
+
+  it('rejects malformed or overflowing day values', () => {
+    expect(() => parseDayFlag('May 22')).toThrow('Invalid date format')
+    expect(() => parseDayFlag('2026-02-31')).toThrow('Invalid date "2026-02-31"')
+    expect(() => shiftDay('2026-13-01', 1)).toThrow('Invalid date "2026-13-01"')
   })
 })


### PR DESCRIPTION
## Summary

Adds a single-day review mode so users can inspect CodeBurn usage for an exact calendar day after the day has passed.

This is meant for the common “worked past midnight, review yesterday later” workflow: the CLI, TUI, JSON output, and macOS menubar can now select one specific day instead of only fixed rolling periods.

## Root cause

CodeBurn had fixed period selectors such as Today, 7 Days, 30 Days, Month, and All. That made it hard to review a specific previous day once midnight passed, especially in the menubar where the selected period always mapped to a moving range.

The menubar also needed separate handling for selected historical days: the menu bar icon should continue showing today's spend, while the opened popover can display a chosen review day.

## What changed

- Add shared local-day helpers for exact day ranges.
- Add `--day <YYYY-MM-DD|today|yesterday>` to `codeburn report`.
- Add `--day <YYYY-MM-DD|today|yesterday>` to `codeburn status --format menubar-json`.
- Reject ambiguous `report --day` usage with `--from` / `--to`.
- Start the TUI in day mode when `report --day` is used.
- Add TUI day navigation with day labels and clamping at today.
- Add a menubar date selector for review days.
- Keep the menubar status item pinned to today's spend while the popover can show a selected day.
- Fix the menubar refresh race where selecting a day could briefly show a false “couldn't load day” error before valid data arrived.
- Close the calendar popover automatically after selecting a date.
- Document the new single-day menubar selector.

## Behavior proof

I used a controlled Claude JSONL fixture with three adjacent days in the same session file:

```text
2026-04-09T23:59:00Z  input 111  output 11
2026-04-10T12:00:00Z  input 222  output 22
2026-04-11T00:01:00Z  input 333  output 33
```

Before this PR, on `origin/main`, the exact-day selector does not exist:

```text
codeburn --format json --provider claude --day 2026-04-10

error: unknown option '--day'
```

After this PR, the same fixture filtered with `--day 2026-04-10` returns only the selected day. The day before and day after are excluded from the current report:

```json
{
  "periodKey": "day",
  "period": "Day (2026-04-10)",
  "overview": {
    "cost": 0.000996,
    "calls": 1,
    "sessions": 1,
    "tokens": {
      "input": 222,
      "output": 22,
      "cacheRead": 0,
      "cacheWrite": 0
    }
  },
  "daily": [
    {
      "date": "2026-04-10",
      "calls": 1,
      "turns": 1,
      "editTurns": 1,
      "oneShotTurns": 1,
      "oneShotRate": 100
    }
  ],
  "topSessions": [
    {
      "project": "myapp",
      "date": "2026-04-10",
      "calls": 1
    }
  ]
}
```

The wider range over the same fixture proves there are three available days, so the single-day output above is actually filtering, not missing data:

```json
{
  "period": "2026-04-09 to 2026-04-11",
  "overview": {
    "calls": 3,
    "tokens": {
      "input": 666,
      "output": 66
    }
  },
  "daily": [
    { "date": "2026-04-09", "calls": 1 },
    { "date": "2026-04-10", "calls": 1 },
    { "date": "2026-04-11", "calls": 1 }
  ]
}
```

The menubar JSON path uses the same selected day for the opened popover:

```json
{
  "label": "Day (2026-04-10)",
  "cost": 0.000996,
  "calls": 1,
  "sessions": 1,
  "providers": {
    "claude": 0.000996
  },
  "topProjects": [
    {
      "name": "myapp",
      "sessions": 1,
      "sessionDates": ["2026-04-10"]
    }
  ]
}
```

Ambiguous CLI usage is rejected instead of silently mixing date modes:

```text
codeburn --format json --provider claude --day 2026-04-10 --from 2026-04-09

Error: --day cannot be combined with --from or --to
```

The macOS menubar app was also installed locally and tested with the calendar selector. Demo video can be attached to this PR.

## Validation

- [x] `npm test -- --run` - 65 files / 932 tests passed.
- [x] `npm run build` - passed.
- [x] `npx tsc --noEmit` - passed.
- [x] `swift build` - passed.
- [x] `git diff --check origin/main...HEAD` - passed.
- [x] Gemini 3.5 Flash High review - PASS.
- [x] GPT 5.5 xhigh review - PASS.
- [x] Claude Opus 4.7 effort max targeted review - PASS on the menubar refresh race and calendar auto-close fixes.
