### PR TITLE
Add lifetime full-history menubar trend across macOS, GNOME, and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ dx codeburn
 
 ```bash
 codeburn                        # interactive dashboard (default: 7 days)
+codeburn -p lifetime            # full history dashboard (uncapped)
 codeburn today                  # today's usage
 codeburn month                  # this month's usage
 codeburn report -p 30days       # rolling 30-day window
@@ -90,7 +91,7 @@ codeburn models --task feature         # filter to feature-development work
 codeburn models --provider claude      # filter to one provider
 ```
 
-Arrow keys switch between Today, 7 Days, 30 Days, Month, and 6 Months (use `--from` / `--to` for an exact historical window). Press `q` to quit, `1` `2` `3` `4` `5` as shortcuts, `c` to open model comparison, `o` to open optimize. The dashboard auto-refreshes every 30 seconds by default (`--refresh 0` to disable). It also shows average cost per session and the five most expensive sessions across all projects.
+Arrow keys switch between Today, 7 Days, 30 Days, Month, 6 Months, and Lifetime (use `--from` / `--to` for an exact historical window). Press `q` to quit, `1` `2` `3` `4` `5` `6` as shortcuts, `c` to open model comparison, `o` to open optimize. The dashboard auto-refreshes every 30 seconds by default (`--refresh 0` to disable). It also shows average cost per session and the five most expensive sessions across all projects.
 
 ## Supported Providers
 
@@ -127,7 +128,7 @@ Provider logos are trademarks of their respective owners. The icon set was sourc
 
 CodeBurn auto-detects which AI coding tools you use. If multiple providers have session data on disk, press `p` in the dashboard to toggle between them.
 
-The `--provider` flag filters any command to a single provider: `codeburn report --provider claude`, `codeburn today --provider codex`, `codeburn export --provider cursor`. Works on all commands: `report`, `today`, `month`, `status`, `export`, `optimize`, `compare`, `yield`.
+The `--provider` flag filters any command to a single provider: `codeburn report --provider claude`, `codeburn today --provider codex`, `codeburn export --provider cursor`. Works on all supported usage commands: `report`, `today`, `month`, `status`, `export`, `optimize`, `compare`, `yield`, `models`.
 
 ### Provider Notes
 
@@ -346,7 +347,7 @@ codeburn menubar
 
 One command: downloads the latest `.app`, installs into `~/Applications`, and launches it. Re-run with `--force` to reinstall. Native Swift and SwiftUI app lives in `mac/` (see `mac/README.md` for build details).
 
-The menubar icon shows the spend period selected in Settings (Today by default; Week, Month, and 6 Months are also available). Non-today periods add a short suffix such as `$42 / mo` so the menu bar value stays clear. Click to open a popover with agent tabs, period switcher (Today, 7 Days, 30 Days, Month, All), Trend, Forecast, Pulse, Stats, and Plan insights, activity and model breakdowns, optimize findings, and CSV/JSON export. Refreshes every 30 seconds.
+The menubar icon shows the spend period selected in Settings (Today by default; Week, Month, 6 Months, and Lifetime are also available). Non-today periods add a short suffix such as `$42 / mo` so the menu bar value stays clear. Click to open a popover with agent tabs, period switcher (Today, 7 Days, 30 Days, Month, 6 Months, Lifetime), Trend, Forecast, Pulse, Stats, and Plan insights, activity and model breakdowns, optimize findings, and CSV/JSON export. Refreshes every 30 seconds.
 
 You can also set the menubar status period from Terminal:
 
