### PR TITLE
Add icon-only menubar display mode

### DIFF
--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -1058,7 +1058,7 @@ enum SubscriptionLoadState: Sendable, Equatable {
 }
 
 enum DisplayMetric: String {
-    case cost, tokens, totalTokens
+    case cost, tokens, totalTokens, iconOnly
 }
 
 enum InsightMode: String, CaseIterable, Identifiable {

--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -746,31 +746,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         let menubarPayload = store.menubarPayload
         let hasPayload = menubarPayload != nil
         let compact = isCompact
-        let suffix = menubarPeriod.menubarSuffix(compact: compact)
-        let valueText: String
-        if store.displayMetric == .tokens, let p = menubarPayload?.current {
-            let out = formatTokensMenubar(Double(p.outputTokens))
-            let inp = formatTokensMenubar(Double(p.inputTokens))
-            valueText = compact ? "↑\(out)↓\(inp)\(suffix)" : " ↑\(out) ↓\(inp)\(suffix)"
-        } else if store.displayMetric == .totalTokens, let p = menubarPayload?.current {
-            let total = formatTokensMenubar(Double(p.inputTokens + p.outputTokens))
-            valueText = compact ? "\(total)\(suffix)" : " \(total) tok\(suffix)"
-        } else {
-            let fallback = compact ? "$-" : "$—"
-            let formatted = menubarPayload?.current.cost
-            valueText = compact
-                ? (formatted?.asCompactCurrencyWhole() ?? fallback) + suffix
-                : " " + (formatted?.asCompactCurrency() ?? fallback) + suffix
-        }
-
-        var textAttrs: [NSAttributedString.Key: Any] = [.font: font, .baselineOffset: -1.0]
-        if !hasPayload {
-            textAttrs[.foregroundColor] = NSColor.secondaryLabelColor
-        }
 
         let composed = NSMutableAttributedString()
         composed.append(NSAttributedString(attachment: attachment))
-        composed.append(NSAttributedString(string: valueText, attributes: textAttrs))
+
+        if store.displayMetric != .iconOnly {
+            let suffix = menubarPeriod.menubarSuffix(compact: compact)
+            let valueText: String
+            if store.displayMetric == .tokens, let p = menubarPayload?.current {
+                let out = formatTokensMenubar(Double(p.outputTokens))
+                let inp = formatTokensMenubar(Double(p.inputTokens))
+                valueText = compact ? "↑\(out)↓\(inp)\(suffix)" : " ↑\(out) ↓\(inp)\(suffix)"
+            } else if store.displayMetric == .totalTokens, let p = menubarPayload?.current {
+                let total = formatTokensMenubar(Double(p.inputTokens + p.outputTokens))
+                valueText = compact ? "\(total)\(suffix)" : " \(total) tok\(suffix)"
+            } else {
+                let fallback = compact ? "$-" : "$—"
+                let formatted = menubarPayload?.current.cost
+                valueText = compact
+                    ? (formatted?.asCompactCurrencyWhole() ?? fallback) + suffix
+                    : " " + (formatted?.asCompactCurrency() ?? fallback) + suffix
+            }
+
+            var textAttrs: [NSAttributedString.Key: Any] = [.font: font, .baselineOffset: -1.0]
+            if !hasPayload {
+                textAttrs[.foregroundColor] = NSColor.secondaryLabelColor
+            }
+            composed.append(NSAttributedString(string: valueText, attributes: textAttrs))
+        }
+
         button.attributedTitle = composed
         button.toolTip = "CodeBurn \(menubarPeriod.menubarMetricLabel)"
     }

--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -47,6 +47,7 @@ private struct GeneralSettingsTab: View {
                     Text("Cost ($)").tag(DisplayMetric.cost)
                     Text("Tokens (↑↓)").tag(DisplayMetric.tokens)
                     Text("Total Tokens").tag(DisplayMetric.totalTokens)
+                    Text("Icon Only").tag(DisplayMetric.iconOnly)
                 }
                 Picker("Period", selection: Binding(
                     get: { store.menubarPeriod },


### PR DESCRIPTION
## Summary
- Adds "Icon Only" option to Settings > General > Metric picker
- When selected, menubar shows only the flame icon (no cost/token text)
- Flame color tinting for quota warnings and daily budget alerts still works
- Persists via existing UserDefaults mechanism (no new keys needed)

## Test plan
- [x] Swift build passes
- [x] Verified in running app: icon-only shows flame without text, switching back to Cost/Tokens restores the value