### PR TITLE
Fix OpenCode provider yielding zero usage (#392)

### DIFF
--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -34,12 +34,19 @@ type SessionRow = {
 type MessageData = {
   role: string
   modelID?: string
+  model?: string
   cost?: number
   tokens?: {
     input?: number
     output?: number
     reasoning?: number
     cache?: { read?: number; write?: number }
+  }
+  usage?: {
+    input_tokens?: number
+    output_tokens?: number
+    cache_creation_input_tokens?: number
+    cache_read_input_tokens?: number
   }
 }
 
@@ -110,6 +117,41 @@ async function findDbFiles(dir: string): Promise<string[]> {
 function parseTimestamp(raw: number): string {
   const ms = raw < 1e12 ? raw * 1000 : raw
   return new Date(ms).toISOString()
+}
+
+type SessionTokenRow = {
+  cost?: number
+  tokens_input?: number
+  tokens_output?: number
+  tokens_reasoning?: number
+  tokens_cache_read?: number
+  tokens_cache_write?: number
+  model_id?: string
+}
+
+function tryQuerySessionTokens(db: SqliteDatabase, sessionId: string): {
+  cost: number; input: number; output: number; reasoning: number
+  cacheRead: number; cacheWrite: number; model: string | undefined
+} | null {
+  try {
+    const rows = db.query<SessionTokenRow>(
+      `SELECT cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write, model_id FROM session WHERE id = ?`,
+      [sessionId],
+    )
+    if (rows.length === 0) return null
+    const r = rows[0]!
+    return {
+      cost: r.cost ?? 0,
+      input: r.tokens_input ?? 0,
+      output: r.tokens_output ?? 0,
+      reasoning: r.tokens_reasoning ?? 0,
+      cacheRead: r.tokens_cache_read ?? 0,
+      cacheWrite: r.tokens_cache_write ?? 0,
+      model: r.model_id ?? undefined,
+    }
+  } catch {
+    return null
+  }
 }
 
 type SchemaCheckResult =
@@ -234,12 +276,16 @@ function createParser(
         }
 
         const currentUserMessageBySession = new Map<string, string>()
+        let yieldCount = 0
+        let parseFailCount = 0
+        let roleSkipCount = 0
 
         for (const msg of messages) {
           let data: MessageData
           try {
             data = JSON.parse(blobToText(msg.data)) as MessageData
           } catch {
+            parseFailCount++
             continue
           }
 
@@ -254,20 +300,28 @@ function createParser(
             continue
           }
 
-          if (data.role !== 'assistant') continue
+          if (data.role !== 'assistant' && data.role !== 'model') {
+            if (data.role !== 'user') roleSkipCount++
+            continue
+          }
 
           const tokens = {
-            input: data.tokens?.input ?? 0,
-            output: data.tokens?.output ?? 0,
+            input: data.tokens?.input ?? data.usage?.input_tokens ?? 0,
+            output: data.tokens?.output ?? data.usage?.output_tokens ?? 0,
             reasoning: data.tokens?.reasoning ?? 0,
-            cacheRead: data.tokens?.cache?.read ?? 0,
-            cacheWrite: data.tokens?.cache?.write ?? 0,
+            cacheRead: data.tokens?.cache?.read ?? data.usage?.cache_read_input_tokens ?? 0,
+            cacheWrite: data.tokens?.cache?.write ?? data.usage?.cache_creation_input_tokens ?? 0,
           }
 
           const msgParts = partsByMsg.get(msg.id) ?? []
-          const toolParts = msgParts.filter((p) => p.type === 'tool' && normalizeToolName(p.tool))
+          const toolParts = msgParts.filter((p) => (p.type === 'tool' || p.type === 'tool-call' || p.type === 'tool_call') && normalizeToolName(p.tool))
           const hasTextOutput = msgParts.some((p) => p.type === 'text' && typeof p.text === 'string' && p.text.trim().length > 0)
-          const hasActivity = hasTextOutput || toolParts.length > 0
+          const hasToolOrTextParts = hasTextOutput || toolParts.length > 0
+          const hasAnySubstantiveParts = msgParts.some((p) =>
+            p.type === 'text' || p.type === 'tool' || p.type === 'tool-call' || p.type === 'tool_call' ||
+            p.type === 'tool-result' || p.type === 'tool_result' || p.type === 'reasoning' || p.type === 'file'
+          )
+          const hasActivity = hasToolOrTextParts || hasAnySubstantiveParts
 
           const allZero =
             tokens.input === 0 &&
@@ -289,7 +343,7 @@ function createParser(
           if (seenKeys.has(dedupKey)) continue
           seenKeys.add(dedupKey)
 
-          const model = data.modelID ?? 'unknown'
+          const model = data.modelID ?? data.model ?? 'unknown'
           let costUSD = calculateCost(
             model,
             tokens.input,
@@ -303,6 +357,7 @@ function createParser(
             costUSD = data.cost
           }
 
+          yieldCount++
           yield {
             provider: 'opencode',
             model,
@@ -321,6 +376,49 @@ function createParser(
             deduplicationKey: dedupKey,
             userMessage: currentUserMessageBySession.get(msg.session_id) ?? '',
             sessionId,
+          }
+        }
+
+        if (yieldCount === 0 && messages.length > 0) {
+          // Fallback: try session-level token columns (newer OpenCode schemas
+          // store aggregated tokens on the session row rather than per-message).
+          const sessionTokens = tryQuerySessionTokens(db, sessionId)
+          if (sessionTokens && (sessionTokens.cost > 0 || sessionTokens.input > 0 || sessionTokens.output > 0)) {
+            const dedupKey = `opencode:${sessionId}:session-level`
+            if (!seenKeys.has(dedupKey)) {
+              seenKeys.add(dedupKey)
+              const model = sessionTokens.model ?? 'unknown'
+              let costUSD = calculateCost(model, sessionTokens.input, sessionTokens.output, sessionTokens.cacheWrite, sessionTokens.cacheRead, 0)
+              if (costUSD === 0 && sessionTokens.cost > 0) costUSD = sessionTokens.cost
+              yield {
+                provider: 'opencode',
+                model,
+                inputTokens: sessionTokens.input,
+                outputTokens: sessionTokens.output,
+                cacheCreationInputTokens: sessionTokens.cacheWrite,
+                cacheReadInputTokens: sessionTokens.cacheRead,
+                cachedInputTokens: sessionTokens.cacheRead,
+                reasoningTokens: sessionTokens.reasoning,
+                webSearchRequests: 0,
+                costUSD,
+                tools: [],
+                bashCommands: [],
+                timestamp: parseTimestamp(messages[0]!.time_created),
+                speed: 'standard',
+                deduplicationKey: dedupKey,
+                userMessage: '',
+                sessionId,
+              }
+              yieldCount++
+            }
+          }
+
+          if (yieldCount === 0 && process.env['CODEBURN_VERBOSE'] === '1') {
+            process.stderr.write(
+              `codeburn: OpenCode session ${sessionId} has ${messages.length} messages ` +
+              `(${parseFailCount} unparseable, ${roleSkipCount} non-user/assistant roles) ` +
+              `but yielded 0 calls. Parts: ${parts.length}.\n`
+            )
           }
         }
       } finally {

--- a/tests/providers/opencode.test.ts
+++ b/tests/providers/opencode.test.ts
@@ -813,4 +813,89 @@ skipUnlessSqlite('opencode provider - session parsing', () => {
     const calls = await collectCalls(createOpenCodeProvider(tmpDir), dbPath, 'sess-1')
     expect(calls).toHaveLength(0)
   })
+
+  it('falls back to session-level tokens when per-message data yields nothing', async () => {
+    const dbPath = createTestDb(tmpDir)
+    withTestDb(dbPath, (db) => {
+      db.exec(`ALTER TABLE session ADD COLUMN cost REAL`)
+      db.exec(`ALTER TABLE session ADD COLUMN tokens_input INTEGER`)
+      db.exec(`ALTER TABLE session ADD COLUMN tokens_output INTEGER`)
+      db.exec(`ALTER TABLE session ADD COLUMN tokens_reasoning INTEGER`)
+      db.exec(`ALTER TABLE session ADD COLUMN tokens_cache_read INTEGER`)
+      db.exec(`ALTER TABLE session ADD COLUMN tokens_cache_write INTEGER`)
+      db.exec(`ALTER TABLE session ADD COLUMN model_id TEXT`)
+
+      insertSession(db, 'sess-1')
+      db.prepare(`UPDATE session SET cost = 0.15, tokens_input = 5000, tokens_output = 2000, tokens_reasoning = 0, tokens_cache_read = 3000, tokens_cache_write = 1000, model_id = 'claude-sonnet-4-20250514' WHERE id = 'sess-1'`).run()
+
+      insertMessage(db, 'msg-1', 'sess-1', 1700000001000, {
+        role: 'assistant', modelID: 'claude-sonnet-4-20250514',
+      })
+    })
+
+    const calls = await collectCalls(createOpenCodeProvider(tmpDir), dbPath, 'sess-1')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.inputTokens).toBe(5000)
+    expect(calls[0]!.outputTokens).toBe(2000)
+    expect(calls[0]!.cacheReadInputTokens).toBe(3000)
+    expect(calls[0]!.cacheCreationInputTokens).toBe(1000)
+    expect(calls[0]!.costUSD).toBeGreaterThan(0)
+    expect(calls[0]!.model).toBe('claude-sonnet-4-20250514')
+    expect(calls[0]!.deduplicationKey).toBe('opencode:sess-1:session-level')
+  })
+
+  it('accepts role "model" as equivalent to "assistant"', async () => {
+    const dbPath = createTestDb(tmpDir)
+    withTestDb(dbPath, (db) => {
+      insertSession(db, 'sess-1')
+      insertMessage(db, 'msg-1', 'sess-1', 1700000001000, {
+        role: 'model', modelID: 'gemini-2.5-pro', cost: 0.03,
+        tokens: { input: 100, output: 200, reasoning: 0, cache: { read: 0, write: 0 } },
+      } as any)
+    })
+
+    const calls = await collectCalls(createOpenCodeProvider(tmpDir), dbPath, 'sess-1')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.model).toBe('gemini-2.5-pro')
+  })
+
+  it('recognizes tool-call and tool_call part types', async () => {
+    const dbPath = createTestDb(tmpDir)
+    withTestDb(dbPath, (db) => {
+      insertSession(db, 'sess-1')
+      insertMessage(db, 'msg-1', 'sess-1', 1700000001000, {
+        role: 'assistant', modelID: 'claude-opus-4-6',
+      })
+      insertPart(db, 'part-1', 'msg-1', 'sess-1', {
+        type: 'tool-call', tool: 'bash',
+        state: { status: 'completed', input: { command: 'ls' } },
+      } as any)
+      insertPart(db, 'part-2', 'msg-1', 'sess-1', {
+        type: 'tool_call', tool: 'edit',
+        state: { status: 'completed', input: {} },
+      } as any)
+    })
+
+    const calls = await collectCalls(createOpenCodeProvider(tmpDir), dbPath, 'sess-1')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.tools).toEqual(['Bash', 'Edit'])
+  })
+
+  it('counts reasoning/file parts as activity even without text or tool parts', async () => {
+    const dbPath = createTestDb(tmpDir)
+    withTestDb(dbPath, (db) => {
+      insertSession(db, 'sess-1')
+      insertMessage(db, 'msg-1', 'sess-1', 1700000001000, {
+        role: 'assistant', modelID: 'claude-opus-4-6',
+      })
+      insertPart(db, 'part-1', 'msg-1', 'sess-1', {
+        type: 'reasoning',
+      } as any)
+    })
+
+    const calls = await collectCalls(createOpenCodeProvider(tmpDir), dbPath, 'sess-1')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.costUSD).toBe(0)
+    expect(calls[0]!.tools).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary
- Broaden part type recognition: `tool-call`, `tool_call`, `tool-result`, `tool_result`, `reasoning`, `file` now count as activity (previously only `text` and `tool`)
- Accept `role: "model"` as equivalent to `role: "assistant"` 
- Fall back to `data.usage.{input_tokens, output_tokens, ...}` when `data.tokens` is absent
- Fall back to `data.model` when `data.modelID` is absent
- Add session-level token fallback: when per-message parsing yields zero calls, read aggregated tokens from session row columns (`tokens_input`, `tokens_output`, etc.)
- Add `--verbose` diagnostic showing parse/skip counts when zero calls are yielded

## Test plan
- [x] All 43 OpenCode provider tests pass (4 new tests added)
- [x] Full suite passes (979 tests)
- [ ] Reporter confirms fix resolves their zero-usage issue

Closes #392