@@ -354,7 +355,7 @@ You can also set the menubar status period from Terminal:
 defaults write org.agentseal.codeburn-menubar CodeBurnMenubarPeriod -string month
 ```
 
-Allowed values are `today`, `week`, `month`, and `sixMonths`. Relaunch the app to apply external defaults changes.
+Allowed values are `today`, `week`, `month`, `sixMonths`, and `lifetime`. Relaunch the app to apply external defaults changes.
 
 **Compact mode** shrinks the menubar item to fit the text, dropping decimals (e.g. `$110` instead of `$110.20`):
 

--- a/gnome/README.md
+++ b/gnome/README.md
@@ -41,7 +41,7 @@ Or use the GNOME Extensions app.
 | Setting | Default | Description |
 |---------|---------|-------------|
 | Refresh Interval | 30s | How often to poll CodeBurn CLI |
-| Default Period | Today | Period shown on open |
+| Default Period | Today | Period shown on open (Today, 7 Days, 30 Days, Month, 6 Months, Lifetime) |
 | Compact Mode | Off | Hide cost label, show icon only |
 | Budget Threshold | $0 | Daily budget alert (0 = disabled) |
 | Budget Alerts | Off | Show warning when budget exceeded |

--- a/gnome/indicator.js
+++ b/gnome/indicator.js
@@ -7,6 +7,7 @@ import Soup from 'gi://Soup?version=3.0';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import { DataClient } from './dataClient.js';
+import { buildPeriodSeries } from './trend-series.js';
 
 const CACHE_TTL_MS = 300_000;
 const TOP_ACTIVITIES = 10;
@@ -19,6 +20,7 @@ const PERIODS = [
   { id: '30days', label: '30 Days' },
   { id: 'month', label: 'Month' },
   { id: 'all', label: '6 Months' },
+  { id: 'lifetime', label: 'Lifetime' },
 ];
 
 const INSIGHTS = [
@@ -585,7 +587,7 @@ class CodeBurnIndicator extends PanelMenu.Button {
     const sessions = Number(current.sessions ?? 0);
     this._heroMeta.set_text(`${calls.toLocaleString()} calls   ${sessions} sessions`);
 
-    this._renderChart(payload?.history?.daily ?? []);
+    this._renderChart(payload);
     this._renderContent();
     this._renderFindings(payload?.optimize ?? {});
     this._updateBudget();
@@ -594,40 +596,49 @@ class CodeBurnIndicator extends PanelMenu.Button {
     this._updatedLabel.set_text(updated ? `Updated ${updated}` : '');
   }
 
-  _renderChart(daily) {
+  _renderChart(payload) {
     this._chartBars.destroy_all_children();
-    const days = Array.isArray(daily) ? daily.slice(-19) : [];
-    if (days.length === 0) {
+    const series = buildPeriodSeries(this._period, payload);
+    const points = Array.isArray(series.points) ? series.points : [];
+    if (points.length === 0) {
       this._chartContainer.visible = false;
       return;
     }
-    const inTotals = days.map(d => Number(d?.inputTokens) || 0);
-    const outTotals = days.map(d => Number(d?.outputTokens) || 0);
-    const totals = inTotals.map((v, i) => v + outTotals[i]);
+    const inTotals = points.map(point => Number(point.inputTokens) || 0);
+    const outTotals = points.map(point => Number(point.outputTokens) || 0);
+    const tokenTotals = inTotals.map((value, index) => value + outTotals[index]);
+    const totalTokens = tokenTotals.reduce((sum, value) => sum + value, 0);
+    const useTokens = totalTokens > 0;
+    const totals = useTokens ? tokenTotals : points.map(point => Number(point.cost) || 0);
     let maxTotal = 1;
     let totalIn = 0;
     let totalOut = 0;
+    let totalCost = 0;
     let hasAnyTokens = false;
-    for (let i = 0; i < days.length; i++) {
+    for (let i = 0; i < points.length; i++) {
       if (totals[i] > maxTotal) maxTotal = totals[i];
       if (totals[i] > 0) hasAnyTokens = true;
       totalIn += inTotals[i];
       totalOut += outTotals[i];
+      totalCost += Number(points[i]?.cost) || 0;
     }
     if (!hasAnyTokens) {
       this._chartContainer.visible = false;
       return;
     }
     this._chartContainer.visible = true;
-    const summaryText = `In: ${formatTokensCompact(totalIn)}  Out: ${formatTokensCompact(totalOut)}`;
+    this._chartLabel.set_text(useTokens ? 'Tokens' : 'Spend');
+    const summaryText = useTokens
+      ? `In: ${formatTokensCompact(totalIn)}  Out: ${formatTokensCompact(totalOut)}`
+      : `Total: ${this._fmt(totalCost)}`;
     this._chartTotal.set_text(summaryText);
     this._chartSummaryText = summaryText;
 
     const chartWidth = 308;
     const gap = 2;
-    const barW = Math.max(4, Math.floor((chartWidth - gap * (days.length - 1)) / days.length));
+    const barW = Math.max(4, Math.floor((chartWidth - gap * (points.length - 1)) / points.length));
 
-    for (let i = 0; i < days.length; i++) {
+    for (let i = 0; i < points.length; i++) {
       const h = Math.max(2, Math.round((totals[i] / maxTotal) * CHART_HEIGHT));
       const col = new St.BoxLayout({ vertical: true, style_class: 'codeburn-chart-col', reactive: true });
       col.set_width(barW);
@@ -640,12 +651,17 @@ class CodeBurnIndicator extends PanelMenu.Button {
       col.add_child(spacer);
       col.add_child(bar);
 
-      const date = days[i]?.date || '';
+      const label = points[i]?.label || '';
       const inTok = formatTokensCompact(inTotals[i]);
       const outTok = formatTokensCompact(outTotals[i]);
-      const cost = days[i]?.cost != null ? this._fmt(days[i].cost) : '';
+      const cost = points[i]?.cost != null ? this._fmt(points[i].cost) : '';
+      const calls = `${Number(points[i]?.calls || 0).toLocaleString()} calls`;
       col.connect('enter-event', () => {
-        this._chartTotal.set_text(`${date}  ${inTok}/${outTok}  ${cost}`);
+        if (useTokens) {
+          this._chartTotal.set_text(`${label}  ${inTok}/${outTok}  ${cost}`);
+        } else {
+          this._chartTotal.set_text(`${label}  ${cost}  ${calls}`);
+        }
         this._chartTotal.add_style_class_name('codeburn-chart-total-hover');
         bar.add_style_class_name('codeburn-chart-bar-hover');
         return Clutter.EVENT_PROPAGATE;
@@ -708,18 +724,20 @@ class CodeBurnIndicator extends PanelMenu.Button {
   }
 
   _renderTrendView() {
-    const daily = this._payload?.history?.daily ?? [];
-    if (!daily.length) {
+    const series = buildPeriodSeries(this._period, this._payload);
+    const points = Array.isArray(series.points) ? series.points : [];
+    if (!points.length) {
       this._contentArea.add_child(new St.Label({ text: 'Not enough history yet', style_class: 'codeburn-empty' }));
       return;
     }
-    for (const d of daily.slice(-7).reverse()) {
+    this._contentArea.add_child(this._sectionTitle(series.windowLabel));
+    for (const point of points.slice(-7).reverse()) {
       const row = new St.BoxLayout({ style_class: 'codeburn-trend-row' });
-      row.add_child(new St.Label({ text: d.date, style_class: 'codeburn-trend-date', x_expand: true }));
-      const costLabel = new St.Label({ text: this._fmt(d.cost), style_class: 'codeburn-trend-cost' });
+      row.add_child(new St.Label({ text: point.label, style_class: 'codeburn-trend-date', x_expand: true }));
+      const costLabel = new St.Label({ text: this._fmt(point.cost), style_class: 'codeburn-trend-cost' });
       costLabel.clutter_text.x_align = Clutter.ActorAlign.END;
       row.add_child(costLabel);
-      const callsLabel = new St.Label({ text: `${Number(d.calls).toLocaleString()} calls`, style_class: 'codeburn-trend-calls' });
+      const callsLabel = new St.Label({ text: `${Number(point.calls).toLocaleString()} calls`, style_class: 'codeburn-trend-calls' });
       callsLabel.clutter_text.x_align = Clutter.ActorAlign.END;
       row.add_child(callsLabel);
       this._contentArea.add_child(row);

--- a/gnome/prefs.js
+++ b/gnome/prefs.js
@@ -28,6 +28,7 @@ const PERIODS = [
   { id: '30days', label: '30 Days' },
   { id: 'month', label: 'Month' },
   { id: 'all', label: '6 Months' },
+  { id: 'lifetime', label: 'Lifetime' },
 ];
 
 export default class CodeBurnPreferences extends ExtensionPreferences {

--- a/gnome/schemas/org.gnome.shell.extensions.codeburn.gschema.xml
+++ b/gnome/schemas/org.gnome.shell.extensions.codeburn.gschema.xml
@@ -13,7 +13,7 @@
     <key name="default-period" type="s">
       <default>'today'</default>
       <summary>Default time period</summary>
-      <description>Period shown when extension opens (today, week, 30days, month, all)</description>
+      <description>Period shown when extension opens (today, week, 30days, month, all, lifetime)</description>
     </key>
 
     <key name="budget-threshold" type="d">

--- a/gnome/trend-series.js
+++ b/gnome/trend-series.js
@@ -1,0 +1,286 @@
+function startOfLocalDay(date = new Date()) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function toDayKey(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseDayKey(dayKey) {
+  const [year, month, day] = String(dayKey).split('-').map(Number);
+  return new Date(year, (month || 1) - 1, day || 1);
+}
+
+function shortDate(dayKey) {
+  const parts = String(dayKey).split('-');
+  return parts.length === 3 ? `${parts[1]}/${parts[2]}` : String(dayKey);
+}
+
+function hourLabel(hour, compact = false) {
+  const normalized = ((hour % 24) + 24) % 24;
+  const value = normalized === 0 ? 12 : (normalized > 12 ? normalized - 12 : normalized);
+  const suffix = normalized < 12 ? (compact ? 'a' : 'AM') : (compact ? 'p' : 'PM');
+  return compact ? `${value}${suffix}` : `${value} ${suffix}`;
+}
+
+function hourRangeLabel(startHour, endHour, compact = false) {
+  const start = hourLabel(startHour, compact);
+  const end = hourLabel(endHour % 24, compact);
+  return compact ? `${start}-${end}` : `${start} - ${end}`;
+}
+
+function monthYearLabel(date) {
+  return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+}
+
+function quarterStart(date) {
+  const startMonth = Math.floor(date.getMonth() / 3) * 3;
+  return new Date(date.getFullYear(), startMonth, 1);
+}
+
+function quarterLabel(date) {
+  return `Q${Math.floor(date.getMonth() / 3) + 1} ${date.getFullYear()}`;
+}
+
+function yearLabel(date) {
+  return String(date.getFullYear());
+}
+
+function startOfWeek(date) {
+  const value = startOfLocalDay(date);
+  value.setDate(value.getDate() - value.getDay());
+  return value;
+}
+
+function mapDailyEntries(daily) {
+  const entryByDate = new Map();
+  for (const entry of Array.isArray(daily) ? daily : []) {
+    if (entry?.date) entryByDate.set(entry.date, entry);
+  }
+  return entryByDate;
+}
+
+function aggregateSeriesRange(entryByDate, start, end) {
+  let cost = 0;
+  let calls = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  const cursor = new Date(start.getTime());
+
+  while (cursor < end) {
+    const entry = entryByDate.get(toDayKey(cursor));
+    if (entry) {
+      cost += Number(entry.cost) || 0;
+      calls += Number(entry.calls) || 0;
+      inputTokens += Number(entry.inputTokens) || 0;
+      outputTokens += Number(entry.outputTokens) || 0;
+    }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return { cost, calls, inputTokens, outputTokens };
+}
+
+function buildDailySeries(daily, dayCount, now = new Date()) {
+  const today = startOfLocalDay(now);
+  const todayKey = toDayKey(today);
+  const entryByDate = mapDailyEntries(daily);
+  const points = [];
+
+  for (let offset = dayCount - 1; offset >= 0; offset--) {
+    const day = new Date(today.getTime());
+    day.setDate(day.getDate() - offset);
+    const key = toDayKey(day);
+    const entry = entryByDate.get(key);
+    points.push({
+      id: key,
+      label: key,
+      cost: Number(entry?.cost) || 0,
+      calls: Number(entry?.calls) || 0,
+      inputTokens: Number(entry?.inputTokens) || 0,
+      outputTokens: Number(entry?.outputTokens) || 0,
+      isCurrent: key === todayKey,
+    });
+  }
+
+  return points;
+}
+
+function buildIntradaySeries(intraday, now = new Date()) {
+  const currentHour = now.getHours();
+  return (Array.isArray(intraday) ? intraday : []).map(bucket => ({
+    id: `hour-${bucket.bucketStartHour}`,
+    label: hourRangeLabel(bucket.bucketStartHour, bucket.bucketEndHour, false),
+    cost: Number(bucket.cost) || 0,
+    calls: Number(bucket.calls) || 0,
+    inputTokens: Number(bucket.inputTokens) || 0,
+    outputTokens: Number(bucket.outputTokens) || 0,
+    isCurrent: currentHour >= bucket.bucketStartHour && currentHour < bucket.bucketEndHour,
+  }));
+}
+
+function buildWeeklySeries(daily, weekCount, now = new Date()) {
+  const entryByDate = mapDailyEntries(daily);
+  const currentWeekStart = startOfWeek(now);
+  const points = [];
+
+  for (let offset = weekCount - 1; offset >= 0; offset--) {
+    const start = new Date(currentWeekStart.getTime());
+    start.setDate(start.getDate() - offset * 7);
+    const end = new Date(start.getTime());
+    end.setDate(end.getDate() + 7);
+    const key = toDayKey(start);
+    const aggregate = aggregateSeriesRange(entryByDate, start, end);
+    points.push({
+      id: `week-${key}`,
+      label: `Week of ${shortDate(key)}`,
+      cost: aggregate.cost,
+      calls: aggregate.calls,
+      inputTokens: aggregate.inputTokens,
+      outputTokens: aggregate.outputTokens,
+      isCurrent: offset === 0,
+    });
+  }
+
+  return points;
+}
+
+function buildMonthlySeries(daily, monthCount, now = new Date()) {
+  const entryByDate = mapDailyEntries(daily);
+  const today = startOfLocalDay(now);
+  const currentMonthStart = new Date(today.getFullYear(), today.getMonth(), 1);
+  const points = [];
+
+  for (let offset = monthCount - 1; offset >= 0; offset--) {
+    const start = new Date(currentMonthStart.getFullYear(), currentMonthStart.getMonth() - offset, 1);
+    const end = new Date(start.getFullYear(), start.getMonth() + 1, 1);
+    const aggregate = aggregateSeriesRange(entryByDate, start, end);
+    points.push({
+      id: `month-${toDayKey(start)}`,
+      label: monthYearLabel(start),
+      cost: aggregate.cost,
+      calls: aggregate.calls,
+      inputTokens: aggregate.inputTokens,
+      outputTokens: aggregate.outputTokens,
+      isCurrent: offset === 0,
+    });
+  }
+
+  return points;
+}
+
+function buildQuarterlySeries(daily, quarterCount, now = new Date()) {
+  const entryByDate = mapDailyEntries(daily);
+  const currentQuarterStart = quarterStart(now);
+  const points = [];
+
+  for (let offset = quarterCount - 1; offset >= 0; offset--) {
+    const start = new Date(currentQuarterStart.getFullYear(), currentQuarterStart.getMonth() - offset * 3, 1);
+    const end = new Date(start.getFullYear(), start.getMonth() + 3, 1);
+    const aggregate = aggregateSeriesRange(entryByDate, start, end);
+    points.push({
+      id: `quarter-${toDayKey(start)}`,
+      label: quarterLabel(start),
+      cost: aggregate.cost,
+      calls: aggregate.calls,
+      inputTokens: aggregate.inputTokens,
+      outputTokens: aggregate.outputTokens,
+      isCurrent: offset === 0,
+    });
+  }
+
+  return points;
+}
+
+function buildYearlySeries(daily, yearCount, now = new Date()) {
+  const entryByDate = mapDailyEntries(daily);
+  const currentYearStart = new Date(now.getFullYear(), 0, 1);
+  const points = [];
+
+  for (let offset = yearCount - 1; offset >= 0; offset--) {
+    const start = new Date(currentYearStart.getFullYear() - offset, 0, 1);
+    const end = new Date(start.getFullYear() + 1, 0, 1);
+    const aggregate = aggregateSeriesRange(entryByDate, start, end);
+    points.push({
+      id: `year-${toDayKey(start)}`,
+      label: yearLabel(start),
+      cost: aggregate.cost,
+      calls: aggregate.calls,
+      inputTokens: aggregate.inputTokens,
+      outputTokens: aggregate.outputTokens,
+      isCurrent: offset === 0,
+    });
+  }
+
+  return points;
+}
+
+export function lifetimeMonthSpan(daily, now = new Date()) {
+  if (!Array.isArray(daily) || daily.length === 0) return 1;
+  const firstKey = daily.map(entry => entry.date).sort()[0];
+  if (!firstKey) return 1;
+  const firstDate = parseDayKey(firstKey);
+  const today = startOfLocalDay(now);
+  const diff = (today.getFullYear() - firstDate.getFullYear()) * 12 + (today.getMonth() - firstDate.getMonth());
+  return Math.max(diff + 1, 1);
+}
+
+export function buildPeriodSeries(period, payload, now = new Date()) {
+  const daily = Array.isArray(payload?.history?.daily) ? payload.history.daily : [];
+  const intraday = Array.isArray(payload?.history?.intraday) ? payload.history.intraday : [];
+
+  switch (period) {
+    case 'today':
+      return {
+        windowLabel: 'Today',
+        points: intraday.length ? buildIntradaySeries(intraday, now) : buildDailySeries(daily, 1, now),
+      };
+    case 'week':
+      return {
+        windowLabel: 'Last 7 days',
+        points: buildDailySeries(daily, 7, now),
+      };
+    case '30days':
+      return {
+        windowLabel: 'Last 30 days',
+        points: buildDailySeries(daily, 30, now),
+      };
+    case 'month':
+      return {
+        windowLabel: 'Month to date',
+        points: buildDailySeries(daily, Math.max(now.getDate(), 1), now),
+      };
+    case 'all':
+      return {
+        windowLabel: 'Recent 26 weeks',
+        points: buildWeeklySeries(daily, 26, now),
+      };
+    case 'lifetime': {
+      const monthSpan = lifetimeMonthSpan(daily, now);
+      if (monthSpan <= 24) {
+        return {
+          windowLabel: 'All time by month',
+          points: buildMonthlySeries(daily, monthSpan, now),
+        };
+      }
+      if (monthSpan <= 60) {
+        return {
+          windowLabel: 'All time by quarter',
+          points: buildQuarterlySeries(daily, Math.ceil(monthSpan / 3), now),
+        };
+      }
+      return {
+        windowLabel: 'All time by year',
+        points: buildYearlySeries(daily, Math.ceil(monthSpan / 12), now),
+      };
+    }
+    default:
+      return {
+        windowLabel: 'Last 7 days',
+        points: buildDailySeries(daily, 7, now),
+      };
+  }
+}

--- a/mac/Package.swift
+++ b/mac/Package.swift
@@ -9,6 +9,9 @@ let package = Package(
     products: [
         .executable(name: "CodeBurnMenubar", targets: ["CodeBurnMenubar"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-testing.git", from: "6.2.3")
+    ],
     targets: [
         .executableTarget(
             name: "CodeBurnMenubar",
@@ -19,7 +22,10 @@ let package = Package(
         ),
         .testTarget(
             name: "CodeBurnMenubarTests",
-            dependencies: ["CodeBurnMenubar"],
+            dependencies: [
+                "CodeBurnMenubar",
+                .product(name: "Testing", package: "swift-testing")
+            ],
             path: "Tests/CodeBurnMenubarTests"
         )
     ]

--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -1003,6 +1003,7 @@ enum Period: String, CaseIterable, Identifiable {
     case thirtyDays = "30 Days"
     case month = "Month"
     case all = "6 Months"
+    case lifetime = "Lifetime"
 
     var id: String { rawValue }
 
@@ -1014,12 +1015,13 @@ enum Period: String, CaseIterable, Identifiable {
         case .thirtyDays: "30days"
         case .month: "month"
         case .all: "all"
+        case .lifetime: "lifetime"
         }
     }
 
     /// Status item metrics intentionally stay to the coarse Settings choices.
     /// The popover still offers 30 Days, but it is not a persisted status metric.
-    static let menubarMetricCases: [Period] = [.today, .sevenDays, .month, .all]
+    static let menubarMetricCases: [Period] = [.today, .sevenDays, .month, .all, .lifetime]
 
     var menubarMetricLabel: String {
         switch self {
@@ -1028,6 +1030,7 @@ enum Period: String, CaseIterable, Identifiable {
         case .thirtyDays: "30 Days"
         case .month: "Month"
         case .all: "6 Months"
+        case .lifetime: "Lifetime"
         }
     }
 
@@ -1038,6 +1041,7 @@ enum Period: String, CaseIterable, Identifiable {
         case .thirtyDays: "30days"
         case .month: "month"
         case .all: "sixMonths"
+        case .lifetime: "lifetime"
         }
     }
 
@@ -1047,6 +1051,7 @@ enum Period: String, CaseIterable, Identifiable {
         case "week", "sevenDays": self = .sevenDays
         case "month": self = .month
         case "sixMonths", "all": self = .all
+        case "lifetime": self = .lifetime
         default: self = .today
         }
     }
@@ -1067,6 +1072,7 @@ enum Period: String, CaseIterable, Identifiable {
         case .thirtyDays: compact ? "/30d" : " / 30d"
         case .month: compact ? "/mo" : " / mo"
         case .all: compact ? "/6mo" : " / 6mo"
+        case .lifetime: compact ? "/all" : " / all"
         }
     }
 }

--- a/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
@@ -7,10 +7,89 @@ struct MenubarPayload: Codable, Sendable {
     let current: CurrentBlock
     let optimize: OptimizeBlock
     let history: HistoryBlock
+    let stats: StatsSummary
+
+    enum CodingKeys: String, CodingKey {
+        case generated, current, optimize, history, stats
+    }
+
+    init(generated: String, current: CurrentBlock, optimize: OptimizeBlock, history: HistoryBlock, stats: StatsSummary) {
+        self.generated = generated
+        self.current = current
+        self.optimize = optimize
+        self.history = history
+        self.stats = stats
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        generated = try c.decode(String.self, forKey: .generated)
+        current = try c.decode(CurrentBlock.self, forKey: .current)
+        optimize = try c.decode(OptimizeBlock.self, forKey: .optimize)
+        history = try c.decode(HistoryBlock.self, forKey: .history)
+        stats = try c.decodeIfPresent(StatsSummary.self, forKey: .stats)
+            ?? StatsSummary(trackedSpend: 0, trackedDays: 0, mostActiveDay: nil, peakDaySpend: nil, currentStreakDays: 0, longestStreakDays: 0)
+    }
+}
+
+struct StatsSummary: Codable, Sendable {
+    let trackedSpend: Double
+    let trackedDays: Int
+    let mostActiveDay: String?
+    let peakDaySpend: Double?
+    let currentStreakDays: Int
+    let longestStreakDays: Int
 }
 
 struct HistoryBlock: Codable, Sendable {
     let daily: [DailyHistoryEntry]
+    let intraday: [IntradayHistoryEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case daily, intraday
+    }
+
+    init(daily: [DailyHistoryEntry], intraday: [IntradayHistoryEntry]) {
+        self.daily = daily
+        self.intraday = intraday
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        daily = try c.decodeIfPresent([DailyHistoryEntry].self, forKey: .daily) ?? []
+        intraday = try c.decodeIfPresent([IntradayHistoryEntry].self, forKey: .intraday) ?? []
+    }
+}
+
+struct IntradayHistoryEntry: Codable, Sendable {
+    let bucketStartHour: Int
+    let bucketEndHour: Int
+    let cost: Double
+    let calls: Int
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheReadTokens: Int
+    let cacheWriteTokens: Int
+    let topModels: [DailyModelBreakdown]
+}
+
+extension IntradayHistoryEntry {
+    enum CodingKeys: String, CodingKey {
+        case bucketStartHour, bucketEndHour, cost, calls, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, topModels
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        bucketStartHour = try c.decode(Int.self, forKey: .bucketStartHour)
+        bucketEndHour = try c.decode(Int.self, forKey: .bucketEndHour)
+        cost = try c.decode(Double.self, forKey: .cost)
+        calls = try c.decode(Int.self, forKey: .calls)
+        inputTokens = try c.decode(Int.self, forKey: .inputTokens)
+        outputTokens = try c.decode(Int.self, forKey: .outputTokens)
+        cacheReadTokens = try c.decode(Int.self, forKey: .cacheReadTokens)
+        cacheWriteTokens = try c.decode(Int.self, forKey: .cacheWriteTokens)
+        topModels = try c.decodeIfPresent([DailyModelBreakdown].self, forKey: .topModels) ?? []
+    }
 }
 
 struct DailyModelBreakdown: Codable, Sendable {
@@ -268,6 +347,7 @@ extension MenubarPayload {
             mcpServers: []
         ),
         optimize: OptimizeBlock(findingCount: 0, savingsUSD: 0, topFindings: []),
-        history: HistoryBlock(daily: [])
+        history: HistoryBlock(daily: [], intraday: []),
+        stats: StatsSummary(trackedSpend: 0, trackedDays: 0, mostActiveDay: nil, peakDaySpend: nil, currentStreakDays: 0, longestStreakDays: 0)
     )
 }

--- a/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
@@ -79,10 +79,10 @@ struct HeatmapSection: View {
             } else {
                 PlanInsight(usage: store.subscription)
             }
-        case .trend: TrendInsight(days: store.payload.history.daily, period: store.selectedPeriod)
+        case .trend: TrendInsight(history: store.payload.history, period: store.selectedPeriod)
         case .forecast: ForecastInsight(days: store.payload.history.daily)
         case .pulse: PulseInsight(payload: store.payload)
-        case .stats: StatsInsight(payload: store.payload)
+        case .stats: StatsInsight(payload: store.payload, period: store.selectedPeriod)
         case .optimize: OptimizeInsight(payload: store.payload)
         }
     }
@@ -119,29 +119,99 @@ private struct InsightPillSwitcher: View {
     }
 }
 
-// MARK: - Trend (14-day bar chart with peak + average)
+// MARK: - Trend (period-aware bar chart with peak + average)
 
 private struct TrendInsight: View {
-    let days: [DailyHistoryEntry]
+    let history: HistoryBlock
     let period: Period
 
-    private var trendDayCount: Int {
+    private var descriptor: TrendDescriptor {
+        let calendar = gregorianCalendar
         switch period {
-        case .today, .sevenDays: return 19
-        case .thirtyDays: return 30
-        case .month: return 31
-        case .all: return min(days.count, 90)
+        case .today:
+            return TrendDescriptor(
+                cadence: .intraday4Hour,
+                windowLabel: "Today",
+                comparisonLabel: "prior day",
+                averageLabel: "Avg/4h",
+                peakLabel: "Peak slot",
+                latestLabel: "Current 4h",
+                comparisonDaySpan: 1,
+                latestMode: .current,
+                peakJoiner: "in"
+            )
+        case .sevenDays:
+            return TrendDescriptor(
+                cadence: .daily(7),
+                windowLabel: "Last 7 days",
+                comparisonLabel: "prior 7d",
+                averageLabel: "Avg/day",
+                peakLabel: "Peak day",
+                latestLabel: "Yesterday",
+                comparisonDaySpan: 7,
+                latestMode: .previousDay,
+                peakJoiner: "on"
+            )
+        case .thirtyDays:
+            return TrendDescriptor(
+                cadence: .daily(30),
+                windowLabel: "Last 30 days",
+                comparisonLabel: "prior 30d",
+                averageLabel: "Avg/day",
+                peakLabel: "Peak day",
+                latestLabel: "Yesterday",
+                comparisonDaySpan: 30,
+                latestMode: .previousDay,
+                peakJoiner: "on"
+            )
+        case .month:
+            let daysElapsed = max(calendar.component(.day, from: Date()), 1)
+            return TrendDescriptor(
+                cadence: .daily(daysElapsed),
+                windowLabel: "Month to date",
+                comparisonLabel: "prior \(daysElapsed)d",
+                averageLabel: "Avg/day",
+                peakLabel: "Peak day",
+                latestLabel: "Yesterday",
+                comparisonDaySpan: daysElapsed,
+                latestMode: .previousDay,
+                peakJoiner: "on"
+            )
+        case .all:
+            return TrendDescriptor(
+                cadence: .weekly(26),
+                windowLabel: "Recent 26 weeks",
+                comparisonLabel: "prior 26w",
+                averageLabel: "Avg/week",
+                peakLabel: "Peak week",
+                latestLabel: "This week",
+                comparisonDaySpan: 26 * 7,
+                latestMode: .current,
+                peakJoiner: "in"
+            )
+        case .lifetime:
+            return lifetimeDescriptor(calendar: calendar)
         }
     }
 
     private var barGap: CGFloat {
-        trendDayCount > 45 ? 2 : 4
+        let count = bars.count
+        if count > 24 { return 2 }
+        if count > 12 { return 3 }
+        return 4
+    }
+
+    private var bars: [TrendBar] {
+        buildTrendBars(history: history, descriptor: descriptor)
     }
 
     var body: some View {
-        let dayCount = trendDayCount
-        let bars = buildTrendBars(from: days, dayCount: dayCount)
-        let stats = computeTrendStats(bars: bars, allDays: days, dayCount: dayCount)
+        let stats = computeTrendStats(
+            bars: bars,
+            allDays: history.daily,
+            comparisonDaySpan: descriptor.comparisonDaySpan,
+            latestMode: descriptor.latestMode
+        )
         // Tokens are real for the .all-providers view; per-provider history doesn't carry
         // token breakdown yet, so fall back to $ when no tokens are present.
         let totalTokens = bars.reduce(0.0) { $0 + $1.tokens }
@@ -150,12 +220,12 @@ private struct TrendInsight: View {
         let maxValue = max(bars.map(metric).max() ?? 1, 0.01)
         let avgValue = bars.isEmpty ? 0 : bars.map(metric).reduce(0, +) / Double(bars.count)
         let peakValue = bars.filter({ metric($0) > 0 }).max(by: { metric($0) < metric($1) })
-        let yesterdayValue = stats.yesterdayBar.map(metric)
+        let latestValue = stats.latestBar.map(metric)
 
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .firstTextBaseline) {
                 VStack(alignment: .leading, spacing: 1) {
-                    Text("Last \(dayCount) days")
+                    Text(descriptor.windowLabel)
                         .font(.system(size: 10, weight: .medium))
                         .foregroundStyle(.tertiary)
                     Text(formatHero(useTokens: useTokens, tokens: totalTokens, dollars: stats.totalThisWindow))
@@ -164,11 +234,11 @@ private struct TrendInsight: View {
                         .foregroundStyle(.primary)
                 }
                 Spacer()
-                if let delta = stats.deltaPercent {
+                if let delta = stats.deltaPercent, let comparisonLabel = descriptor.comparisonLabel {
                     HStack(spacing: 3) {
                         Image(systemName: delta >= 0 ? "arrow.up.right" : "arrow.down.right")
                             .font(.system(size: 9, weight: .bold))
-                        Text("\(delta >= 0 ? "+" : "")\(String(format: "%.0f", delta))% vs prior \(dayCount)d")
+                        Text("\(delta >= 0 ? "+" : "")\(String(format: "%.0f", delta))% vs \(comparisonLabel)")
                             .font(.system(size: 10.5))
                             .monospacedDigit()
                     }
@@ -187,9 +257,9 @@ private struct TrendInsight: View {
             .zIndex(1)
 
             HStack(spacing: 14) {
-                MiniStat(label: "Avg/day", value: formatValue(avgValue, useTokens: useTokens))
-                MiniStat(label: "Peak", value: peakLabel(peakValue, metric: metric, useTokens: useTokens))
-                MiniStat(label: "Yesterday", value: yesterdayValue.map { formatValue($0, useTokens: useTokens) } ?? "—")
+                MiniStat(label: descriptor.averageLabel, value: formatValue(avgValue, useTokens: useTokens))
+                MiniStat(label: descriptor.peakLabel, value: peakLabel(peakValue, metric: metric, useTokens: useTokens, joiner: descriptor.peakJoiner))
+                MiniStat(label: descriptor.latestLabel, value: latestValue.map { formatValue($0, useTokens: useTokens) } ?? "—")
             }
         }
     }
@@ -202,9 +272,9 @@ private struct TrendInsight: View {
         useTokens ? "\(formatTokens(v)) tok" : v.asCompactCurrency()
     }
 
-    private func peakLabel(_ peak: TrendBar?, metric: (TrendBar) -> Double, useTokens: Bool) -> String {
+    private func peakLabel(_ peak: TrendBar?, metric: (TrendBar) -> Double, useTokens: Bool, joiner: String) -> String {
         guard let peak, metric(peak) > 0 else { return "—" }
-        return "\(formatValue(metric(peak), useTokens: useTokens)) on \(shortDate(peak.date))"
+        return "\(formatValue(metric(peak), useTokens: useTokens)) \(joiner) \(peak.shortLabel)"
     }
 
     private func formatTokens(_ n: Double) -> String {
@@ -213,10 +283,8 @@ private struct TrendInsight: View {
         return String(format: "%.0f", n)
     }
 
-    private func shortDate(_ ymd: String) -> String {
-        let parts = ymd.split(separator: "-")
-        guard parts.count == 3 else { return ymd }
-        return "\(parts[1])/\(parts[2])"
+    private func lifetimeDescriptor(calendar: Calendar) -> TrendDescriptor {
+        makeLifetimeDescriptor(days: history.daily, calendar: calendar)
     }
 }
 
@@ -320,7 +388,7 @@ private struct BarColumn: View {
     }
 
     private var barColor: Color {
-        if bar.isToday { return Theme.brandAccent }
+        if bar.isCurrent { return Theme.brandAccent }
         if value <= 0 { return Color.secondary.opacity(0.15) }
         if isHovered { return Theme.brandAccent.opacity(0.85) }
         let ratio = maxValue > 0 ? value / maxValue : 0
@@ -362,7 +430,7 @@ private struct BarTooltipCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             HStack(alignment: .firstTextBaseline) {
-                Text(prettyDate(bar.date))
+                Text(bar.label)
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(primaryText)
                 Spacer()
@@ -446,12 +514,14 @@ private struct MiniStat: View {
 }
 
 private struct TrendBar: Identifiable {
-    var id: String { date }
-    let date: String
+    let id: String
+    let label: String
+    let shortLabel: String
+    let anchorDateKey: String
     let cost: Double
     let inputTokens: Double
     let outputTokens: Double
-    let isToday: Bool
+    let isCurrent: Bool
     let topModels: [DailyModelBreakdown]
 
     var tokens: Double { inputTokens + outputTokens }
@@ -459,18 +529,65 @@ private struct TrendBar: Identifiable {
 
 private struct TrendStats {
     let totalThisWindow: Double
-    let avgPerDay: Double
-    let peak: TrendBar?
-    let activeDays: Int
     let deltaPercent: Double?
-    let yesterdayBar: TrendBar?
+    let latestBar: TrendBar?
 }
 
-private func buildTrendBars(from days: [DailyHistoryEntry], dayCount: Int) -> [TrendBar] {
+private enum TrendCadence {
+    case intraday4Hour
+    case daily(Int)
+    case weekly(Int)
+    case monthly(Int)
+    case quarterly(Int)
+    case yearly(Int)
+}
+
+private enum TrendLatestMode {
+    case current
+    case previousDay
+}
+
+private struct TrendDescriptor {
+    let cadence: TrendCadence
+    let windowLabel: String
+    let comparisonLabel: String?
+    let averageLabel: String
+    let peakLabel: String
+    let latestLabel: String
+    let comparisonDaySpan: Int?
+    let latestMode: TrendLatestMode
+    let peakJoiner: String
+}
+
+private struct TrendAggregate {
+    let cost: Double
+    let inputTokens: Double
+    let outputTokens: Double
+    let topModels: [DailyModelBreakdown]
+}
+
+private func buildTrendBars(history: HistoryBlock, descriptor: TrendDescriptor, now: Date = Date()) -> [TrendBar] {
+    switch descriptor.cadence {
+    case .intraday4Hour:
+        return buildIntradayTrendBars(from: history.intraday, now: now)
+    case .daily(let dayCount):
+        return buildDailyTrendBars(from: history.daily, dayCount: dayCount, now: now)
+    case .weekly(let weekCount):
+        return buildWeeklyTrendBars(from: history.daily, weekCount: weekCount, now: now)
+    case .monthly(let monthCount):
+        return buildMonthlyTrendBars(from: history.daily, monthCount: monthCount, now: now)
+    case .quarterly(let quarterCount):
+        return buildQuarterlyTrendBars(from: history.daily, quarterCount: quarterCount, now: now)
+    case .yearly(let yearCount):
+        return buildYearlyTrendBars(from: history.daily, yearCount: yearCount, now: now)
+    }
+}
+
+private func buildDailyTrendBars(from days: [DailyHistoryEntry], dayCount: Int, now: Date = Date()) -> [TrendBar] {
     let calendar = gregorianCalendar
     let formatter = yyyymmdd
     let entryByDate = Dictionary(days.map { ($0.date, $0) }, uniquingKeysWith: { _, new in new })
-    let today = calendar.startOfDay(for: Date())
+    let today = calendar.startOfDay(for: now)
     let todayKey = formatter.string(from: today)
 
     var bars: [TrendBar] = []
@@ -479,30 +596,211 @@ private func buildTrendBars(from days: [DailyHistoryEntry], dayCount: Int) -> [T
         let key = formatter.string(from: d)
         let entry = entryByDate[key]
         bars.append(TrendBar(
-            date: key,
+            id: key,
+            label: prettyDate(key),
+            shortLabel: shortDate(key),
+            anchorDateKey: key,
             cost: entry?.cost ?? 0,
             inputTokens: Double(entry?.inputTokens ?? 0),
             outputTokens: Double(entry?.outputTokens ?? 0),
-            isToday: key == todayKey,
+            isCurrent: key == todayKey,
             topModels: entry?.topModels ?? []
         ))
     }
     return bars
 }
 
-private func computeTrendStats(bars: [TrendBar], allDays: [DailyHistoryEntry], dayCount: Int) -> TrendStats {
+private func buildIntradayTrendBars(from buckets: [IntradayHistoryEntry], now: Date = Date()) -> [TrendBar] {
+    let currentHour = gregorianCalendar.component(.hour, from: now)
+    let today = gregorianCalendar.startOfDay(for: now)
+    let todayKey = yyyymmdd.string(from: today)
+
+    return buckets.map { bucket in
+        TrendBar(
+            id: "hour-\(bucket.bucketStartHour)",
+            label: hourRangeLabel(startHour: bucket.bucketStartHour, endHour: bucket.bucketEndHour, compact: false),
+            shortLabel: hourRangeLabel(startHour: bucket.bucketStartHour, endHour: bucket.bucketEndHour, compact: true),
+            anchorDateKey: todayKey,
+            cost: bucket.cost,
+            inputTokens: Double(bucket.inputTokens),
+            outputTokens: Double(bucket.outputTokens),
+            isCurrent: currentHour >= bucket.bucketStartHour && currentHour < bucket.bucketEndHour,
+            topModels: bucket.topModels
+        )
+    }
+}
+
+private func buildWeeklyTrendBars(from days: [DailyHistoryEntry], weekCount: Int, now: Date = Date()) -> [TrendBar] {
+    let calendar = gregorianCalendar
+    let today = calendar.startOfDay(for: now)
+    guard let currentWeek = calendar.dateInterval(of: .weekOfYear, for: today) else { return [] }
+    let entryByDate = Dictionary(days.map { ($0.date, $0) }, uniquingKeysWith: { _, new in new })
+    let formatter = yyyymmdd
+
+    return (0..<weekCount).reversed().compactMap { offset in
+        guard let start = calendar.date(byAdding: .weekOfYear, value: -offset, to: currentWeek.start),
+              let end = calendar.date(byAdding: .day, value: 7, to: start) else { return nil }
+        let aggregate = aggregateTrendRange(entryByDate: entryByDate, start: start, end: end)
+        let key = formatter.string(from: start)
+        return TrendBar(
+            id: "week-\(key)",
+            label: "Week of \(shortDate(key))",
+            shortLabel: "wk of \(shortDate(key))",
+            anchorDateKey: key,
+            cost: aggregate.cost,
+            inputTokens: aggregate.inputTokens,
+            outputTokens: aggregate.outputTokens,
+            isCurrent: offset == 0,
+            topModels: aggregate.topModels
+        )
+    }
+}
+
+private func buildMonthlyTrendBars(from days: [DailyHistoryEntry], monthCount: Int, now: Date = Date()) -> [TrendBar] {
+    let calendar = gregorianCalendar
+    let today = calendar.startOfDay(for: now)
+    let currentMonthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: today)) ?? today
+    let entryByDate = Dictionary(days.map { ($0.date, $0) }, uniquingKeysWith: { _, new in new })
+    let formatter = yyyymmdd
+
+    return (0..<monthCount).reversed().compactMap { offset in
+        guard let start = calendar.date(byAdding: .month, value: -offset, to: currentMonthStart),
+              let end = calendar.date(byAdding: .month, value: 1, to: start) else { return nil }
+        let aggregate = aggregateTrendRange(entryByDate: entryByDate, start: start, end: end)
+        let key = formatter.string(from: start)
+        return TrendBar(
+            id: "month-\(key)",
+            label: monthYearLabel(start),
+            shortLabel: monthYearLabel(start),
+            anchorDateKey: key,
+            cost: aggregate.cost,
+            inputTokens: aggregate.inputTokens,
+            outputTokens: aggregate.outputTokens,
+            isCurrent: offset == 0,
+            topModels: aggregate.topModels
+        )
+    }
+}
+
+private func buildQuarterlyTrendBars(from days: [DailyHistoryEntry], quarterCount: Int, now: Date = Date()) -> [TrendBar] {
+    let calendar = gregorianCalendar
+    let today = calendar.startOfDay(for: now)
+    let currentQuarterStart = quarterStart(for: today, calendar: calendar)
+    let entryByDate = Dictionary(days.map { ($0.date, $0) }, uniquingKeysWith: { _, new in new })
+    let formatter = yyyymmdd
+
+    return (0..<quarterCount).reversed().compactMap { offset in
+        guard let start = calendar.date(byAdding: .month, value: -(offset * 3), to: currentQuarterStart),
+              let end = calendar.date(byAdding: .month, value: 3, to: start) else { return nil }
+        let aggregate = aggregateTrendRange(entryByDate: entryByDate, start: start, end: end)
+        let key = formatter.string(from: start)
+        return TrendBar(
+            id: "quarter-\(key)",
+            label: quarterLabel(start, calendar: calendar),
+            shortLabel: quarterLabel(start, calendar: calendar),
+            anchorDateKey: key,
+            cost: aggregate.cost,
+            inputTokens: aggregate.inputTokens,
+            outputTokens: aggregate.outputTokens,
+            isCurrent: offset == 0,
+            topModels: aggregate.topModels
+        )
+    }
+}
+
+private func buildYearlyTrendBars(from days: [DailyHistoryEntry], yearCount: Int, now: Date = Date()) -> [TrendBar] {
+    let calendar = gregorianCalendar
+    let today = calendar.startOfDay(for: now)
+    let currentYearStart = calendar.date(from: calendar.dateComponents([.year], from: today)) ?? today
+    let entryByDate = Dictionary(days.map { ($0.date, $0) }, uniquingKeysWith: { _, new in new })
+    let formatter = yyyymmdd
+
+    return (0..<yearCount).reversed().compactMap { offset in
+        guard let start = calendar.date(byAdding: .year, value: -offset, to: currentYearStart),
+              let end = calendar.date(byAdding: .year, value: 1, to: start) else { return nil }
+        let aggregate = aggregateTrendRange(entryByDate: entryByDate, start: start, end: end)
+        let key = formatter.string(from: start)
+        return TrendBar(
+            id: "year-\(key)",
+            label: yearLabel(start, calendar: calendar),
+            shortLabel: yearLabel(start, calendar: calendar),
+            anchorDateKey: key,
+            cost: aggregate.cost,
+            inputTokens: aggregate.inputTokens,
+            outputTokens: aggregate.outputTokens,
+            isCurrent: offset == 0,
+            topModels: aggregate.topModels
+        )
+    }
+}
+
+private func aggregateTrendRange(entryByDate: [String: DailyHistoryEntry], start: Date, end: Date) -> TrendAggregate {
+    let calendar = gregorianCalendar
+    let formatter = yyyymmdd
+    var cursor = start
+    var cost = 0.0
+    var inputTokens = 0.0
+    var outputTokens = 0.0
+    var topModelTotals: [String: (calls: Int, cost: Double, inputTokens: Int, outputTokens: Int)] = [:]
+
+    while cursor < end {
+        let key = formatter.string(from: cursor)
+        if let entry = entryByDate[key] {
+            cost += entry.cost
+            inputTokens += Double(entry.inputTokens)
+            outputTokens += Double(entry.outputTokens)
+
+            for model in entry.topModels {
+                let existing = topModelTotals[model.name] ?? (calls: 0, cost: 0, inputTokens: 0, outputTokens: 0)
+                topModelTotals[model.name] = (
+                    calls: existing.calls + model.calls,
+                    cost: existing.cost + model.cost,
+                    inputTokens: existing.inputTokens + model.inputTokens,
+                    outputTokens: existing.outputTokens + model.outputTokens
+                )
+            }
+        }
+
+        guard let next = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
+        cursor = next
+    }
+
+    let topModels = topModelTotals
+        .map { name, total in
+            DailyModelBreakdown(
+                name: name,
+                cost: total.cost,
+                calls: total.calls,
+                inputTokens: total.inputTokens,
+                outputTokens: total.outputTokens
+            )
+        }
+        .sorted { $0.cost > $1.cost }
+        .prefix(5)
+
+    return TrendAggregate(
+        cost: cost,
+        inputTokens: inputTokens,
+        outputTokens: outputTokens,
+        topModels: Array(topModels)
+    )
+}
+
+private func computeTrendStats(
+    bars: [TrendBar],
+    allDays: [DailyHistoryEntry],
+    comparisonDaySpan: Int?,
+    latestMode: TrendLatestMode
+) -> TrendStats {
     let total = bars.reduce(0.0) { $0 + $1.cost }
-    let active = bars.filter { $0.cost > 0 }.count
-    let avg = bars.isEmpty ? 0 : total / Double(bars.count)
-    let peak = bars.filter { $0.cost > 0 }.max(by: { $0.cost < $1.cost })
 
     let calendar = gregorianCalendar
     let formatter = yyyymmdd
     let today = calendar.startOfDay(for: Date())
-    let priorWindowStart = calendar.date(byAdding: .day, value: -(2 * dayCount - 1), to: today)
-    let thisWindowStart = calendar.date(byAdding: .day, value: -(dayCount - 1), to: today)
     var deltaPercent: Double? = nil
-    if let priorStart = priorWindowStart, let thisStart = thisWindowStart {
+    if let comparisonDaySpan,
+       let priorStart = calendar.date(byAdding: .day, value: -(2 * comparisonDaySpan - 1), to: today),
+       let thisStart = calendar.date(byAdding: .day, value: -(comparisonDaySpan - 1), to: today) {
         let priorStartStr = formatter.string(from: priorStart)
         let thisStartStr = formatter.string(from: thisStart)
         let priorTotal = allDays
@@ -513,18 +811,142 @@ private func computeTrendStats(bars: [TrendBar], allDays: [DailyHistoryEntry], d
         }
     }
 
-    let yesterdayDate = calendar.date(byAdding: .day, value: -1, to: today)
-    let yesterdayKey = yesterdayDate.map { formatter.string(from: $0) }
-    let yesterdayBar = bars.first(where: { $0.date == yesterdayKey })
+    let latestBar: TrendBar?
+    switch latestMode {
+    case .current:
+        latestBar = bars.last(where: { $0.isCurrent })
+    case .previousDay:
+        let yesterdayDate = calendar.date(byAdding: .day, value: -1, to: today)
+        let yesterdayKey = yesterdayDate.map { formatter.string(from: $0) }
+        latestBar = bars.first(where: { $0.anchorDateKey == yesterdayKey })
+    }
 
     return TrendStats(
         totalThisWindow: total,
-        avgPerDay: avg,
-        peak: peak,
-        activeDays: active,
         deltaPercent: deltaPercent,
-        yesterdayBar: yesterdayBar
+        latestBar: latestBar
     )
+}
+
+private func hourRangeLabel(startHour: Int, endHour: Int, compact: Bool) -> String {
+    let start = hourLabel(startHour, compact: compact)
+    let end = hourLabel(endHour % 24, compact: compact)
+    return compact ? "\(start)-\(end)" : "\(start) - \(end)"
+}
+
+private func hourLabel(_ hour: Int, compact: Bool) -> String {
+    let normalized = (hour + 24) % 24
+    let value = normalized == 0 ? 12 : (normalized > 12 ? normalized - 12 : normalized)
+    let suffix = normalized < 12 ? (compact ? "a" : "AM") : (compact ? "p" : "PM")
+    return compact ? "\(value)\(suffix)" : "\(value) \(suffix)"
+}
+
+private func monthYearLabel(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "MMM yyyy"
+    return formatter.string(from: date)
+}
+
+private func lifetimeMonthSpan(calendar: Calendar, days: [DailyHistoryEntry], now: Date = Date()) -> Int {
+    let today = calendar.startOfDay(for: now)
+    let currentMonthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: today)) ?? today
+
+    guard let firstDateKey = days.map(\ .date).min(),
+          let firstDate = yyyymmdd.date(from: firstDateKey) else {
+        return 1
+    }
+
+    let firstMonthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: firstDate)) ?? firstDate
+    let firstComponents = calendar.dateComponents([.year, .month], from: firstMonthStart)
+    let currentComponents = calendar.dateComponents([.year, .month], from: currentMonthStart)
+    let firstYear = firstComponents.year ?? currentComponents.year ?? 0
+    let firstMonth = firstComponents.month ?? currentComponents.month ?? 1
+    let currentYear = currentComponents.year ?? firstYear
+    let currentMonth = currentComponents.month ?? firstMonth
+    let diff = (currentYear - firstYear) * 12 + (currentMonth - firstMonth)
+    return max(diff + 1, 1)
+}
+
+private func makeLifetimeDescriptor(days: [DailyHistoryEntry], calendar: Calendar, now: Date = Date()) -> TrendDescriptor {
+    let monthSpan = lifetimeMonthSpan(calendar: calendar, days: days, now: now)
+    if monthSpan <= 24 {
+        return TrendDescriptor(
+            cadence: .monthly(monthSpan),
+            windowLabel: "All time by month",
+            comparisonLabel: nil,
+            averageLabel: "Avg/month",
+            peakLabel: "Peak month",
+            latestLabel: "This month",
+            comparisonDaySpan: nil,
+            latestMode: .current,
+            peakJoiner: "in"
+        )
+    }
+
+    if monthSpan <= 60 {
+        let quarterCount = Int(ceil(Double(monthSpan) / 3.0))
+        return TrendDescriptor(
+            cadence: .quarterly(quarterCount),
+            windowLabel: "All time by quarter",
+            comparisonLabel: nil,
+            averageLabel: "Avg/quarter",
+            peakLabel: "Peak quarter",
+            latestLabel: "This quarter",
+            comparisonDaySpan: nil,
+            latestMode: .current,
+            peakJoiner: "in"
+        )
+    }
+
+    let yearCount = Int(ceil(Double(monthSpan) / 12.0))
+    return TrendDescriptor(
+        cadence: .yearly(yearCount),
+        windowLabel: "All time by year",
+        comparisonLabel: nil,
+        averageLabel: "Avg/year",
+        peakLabel: "Peak year",
+        latestLabel: "This year",
+        comparisonDaySpan: nil,
+        latestMode: .current,
+        peakJoiner: "in"
+    )
+}
+
+struct LifetimeTrendTestSummary: Equatable {
+    let windowLabel: String
+    let labels: [String]
+}
+
+func makeLifetimeTrendTestSummary(days: [DailyHistoryEntry], now: Date) -> LifetimeTrendTestSummary {
+    let descriptor = makeLifetimeDescriptor(days: days, calendar: gregorianCalendar, now: now)
+    let bars = buildTrendBars(history: HistoryBlock(daily: days, intraday: []), descriptor: descriptor, now: now)
+    return LifetimeTrendTestSummary(windowLabel: descriptor.windowLabel, labels: bars.map(\.label))
+}
+
+private func quarterStart(for date: Date, calendar: Calendar) -> Date {
+    let components = calendar.dateComponents([.year, .month], from: date)
+    let month = components.month ?? 1
+    let quarterMonth = ((month - 1) / 3) * 3 + 1
+    return calendar.date(from: DateComponents(year: components.year, month: quarterMonth, day: 1)) ?? date
+}
+
+private func quarterLabel(_ date: Date, calendar: Calendar) -> String {
+    let components = calendar.dateComponents([.year, .month], from: date)
+    let month = components.month ?? 1
+    let quarter = ((month - 1) / 3) + 1
+    let year = components.year ?? 0
+    return "Q\(quarter) \(year)"
+}
+
+private func yearLabel(_ date: Date, calendar: Calendar) -> String {
+    String(calendar.component(.year, from: date))
+}
+
+private func shortDate(_ ymd: String) -> String {
+    let parts = ymd.split(separator: "-")
+    guard parts.count == 3 else { return ymd }
+    return "\(parts[1])/\(parts[2])"
 }
 
 // MARK: - Forecast
@@ -833,9 +1255,10 @@ private struct OptimizeSavingsBadge: View {
 
 private struct StatsInsight: View {
     let payload: MenubarPayload
+    let period: Period
 
     var body: some View {
-        let stats = computeAllStats(payload: payload)
+        let stats = computeAllStats(payload: payload, period: period)
 
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top, spacing: 14) {
@@ -848,22 +1271,22 @@ private struct StatsInsight: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 VStack(alignment: .leading, spacing: 8) {
-                    StatRow(label: "Sessions today", value: "\(payload.current.sessions)")
-                    StatRow(label: "Calls today", value: payload.current.calls.asThousandsSeparated())
+                    StatRow(label: stats.sessionsLabel, value: "\(payload.current.sessions)")
+                    StatRow(label: stats.callsLabel, value: payload.current.calls.asThousandsSeparated())
                     StatRow(label: "Current streak", value: stats.currentStreak)
                     StatRow(label: "Longest streak", value: stats.longestStreak)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            if let lifetime = stats.lifetimeTotal {
+            if let trackedSpend = stats.trackedSpend {
                 Divider().opacity(0.5)
                 HStack {
-                    Text("Tracked spend (last \(stats.historyDayCount) days)")
+                    Text(stats.trackedSpendLabel)
                         .font(.system(size: 10.5, weight: .medium))
                         .foregroundStyle(.tertiary)
                     Spacer()
-                    Text(lifetime.asCurrency())
+                    Text(trackedSpend.asCurrency())
                         .font(.system(size: 13, weight: .semibold, design: .rounded))
                         .monospacedDigit()
                         .foregroundStyle(Theme.brandAccent)
@@ -1024,8 +1447,9 @@ private struct TopProjectsList: View {
                             .lineLimit(1)
                         Spacer()
                         Text("\(project.sessions) sess")
-                            .font(.system(size: 9.5))
-                            .foregroundStyle(.quaternary)
+                            .font(.system(size: 9.5, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
                         Text(project.cost.asCompactCurrency())
                             .font(.codeMono(size: 10.5, weight: .semibold))
                             .foregroundStyle(.secondary)
@@ -1254,11 +1678,13 @@ private struct AllStats {
     let peakDaySpend: String
     let currentStreak: String
     let longestStreak: String
-    let lifetimeTotal: Double?
-    let historyDayCount: Int
+    let trackedSpend: Double?
+    let trackedSpendLabel: String
+    let sessionsLabel: String
+    let callsLabel: String
 }
 
-@MainActor private func computeAllStats(payload: MenubarPayload) -> AllStats {
+@MainActor private func computeAllStats(payload: MenubarPayload, period: Period) -> AllStats {
     let history = payload.history.daily
     let favoriteModel = payload.current.topModels.first?.name ?? "—"
 
@@ -1267,7 +1693,6 @@ private struct AllStats {
     let displayFormatter = mmmDayFormat
 
     let now = Date()
-    let today = calendar.startOfDay(for: now)
     let comps = calendar.dateComponents([.year, .month, .day], from: now)
 
     var activeDaysFraction = "—"
@@ -1280,57 +1705,61 @@ private struct AllStats {
         activeDaysFraction = "\(mtdActive)/\(rangeOfMonth.count)"
     }
 
-    let peak = history.max(by: { $0.cost < $1.cost })
     let mostActiveDay: String
     let peakDaySpend: String
-    if let peak, peak.cost > 0, let date = formatter.date(from: peak.date) {
+    if let peakDate = payload.stats.mostActiveDay,
+       let peakValue = payload.stats.peakDaySpend,
+       peakValue > 0,
+       let date = formatter.date(from: peakDate) {
         mostActiveDay = displayFormatter.string(from: date)
-        peakDaySpend = peak.cost.asCompactCurrency()
+        peakDaySpend = peakValue.asCompactCurrency()
     } else {
         mostActiveDay = "—"
         peakDaySpend = "—"
     }
 
-    let costByDate = Dictionary(history.map { ($0.date, $0.cost) }, uniquingKeysWith: +)
-
-    var currentStreak = 0
-    for offset in 0..<400 {
-        guard let d = calendar.date(byAdding: .day, value: -offset, to: today) else { break }
-        let key = formatter.string(from: d)
-        if (costByDate[key] ?? 0) > 0 { currentStreak += 1 } else { break }
+    let trackedSpend: Double? = payload.stats.trackedSpend > 0 ? payload.stats.trackedSpend : nil
+    let trackedSpendLabel: String
+    let sessionsLabel: String
+    let callsLabel: String
+    switch period {
+    case .today:
+        trackedSpendLabel = "Tracked spend (today)"
+        sessionsLabel = "Sessions today"
+        callsLabel = "Calls today"
+    case .sevenDays:
+        trackedSpendLabel = "Tracked spend (last 7 days)"
+        sessionsLabel = "Sessions (last 7 days)"
+        callsLabel = "Calls (last 7 days)"
+    case .thirtyDays:
+        trackedSpendLabel = "Tracked spend (last 30 days)"
+        sessionsLabel = "Sessions (last 30 days)"
+        callsLabel = "Calls (last 30 days)"
+    case .month:
+        trackedSpendLabel = "Tracked spend (this month)"
+        sessionsLabel = "Sessions (this month)"
+        callsLabel = "Calls (this month)"
+    case .all:
+        trackedSpendLabel = "Tracked spend (last 6 months)"
+        sessionsLabel = "Sessions (last 6 months)"
+        callsLabel = "Calls (last 6 months)"
+    case .lifetime:
+        trackedSpendLabel = "Tracked spend (all time)"
+        sessionsLabel = "Sessions (all time)"
+        callsLabel = "Calls (all time)"
     }
-
-    var longestStreak = 0
-    var running = 0
-    if let firstDate = history.map(\.date).min(),
-       let lastDate = history.map(\.date).max(),
-       let start = formatter.date(from: firstDate),
-       let end = formatter.date(from: lastDate) {
-        var cursor = start
-        while cursor <= end {
-            let key = formatter.string(from: cursor)
-            if (costByDate[key] ?? 0) > 0 {
-                running += 1
-                longestStreak = max(longestStreak, running)
-            } else {
-                running = 0
-            }
-            guard let next = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
-            cursor = next
-        }
-    }
-
-    let lifetimeTotal: Double? = history.isEmpty ? nil : history.reduce(0.0) { $0 + $1.cost }
 
     return AllStats(
         favoriteModel: favoriteModel,
         activeDaysFraction: activeDaysFraction,
         mostActiveDay: mostActiveDay,
         peakDaySpend: peakDaySpend,
-        currentStreak: currentStreak == 0 ? "—" : "\(currentStreak) days",
-        longestStreak: longestStreak == 0 ? "—" : "\(longestStreak) days",
-        lifetimeTotal: lifetimeTotal,
-        historyDayCount: history.count
+        currentStreak: payload.stats.currentStreakDays == 0 ? "—" : "\(payload.stats.currentStreakDays) days",
+        longestStreak: payload.stats.longestStreakDays == 0 ? "—" : "\(payload.stats.longestStreakDays) days",
+        trackedSpend: trackedSpend,
+        trackedSpendLabel: trackedSpendLabel,
+        sessionsLabel: sessionsLabel,
+        callsLabel: callsLabel
     )
 }
 

--- a/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
@@ -171,6 +171,7 @@ private struct EmptyProviderState: View {
         case .thirtyDays: "the last 30 days"
         case .month: "this month"
         case .all: "the last 6 months"
+        case .lifetime: "all time"
         }
     }
 }

--- a/mac/Sources/CodeBurnMenubar/Views/PeriodSegmentedControl.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/PeriodSegmentedControl.swift
@@ -11,11 +11,14 @@ struct PeriodSegmentedControl: View {
                 } label: {
                     Text(period.rawValue)
                         .font(.system(size: 11, weight: .medium))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.85)
                         .foregroundStyle(store.selectedPeriod == period ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 4)
                         .contentShape(Rectangle())
                 }
+                .frame(maxWidth: .infinity)
                 .buttonStyle(.plain)
                 .background(
                     RoundedRectangle(cornerRadius: 5)

--- a/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
@@ -28,7 +28,8 @@ private func menubarPayload(cost: Double) -> MenubarPayload {
             mcpServers: []
         ),
         optimize: OptimizeBlock(findingCount: 0, savingsUSD: 0, topFindings: []),
-        history: HistoryBlock(daily: [])
+        history: HistoryBlock(daily: [], intraday: []),
+        stats: StatsSummary(trackedSpend: cost, trackedDays: 1, mostActiveDay: nil, peakDaySpend: cost, currentStreakDays: 1, longestStreakDays: 1)
     )
 }
 

--- a/mac/Tests/CodeBurnMenubarTests/LifetimeTrendCadenceTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/LifetimeTrendCadenceTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import CodeBurnMenubar
+
+private let utcCalendar: Calendar = {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+    return calendar
+}()
+
+private let fixedNow = utcCalendar.date(from: DateComponents(year: 2026, month: 5, day: 24, hour: 12))!
+
+private func monthEntries(startYear: Int, startMonth: Int, endYear: Int, endMonth: Int) -> [DailyHistoryEntry] {
+    var entries: [DailyHistoryEntry] = []
+    var year = startYear
+    var month = startMonth
+    var index = 0
+
+    while year < endYear || (year == endYear && month <= endMonth) {
+        entries.append(
+            DailyHistoryEntry(
+                date: String(format: "%04d-%02d-15", year, month),
+                cost: 10 + Double(index),
+                calls: 20 + index,
+                inputTokens: 1_000 + index * 100,
+                outputTokens: 250 + index * 25,
+                cacheReadTokens: 0,
+                cacheWriteTokens: 0,
+                topModels: []
+            )
+        )
+
+        month += 1
+        index += 1
+        if month == 13 {
+            month = 1
+            year += 1
+        }
+    }
+
+    return entries
+}
+
+@Suite("Lifetime trend cadence")
+struct LifetimeTrendCadenceTests {
+    @Test("uses monthly cadence through 24 months")
+    func monthlyLifetimeCadence() {
+        let summary = makeLifetimeTrendTestSummary(days: monthEntries(startYear: 2025, startMonth: 12, endYear: 2026, endMonth: 5), now: fixedNow)
+
+        #expect(summary.windowLabel == "All time by month")
+        #expect(summary.labels == ["Dec 2025", "Jan 2026", "Feb 2026", "Mar 2026", "Apr 2026", "May 2026"])
+    }
+
+    @Test("switches to quarterly cadence after 24 months")
+    func quarterlyLifetimeCadence() {
+        let summary = makeLifetimeTrendTestSummary(days: monthEntries(startYear: 2023, startMonth: 1, endYear: 2026, endMonth: 5), now: fixedNow)
+
+        #expect(summary.windowLabel == "All time by quarter")
+        #expect(summary.labels.count == 14)
+        #expect(summary.labels.first == "Q1 2023")
+        #expect(summary.labels.last == "Q2 2026")
+    }
+
+    @Test("switches to yearly cadence beyond 60 months")
+    func yearlyLifetimeCadence() {
+        let summary = makeLifetimeTrendTestSummary(days: monthEntries(startYear: 2020, startMonth: 1, endYear: 2026, endMonth: 5), now: fixedNow)
+
+        #expect(summary.windowLabel == "All time by year")
+        #expect(summary.labels == ["2020", "2021", "2022", "2023", "2024", "2025", "2026"])
+    }
+}

--- a/mac/Tests/CodeBurnMenubarTests/MenubarPeriodSettingsTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/MenubarPeriodSettingsTests.swift
@@ -1,48 +1,60 @@
 import Foundation
-import XCTest
+import Testing
 @testable import CodeBurnMenubar
 
-final class MenubarPeriodSettingsTests: XCTestCase {
-    func testSettingsPickerExposesRequestedPeriods() {
-        XCTAssertEqual(Period.menubarMetricCases, [.today, .sevenDays, .month, .all])
+@Suite("Menubar period settings")
+struct MenubarPeriodSettingsTests {
+    @Test("settings picker exposes requested periods")
+    func settingsPickerExposesRequestedPeriods() {
+        #expect(Period.menubarMetricCases == [.today, .sevenDays, .month, .all, .lifetime])
     }
 
-    func testDefaultsValuesMapToPeriods() {
-        XCTAssertEqual(Period(menubarDefaultsValue: "today"), .today)
-        XCTAssertEqual(Period(menubarDefaultsValue: "week"), .sevenDays)
-        XCTAssertEqual(Period(menubarDefaultsValue: "month"), .month)
-        XCTAssertEqual(Period(menubarDefaultsValue: "sixMonths"), .all)
-        XCTAssertEqual(Period(menubarDefaultsValue: "all"), .all)
-        XCTAssertEqual(Period(menubarDefaultsValue: "30days"), .today)
-        XCTAssertEqual(Period(menubarDefaultsValue: "bogus"), .today)
-        XCTAssertEqual(Period(menubarDefaultsValue: nil), .today)
+    @Test("defaults values map to periods")
+    func defaultsValuesMapToPeriods() {
+        #expect(Period(menubarDefaultsValue: "today") == .today)
+        #expect(Period(menubarDefaultsValue: "week") == .sevenDays)
+        #expect(Period(menubarDefaultsValue: "month") == .month)
+        #expect(Period(menubarDefaultsValue: "sixMonths") == .all)
+        #expect(Period(menubarDefaultsValue: "all") == .all)
+        #expect(Period(menubarDefaultsValue: "lifetime") == .lifetime)
+        #expect(Period(menubarDefaultsValue: "30days") == .today)
+        #expect(Period(menubarDefaultsValue: "bogus") == .today)
+        #expect(Period(menubarDefaultsValue: nil) == .today)
     }
 
-    func testPeriodsPersistCanonicalDefaultsValues() throws {
+    @Test("periods persist canonical defaults values")
+    func periodsPersistCanonicalDefaultsValues() throws {
         let suiteName = "CodeBurnMenubarTests.\(UUID().uuidString)"
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         Period.sevenDays.persistAsMenubarDefault(defaults: defaults)
-        XCTAssertEqual(defaults.string(forKey: "CodeBurnMenubarPeriod"), "week")
-        XCTAssertEqual(Period.savedMenubarPeriod(defaults: defaults), .sevenDays)
+        #expect(defaults.string(forKey: "CodeBurnMenubarPeriod") == "week")
+        #expect(Period.savedMenubarPeriod(defaults: defaults) == .sevenDays)
 
         Period.all.persistAsMenubarDefault(defaults: defaults)
-        XCTAssertEqual(defaults.string(forKey: "CodeBurnMenubarPeriod"), "sixMonths")
-        XCTAssertEqual(Period.savedMenubarPeriod(defaults: defaults), .all)
+        #expect(defaults.string(forKey: "CodeBurnMenubarPeriod") == "sixMonths")
+        #expect(Period.savedMenubarPeriod(defaults: defaults) == .all)
+
+        Period.lifetime.persistAsMenubarDefault(defaults: defaults)
+        #expect(defaults.string(forKey: "CodeBurnMenubarPeriod") == "lifetime")
+        #expect(Period.savedMenubarPeriod(defaults: defaults) == .lifetime)
 
         Period.thirtyDays.persistAsMenubarDefault(defaults: defaults)
-        XCTAssertEqual(defaults.string(forKey: "CodeBurnMenubarPeriod"), "today")
-        XCTAssertEqual(Period.savedMenubarPeriod(defaults: defaults), .today)
+        #expect(defaults.string(forKey: "CodeBurnMenubarPeriod") == "today")
+        #expect(Period.savedMenubarPeriod(defaults: defaults) == .today)
     }
 
-    func testNonTodayPeriodsRenderCompactAndRegularSuffixes() {
-        XCTAssertEqual(Period.today.menubarSuffix(compact: false), "")
-        XCTAssertEqual(Period.sevenDays.menubarSuffix(compact: false), " / wk")
-        XCTAssertEqual(Period.month.menubarSuffix(compact: false), " / mo")
-        XCTAssertEqual(Period.all.menubarSuffix(compact: false), " / 6mo")
-        XCTAssertEqual(Period.sevenDays.menubarSuffix(compact: true), "/wk")
-        XCTAssertEqual(Period.month.menubarSuffix(compact: true), "/mo")
-        XCTAssertEqual(Period.all.menubarSuffix(compact: true), "/6mo")
+    @Test("non-today periods render compact and regular suffixes")
+    func nonTodayPeriodsRenderCompactAndRegularSuffixes() {
+        #expect(Period.today.menubarSuffix(compact: false) == "")
+        #expect(Period.sevenDays.menubarSuffix(compact: false) == " / wk")
+        #expect(Period.month.menubarSuffix(compact: false) == " / mo")
+        #expect(Period.all.menubarSuffix(compact: false) == " / 6mo")
+        #expect(Period.lifetime.menubarSuffix(compact: false) == " / all")
+        #expect(Period.sevenDays.menubarSuffix(compact: true) == "/wk")
+        #expect(Period.month.menubarSuffix(compact: true) == "/mo")
+        #expect(Period.all.menubarSuffix(compact: true) == "/6mo")
+        #expect(Period.lifetime.menubarSuffix(compact: true) == "/all")
     }
 }

--- a/src/cli-date.ts
+++ b/src/cli-date.ts
@@ -8,16 +8,16 @@ const END_OF_DAY_MINUTES = 59
 const END_OF_DAY_SECONDS = 59
 const END_OF_DAY_MS = 999
 
-// "All Time" is intentionally bounded to the last 6 months. Older data is
-// rarely actionable for a cost tracker, and capping the range keeps the parse
-// path bounded so providers like Codex/Cursor with sparse multi-year history
-// still load in seconds. Users who need an unbounded window can use
-// `--from` / `--to`.
-const ALL_TIME_MONTHS = 6
+// The "all" period is intentionally bounded to the last 6 months. Older data
+// is rarely actionable for a cost tracker, and capping the range keeps the
+// parse path bounded so providers like Codex/Cursor with sparse multi-year
+// history still load in seconds. Users who need an unbounded window can use
+// the explicit `lifetime` period or `--from` / `--to`.
+const SIX_MONTH_PERIOD_MONTHS = 6
 
-export type Period = 'today' | 'week' | '30days' | 'month' | 'all'
+export type Period = 'today' | 'week' | '30days' | 'month' | 'all' | 'lifetime'
 
-export const PERIODS: Period[] = ['today', 'week', '30days', 'month', 'all']
+export const PERIODS: Period[] = ['today', 'week', '30days', 'month', 'all', 'lifetime']
 
 // Short labels suitable for the dashboard tab strip. Long-form labels for
 // header text come from `getDateRange().label`.
@@ -27,9 +27,10 @@ export const PERIOD_LABELS: Record<Period, string> = {
   '30days': '30 Days',
   month: 'This Month',
   all: '6 Months',
+  lifetime: 'Lifetime',
 }
 
-const VALID_PERIODS: ReadonlyArray<Period> = ['today', 'week', '30days', 'month', 'all']
+const VALID_PERIODS: ReadonlyArray<Period> = ['today', 'week', '30days', 'month', 'all', 'lifetime']
 
 export function toPeriod(s: string): Period {
   if ((VALID_PERIODS as readonly string[]).includes(s)) return s as Period
@@ -95,8 +96,8 @@ export function parseDateRangeFlags(from: string | undefined, to: string | undef
  * surfaces a few extra inputs not exposed in the dashboard tab strip
  * (e.g. `'yesterday'`). Unknown values fall back to `'week'`.
  *
- * Note: `'all'` is bounded to the last 6 months. Use `--from`/`--to` for
- * an unbounded historical window.
+ * Note: `'all'` is bounded to the last 6 months. Use `'lifetime'` or
+ * `--from`/`--to` for an unbounded historical window.
  */
 export function getDateRange(period: string): { range: DateRange; label: string } {
   const now = new Date()
@@ -133,12 +134,16 @@ export function getDateRange(period: string): { range: DateRange; label: string 
       return { range: { start, end }, label: 'Last 30 Days' }
     }
     case 'all': {
-      const start = new Date(now.getFullYear(), now.getMonth() - ALL_TIME_MONTHS, 1)
+      const start = new Date(now.getFullYear(), now.getMonth() - SIX_MONTH_PERIOD_MONTHS, 1)
       return { range: { start, end }, label: 'Last 6 months' }
+    }
+    case 'lifetime': {
+      const start = new Date(1970, 0, 1)
+      return { range: { start, end }, label: 'Lifetime' }
     }
     default: {
       process.stderr.write(
-        `codeburn: unknown period "${period}". Valid values: today, week, 30days, month, all.\n`
+        `codeburn: unknown period "${period}". Valid values: today, week, 30days, month, all, lifetime.\n`
       )
       process.exit(1)
     }

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -170,9 +170,9 @@ export function withDailyCacheLock<T>(fn: () => Promise<T>): Promise<T> {
 
 export const MS_PER_DAY = 24 * 60 * 60 * 1000
 export const BACKFILL_DAYS = 365
-// Keep 2 years of history so the longest UI-exposed period (6 months
-// today, with headroom for future longer windows) always reads from
-// cache while old entries get pruned.
+// Keep 2 years of history so recent UI windows and the 365-day trend
+// bootstrap always read from cache while old entries get pruned.
+// Lifetime totals deliberately bypass this bounded cache and re-parse.
 export const DAILY_CACHE_RETENTION_DAYS = 730
 
 export function toDateString(date: Date): string {

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -24,7 +24,7 @@ const ORANGE = '#FF8C42'
 const DIM = '#555555'
 const GOLD = '#FFD700'
 const PLAN_BAR_WIDTH = 10
-const HEAVY_PERIODS = new Set<Period>(['30days', 'month', 'all'])
+const HEAVY_PERIODS = new Set<Period>(['30days', 'month', 'all', 'lifetime'])
 
 const LANG_DISPLAY_NAMES: Record<string, string> = {
   javascript: 'JavaScript', typescript: 'TypeScript', python: 'Python',
@@ -665,7 +665,8 @@ function StatusBar({ width, showProvider, view, findingCount, optimizeAvailable,
             <Text color={ORANGE} bold>2</Text><Text dimColor> week   </Text>
             <Text color={ORANGE} bold>3</Text><Text dimColor> 30 days   </Text>
             <Text color={ORANGE} bold>4</Text><Text dimColor> month   </Text>
-            <Text color={ORANGE} bold>5</Text><Text dimColor> 6 months</Text>
+            <Text color={ORANGE} bold>5</Text><Text dimColor> 6 months   </Text>
+            <Text color={ORANGE} bold>6</Text><Text dimColor> lifetime</Text>
           </>
         )}
         {!isOptimize && optimizeAvailable && (
@@ -690,7 +691,9 @@ function DashboardContent({ projects, period, columns, activeProvider, budgets, 
   const isCursor = activeProvider === 'cursor'
   if (projects.length === 0) return <Panel title="CodeBurn" color={ORANGE} width={dashWidth}><Text dimColor>No usage data found for {PERIOD_LABELS[period]}.</Text></Panel>
   const pw = wide ? halfWidth : dashWidth
-  const days = period === 'all' ? undefined : (period === 'month' || period === '30days' ? 31 : 14)
+  const days = period === 'all' || period === 'lifetime'
+    ? undefined
+    : (period === 'month' || period === '30days' ? 31 : 14)
   return (
     <Box flexDirection="column" width={dashWidth}>
       <Overview projects={projects} label={PERIOD_LABELS[period]} width={dashWidth} planUsages={planUsages} />
@@ -908,6 +911,7 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
     else if (input === '3') switchPeriodImmediate('30days')
     else if (input === '4') switchPeriodImmediate('month')
     else if (input === '5') switchPeriodImmediate('all')
+    else if (input === '6') switchPeriodImmediate('lifetime')
   })
 
   const headerLabel = customRangeLabel ?? PERIOD_LABELS[period]

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { loadPricing, setModelAliases } from './models.js'
 import { parseAllSessions, filterProjectsByName, filterProjectsByDateRange, clearSessionCache } from './parser.js'
 import { convertCost } from './currency.js'
 import { renderStatusBar } from './format.js'
-import { type PeriodData, type ProviderCost, type BreakdownArrays } from './menubar-json.js'
+import { type IntradayHistoryEntry, type PeriodData, type ProviderCost, type BreakdownArrays } from './menubar-json.js'
 import { buildMenubarPayload } from './menubar-json.js'
 import { getDaysInRange, ensureCacheHydrated, loadDailyCache, emptyCache, BACKFILL_DAYS, toDateString, type DailyCache } from './daily-cache.js'
 import { aggregateProjectsIntoDays, buildPeriodDataFromDays, dateKey } from './day-aggregator.js'
@@ -53,6 +53,122 @@ function parseNumber(value: string): number {
 
 function parseInteger(value: string): number {
   return parseInt(value, 10)
+}
+
+function buildIntradayHistory(projects: ProjectSummary[], bucketHours = 4): IntradayHistoryEntry[] {
+  const bucketStarts = Array.from({ length: Math.floor(24 / bucketHours) }, (_, i) => i * bucketHours)
+  const byBucket = new Map<number, {
+    cost: number
+    calls: number
+    inputTokens: number
+    outputTokens: number
+    cacheReadTokens: number
+    cacheWriteTokens: number
+    models: Map<string, { calls: number; cost: number; inputTokens: number; outputTokens: number }>
+  }>()
+  for (const start of bucketStarts) {
+    byBucket.set(start, {
+      cost: 0,
+      calls: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      models: new Map(),
+    })
+  }
+
+  const now = new Date()
+  const todayKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      for (const turn of session.turns) {
+        for (const call of turn.assistantCalls) {
+          const when = new Date(call.timestamp)
+          const callDay = `${when.getFullYear()}-${String(when.getMonth() + 1).padStart(2, '0')}-${String(when.getDate()).padStart(2, '0')}`
+          if (callDay !== todayKey) continue
+
+          const bucketStartHour = Math.floor(when.getHours() / bucketHours) * bucketHours
+          const bucket = byBucket.get(bucketStartHour)
+          if (!bucket) continue
+
+          bucket.cost += call.costUSD
+          bucket.calls += 1
+          bucket.inputTokens += call.usage.inputTokens
+          bucket.outputTokens += call.usage.outputTokens
+          bucket.cacheReadTokens += call.usage.cacheReadInputTokens
+          bucket.cacheWriteTokens += call.usage.cacheCreationInputTokens
+
+          const model = bucket.models.get(call.model) ?? {
+            calls: 0,
+            cost: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+          }
+          model.calls += 1
+          model.cost += call.costUSD
+          model.inputTokens += call.usage.inputTokens
+          model.outputTokens += call.usage.outputTokens
+          bucket.models.set(call.model, model)
+        }
+      }
+    }
+  }
+
+  return bucketStarts.map(bucketStartHour => {
+    const bucketEndHour = bucketStartHour + bucketHours
+    const bucket = byBucket.get(bucketStartHour)!
+    const topModels = [...bucket.models.entries()]
+      .sort(([, a], [, b]) => b.cost - a.cost)
+      .slice(0, 5)
+      .map(([name, model]) => ({
+        name,
+        cost: model.cost,
+        calls: model.calls,
+        inputTokens: model.inputTokens,
+        outputTokens: model.outputTokens,
+      }))
+
+    return {
+      bucketStartHour,
+      bucketEndHour,
+      cost: bucket.cost,
+      calls: bucket.calls,
+      inputTokens: bucket.inputTokens,
+      outputTokens: bucket.outputTokens,
+      cacheReadTokens: bucket.cacheReadTokens,
+      cacheWriteTokens: bucket.cacheWriteTokens,
+      topModels,
+    }
+  })
+}
+
+function mapAggregatedDaysToDailyHistory(days: ReturnType<typeof aggregateProjectsIntoDays>) {
+  return days.map(d => {
+    const topModels = Object.entries(d.models)
+      .filter(([name]) => name !== '<synthetic>')
+      .sort(([, a], [, b]) => b.cost - a.cost)
+      .slice(0, 5)
+      .map(([name, m]) => ({
+        name,
+        cost: m.cost,
+        calls: m.calls,
+        inputTokens: m.inputTokens,
+        outputTokens: m.outputTokens,
+      }))
+
+    return {
+      date: d.date,
+      cost: d.cost,
+      calls: d.calls,
+      inputTokens: d.inputTokens,
+      outputTokens: d.outputTokens,
+      cacheReadTokens: d.cacheReadTokens,
+      cacheWriteTokens: d.cacheWriteTokens,
+      topModels,
+    }
+  })
 }
 
 type JsonPlanSummary = {
@@ -360,7 +476,7 @@ function buildJsonReport(projects: ProjectSummary[], period: string, periodKey: 
 program
   .command('report', { isDefault: true })
   .description('Interactive usage dashboard')
-  .option('-p, --period <period>', 'Starting period: today, week, 30days, month, all', 'week')
+  .option('-p, --period <period>', 'Starting period: today, week, 30days, month, all, lifetime', 'week')
   .option('--from <date>', 'Start date (YYYY-MM-DD). Overrides --period when set')
   .option('--to <date>', 'End date (YYYY-MM-DD). Overrides --period when set')
   .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
@@ -446,7 +562,7 @@ program
   .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
   .option('--project <name>', 'Show only projects matching name (repeatable)', collect, [])
   .option('--exclude <name>', 'Exclude projects matching name (repeatable)', collect, [])
-  .option('--period <period>', 'Primary period for menubar-json: today, week, 30days, month, all', 'today')
+  .option('--period <period>', 'Primary period for menubar-json: today, week, 30days, month, all, lifetime', 'today')
   .option('--no-optimize', 'Skip optimize findings (menubar-json only, faster)')
   .action(async (opts) => {
     assertFormat(opts.format, ['terminal', 'menubar-json', 'json'], 'status')
@@ -455,6 +571,8 @@ program
     const fp = (p: ProjectSummary[]) => filterProjectsByName(p, opts.project, opts.exclude)
     if (opts.format === 'menubar-json') {
       const periodInfo = getDateRange(opts.period)
+      const isTodayOnly = opts.period === 'today'
+      const isLifetime = opts.period === 'lifetime'
       const now = new Date()
       const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
       const todayRange: DateRange = { start: todayStart, end: now }
@@ -485,23 +603,28 @@ program
       let scanProjects: ProjectSummary[]
       let scanRange: DateRange
       let cache: DailyCache
+      let selectedPeriodDays: ReturnType<typeof aggregateProjectsIntoDays>
+      let intradayHistory: IntradayHistoryEntry[] | undefined
       let todayProviderData: PeriodData | null = null
 
       if (isAllProviders) {
         cache = await hydrateCache()
         const todayProjects = await getTodayAllProjects()
         const todayDays = await getTodayAllDays()
-        const historicalDays = getDaysInRange(cache, rangeStartStr, yesterdayStr)
-        const todayInRange = todayDays.filter(d => d.date >= rangeStartStr && d.date <= rangeEndStr)
-        const allDays = [...historicalDays, ...todayInRange].sort((a, b) => a.date.localeCompare(b.date))
-        currentData = buildPeriodDataFromDays(allDays, periodInfo.label)
-        const isTodayOnly = opts.period === 'today'
         if (isTodayOnly) {
           scanProjects = todayProjects
           scanRange = todayRange
         } else {
           scanProjects = fp(await parseAllSessions(periodInfo.range, 'all'))
           scanRange = periodInfo.range
+        }
+        if (isLifetime) {
+          currentData = buildPeriodData(periodInfo.label, scanProjects)
+        } else {
+          const historicalDays = getDaysInRange(cache, rangeStartStr, yesterdayStr)
+          const todayInRange = todayDays.filter(d => d.date >= rangeStartStr && d.date <= rangeEndStr)
+          const allDays = [...historicalDays, ...todayInRange].sort((a, b) => a.date.localeCompare(b.date))
+          currentData = buildPeriodDataFromDays(allDays, periodInfo.label)
         }
       } else {
         cache = await loadDailyCache()
@@ -512,6 +635,9 @@ program
         scanRange = periodInfo.range
       }
 
+        selectedPeriodDays = aggregateProjectsIntoDays(scanProjects)
+        intradayHistory = isTodayOnly ? buildIntradayHistory(scanProjects) : undefined
+
       // PROVIDERS
       // For .all: enumerate every provider with cost across the period (from cache) + installed-but-zero.
       // For specific: just this single provider with its scoped cost.
@@ -519,10 +645,12 @@ program
       const displayNameByName = new Map(allProviders.map(p => [p.name, p.displayName]))
       const providers: ProviderCost[] = []
       if (isAllProviders) {
-        const allDaysForProviders = [
-          ...getDaysInRange(cache, rangeStartStr, yesterdayStr),
-          ...(await getTodayAllDays()).filter(d => d.date === todayStr),
-        ]
+        const allDaysForProviders = isLifetime
+          ? selectedPeriodDays
+          : [
+              ...getDaysInRange(cache, rangeStartStr, yesterdayStr),
+              ...(await getTodayAllDays()).filter(d => d.date === todayStr),
+            ]
         const providerTotals: Record<string, number> = {}
         for (const d of allDaysForProviders) {
           for (const [name, p] of Object.entries(d.providers)) {
@@ -542,7 +670,9 @@ program
         providers.push({ name: display, cost: currentData.cost })
       }
 
-      // DAILY HISTORY (last 365 days)
+      // DAILY HISTORY
+      // Non-lifetime periods use the last 365 days from cache. Lifetime keeps the full
+      // selected-period daily history so desktop renderers can aggregate older years.
       // Cache stores per-provider cost+calls per day in DailyEntry.providers, so we can derive
       // a provider-filtered history without re-parsing. Tokens aren't broken down per provider
       // in the cache, so the filtered view shows zero tokens (heatmap/trend still works on cost).
@@ -550,7 +680,9 @@ program
       const allCacheDays = getDaysInRange(cache, historyStartStr, yesterdayStr)
 
       let dailyHistory
-      if (isAllProviders) {
+      if (isLifetime) {
+        dailyHistory = mapAggregatedDaysToDailyHistory(selectedPeriodDays)
+      } else if (isAllProviders) {
         const todayDays = (await getTodayAllDays()).filter(d => d.date === todayStr)
         const fullHistory = [...allCacheDays, ...todayDays]
         dailyHistory = fullHistory.map(d => {
@@ -591,7 +723,7 @@ program
             topModels: emptyModels,
           }
         })
-        const todayFromParse = aggregateProjectsIntoDays(scanProjects)
+        const todayFromParse = selectedPeriodDays
           .filter(d => d.date === todayStr)
           .map(d => {
             const prov = d.providers[pf] ?? { calls: 0, cost: 0 }
@@ -719,7 +851,19 @@ program
       })()
 
       const optimize = opts.optimize === false ? null : await scanAndDetect(scanProjects, scanRange)
-      console.log(JSON.stringify(buildMenubarPayload(currentData, providers, optimize, dailyHistory, retryTax, routingWaste, breakdowns)))
+      const statsHistory = selectedPeriodDays.map(d => ({ date: d.date, cost: d.cost }))
+  console.log(JSON.stringify(buildMenubarPayload(
+    currentData,
+    providers,
+    optimize,
+    dailyHistory,
+    intradayHistory,
+    statsHistory,
+    retryTax,
+    routingWaste,
+    isLifetime,
+    breakdowns,
+  )))
       return
     }
 
@@ -1152,7 +1296,7 @@ program
 program
   .command('optimize')
   .description('Find token waste and get exact fixes')
-  .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all', '30days')
+  .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all, lifetime', '30days')
   .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
   .action(async (opts) => {
     await loadPricing()
@@ -1164,7 +1308,7 @@ program
 program
   .command('compare')
   .description('Compare two AI models side-by-side')
-  .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all', 'all')
+  .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all, lifetime', 'all')
   .option('--provider <provider>', 'Filter by provider (e.g. claude, gemini, cursor, copilot)', 'all')
   .action(async (opts) => {
     await loadPricing()
@@ -1175,7 +1319,7 @@ program
 program
   .command('models')
   .description('Per-model token + cost table, optionally exploded by task type')
-  .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all', '30days')
+  .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all, lifetime', '30days')
   .option('--from <date>', 'Custom range start (YYYY-MM-DD)')
   .option('--to <date>', 'Custom range end (YYYY-MM-DD)')
   .option('--provider <provider>', 'Filter by provider (e.g. claude, codex, cursor)', 'all')
@@ -1231,7 +1375,7 @@ program
 program
   .command('yield')
   .description('Track which AI spend shipped to main vs reverted/abandoned (experimental)')
-  .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all', 'week')
+  .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all, lifetime', 'week')
   .action(async (opts) => {
     const { computeYield, formatYieldSummary } = await import('./yield.js')
     await loadPricing()

--- a/src/menubar-json.ts
+++ b/src/menubar-json.ts
@@ -1,4 +1,4 @@
-/// Rollup of one time window (today / 7 days / 30 days / month / all) used as the canonical
+/// Rollup of one time window (today / 7 days / 30 days / month / 6 months / lifetime) used as the canonical
 /// input to the menubar payload. Built inside the CLI and also consumed by the day-aggregator
 /// when hydrating per-day cache entries.
 export type PeriodData = {
@@ -49,6 +49,27 @@ export type DailyHistoryEntry = {
   cacheReadTokens: number
   cacheWriteTokens: number
   topModels: DailyModelBreakdown[]
+}
+
+export type IntradayHistoryEntry = {
+  bucketStartHour: number
+  bucketEndHour: number
+  cost: number
+  calls: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  topModels: DailyModelBreakdown[]
+}
+
+export type StatsSummaryEntry = {
+  trackedSpend: number
+  trackedDays: number
+  mostActiveDay: string | null
+  peakDaySpend: number | null
+  currentStreakDays: number
+  longestStreakDays: number
 }
 
 export type MenubarPayload = {
@@ -139,6 +160,78 @@ export type MenubarPayload = {
   }
   history: {
     daily: DailyHistoryEntry[]
+    intraday: IntradayHistoryEntry[]
+  }
+  stats: StatsSummaryEntry
+}
+
+function parseLocalDay(day: string): Date {
+  const [year, month, date] = day.split('-').map(Number) as [number, number, number]
+  return new Date(year, month - 1, date)
+}
+
+function toDayKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+function buildStatsSummary(days: Array<Pick<DailyHistoryEntry, 'date' | 'cost'>> | undefined): StatsSummaryEntry {
+  if (!days || days.length === 0) {
+    return {
+      trackedSpend: 0,
+      trackedDays: 0,
+      mostActiveDay: null,
+      peakDaySpend: null,
+      currentStreakDays: 0,
+      longestStreakDays: 0,
+    }
+  }
+
+  const sorted = [...days].sort((a, b) => a.date.localeCompare(b.date))
+  const trackedSpend = sorted.reduce((sum, day) => sum + day.cost, 0)
+  const peakDay = sorted.reduce<Pick<DailyHistoryEntry, 'date' | 'cost'> | null>(
+    (best, day) => (best === null || day.cost > best.cost ? day : best),
+    null,
+  )
+
+  const costByDate = new Map(sorted.map(day => [day.date, day.cost]))
+  const today = new Date()
+  const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+  const firstTracked = parseLocalDay(sorted[0]!.date)
+  const lastTracked = parseLocalDay(sorted[sorted.length - 1]!.date)
+
+  let currentStreakDays = 0
+  let cursor = todayStart
+  while (cursor >= firstTracked) {
+    const dayKey = toDayKey(cursor)
+    if ((costByDate.get(dayKey) ?? 0) > 0) {
+      currentStreakDays += 1
+      cursor = new Date(cursor.getFullYear(), cursor.getMonth(), cursor.getDate() - 1)
+      continue
+    }
+    break
+  }
+
+  let longestStreakDays = 0
+  let runningStreak = 0
+  cursor = firstTracked
+  while (cursor <= lastTracked) {
+    const dayKey = toDayKey(cursor)
+    if ((costByDate.get(dayKey) ?? 0) > 0) {
+      runningStreak += 1
+      longestStreakDays = Math.max(longestStreakDays, runningStreak)
+    } else {
+      runningStreak = 0
+    }
+    cursor = new Date(cursor.getFullYear(), cursor.getMonth(), cursor.getDate() + 1)
+  }
+
+  return {
+    trackedSpend,
+    trackedDays: sorted.length,
+    mostActiveDay: peakDay?.date ?? null,
+    peakDaySpend: peakDay?.cost ?? null,
+    currentStreakDays,
+    longestStreakDays,
   }
 }
 
@@ -207,11 +300,21 @@ function buildProviders(providers: ProviderCost[]): Record<string, number> {
   return map
 }
 
-function buildHistory(daily: DailyHistoryEntry[] | undefined): MenubarPayload['history'] {
-  if (!daily || daily.length === 0) return { daily: [] }
-  const sorted = [...daily].sort((a, b) => a.date.localeCompare(b.date))
-  const trimmed = sorted.slice(-HISTORY_DAYS_LIMIT)
-  return { daily: trimmed }
+function buildHistory(
+  daily: DailyHistoryEntry[] | undefined,
+  intraday: IntradayHistoryEntry[] | undefined,
+  retainFullDailyHistory = false,
+): MenubarPayload['history'] {
+  const dailyEntries = !daily || daily.length === 0
+    ? []
+    : (() => {
+        const sorted = [...daily].sort((a, b) => a.date.localeCompare(b.date))
+        return retainFullDailyHistory ? sorted : sorted.slice(-HISTORY_DAYS_LIMIT)
+      })()
+  const intradayEntries = !intraday || intraday.length === 0
+    ? []
+    : [...intraday].sort((a, b) => a.bucketStartHour - b.bucketStartHour)
+  return { daily: dailyEntries, intraday: intradayEntries }
 }
 
 function buildTopProjects(projects: PeriodData['projects']): MenubarPayload['current']['topProjects'] {
@@ -262,8 +365,11 @@ export function buildMenubarPayload(
   providers: ProviderCost[],
   optimize: OptimizeResult | null,
   dailyHistory?: DailyHistoryEntry[],
+  intradayHistory?: IntradayHistoryEntry[],
+  statsHistory?: Array<Pick<DailyHistoryEntry, 'date' | 'cost'>>,
   retryTax?: MenubarPayload['current']['retryTax'],
   routingWaste?: MenubarPayload['current']['routingWaste'],
+  retainFullDailyHistory = false,
   breakdowns?: BreakdownArrays,
 ): MenubarPayload {
   return {
@@ -291,6 +397,7 @@ export function buildMenubarPayload(
       mcpServers: breakdowns?.mcpServers ?? [],
     },
     optimize: buildOptimize(optimize),
-    history: buildHistory(dailyHistory),
+    history: buildHistory(dailyHistory, intradayHistory, retainFullDailyHistory),
+    stats: buildStatsSummary(statsHistory),
   }
 }

--- a/tests/cli-date.test.ts
+++ b/tests/cli-date.test.ts
@@ -44,6 +44,17 @@ describe('getDateRange', () => {
     expect(range.start.getDate()).toBe(1)
   })
 
+  it('"lifetime" starts at local epoch and stays open-ended through today', () => {
+    const { range, label } = getDateRange('lifetime')
+
+    expect(label).toBe('Lifetime')
+    expect(range.start.getFullYear()).toBe(1970)
+    expect(range.start.getMonth()).toBe(0)
+    expect(range.start.getDate()).toBe(1)
+    expect(range.end.getHours()).toBe(23)
+    expect(range.end.getMinutes()).toBe(59)
+  })
+
   it('"week" returns the last 7 days', () => {
     const { range, label } = getDateRange('week')
     expect(label).toBe('Last 7 Days')
@@ -88,7 +99,7 @@ describe('getDateRange', () => {
 
 describe('PERIODS / PERIOD_LABELS', () => {
   it('exposes the expected period set', () => {
-    expect(PERIODS).toEqual(['today', 'week', '30days', 'month', 'all'])
+    expect(PERIODS).toEqual(['today', 'week', '30days', 'month', 'all', 'lifetime'])
   })
 
   it('has a label for every period', () => {
@@ -102,11 +113,15 @@ describe('PERIODS / PERIOD_LABELS', () => {
     // ("Last 6 months") comes from getDateRange().label.
     expect(PERIOD_LABELS.all).toBe('6 Months')
   })
+
+  it('"lifetime" tab label is explicit about the unbounded range', () => {
+    expect(PERIOD_LABELS.lifetime).toBe('Lifetime')
+  })
 })
 
 describe('toPeriod', () => {
   it('round-trips known periods', () => {
-    const known: Period[] = ['today', 'week', '30days', 'month', 'all']
+    const known: Period[] = ['today', 'week', '30days', 'month', 'all', 'lifetime']
     for (const p of known) {
       expect(toPeriod(p)).toBe(p)
     }

--- a/tests/cli-status-menubar.test.ts
+++ b/tests/cli-status-menubar.test.ts
@@ -89,6 +89,7 @@ describe('codeburn status --format menubar-json', () => {
       expect(payload).toHaveProperty('current')
       expect(payload).toHaveProperty('optimize')
       expect(payload).toHaveProperty('history')
+      expect(payload).toHaveProperty('stats')
 
       const current = payload['current'] as Record<string, unknown>
       expect(current['cost']).toBeGreaterThan(0)
@@ -99,8 +100,243 @@ describe('codeburn status --format menubar-json', () => {
       expect(current).toHaveProperty('topModels')
       expect(current).toHaveProperty('providers')
 
-      const history = payload['history'] as { daily: unknown[] }
+      const history = payload['history'] as { daily: unknown[]; intraday: Array<Record<string, unknown>> }
       expect(Array.isArray(history.daily)).toBe(true)
+      expect(Array.isArray(history.intraday)).toBe(true)
+      expect(history.intraday).toHaveLength(6)
+      expect(history.intraday.some(bucket => Number(bucket['calls'] ?? 0) > 0)).toBe(true)
+
+      const stats = payload['stats'] as Record<string, unknown>
+      expect(stats['trackedSpend']).toBeGreaterThan(0)
+      expect(stats['trackedDays']).toBeGreaterThan(0)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('supports the lifetime period for sessions older than the cache window', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-menubar-lifetime-'))
+
+    try {
+      const projectDir = join(home, '.claude', 'projects', 'archive-app')
+      await mkdir(projectDir, { recursive: true })
+
+      const base = new Date(Date.now() - 900 * 24 * 3600_000)
+      const ts1 = base.toISOString().replace(/\.\d+Z$/, 'Z')
+      const ts2 = new Date(base.getTime() + 60_000).toISOString().replace(/\.\d+Z$/, 'Z')
+      const ts3 = new Date(base.getTime() + 120_000).toISOString().replace(/\.\d+Z$/, 'Z')
+      const ts4 = new Date(base.getTime() + 180_000).toISOString().replace(/\.\d+Z$/, 'Z')
+
+      await writeFile(
+        join(projectDir, 'session.jsonl'),
+        [
+          userLine('s-old', ts1),
+          assistantLine('s-old', ts2, 'msg-old-1'),
+          userLine('s-old', ts3),
+          assistantLine('s-old', ts4, 'msg-old-2'),
+        ].join('\n'),
+      )
+
+      const result = runCli([
+        'status',
+        '--format', 'menubar-json',
+        '--period', 'lifetime',
+        '--provider', 'all',
+        '--no-optimize',
+      ], home)
+
+      expect(result.status, `stderr: ${result.stderr}`).toBe(0)
+
+      const payload = JSON.parse(result.stdout) as {
+        current: { label: string; cost: number; calls: number; sessions: number }
+        stats: { trackedSpend: number; trackedDays: number }
+        history: { daily: Array<{ date: string }> }
+      }
+
+      expect(payload.current.label).toBe('Lifetime')
+      expect(payload.current.cost).toBeGreaterThan(0)
+      expect(payload.current.calls).toBe(2)
+      expect(payload.current.sessions).toBe(1)
+      expect(payload.stats.trackedSpend).toBeCloseTo(payload.current.cost)
+      expect(payload.stats.trackedDays).toBe(1)
+      expect(payload.history.daily.some(day => day.date === ts1.slice(0, 10))).toBe(true)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('supports the lifetime period for a specific provider', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-menubar-lifetime-provider-'))
+
+    try {
+      const projectDir = join(home, '.claude', 'projects', 'provider-archive-app')
+      await mkdir(projectDir, { recursive: true })
+
+      const base = new Date(Date.now() - 900 * 24 * 3600_000)
+      const ts1 = base.toISOString().replace(/\.\d+Z$/, 'Z')
+      const ts2 = new Date(base.getTime() + 60_000).toISOString().replace(/\.\d+Z$/, 'Z')
+
+      await writeFile(
+        join(projectDir, 'session.jsonl'),
+        [
+          userLine('s-provider-old', ts1),
+          assistantLine('s-provider-old', ts2, 'msg-provider-old-1'),
+        ].join('\n'),
+      )
+
+      const result = runCli([
+        'status',
+        '--format', 'menubar-json',
+        '--period', 'lifetime',
+        '--provider', 'claude',
+        '--no-optimize',
+      ], home)
+
+      expect(result.status, `stderr: ${result.stderr}`).toBe(0)
+
+      const payload = JSON.parse(result.stdout) as {
+        current: { label: string; cost: number; calls: number; sessions: number }
+        stats: { trackedSpend: number; trackedDays: number }
+        history: { daily: Array<{ date: string }> }
+      }
+
+      expect(payload.current.label).toBe('Lifetime')
+      expect(payload.current.cost).toBeGreaterThan(0)
+      expect(payload.current.calls).toBe(1)
+      expect(payload.current.sessions).toBe(1)
+      expect(payload.stats.trackedSpend).toBeCloseTo(payload.current.cost)
+      expect(payload.stats.trackedDays).toBe(1)
+      expect(payload.history.daily.some(day => day.date === ts1.slice(0, 10))).toBe(true)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('retains multi-year lifetime history for 2024 and 2025 sessions', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-menubar-lifetime-multiyear-'))
+
+    try {
+      const projectDir = join(home, '.claude', 'projects', 'history-app')
+      await mkdir(projectDir, { recursive: true })
+
+      const ts2024a = '2024-02-15T10:00:00Z'
+      const ts2024b = '2024-02-15T10:01:00Z'
+      const ts2025a = '2025-06-10T14:00:00Z'
+      const ts2025b = '2025-06-10T14:01:00Z'
+      const ts2026a = '2026-05-20T09:00:00Z'
+      const ts2026b = '2026-05-20T09:01:00Z'
+
+      await writeFile(
+        join(projectDir, 'session-2024.jsonl'),
+        [
+          userLine('s-2024', ts2024a),
+          assistantLine('s-2024', ts2024b, 'msg-2024-1'),
+        ].join('\n'),
+      )
+      await writeFile(
+        join(projectDir, 'session-2025.jsonl'),
+        [
+          userLine('s-2025', ts2025a),
+          assistantLine('s-2025', ts2025b, 'msg-2025-1'),
+        ].join('\n'),
+      )
+      await writeFile(
+        join(projectDir, 'session-2026.jsonl'),
+        [
+          userLine('s-2026', ts2026a),
+          assistantLine('s-2026', ts2026b, 'msg-2026-1'),
+        ].join('\n'),
+      )
+
+      const result = runCli([
+        'status',
+        '--format', 'menubar-json',
+        '--period', 'lifetime',
+        '--provider', 'all',
+        '--no-optimize',
+      ], home)
+
+      expect(result.status, `stderr: ${result.stderr}`).toBe(0)
+
+      const payload = JSON.parse(result.stdout) as {
+        current: { label: string; sessions: number }
+        history: { daily: Array<{ date: string }> }
+        stats: { trackedDays: number }
+      }
+
+      expect(payload.current.label).toBe('Lifetime')
+      expect(payload.current.sessions).toBe(3)
+      expect(payload.stats.trackedDays).toBe(3)
+      expect(payload.history.daily.map(day => day.date)).toEqual(expect.arrayContaining([
+        '2024-02-15',
+        '2025-06-10',
+        '2026-05-20',
+      ]))
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('retains older lifetime history for yearly desktop aggregation', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-menubar-lifetime-yearly-'))
+
+    try {
+      const projectDir = join(home, '.claude', 'projects', 'yearly-history-app')
+      await mkdir(projectDir, { recursive: true })
+
+      const ts2020a = '2020-01-15T10:00:00Z'
+      const ts2020b = '2020-01-15T10:01:00Z'
+      const ts2023a = '2023-07-11T14:00:00Z'
+      const ts2023b = '2023-07-11T14:01:00Z'
+      const ts2026a = '2026-05-20T09:00:00Z'
+      const ts2026b = '2026-05-20T09:01:00Z'
+
+      await writeFile(
+        join(projectDir, 'session-2020.jsonl'),
+        [
+          userLine('s-2020', ts2020a),
+          assistantLine('s-2020', ts2020b, 'msg-2020-1'),
+        ].join('\n'),
+      )
+      await writeFile(
+        join(projectDir, 'session-2023.jsonl'),
+        [
+          userLine('s-2023', ts2023a),
+          assistantLine('s-2023', ts2023b, 'msg-2023-1'),
+        ].join('\n'),
+      )
+      await writeFile(
+        join(projectDir, 'session-2026.jsonl'),
+        [
+          userLine('s-2026-yearly', ts2026a),
+          assistantLine('s-2026-yearly', ts2026b, 'msg-2026-yearly-1'),
+        ].join('\n'),
+      )
+
+      const result = runCli([
+        'status',
+        '--format', 'menubar-json',
+        '--period', 'lifetime',
+        '--provider', 'all',
+        '--no-optimize',
+      ], home)
+
+      expect(result.status, `stderr: ${result.stderr}`).toBe(0)
+
+      const payload = JSON.parse(result.stdout) as {
+        current: { label: string; sessions: number }
+        history: { daily: Array<{ date: string }> }
+        stats: { trackedDays: number }
+      }
+
+      expect(payload.current.label).toBe('Lifetime')
+      expect(payload.current.sessions).toBe(3)
+      expect(payload.stats.trackedDays).toBe(3)
+      expect(payload.history.daily.map(day => day.date)).toEqual(expect.arrayContaining([
+        '2020-01-15',
+        '2023-07-11',
+        '2026-05-20',
+      ]))
     } finally {
       await rm(home, { recursive: true, force: true })
     }

--- a/tests/gnome-trend-series.test.ts
+++ b/tests/gnome-trend-series.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPeriodSeries, lifetimeMonthSpan } from '../gnome/trend-series.js'
+
+function monthEntries(startYear: number, startMonth: number, endYear: number, endMonth: number) {
+  const entries: Array<{
+    date: string
+    cost: number
+    calls: number
+    inputTokens: number
+    outputTokens: number
+  }> = []
+  let year = startYear
+  let month = startMonth
+  let index = 0
+
+  while (year < endYear || (year === endYear && month <= endMonth)) {
+    entries.push({
+      date: `${year}-${String(month).padStart(2, '0')}-15`,
+      cost: 10 + index,
+      calls: 20 + index,
+      inputTokens: 1_000 + index * 100,
+      outputTokens: 250 + index * 25,
+    })
+
+    month += 1
+    index += 1
+    if (month === 13) {
+      month = 1
+      year += 1
+    }
+  }
+
+  return entries
+}
+
+describe('GNOME trend cadence helper', () => {
+  const now = new Date(2026, 4, 24, 12)
+
+  it('uses intraday buckets for Today when intraday history is available', () => {
+    const series = buildPeriodSeries('today', {
+      history: {
+        intraday: [
+          { bucketStartHour: 0, bucketEndHour: 4, cost: 1, calls: 2, inputTokens: 100, outputTokens: 25 },
+          { bucketStartHour: 4, bucketEndHour: 8, cost: 2, calls: 3, inputTokens: 200, outputTokens: 50 },
+        ],
+        daily: [],
+      },
+    }, now)
+
+    expect(series.windowLabel).toBe('Today')
+    expect(series.points).toHaveLength(2)
+    expect(series.points.map(point => point.label)).toEqual(['12 AM - 4 AM', '4 AM - 8 AM'])
+  })
+
+  it('uses weekly aggregation for 6 Months', () => {
+    const series = buildPeriodSeries('all', {
+      history: {
+        daily: monthEntries(2025, 12, 2026, 5),
+        intraday: [],
+      },
+    }, now)
+
+    expect(series.windowLabel).toBe('Recent 26 weeks')
+    expect(series.points).toHaveLength(26)
+    expect(series.points[0]?.label).toMatch(/^Week of /)
+    expect(series.points.at(-1)?.isCurrent).toBe(true)
+  })
+
+  it('keeps Lifetime monthly through 24 months', () => {
+    const daily = monthEntries(2025, 12, 2026, 5)
+    const series = buildPeriodSeries('lifetime', { history: { daily, intraday: [] } }, now)
+
+    expect(lifetimeMonthSpan(daily, now)).toBe(6)
+    expect(series.windowLabel).toBe('All time by month')
+    expect(series.points).toHaveLength(6)
+    expect(series.points.map(point => point.label)).toEqual([
+      'Dec 2025',
+      'Jan 2026',
+      'Feb 2026',
+      'Mar 2026',
+      'Apr 2026',
+      'May 2026',
+    ])
+  })
+
+  it('switches Lifetime to quarterly after 24 months', () => {
+    const daily = monthEntries(2023, 1, 2026, 5)
+    const series = buildPeriodSeries('lifetime', { history: { daily, intraday: [] } }, now)
+
+    expect(lifetimeMonthSpan(daily, now)).toBe(41)
+    expect(series.windowLabel).toBe('All time by quarter')
+    expect(series.points).toHaveLength(14)
+    expect(series.points[0]?.label).toBe('Q1 2023')
+    expect(series.points.at(-1)?.label).toBe('Q2 2026')
+  })
+
+  it('switches Lifetime to yearly beyond 60 months', () => {
+    const daily = monthEntries(2020, 1, 2026, 5)
+    const series = buildPeriodSeries('lifetime', { history: { daily, intraday: [] } }, now)
+
+    expect(lifetimeMonthSpan(daily, now)).toBe(77)
+    expect(series.windowLabel).toBe('All time by year')
+    expect(series.points).toHaveLength(7)
+    expect(series.points.map(point => point.label)).toEqual([
+      '2020',
+      '2021',
+      '2022',
+      '2023',
+      '2024',
+      '2025',
+      '2026',
+    ])
+  })
+})

--- a/tests/menubar-json.test.ts
+++ b/tests/menubar-json.test.ts
@@ -204,8 +204,40 @@ describe('buildMenubarPayload', () => {
     })
     const payload = buildMenubarPayload(emptyPeriod('Today'), [], null, history)
     expect(payload.history.daily).toHaveLength(365)
+    expect(payload.history.intraday).toEqual([])
     expect(payload.history.daily[0]!.date < payload.history.daily[364]!.date).toBe(true)
     expect(payload.history.daily[364]!.date).toBe(history[399]!.date)
+  })
+
+  it('preserves intraday history entries sorted by bucket start hour', () => {
+    const intraday = [
+      {
+        bucketStartHour: 20,
+        bucketEndHour: 24,
+        cost: 2,
+        calls: 1,
+        inputTokens: 10,
+        outputTokens: 20,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        topModels: [],
+      },
+      {
+        bucketStartHour: 0,
+        bucketEndHour: 4,
+        cost: 1,
+        calls: 1,
+        inputTokens: 5,
+        outputTokens: 10,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        topModels: [],
+      },
+    ]
+
+    const payload = buildMenubarPayload(emptyPeriod('Today'), [], null, undefined, intraday)
+
+    expect(payload.history.intraday.map(bucket => bucket.bucketStartHour)).toEqual([0, 20])
   })
 
   it('preserves token fields in dailyHistory entries', () => {
@@ -221,6 +253,15 @@ describe('buildMenubarPayload', () => {
   it('returns empty history when none supplied', () => {
     const payload = buildMenubarPayload(emptyPeriod('Today'), [], null)
     expect(payload.history.daily).toEqual([])
+    expect(payload.history.intraday).toEqual([])
+    expect(payload.stats).toEqual({
+      trackedSpend: 0,
+      trackedDays: 0,
+      mostActiveDay: null,
+      peakDaySpend: null,
+      currentStreakDays: 0,
+      longestStreakDays: 0,
+    })
   })
 
   it('drops providers with negative cost defensively', () => {
@@ -230,5 +271,56 @@ describe('buildMenubarPayload', () => {
     ]
     const payload = buildMenubarPayload(emptyPeriod('Today'), providers, null)
     expect(payload.current.providers).toEqual({ claude: 76.45 })
+  })
+
+  it('computes stats from the full selected-period history even when chart history is trimmed', () => {
+    const statsHistory = Array.from({ length: 500 }, (_, i) => {
+      const d = new Date(2025, 0, 1)
+      d.setDate(d.getDate() + i)
+      return {
+        date: d.toISOString().slice(0, 10),
+        cost: i === 499 ? 50 : 1,
+      }
+    })
+    const chartHistory = statsHistory.map(day => ({
+      ...day,
+      calls: 1,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      topModels: [],
+    }))
+
+    const payload = buildMenubarPayload(emptyPeriod('Lifetime'), [], null, chartHistory, undefined, statsHistory)
+
+    expect(payload.history.daily).toHaveLength(365)
+    expect(payload.stats.trackedDays).toBe(500)
+    expect(payload.stats.trackedSpend).toBe(549)
+    expect(payload.stats.mostActiveDay).toBe(statsHistory[499]!.date)
+    expect(payload.stats.peakDaySpend).toBe(50)
+  })
+
+  it('can retain full daily history for lifetime trend aggregation', () => {
+    const dailyHistory = Array.from({ length: 500 }, (_, i) => {
+      const d = new Date(2024, 0, 1)
+      d.setDate(d.getDate() + i)
+      return {
+        date: d.toISOString().slice(0, 10),
+        cost: 1,
+        calls: 1,
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        topModels: [],
+      }
+    })
+
+    const payload = buildMenubarPayload(emptyPeriod('Lifetime'), [], null, dailyHistory, undefined, undefined, undefined, undefined, true)
+
+    expect(payload.history.daily).toHaveLength(500)
+    expect(payload.history.daily[0]!.date).toBe(dailyHistory[0]!.date)
+    expect(payload.history.daily[499]!.date).toBe(dailyHistory[499]!.date)
   })
 })


### PR DESCRIPTION
## Issue Reference

Proposed issue reference: `#389`

