### PR TITLE
Fix menubar installer CLI path lookup

### DIFF
--- a/src/menubar-installer.ts
+++ b/src/menubar-installer.ts
@@ -216,14 +216,7 @@ async function resolvePersistentCodeburnPath(): Promise<string> {
     throw new Error(PERSISTENT_CLI_REQUIRED_MESSAGE)
   }
 
-  const path = resolvePersistentCodeburnPathFromWhichOutput(output)
-  if (!path.startsWith('/')) {
-    throw new Error('Resolved codeburn path is not absolute.')
-  }
-  if (isTransientNpxPath(path)) {
-    throw new Error(PERSISTENT_CLI_REQUIRED_MESSAGE)
-  }
-  return path
+  return resolvePersistentCodeburnPathFromWhichOutput(output)
 }
 
 async function persistCodeburnPath(): Promise<void> {

--- a/src/menubar-installer.ts
+++ b/src/menubar-installer.ts
@@ -18,6 +18,9 @@ const APP_PROCESS_NAME = 'CodeBurnMenubar'
 const SUPPORTED_OS = 'darwin'
 const MIN_MACOS_MAJOR = 14
 const PERSISTED_CLI_PATH = join(homedir(), 'Library', 'Application Support', 'CodeBurn', 'codeburn-cli-path.v1')
+const PERSISTENT_CLI_REQUIRED_MESSAGE =
+  'The menubar app needs a persistent codeburn command. Install CodeBurn globally first: npm install -g codeburn'
+const DEFAULT_CLI_LOOKUP_PATHS = ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin']
 
 export type InstallResult = { installedPath: string; launched: boolean }
 
@@ -50,6 +53,30 @@ export function resolveLatestMenubarReleaseAssets(releases: ReleaseResponse[]): 
     }
   }
   throw new Error('No mac-v* release with a CodeBurnMenubar-v*.zip and checksum was found.')
+}
+
+export function buildPersistentCodeburnLookupPath(existingPath = process.env.PATH ?? ''): string {
+  const parts = existingPath.split(':').filter(Boolean)
+  for (const fallback of DEFAULT_CLI_LOOKUP_PATHS) {
+    if (!parts.includes(fallback)) parts.push(fallback)
+  }
+  return parts.join(':')
+}
+
+function isTransientNpxPath(path: string): boolean {
+  return path.includes('/_npx/') || path.includes('/.npm/_npx/')
+}
+
+export function resolvePersistentCodeburnPathFromWhichOutput(output: string): string {
+  const paths = output
+    .split(/\r?\n/)
+    .map(path => path.trim())
+    .filter(Boolean)
+
+  const persistentPath = paths.find(path => path.startsWith('/') && !isTransientNpxPath(path))
+  if (persistentPath) return persistentPath
+
+  throw new Error(PERSISTENT_CLI_REQUIRED_MESSAGE)
 }
 
 function userApplicationsDir(): string {
@@ -177,18 +204,24 @@ async function verifyBundleIdentity(appPath: string): Promise<void> {
 }
 
 async function resolvePersistentCodeburnPath(): Promise<string> {
-  const path = await captureCommand('/usr/bin/env', [
-    'PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin',
-    'which',
-    'codeburn',
-  ])
+  let output = ''
+  try {
+    output = await captureCommand('/usr/bin/env', [
+      `PATH=${buildPersistentCodeburnLookupPath()}`,
+      'which',
+      '-a',
+      'codeburn',
+    ])
+  } catch {
+    throw new Error(PERSISTENT_CLI_REQUIRED_MESSAGE)
+  }
+
+  const path = resolvePersistentCodeburnPathFromWhichOutput(output)
   if (!path.startsWith('/')) {
     throw new Error('Resolved codeburn path is not absolute.')
   }
-  if (path.includes('/_npx/') || path.includes('/.npm/_npx/')) {
-    throw new Error(
-      'The menubar app needs a persistent codeburn command. Install CodeBurn globally first: npm install -g codeburn'
-    )
+  if (isTransientNpxPath(path)) {
+    throw new Error(PERSISTENT_CLI_REQUIRED_MESSAGE)
   }
   return path
 }

--- a/tests/menubar-installer.test.ts
+++ b/tests/menubar-installer.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildPersistentCodeburnLookupPath,
   resolveLatestMenubarReleaseAssets,
   resolveMenubarReleaseAssets,
+  resolvePersistentCodeburnPathFromWhichOutput,
   type ReleaseResponse,
 } from '../src/menubar-installer.js'
 
@@ -71,5 +73,27 @@ describe('resolveMenubarReleaseAssets', () => {
 
     expect(resolved.release.tag_name).toBe('mac-v0.9.8')
     expect(resolved.zip.name).toBe('CodeBurnMenubar-v0.9.8.zip')
+  })
+
+  it('preserves the caller PATH when building the persistent CLI lookup PATH', () => {
+    const lookupPath = buildPersistentCodeburnLookupPath('/Users/me/.nvm/versions/node/v22.13.0/bin:/usr/bin')
+
+    expect(lookupPath.split(':')).toContain('/Users/me/.nvm/versions/node/v22.13.0/bin')
+    expect(lookupPath.split(':')).toContain('/opt/homebrew/bin')
+  })
+
+  it('selects a persistent codeburn binary when npx is first in which output', () => {
+    const resolved = resolvePersistentCodeburnPathFromWhichOutput([
+      '/Users/me/.npm/_npx/abcd/node_modules/.bin/codeburn',
+      '/Users/me/.nvm/versions/node/v22.13.0/bin/codeburn',
+    ].join('\n'))
+
+    expect(resolved).toBe('/Users/me/.nvm/versions/node/v22.13.0/bin/codeburn')
+  })
+
+  it('shows the install guidance instead of a raw env failure when only npx is available', () => {
+    expect(() => resolvePersistentCodeburnPathFromWhichOutput(
+      '/Users/me/.npm/_npx/abcd/node_modules/.bin/codeburn'
+    )).toThrow(/Install CodeBurn globally first/)
   })
 })


