### PR TITLE
fix(cli): restore antigravity-hook command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,11 @@ import { formatDateRangeLabel, parseDateRangeFlags, parseDayFlag, parseDaysFlag,
 import { runOptimize, scanAndDetect } from './optimize.js'
 import { renderCompare } from './compare.js'
 import { getAllProviders } from './providers/index.js'
+import {
+  installAntigravityStatusLineHook,
+  runAgyStatusLineHook,
+  uninstallAntigravityStatusLineHook,
+} from './antigravity-statusline.js'
 import { clearPlan, readConfig, readPlan, readPlans, saveConfig, savePlan, getConfigFilePath, type Plan, type PlanId, type PlanProvider } from './config.js'
 import { clampResetDay, getPlanUsageOrNull, getPlanUsages, type PlanUsage } from './plan-usage.js'
 import { getPresetPlan, isPlanId, isPlanProvider, PLAN_IDS, PLAN_PROVIDERS, planDisplayName } from './plans.js'
@@ -1224,6 +1229,45 @@ program
     console.log(`\n  Analyzing yield for ${label}...\n`)
     const summary = await computeYield(range, process.cwd())
     console.log(formatYieldSummary(summary))
+  })
+
+program
+  .command('antigravity-hook')
+  .description('Install or remove exact Antigravity CLI usage capture')
+  .argument('<action>', 'install or uninstall')
+  .option('--force', 'Replace an existing custom Antigravity CLI statusLine command')
+  .action(async (action: string, opts: { force?: boolean }) => {
+    try {
+      if (action === 'install') {
+        const result = await installAntigravityStatusLineHook(!!opts.force)
+        console.log(result === 'already-installed'
+          ? '\n  Antigravity CLI usage capture is already installed.\n'
+          : '\n  Antigravity CLI usage capture installed.\n')
+        return
+      }
+      if (action === 'uninstall') {
+        const result = await uninstallAntigravityStatusLineHook()
+        console.log(result === 'not-installed'
+          ? '\n  Antigravity CLI usage capture is not installed.\n'
+          : result === 'restored'
+            ? '\n  Antigravity CLI usage capture removed; previous statusLine restored.\n'
+          : '\n  Antigravity CLI usage capture removed.\n')
+        return
+      }
+      console.error('\n  Usage: codeburn antigravity-hook <install|uninstall>\n')
+      process.exit(1)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`\n  Antigravity hook failed: ${message}\n`)
+      process.exit(1)
+    }
+  })
+
+program
+  .command('agy-statusline-hook', { hidden: true })
+  .description('Internal Antigravity CLI statusLine hook')
+  .action(async () => {
+    await runAgyStatusLineHook()
   })
 
 program.parse()


### PR DESCRIPTION
In commit 5800179, the Commander configuration for `antigravity-hook` and `agy-statusline-hook` commands in `src/main.ts` was accidentally deleted during conflict resolution. This commit restores them along with the missing imports.