## Summary

- Solved items count: `8` total.
  - `2` Lifetime correctness fixes (`Lifetime` period wiring + uncapped/full-history semantics)
  - `6` desktop menubar follow-up fixes (Trend cadence mismatch, `Lifetime` Stats semantics, Top Projects session-count contrast, backward-compatible `stats` payload decoding, GNOME period-aware chart/trend rendering, and period-appropriate visualization)
- Coverage count: `4` product surfaces + `2` docs surfaces.
  - Product surfaces: CLI, dashboard, macOS desktop menubar, GNOME desktop extension
  - Docs surfaces: root README + GNOME README
- Validation count: `5` core validations completed.
  - CLI/dashboard tests + build
  - macOS menubar build + live UI verification
  - GNOME desktop extension runtime wiring verification
  - Menubar JSON contract regression coverage
  - Cross-surface lifetime cadence regression coverage

## What Changed

- Added a separate selected-period stats summary to the menubar payload so Stats can use true selected-period totals without forcing Trend to render unbounded daily bars.
- Lifetime now retains full selected-period daily history in the menubar payload instead of trimming it to the generic 365-day chart cache, so older years remain available for aggregation.
- Added real intraday history to the menubar payload for `Today`, using `6 x 4-hour` buckets.
- Updated Trend to use period-appropriate bar cadences:
  - `Today`: `6 x 4-hour` buckets
  - `7 Days`: daily bars
  - `30 Days`: daily bars
  - `Month`: month-to-date daily bars
  - `6 Months`: weekly bars across `Recent 26 weeks`
  - `Lifetime`: adaptive full-history bars
    - `<= 24 months`: monthly
    - `<= 60 months`: quarterly
    - `> 60 months`: yearly
