### PR TITLE
Pause menubar refresh after repeated stalls

### DIFF
--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -44,6 +44,7 @@ final class AppStore {
     var subscriptionError: String?
     var subscriptionLoadState: SubscriptionLoadState = ClaudeCredentialStore.isBootstrapCompleted ? .dormant : .notBootstrapped
     var capacityEstimates: [String: CapacityEstimate] = [:]
+    var refreshPauseMessage: String?
 
     var codexUsage: CodexUsage?
     var codexError: String?
@@ -217,6 +218,17 @@ final class AppStore {
         if clearCache {
             cache.removeAll()
         }
+    }
+
+    func pauseAutomaticRefresh(until: Date, consecutiveStalls: Int) {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        refreshPauseMessage = "Refresh paused until \(formatter.string(from: until)) after \(consecutiveStalls) stalled attempts. Click retry to resume."
+    }
+
+    func clearRefreshPause() {
+        refreshPauseMessage = nil
     }
 
     private let loadingWatchdogSeconds: TimeInterval = 60
@@ -472,10 +484,12 @@ final class AppStore {
             await captureSnapshots(for: usage)
             return true
         } catch let err as ClaudeSubscriptionService.FetchError {
+            if Task.isCancelled { return false }
             guard gen == claudeRefreshGen else { return false }
             applyFetchError(err)
             return false
         } catch {
+            if Task.isCancelled { return false }
             guard gen == claudeRefreshGen else { return false }
             subscriptionError = sanitizeForUI(String(describing: error))
             subscriptionLoadState = .failed
@@ -543,10 +557,12 @@ final class AppStore {
             codexLoadState = .loaded
             return true
         } catch let err as CodexSubscriptionService.FetchError {
+            if Task.isCancelled { return false }
             guard gen == codexRefreshGen else { return false }
             applyCodexFetchError(err)
             return false
         } catch {
+            if Task.isCancelled { return false }
             guard gen == codexRefreshGen else { return false }
             codexError = sanitizeForUI(String(describing: error))
             codexLoadState = .failed

--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -47,9 +47,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var manualRefreshTask: Task<Void, Never>?
     private var manualRefreshGeneration: UInt64 = 0
     private var claudeQuotaRefreshTask: Task<Bool, Never>?
+    private var claudeQuotaRefreshGeneration: UInt64 = 0
     private var codexQuotaRefreshTask: Task<Bool, Never>?
+    private var codexQuotaRefreshGeneration: UInt64 = 0
     private var refreshLoopHeartbeatAt: Date = .distantPast
     private var lastLaunchAgentHeartbeatAt: Date = .distantPast
+    private var forceRefreshBackoff = RefreshBackoff()
 
     func applicationWillFinishLaunching(_ notification: Notification) {
         // Set accessory policy before the app's focus chain forms. On macOS Tahoe
@@ -168,6 +171,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         manualRefreshTask?.cancel()
         manualRefreshTask = nil
         manualRefreshGeneration &+= 1
+        cancelLiveQuotaRefreshTasks()
         statusPayloadRefreshTask?.cancel()
         statusPayloadRefreshTask = nil
         statusPayloadRefreshStartedAt = nil
@@ -187,6 +191,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             manualRefreshTask?.cancel()
             manualRefreshTask = nil
             manualRefreshGeneration &+= 1
+            cancelLiveQuotaRefreshTasks()
             statusPayloadRefreshTask?.cancel()
             statusPayloadRefreshTask = nil
             statusPayloadRefreshStartedAt = nil
@@ -293,6 +298,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     private var lastRefreshTime: Date = .distantPast
 
+    private func cancelLiveQuotaRefreshTasks() {
+        claudeQuotaRefreshTask?.cancel()
+        claudeQuotaRefreshTask = nil
+        claudeQuotaRefreshGeneration &+= 1
+        codexQuotaRefreshTask?.cancel()
+        codexQuotaRefreshTask = nil
+        codexQuotaRefreshGeneration &+= 1
+    }
+
+    private func isForceRefreshPaused(now: Date = Date()) -> Bool {
+        if forceRefreshBackoff.isPaused(now: now) {
+            if let until = forceRefreshBackoff.pausedUntil {
+                store.pauseAutomaticRefresh(
+                    until: until,
+                    consecutiveStalls: forceRefreshBackoff.consecutiveStalls
+                )
+            }
+            return true
+        }
+        store.clearRefreshPause()
+        return false
+    }
+
     @discardableResult
     private func clearStaleForceRefreshIfNeeded(now: Date = Date()) -> Bool {
         if forceRefreshTask != nil {
@@ -300,7 +328,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 NSLog("CodeBurn: force refresh task had no start timestamp - clearing")
                 forceRefreshTask?.cancel()
                 forceRefreshTask = nil
+                forceRefreshStartedAt = nil
                 forceRefreshGeneration &+= 1
+                cancelLiveQuotaRefreshTasks()
                 store.resetLoadingState()
                 return true
             }
@@ -311,6 +341,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             forceRefreshTask = nil
             forceRefreshStartedAt = nil
             forceRefreshGeneration &+= 1
+            cancelLiveQuotaRefreshTasks()
+            if let pausedUntil = forceRefreshBackoff.recordStall(now: now) {
+                store.pauseAutomaticRefresh(
+                    until: pausedUntil,
+                    consecutiveStalls: forceRefreshBackoff.consecutiveStalls
+                )
+                NSLog("CodeBurn: force refresh paused after %d consecutive stalls until %@",
+                      forceRefreshBackoff.consecutiveStalls,
+                      pausedUntil as NSDate)
+            }
             store.resetLoadingState()
             return true
         }
@@ -365,6 +405,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private func forceRefresh(bypassRateLimit: Bool = false, forceQuota: Bool = false) {
         let now = Date()
         _ = clearStaleForceRefreshIfNeeded(now: now)
+        guard !isForceRefreshPaused(now: now) else { return }
         if forceRefreshTask != nil {
             refreshTodayStatusPayloadIfNeeded(reason: "blocked force refresh")
         }
@@ -385,13 +426,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             }
             _ = await main
             refreshStatusButton()
+            _ = await quotas
             await MainActor.run { [weak self] in
                 guard let self, self.forceRefreshGeneration == generation else { return }
+                self.forceRefreshBackoff.recordSuccess()
+                self.store.clearRefreshPause()
                 self.forceRefreshTask = nil
                 self.forceRefreshStartedAt = nil
                 self.lastRefreshTime = Date()
             }
-            _ = await quotas
         }
     }
 
@@ -458,9 +501,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         let task = Task { [store] in
             await store.refreshSubscriptionReportingSuccess()
         }
+        claudeQuotaRefreshGeneration &+= 1
+        let generation = claudeQuotaRefreshGeneration
         claudeQuotaRefreshTask = task
         let result = await task.value
-        if claudeQuotaRefreshTask != nil {
+        if claudeQuotaRefreshGeneration == generation {
             claudeQuotaRefreshTask = nil
         }
         return result
@@ -473,9 +518,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         let task = Task { [store] in
             await store.refreshCodexReportingSuccess()
         }
+        codexQuotaRefreshGeneration &+= 1
+        let generation = codexQuotaRefreshGeneration
         codexQuotaRefreshTask = task
         let result = await task.value
-        if codexQuotaRefreshTask != nil {
+        if codexQuotaRefreshGeneration == generation {
             codexQuotaRefreshTask = nil
         }
         return result
@@ -513,10 +560,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     }
 
     private func runRefreshLoopTick(reason: String, forcePayload: Bool = false, forceQuota: Bool = false) {
-        refreshLoopHeartbeatAt = Date()
+        let now = Date()
+        refreshLoopHeartbeatAt = now
         let hadForceRefreshInFlight = forceRefreshTask != nil
-        let clearedStaleForceRefresh = clearStaleForceRefreshIfNeeded()
-        let clearedStaleStatusRefresh = clearStaleStatusPayloadRefreshIfNeeded()
+        let clearedStaleForceRefresh = clearStaleForceRefreshIfNeeded(now: now)
+        let clearedStaleStatusRefresh = clearStaleStatusPayloadRefreshIfNeeded(now: now)
+        guard !isForceRefreshPaused(now: now) else { return }
         let clearedStaleLoading = store.clearStaleLoadingIfNeeded()
         let statusPayloadStale = store.needsStatusPayloadRefresh
         let sinceLast = Date().timeIntervalSince(lastRefreshTime)
@@ -570,6 +619,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         statusPayloadRefreshGeneration &+= 1
         pendingRefreshWork?.cancel()
         pendingRefreshWork = nil
+        cancelLiveQuotaRefreshTasks()
+        forceRefreshBackoff.retryNow(resetStallCount: false)
+        store.clearRefreshPause()
         stopRefreshTimer()
         store.resetRefreshState(clearCache: true)
         lastRefreshTime = .distantPast
@@ -592,6 +644,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             self.refreshStatusButton()
             _ = await quotas
             guard self.manualRefreshGeneration == generation, !Task.isCancelled else { return }
+            self.forceRefreshBackoff.recordSuccess()
+            self.store.clearRefreshPause()
             self.manualRefreshTask = nil
             if self.refreshTimer == nil {
                 self.startRefreshLoop()

--- a/mac/Sources/CodeBurnMenubar/Data/UpdateChecker.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/UpdateChecker.swift
@@ -58,6 +58,7 @@ final class UpdateChecker {
         updateError = nil
         guard let url = URL(string: releasesAPI) else { return }
         var request = URLRequest(url: url)
+        request.timeoutInterval = 30
         request.setValue("codeburn-menubar-updater", forHTTPHeaderField: "User-Agent")
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
 

--- a/mac/Sources/CodeBurnMenubar/RefreshBackoff.swift
+++ b/mac/Sources/CodeBurnMenubar/RefreshBackoff.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct RefreshBackoff {
+    let stallThreshold: Int
+    let initialDelay: TimeInterval
+    let maximumDelay: TimeInterval
+
+    private(set) var consecutiveStalls = 0
+    private(set) var pausedUntil: Date?
+
+    init(stallThreshold: Int = 3, initialDelay: TimeInterval = 30, maximumDelay: TimeInterval = 300) {
+        self.stallThreshold = stallThreshold
+        self.initialDelay = initialDelay
+        self.maximumDelay = maximumDelay
+    }
+
+    mutating func recordStall(now: Date = Date()) -> Date? {
+        consecutiveStalls += 1
+        guard consecutiveStalls >= stallThreshold else { return nil }
+
+        let exponent = max(0, consecutiveStalls - stallThreshold)
+        let multiplier = pow(2.0, Double(exponent))
+        let delay = min(initialDelay * multiplier, maximumDelay)
+        let until = now.addingTimeInterval(delay)
+        pausedUntil = until
+        return until
+    }
+
+    mutating func recordSuccess() {
+        consecutiveStalls = 0
+        pausedUntil = nil
+    }
+
+    mutating func retryNow(resetStallCount: Bool = false) {
+        pausedUntil = nil
+        if resetStallCount {
+            consecutiveStalls = 0
+        }
+    }
+
+    mutating func isPaused(now: Date = Date()) -> Bool {
+        guard let pausedUntil else { return false }
+        if pausedUntil > now { return true }
+        self.pausedUntil = nil
+        return false
+    }
+}

--- a/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
@@ -11,6 +11,14 @@ struct MenuBarContent: View {
 
             Divider()
 
+            if let message = store.refreshPauseMessage {
+                RefreshPausedBanner(
+                    message: message,
+                    retry: { refreshNow() }
+                )
+                Divider()
+            }
+
             if showAgentTabs {
                 AgentTabStrip()
                 Divider()
@@ -110,6 +118,32 @@ struct MenuBarContent: View {
         return !payload.current.providers.isEmpty
     }
 
+}
+
+private struct RefreshPausedBanner: View {
+    let message: String
+    let retry: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "pause.circle.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Theme.brandAccent)
+            Text(message)
+                .font(.system(size: 10.5, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 6)
+            Button("Retry", action: retry)
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.brandAccent)
+                .controlSize(.small)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.secondary.opacity(0.08))
+    }
 }
 
 private struct EmptyProviderState: View {
@@ -594,11 +628,7 @@ struct FooterBar: View {
     }
 
     private func refreshNow() {
-        if let delegate = NSApp.delegate as? AppDelegate {
-            delegate.refreshSubscriptionNow()
-        } else {
-            Task { await store.refresh(includeOptimize: false, force: true, showLoading: true) }
-        }
+        MenuBarContent.refreshNow(store: store)
     }
 
     private enum ExportFormat {
@@ -662,5 +692,19 @@ struct FooterBar: View {
         }
 
         CLICurrencyConfig.persist(code: code)
+    }
+}
+
+private extension MenuBarContent {
+    static func refreshNow(store: AppStore) {
+        if let delegate = NSApp.delegate as? AppDelegate {
+            delegate.refreshSubscriptionNow()
+        } else {
+            Task { await store.refresh(includeOptimize: false, force: true, showLoading: true) }
+        }
+    }
+
+    func refreshNow() {
+        Self.refreshNow(store: store)
     }
 }

--- a/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
@@ -16,7 +16,16 @@ private func menubarPayload(cost: Double) -> MenubarPayload {
             cacheHitPercent: 0,
             topActivities: [],
             topModels: [],
-            providers: ["claude": cost]
+            providers: ["claude": cost],
+            topProjects: [],
+            modelEfficiency: [],
+            topSessions: [],
+            retryTax: RetryTax(totalUSD: 0, retries: 0, editTurns: 0, byModel: []),
+            routingWaste: RoutingWaste(totalSavingsUSD: 0, baselineModel: "", baselineCostPerEdit: 0, byModel: []),
+            tools: [],
+            skills: [],
+            subagents: [],
+            mcpServers: []
         ),
         optimize: OptimizeBlock(findingCount: 0, savingsUSD: 0, topFindings: []),
         history: HistoryBlock(daily: [])
@@ -80,5 +89,17 @@ struct AppStoreRefreshRecoveryTests {
         #expect(store.needsInteractivePayloadRefresh)
         #expect(store.hasMissingInteractivePayloadWithoutAttempt)
         #expect(store.shouldResetInteractiveRefreshPipeline)
+    }
+
+    @Test("refresh pause message is visible and clearable")
+    func refreshPauseMessageIsVisibleAndClearable() {
+        let store = AppStore()
+
+        store.pauseAutomaticRefresh(until: Date(timeIntervalSince1970: 4_000), consecutiveStalls: 3)
+        #expect(store.refreshPauseMessage?.contains("Refresh paused") == true)
+        #expect(store.refreshPauseMessage?.contains("3 stalled attempts") == true)
+
+        store.clearRefreshPause()
+        #expect(store.refreshPauseMessage == nil)
     }
 }

--- a/mac/Tests/CodeBurnMenubarTests/RefreshBackoffTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/RefreshBackoffTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import CodeBurnMenubar
+
+@Suite("Refresh backoff")
+struct RefreshBackoffTests {
+    @Test("pauses after threshold and escalates exponentially")
+    func pausesAfterThresholdAndEscalatesExponentially() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        var backoff = RefreshBackoff(stallThreshold: 3, initialDelay: 30, maximumDelay: 300)
+
+        #expect(backoff.recordStall(now: now) == nil)
+        #expect(backoff.recordStall(now: now) == nil)
+
+        let firstPause = backoff.recordStall(now: now)
+        #expect(firstPause == now.addingTimeInterval(30))
+        let pausedBeforeExpiry = backoff.isPaused(now: now.addingTimeInterval(29))
+        #expect(pausedBeforeExpiry)
+        let pausedAfterExpiry = backoff.isPaused(now: now.addingTimeInterval(31))
+        #expect(!pausedAfterExpiry)
+
+        let secondPause = backoff.recordStall(now: now)
+        #expect(secondPause == now.addingTimeInterval(60))
+
+        _ = backoff.recordStall(now: now)
+        _ = backoff.recordStall(now: now)
+        _ = backoff.recordStall(now: now)
+        _ = backoff.recordStall(now: now)
+        let cappedPause = backoff.recordStall(now: now)
+        #expect(cappedPause == now.addingTimeInterval(300))
+    }
+
+    @Test("success clears stall count and pause")
+    func successClearsStallCountAndPause() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        var backoff = RefreshBackoff(stallThreshold: 1, initialDelay: 30, maximumDelay: 300)
+
+        #expect(backoff.recordStall(now: now) == now.addingTimeInterval(30))
+        backoff.recordSuccess()
+
+        #expect(backoff.consecutiveStalls == 0)
+        #expect(backoff.pausedUntil == nil)
+        #expect(backoff.recordStall(now: now) == now.addingTimeInterval(30))
+    }
+
+    @Test("manual retry clears pause without erasing stall history")
+    func manualRetryClearsPauseWithoutErasingStallHistory() {
+        let now = Date(timeIntervalSince1970: 3_000)
+        var backoff = RefreshBackoff(stallThreshold: 1, initialDelay: 30, maximumDelay: 300)
+
+        _ = backoff.recordStall(now: now)
+        backoff.retryNow(resetStallCount: false)
+
+        #expect(backoff.pausedUntil == nil)
+        #expect(backoff.consecutiveStalls == 1)
+    }
+}


### PR DESCRIPTION
## Summary
- add a small refresh backoff policy that pauses automatic force refresh after 3 consecutive watchdog stalls, then retries with exponential backoff from 30s up to 5m
- cancel Claude/Codex live quota single-flight tasks when force/manual refresh recovery cancels the parent refresh, and guard old quota tasks from clearing newer task handles
- show a menubar pause banner with a Retry action, and clear the pause after a successful refresh
- add explicit request timeout to the update check path; Claude/Codex usage and token refresh requests already had 30s request timeouts

## Why
The existing force-refresh watchdog cancelled only the outer `forceRefreshTask` and immediately let the next timer tick start the same force-refresh path again. If the underlying refresh path repeatedly stalled, the app could log `force refresh stuck ... cancelling and restarting` every watchdog interval forever while the menu data stayed stale.

The quota refresh path also used unstructured single-flight tasks. Cancelling the parent force refresh did not clear those handles, so a later refresh could wait on the same stuck single-flight task rather than starting cleanly.

## Tests
```sh
swift build
DYLD_FRAMEWORK_PATH=/Library/Developer/CommandLineTools/Library/Developer/Frameworks \
DYLD_LIBRARY_PATH=/Library/Developer/CommandLineTools/Library/Developer/usr/lib \
swift test --enable-swift-testing \
  -Xswiftc -F -Xswiftc /Library/Developer/CommandLineTools/Library/Developer/Frameworks \
  -Xlinker -F -Xlinker /Library/Developer/CommandLineTools/Library/Developer/Frameworks \
  -Xlinker -rpath -Xlinker /Library/Developer/CommandLineTools/Library/Developer/Frameworks \
  -Xlinker -rpath -Xlinker /Library/Developer/CommandLineTools/Library/Developer/usr/lib
```