### PR DESCRIPTION
## Summary

Closes #384 by making the macOS menubar installer resolve a persistent `codeburn` binary from the caller's real PATH instead of a hard-coded Homebrew/system-only PATH.

## Root cause

`codeburn menubar` persists the CLI path so the installed Swift menubar app can keep launching `codeburn` later from a GUI process. The lookup used:

```text
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin which codeburn
```

That drops the PATH that successfully launched the installer. Users with global installs under Node version managers such as nvm, fnm, volta, or asdf can run `codeburn menubar` from their shell, but the installer lookup cannot see that `codeburn` binary and reports the raw subprocess failure:

```text
Menubar install failed: /usr/bin/env exited with status 1
```

It also only looked at the first `which` match, so a transient `npx` shim could mask a later persistent install.

## What changed

- Preserve the caller's PATH when resolving the persistent `codeburn` command.
- Append the existing GUI-friendly fallback paths (`/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `/bin`) without dropping user Node-manager paths.
- Switch from `which codeburn` to `which -a codeburn` and choose the first absolute non-`npx` match.
- Convert lookup failures into the existing actionable install guidance instead of exposing `/usr/bin/env exited with status 1`.
- Add regression coverage for nvm-style PATH preservation, npx-first lookup output, and the only-npx error path.

## Validation

Concrete fixture for the bug path:

```text
lookup PATH input:
/Users/me/.nvm/versions/node/v22.13.0/bin:/usr/bin

which -a output:
/Users/me/.npm/_npx/abcd/node_modules/.bin/codeburn
/Users/me/.nvm/versions/node/v22.13.0/bin/codeburn
```

Before this change, the installer used a fixed PATH and could not see the nvm entry. With an unavailable lookup, the user-facing CLI error was:

```text
Menubar install failed: /usr/bin/env exited with status 1
```

After this change, the same lookup shape keeps the caller PATH and selects the persistent binary:

```text
selected: /Users/me/.nvm/versions/node/v22.13.0/bin/codeburn
```

The only-npx case now returns actionable guidance instead of the raw env failure:

```text
The menubar app needs a persistent codeburn command. Install CodeBurn globally first: npm install -g codeburn
```

Checks:

```text
npm test -- tests/cli-status-menubar.test.ts --run
npm test -- tests/menubar-installer.test.ts
npm test -- --run
npm run build
git diff --check
Claude Opus 4.7 effort max review - PASS
Gemini 3.5 Flash High review via agy CLI - PASS
```

Notes:

- Full suite after restoring the generated LiteLLM snapshot: 65 files, 927 tests passed.
- `npm run build` passes and regenerates `src/data/litellm-snapshot.json`; that generated snapshot refresh was restored because it is unrelated to this fix.