- Kept `Lifetime` Stats all-time with `Tracked spend (all time)`.
- Removed the orange comparison badge from `Lifetime`, since there is no sensible fixed prior-window comparison once the chart spans full history.
- Updated the macOS menubar status-period setting to include `Lifetime`, so the always-visible status item can track the same uncapped period independently from the popover.
- Improved Top Projects session-count visibility in the macOS popover.
- Made the Swift menubar decoder tolerate older payloads that do not yet contain the new `stats` block.

## Trend Window Approach

For this compact popover UI, I found that forcing every period into daily bars did not feel like the best tradeoff. The bars become visually dense, hover targets get worse, and the chart communicates the trend less clearly.

In this PR, I used the following approach:

- `Today` uses intraday buckets instead of a single daily bar.
- Short multi-day periods render their real selected window using daily bars.
- `6 Months` uses weekly aggregation so the full half-year can fit cleanly.
- `Lifetime` uses full-history aggregation rather than a fixed recent window:
  - monthly through 24 months of history
  - quarterly through 60 months of history
  - yearly beyond 60 months

My goal here was to keep each selected period semantically correct while still keeping the chart legible. If there is a better presentation for any of these windows, I am very open to adjusting it.

## Testing

- [x] I have tested this locally against real data (not just unit tests)
- [x] `npm test` passes
- [x] `npm run build` succeeds

Additional validation performed:

- Full Vitest suite passed:
  - `npm test`
- Focused menubar regression suites passed:
  - `npm test -- --run tests/menubar-json.test.ts tests/gnome-trend-series.test.ts tests/cli-status-menubar.test.ts`
- Added explicit multi-year regression coverage for older Lifetime history, including a mock `2024/2025/2026` dataset.
- Added GNOME cadence regression coverage for `Today`, `6 Months`, and `Lifetime` monthly/quarterly/yearly aggregation.
- Added provider-scoped Lifetime regression coverage for `--provider claude`.
- `swift build` passed after the Trend aggregation refactor.
- `swift test` now runs under an explicit `swift-testing` package dependency in `mac/Package.swift`.
- Added macOS lifetime cadence regression coverage for monthly, quarterly, and yearly Lifetime trend selection.
- Added macOS menubar status-period regression coverage for persisted `Lifetime` selection and suffix rendering.
- Cross-surface UI checks passed:
  - CLI/dashboard period options include `Lifetime`.
  - macOS menubar period control and status-period setting both include `Lifetime` and render adaptive monthly/quarterly/yearly bars based on full history.
  - GNOME indicator + prefs include `Lifetime` as a selectable default period.
- Live macOS menubar verification passed:
  - `Today` now shows `6 x 4-hour` bars with `Avg/4h`, `Peak slot`, and `Current 4h`
  - `7 Days` now shows `Last 7 days`
  - `6 Months` now shows `Recent 26 weeks` with weekly bars
  - Actual local data (`61` tracked days) now shows `Lifetime` as `All time by month`
  - Synthetic `2024-2026` data shows `Lifetime` as `All time by quarter`
  - Synthetic `2020-2026` data shows `Lifetime` as `All time by year`
  - `Lifetime` Stats now shows `Tracked spend (all time)`
- Live GNOME lifetime cadence verification passed with synthetic exported snapshots:
  - Synthetic `2023-2026` snapshot shows `Lifetime` as `All time by quarter`
  - Synthetic `2020-2026` snapshot shows `Lifetime` as `All time by year`


## Screenshots

| Surface | State | Period | Before | After |
|--------|-------|--------|--------|-------|
| macOS | View | Lifetime | ![before-lifetime](https://github.com/user-attachments/assets/e5b51d34-18dd-4452-b1ad-654696cc83b9) | ![after-lifetime](https://github.com/user-attachments/assets/2db0b3ed-0eb5-44f6-aee5-2995d186483a) |
| macOS | Trend | Today | <img width="364" height="498" alt="before-today-trend" src="https://github.com/user-attachments/assets/1f0a6477-d72a-4336-8ea1-b39db442502c" /> | <img width="362" height="478" alt="after-today-trend" src="https://github.com/user-attachments/assets/1ada07a5-aa2c-4fe2-a820-cd6e98cd7b8d" /> |
| macOS | Stats | Today | <img width="361" height="487" alt="before-today-stats" src="https://github.com/user-attachments/assets/003e263e-35de-4ce7-a80f-df46bf45d904" /> | <img width="364" height="477" alt="after-today-stats" src="https://github.com/user-attachments/assets/ffe02078-c4fd-422e-885d-4f503901e1ed" /> |
| macOS | Trend | 7 Days | <img width="359" height="676" alt="before-7days-trend" src="https://github.com/user-attachments/assets/4cfa01db-db47-4052-a91a-1c9803392ffd" /> | <img width="418" height="783" alt="after-7days-trend" src="https://github.com/user-attachments/assets/47c46d42-557c-4a80-8388-bf5dd1031bd6" /> |
| macOS | Stats | 7 Days | <img width="362" height="486" alt="before-7days-stats" src="https://github.com/user-attachments/assets/93dd9157-aa0f-486d-98f7-0a53491348e9" /> | <img width="367" height="471" alt="after-7days-stats" src="https://github.com/user-attachments/assets/34124ffe-f517-411d-9f73-d6194999f5e6" /> |
| macOS | Stats | Month | <img width="362" height="490" alt="before-month-stats" src="https://github.com/user-attachments/assets/73ee1035-21b3-46b9-ab73-e2fe57c4a5d0" /> | <img width="357" height="463" alt="after-month-stats" src="https://github.com/user-attachments/assets/ee3934b4-41d6-482b-8bda-c3a4a703c0fd" /> |
| macOS | Trend | 6 Months | <img width="362" height="671" alt="before-6months-trend" src="https://github.com/user-attachments/assets/858df1c4-9593-4947-b50d-7e3a4d87ce19" /> | <img width="379" height="650" alt="after-6months-trend" src="https://github.com/user-attachments/assets/bcb2543a-fcec-4fc6-b646-d7bc3af57a6c" /> |
| macOS | Stats | 6 Months | <img width="366" height="489" alt="before-6months-stats" src="https://github.com/user-attachments/assets/b7c25c86-5d45-4a08-8cc3-1050111d1a3a" /> | <img width="368" height="470" alt="after-6months-stats" src="https://github.com/user-attachments/assets/5424fa4f-1ecc-4579-9c65-952f3899c74b" /> |
| macOS | Stats | 30 Days | <img width="363" height="499" alt="before-30days-stats" src="https://github.com/user-attachments/assets/1116e52d-4e36-499d-87e2-49f1b705a0df" /> | <img width="362" height="463" alt="after-30days-stats" src="https://github.com/user-attachments/assets/549afe55-34cf-421d-a1d9-03bdc02db83f" /> |
| macOS | Trend | Lifetime (monthly) | N/A | <img width="354" height="473" alt="lifetime-trend-monthly" src="https://github.com/user-attachments/assets/5e58e8ae-7310-48f7-bea5-98158223ced3" /> |
| macOS | Trend | Lifetime (quarterly) | N/A | <img width="422" height="760" alt="lifetime-trend-quarterly" src="https://github.com/user-attachments/assets/121a1ba1-089b-4201-9197-46de0a738126" /> |
| macOS | Trend | Lifetime (yearly) | N/A | <img width="390" height="705" alt="lifetime-trend-yearly" src="https://github.com/user-attachments/assets/2a169b5b-0e83-42fe-89c3-068edddce449" /> |
| macOS | Stats | Lifetime (detail) | N/A | <img width="280" alt="lifetime-stat" src="https://github.com/user-attachments/assets/d869eca7-8d92-4813-b7bf-aea9ad39d7b1" /> || GNOME | Trend | Today | _(pending image)_ | _(pending image)_ |
| GNOME | View | Lifetime | <img width="725" height="154" alt="before-lifetime-gnome" src="https://github.com/user-attachments/assets/57712904-61b6-4085-9742-0ef8e13a2a26" /> | <img width="697" height="110" alt="after-lifetime-gnome" src="https://github.com/user-attachments/assets/0863ebca-ddfc-4b7a-9e8e-aeb8bbb183c3" /> |
| GNOME | Trend | Today | <img width="414" height="613" alt="before-today-trend-gnome" src="https://github.com/user-attachments/assets/eda6142c-76f3-487c-8e06-c6d034157509" /> | <img width="349" height="560" alt="after-today-trend-gnome" src="https://github.com/user-attachments/assets/330a8327-4579-4d7d-84d6-b2420656666c" /> |
| GNOME | Trend | 7 Days | <img width="365" height="592" alt="before-7days-trend-gnome" src="https://github.com/user-attachments/assets/bc0777eb-0c28-49e3-aa46-2669e9d215ca" /> | <img width="365" height="597" alt="after-7days-trend-gnome" src="https://github.com/user-attachments/assets/dc29ef75-b89e-4fd0-b83f-01bd5d59cef7" /> |
| GNOME | Trend | Month | <img width="343" height="585" alt="before-months-trend-gnome" src="https://github.com/user-attachments/assets/edb3358d-f60f-4f4c-b45c-35a95da96a7b" /> | <img width="355" height="541" alt="after-month-trend-gnome" src="https://github.com/user-attachments/assets/19252c7d-ae4d-42ff-81b6-c8d1e8bc689e" /> |
| GNOME | Trend | 30 Days | <img width="357" height="589" alt="before-30days-trend-gnaome" src="https://github.com/user-attachments/assets/2b6254ce-05d5-4bde-8006-da1faf722df4" /> | <img width="383" height="579" alt="after-30days-trend-gnome" src="https://github.com/user-attachments/assets/48136cc1-d2f9-44d8-8002-d70e5e57cf1d" /> |
| GNOME | Trend | 6 Months | <img width="357" height="576" alt="before-6months-trend-gnome" src="https://github.com/user-attachments/assets/5e4836e5-eda8-4c59-878c-e114d3d4a225" /> | <img width="356" height="556" alt="after-6months-trend-gnome" src="https://github.com/user-attachments/assets/74dd49b3-a6d1-4d7a-b13c-fe8cc3d8310a" /> |
| GNOME | Trend | Lifetime (monthly) | N/A | <img alt="lifetime-trend-monthly-gnome" src="https://github.com/user-attachments/assets/0ca47a3f-c17b-46b2-8d28-4bea048a01ab" /> |
| GNOME | Trend | Lifetime (quarterly, synthetic 2023-2026) | N/A | <img width="390" alt="lifetime-trend-quarterly-gnome" src="https://github.com/user-attachments/assets/5202555d-0483-437a-bc45-e3f78a0610bf" /> |
| GNOME | Trend | Lifetime (yearly, synthetic 2020-2026) | N/A | <img width="280" alt="lifetime-trend-yearly-gnome" src="https://github.com/user-attachments/assets/4eac9ae9-3d93-4ca3-a028-42f3ccaa506d" /> |