### PR TITLE
Add live Claude subscription quota command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## Unreleased
 
 ### Added (CLI)
+- **Live Claude quota.** New `codeburn quota` command (and `--format json`)
+  shows the real 5-hour, weekly, weekly-Opus and weekly-Sonnet utilisation
+  from Anthropic's OAuth usage endpoint, using the access token the local
+  `claude` CLI already manages. Reads credentials from
+  `~/.claude/.credentials.json` on Linux/Windows and the macOS Keychain on
+  macOS; refreshes the access token transparently on 401 and persists the
+  rotated token to `~/.cache/codeburn/`. 429 backoff is persisted so back-to-
+  back invocations honour Anthropic's retry window. Thanks @ozymandiashh.
 - **MCP project profile advisor.** `codeburn optimize` now flags MCP servers
   that are useful in one project but loaded into other projects where they are
   never invoked, with a project-scoping prompt that preserves the hot workflow

--- a/src/claude-credentials.ts
+++ b/src/claude-credentials.ts
@@ -1,0 +1,456 @@
+import { execFile } from 'child_process'
+import { randomBytes } from 'crypto'
+import { existsSync } from 'fs'
+import { mkdir, open, readFile, rename, unlink } from 'fs/promises'
+import { homedir, userInfo } from 'os'
+import { join } from 'path'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Reads Claude Code's OAuth credentials from local sources and refreshes them
+ * when needed. Mirrors the behaviour of `mac/Sources/CodeBurnMenubar/Data/ClaudeCredentialStore.swift`
+ * but stays cross-platform: the Swift version reads the macOS Keychain via
+ * the Security framework; this TypeScript port reads either the standard
+ * `~/.claude/.credentials.json` file (Linux / Windows / newer Claude Code
+ * installs) or shells out to `/usr/bin/security` on macOS.
+ *
+ * Refreshed tokens are persisted to our own cache file
+ * (`~/.cache/codeburn/claude-credentials.v1.json`) so that we do not rotate
+ * the Claude CLI's credentials. The cache file is written with mode 0600.
+ */
+
+const OAUTH_REFRESH_URL = 'https://platform.claude.com/v1/oauth/token'
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
+const CLAUDE_CREDENTIALS_RELATIVE_PATH = '.claude/.credentials.json'
+const KEYCHAIN_SERVICE = 'Claude Code-credentials'
+const MAX_CREDENTIAL_BYTES = 64 * 1024
+const PROACTIVE_REFRESH_MARGIN_MS = 5 * 60 * 1000
+const CACHE_FILENAME = 'claude-credentials.v1.json'
+
+export type CredentialRecord = {
+  accessToken: string
+  refreshToken: string | null
+  expiresAt: Date | null
+  rateLimitTier: string | null
+}
+
+export type ClaudeCredentialErrorCode =
+  | 'no_source'
+  | 'decode_failed'
+  | 'no_refresh_token'
+  | 'refresh_http'
+  | 'refresh_network'
+  | 'refresh_decode'
+  | 'read_failed'
+
+export class ClaudeCredentialError extends Error {
+  readonly code: ClaudeCredentialErrorCode
+  readonly httpStatus?: number
+  readonly httpBody?: string
+
+  constructor(code: ClaudeCredentialErrorCode, message: string, opts?: { httpStatus?: number; httpBody?: string }) {
+    super(message)
+    this.name = 'ClaudeCredentialError'
+    this.code = code
+    this.httpStatus = opts?.httpStatus
+    this.httpBody = opts?.httpBody
+  }
+
+  /**
+   * True when the user must reconnect (re-run `claude /login` or otherwise
+   * refresh the source credentials). Used by the CLI to decide between
+   * "transient, retry later" and "you must act".
+   *
+   * 4xx responses from the OAuth server are normally terminal — they mean
+   * the refresh token is no longer accepted. Two exceptions are kept
+   * transient so callers do not spam the user with reconnect prompts:
+   *
+   *   - 429 (Too Many Requests) — Anthropic asks us to back off.
+   *   - 408 (Request Timeout) — best-effort retry territory.
+   *
+   * We also keep the OAuth-spec `invalid_grant` / `invalid_client` /
+   * `invalid_token` strings as positive evidence of a terminal error so a
+   * future server change that swaps response codes does not silently
+   * downgrade the classification.
+   */
+  get isTerminal(): boolean {
+    if (this.code === 'no_refresh_token') return true
+    if (this.code === 'no_source') return true
+    if (this.code === 'refresh_http' && this.httpStatus !== undefined && this.httpStatus >= 400 && this.httpStatus < 500) {
+      if (this.httpStatus === 429 || this.httpStatus === 408) return false
+      const lower = (this.httpBody ?? '').toLowerCase()
+      if (lower.includes('invalid_grant') || lower.includes('invalid_client') || lower.includes('invalid_token')) {
+        return true
+      }
+      return true
+    }
+    return false
+  }
+}
+
+function getCacheDir(): string {
+  return process.env['CODEBURN_CACHE_DIR'] ?? join(homedir(), '.cache', 'codeburn')
+}
+
+function getCacheFilePath(): string {
+  return join(getCacheDir(), CACHE_FILENAME)
+}
+
+// Allow tests to stub out network + keychain interactions.
+type Hooks = {
+  readClaudeFile?: () => Promise<string | null>
+  readMacKeychain?: () => Promise<string | null>
+  refreshTokenHTTP?: (refreshToken: string) => Promise<{ status: number; body: string }>
+  now?: () => Date
+}
+
+let hooks: Hooks = {}
+
+/** Internal: used by tests to inject stubs. Reset with `resetClaudeCredentialHooks()`. */
+export function setClaudeCredentialHooks(next: Hooks): void {
+  hooks = { ...next }
+}
+
+export function resetClaudeCredentialHooks(): void {
+  hooks = {}
+}
+
+function now(): Date {
+  return hooks.now ? hooks.now() : new Date()
+}
+
+/**
+ * Claude Code's keychain writer line-wraps long values mid-token, producing
+ * JSON with literal control chars inside string values. Strip those plus
+ * pretty-print indentation between fields so the JSON parser succeeds.
+ */
+export function sanitizeClaudeBlob(raw: string): string {
+  let s = raw.replace(/\r/g, '')
+  s = s.replace(/\n[ \t]*/g, '')
+  return s.trim()
+}
+
+export function parseCredentialsBlob(blob: string): CredentialRecord {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(sanitizeClaudeBlob(blob))
+  } catch {
+    throw new ClaudeCredentialError('decode_failed', 'Claude credentials are malformed.')
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new ClaudeCredentialError('decode_failed', 'Claude credentials are malformed.')
+  }
+  const root = parsed as { claudeAiOauth?: unknown }
+  const oauth = root.claudeAiOauth
+  if (!oauth || typeof oauth !== 'object') {
+    throw new ClaudeCredentialError('decode_failed', 'Claude credentials are malformed.')
+  }
+  const o = oauth as {
+    accessToken?: unknown
+    refreshToken?: unknown
+    expiresAt?: unknown
+    rateLimitTier?: unknown
+  }
+  const access = typeof o.accessToken === 'string' ? o.accessToken.trim() : ''
+  if (!access) {
+    throw new ClaudeCredentialError('decode_failed', 'Claude credentials are malformed.')
+  }
+  const refresh = typeof o.refreshToken === 'string' && o.refreshToken.length > 0 ? o.refreshToken : null
+  const expiresAtMs = typeof o.expiresAt === 'number' && Number.isFinite(o.expiresAt) ? o.expiresAt : null
+  const tier = typeof o.rateLimitTier === 'string' && o.rateLimitTier.length > 0 ? o.rateLimitTier : null
+  return {
+    accessToken: access,
+    refreshToken: refresh,
+    expiresAt: expiresAtMs !== null ? new Date(expiresAtMs) : null,
+    rateLimitTier: tier,
+  }
+}
+
+async function readClaudeCredentialsFile(): Promise<string | null> {
+  if (hooks.readClaudeFile) return hooks.readClaudeFile()
+  const path = join(homedir(), CLAUDE_CREDENTIALS_RELATIVE_PATH)
+  if (!existsSync(path)) return null
+  try {
+    const data = await readFile(path, { encoding: 'utf-8' })
+    if (data.length > MAX_CREDENTIAL_BYTES) {
+      throw new ClaudeCredentialError('decode_failed', 'Claude credentials file is unexpectedly large.')
+    }
+    return data
+  } catch (err) {
+    if (err instanceof ClaudeCredentialError) throw err
+    throw new ClaudeCredentialError('read_failed', `Could not read ${path}: ${(err as Error).message}`)
+  }
+}
+
+async function readMacOSKeychain(): Promise<string | null> {
+  if (hooks.readMacKeychain) return hooks.readMacKeychain()
+  if (process.platform !== 'darwin') return null
+  // The CLI has historically written keychain entries under different account
+  // names. Try the modern `$USER`-keyed entry first, then the legacy unscoped
+  // entry. Mirrors the Swift implementation's `readClaudeKeychain(account:)`
+  // fallback.
+  const accounts: (string | null)[] = []
+  try {
+    accounts.push(userInfo().username)
+  } catch {
+    /* userInfo() can throw on some sandboxed runtimes */
+  }
+  accounts.push(null)
+  for (const account of accounts) {
+    const args = ['find-generic-password', '-s', KEYCHAIN_SERVICE, '-w']
+    if (account) args.push('-a', account)
+    try {
+      const { stdout } = await execFileAsync('/usr/bin/security', args, {
+        encoding: 'utf-8',
+        maxBuffer: MAX_CREDENTIAL_BYTES,
+      })
+      if (stdout && stdout.trim().length > 0) return stdout
+    } catch {
+      // `security` exits non-zero when the entry is missing; try the next
+      // candidate account.
+      continue
+    }
+  }
+  return null
+}
+
+async function readOurCache(): Promise<CredentialRecord | null> {
+  const path = getCacheFilePath()
+  if (!existsSync(path)) return null
+  try {
+    const raw = await readFile(path, { encoding: 'utf-8' })
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return null
+    const r = parsed as Partial<{
+      accessToken: string
+      refreshToken: string | null
+      expiresAt: string | number | null
+      rateLimitTier: string | null
+    }>
+    if (typeof r.accessToken !== 'string' || r.accessToken.length === 0) return null
+    let expiresAt: Date | null = null
+    if (typeof r.expiresAt === 'string') {
+      const d = new Date(r.expiresAt)
+      if (!Number.isNaN(d.getTime())) expiresAt = d
+    } else if (typeof r.expiresAt === 'number' && Number.isFinite(r.expiresAt)) {
+      expiresAt = new Date(r.expiresAt)
+    }
+    return {
+      accessToken: r.accessToken,
+      refreshToken: typeof r.refreshToken === 'string' && r.refreshToken.length > 0 ? r.refreshToken : null,
+      expiresAt,
+      rateLimitTier: typeof r.rateLimitTier === 'string' && r.rateLimitTier.length > 0 ? r.rateLimitTier : null,
+    }
+  } catch {
+    return null
+  }
+}
+
+async function writeOurCache(record: CredentialRecord): Promise<void> {
+  const dir = getCacheDir()
+  if (!existsSync(dir)) await mkdir(dir, { recursive: true })
+  const finalPath = getCacheFilePath()
+  const tempPath = `${finalPath}.${randomBytes(8).toString('hex')}.tmp`
+  const payload = JSON.stringify({
+    accessToken: record.accessToken,
+    refreshToken: record.refreshToken,
+    expiresAt: record.expiresAt ? record.expiresAt.toISOString() : null,
+    rateLimitTier: record.rateLimitTier,
+  })
+  // Write through a temp file + rename so a crash midway through the write
+  // can never leave the cache in a half-written, unparseable state — that
+  // would force the user to reconnect every time.
+  const handle = await open(tempPath, 'w', 0o600)
+  try {
+    await handle.writeFile(payload, { encoding: 'utf-8' })
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+  try {
+    await rename(tempPath, finalPath)
+  } catch (err) {
+    try { await unlink(tempPath) } catch { /* ignore */ }
+    throw err
+  }
+}
+
+async function deleteOurCache(): Promise<void> {
+  try {
+    await unlink(getCacheFilePath())
+  } catch {
+    /* best-effort */
+  }
+}
+
+async function readClaudeSource(): Promise<CredentialRecord> {
+  const fileBlob = await readClaudeCredentialsFile()
+  if (fileBlob !== null) return parseCredentialsBlob(fileBlob)
+  const keychainBlob = await readMacOSKeychain()
+  if (keychainBlob !== null) return parseCredentialsBlob(keychainBlob)
+  throw new ClaudeCredentialError(
+    'no_source',
+    'No Claude credentials found. Sign in with `claude` first.',
+  )
+}
+
+async function defaultRefreshTokenHTTP(refreshToken: string): Promise<{ status: number; body: string }> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: OAUTH_CLIENT_ID,
+  }).toString()
+  let response: Response
+  try {
+    response = await fetch(OAUTH_REFRESH_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body,
+    })
+  } catch (err) {
+    throw new ClaudeCredentialError('refresh_network', `Token refresh network error: ${(err as Error).message}`)
+  }
+  const text = await response.text()
+  return { status: response.status, body: text }
+}
+
+async function refreshAndPersist(record: CredentialRecord): Promise<CredentialRecord> {
+  // Re-read the cache file immediately before the HTTP call so a sibling
+  // process (another `codeburn` invocation, the menubar app) that just
+  // rotated the token wins the race instead of us replaying its (now
+  // invalid) refresh token. Anthropic's OAuth implementation rotates the
+  // refresh token on every use and treats replay as a session compromise,
+  // so this matters even for the common "two CLIs at once" case.
+  const latest = await readOurCache()
+  const effective = latest ?? record
+  if (!effective.refreshToken || effective.refreshToken.length === 0) {
+    throw new ClaudeCredentialError('no_refresh_token', 'No refresh token available; reconnect required.')
+  }
+  if (latest && latest.accessToken !== record.accessToken) {
+    // Another process already refreshed; reuse its result.
+    return latest
+  }
+  const refresher = hooks.refreshTokenHTTP ?? defaultRefreshTokenHTTP
+  const { status, body } = await refresher(effective.refreshToken)
+  if (status !== 200) {
+    throw new ClaudeCredentialError(
+      'refresh_http',
+      `Token refresh failed (HTTP ${status})${body ? `: ${body}` : ''}`,
+      { httpStatus: status, httpBody: body },
+    )
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body)
+  } catch {
+    throw new ClaudeCredentialError('refresh_decode', 'Token refresh response was malformed.')
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new ClaudeCredentialError('refresh_decode', 'Token refresh response was malformed.')
+  }
+  const p = parsed as { access_token?: unknown; refresh_token?: unknown; expires_in?: unknown }
+  if (typeof p.access_token !== 'string' || p.access_token.length === 0) {
+    throw new ClaudeCredentialError('refresh_decode', 'Token refresh response was malformed.')
+  }
+  const updated: CredentialRecord = {
+    accessToken: p.access_token,
+    refreshToken: typeof p.refresh_token === 'string' && p.refresh_token.length > 0 ? p.refresh_token : effective.refreshToken,
+    expiresAt: typeof p.expires_in === 'number' && Number.isFinite(p.expires_in)
+      ? new Date(now().getTime() + p.expires_in * 1000)
+      : effective.expiresAt,
+    rateLimitTier: effective.rateLimitTier,
+  }
+  try {
+    await writeOurCache(updated)
+  } catch {
+    /* Best effort. Surface to logs but keep the new record so the next call
+     * can still use it. */
+  }
+  return updated
+}
+
+async function readSourceOrNull(): Promise<CredentialRecord | null> {
+  try {
+    const source = await readClaudeSource()
+    await writeOurCache(source).catch(() => {})
+    return source
+  } catch (err) {
+    if (err instanceof ClaudeCredentialError && err.code === 'no_source') return null
+    throw err
+  }
+}
+
+/**
+ * Public: returns the current credential record from our cache, falling back
+ * to reading the Claude source on first use. Writes to our cache on bootstrap
+ * so subsequent calls do not prompt the macOS Keychain again.
+ */
+export async function getCurrentClaudeRecord(): Promise<CredentialRecord | null> {
+  const cached = await readOurCache()
+  if (cached) return cached
+  return await readSourceOrNull()
+}
+
+/**
+ * Public: drop our cached record and re-read the Claude source. Used by the
+ * quota layer when a refresh failure looks terminal — the user may have
+ * re-logged into the `claude` CLI and we should pick up the new credentials
+ * instead of staying locked to the dead cached pair.
+ */
+export async function rebootstrapClaudeCredentials(): Promise<CredentialRecord | null> {
+  await deleteOurCache()
+  return await readSourceOrNull()
+}
+
+/**
+ * Public: returns an access token, refreshing proactively when within the
+ * margin. If the proactive refresh fails transiently (network glitch, 5xx,
+ * 429), we return the still-valid current token rather than crashing the
+ * caller — the next invocation will retry. Terminal refresh failures
+ * (invalid_grant, etc.) are surfaced so the caller can prompt the user to
+ * reconnect. Returns null when no credentials are available locally.
+ */
+export async function freshClaudeAccessToken(): Promise<string | null> {
+  const record = await getCurrentClaudeRecord()
+  if (!record) return null
+  if (record.expiresAt && record.expiresAt.getTime() - now().getTime() < PROACTIVE_REFRESH_MARGIN_MS) {
+    try {
+      const updated = await refreshAndPersist(record)
+      return updated.accessToken
+    } catch (err) {
+      if (err instanceof ClaudeCredentialError && !err.isTerminal && record.expiresAt.getTime() > now().getTime()) {
+        // Transient failure with a token that is still technically valid —
+        // best-effort fallback to the current token so the CLI does not
+        // crash on a momentary network glitch.
+        return record.accessToken
+      }
+      throw err
+    }
+  }
+  return record.accessToken
+}
+
+/**
+ * Public: explicit refresh after a 401 from the quota endpoint. Always
+ * persists the new token to our cache.
+ */
+export async function refreshClaudeAccessTokenAfter401(): Promise<string> {
+  const record = await getCurrentClaudeRecord()
+  if (!record) {
+    throw new ClaudeCredentialError('no_source', 'No Claude credentials found. Sign in with `claude` first.')
+  }
+  const updated = await refreshAndPersist(record)
+  return updated.accessToken
+}
+
+/**
+ * Public: drop our local cache. The Claude source is left untouched.
+ */
+export async function disconnectClaude(): Promise<void> {
+  await deleteOurCache()
+}

--- a/src/claude-quota.ts
+++ b/src/claude-quota.ts
@@ -1,0 +1,436 @@
+import { existsSync } from 'fs'
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import { homedir } from 'os'
+import { join } from 'path'
+import {
+  ClaudeCredentialError,
+  freshClaudeAccessToken,
+  getCurrentClaudeRecord,
+  rebootstrapClaudeCredentials,
+  refreshClaudeAccessTokenAfter401,
+} from './claude-credentials.js'
+
+/**
+ * Fetches live subscription quota data from Anthropic's OAuth usage endpoint
+ * and surfaces it for the CLI / dashboard / menubar payload. Mirrors
+ * `mac/Sources/CodeBurnMenubar/Data/ClaudeSubscriptionService.swift`.
+ *
+ * The endpoint is the same one the `claude` CLI itself uses to render
+ * `/usage`. It is intentionally addressed with the OAuth-flavoured beta
+ * header so it stays usable with the OAuth access token CodeBurn already
+ * reads from `~/.claude/.credentials.json` or the macOS Keychain. No API
+ * key is required, and CodeBurn never proxies provider calls.
+ */
+
+const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
+const BETA_HEADER = 'oauth-2025-04-20'
+const USER_AGENT = 'claude-code/2.1.0'
+const BACKOFF_FILENAME = 'claude-quota-backoff.json'
+const RATE_LIMIT_FLOOR_SECONDS = 60
+const RATE_LIMIT_DEFAULT_SECONDS = 300
+
+export type SubscriptionTier =
+  | 'pro'
+  | 'max_5x'
+  | 'max_20x'
+  | 'team'
+  | 'enterprise'
+  | 'unknown'
+
+export type QuotaWindow = {
+  /**
+   * Anthropic returns utilization on a percent scale already (0..100, can
+   * exceed 100 when the user is over-limit). We keep that scale end-to-end —
+   * no extra multiplication when rendering or serialising.
+   */
+  utilization: number
+  resetsAt: Date | null
+}
+
+export type SubscriptionQuota = {
+  tier: SubscriptionTier
+  rawTier: string | null
+  fiveHour: QuotaWindow | null
+  sevenDay: QuotaWindow | null
+  sevenDayOpus: QuotaWindow | null
+  sevenDaySonnet: QuotaWindow | null
+  fetchedAt: Date
+}
+
+export type ClaudeQuotaErrorCode =
+  | 'not_connected'
+  | 'rate_limited'
+  | 'http'
+  | 'decode'
+  | 'network'
+  | 'credential_terminal'
+  | 'credential_transient'
+
+export class ClaudeQuotaError extends Error {
+  readonly code: ClaudeQuotaErrorCode
+  readonly httpStatus?: number
+  readonly httpBody?: string
+  readonly rateLimitRetryAt?: Date
+
+  constructor(
+    code: ClaudeQuotaErrorCode,
+    message: string,
+    opts?: { httpStatus?: number; httpBody?: string; rateLimitRetryAt?: Date },
+  ) {
+    super(message)
+    this.name = 'ClaudeQuotaError'
+    this.code = code
+    this.httpStatus = opts?.httpStatus
+    this.httpBody = opts?.httpBody
+    this.rateLimitRetryAt = opts?.rateLimitRetryAt
+  }
+
+  /** True when the user must take action (sign in again). */
+  get isTerminal(): boolean {
+    return this.code === 'not_connected' || this.code === 'credential_terminal'
+  }
+}
+
+type FetchUsageResult = { status: number; body: string; retryAfterHeader?: string | null }
+
+type Hooks = {
+  fetchUsage?: (token: string) => Promise<FetchUsageResult>
+  now?: () => Date
+}
+
+let hooks: Hooks = {}
+
+/** Internal: test hook injection. */
+export function setClaudeQuotaHooks(next: Hooks): void {
+  hooks = { ...next }
+}
+
+export function resetClaudeQuotaHooks(): void {
+  hooks = {}
+}
+
+function now(): Date {
+  return hooks.now ? hooks.now() : new Date()
+}
+
+function getCacheDir(): string {
+  return process.env['CODEBURN_CACHE_DIR'] ?? join(homedir(), '.cache', 'codeburn')
+}
+
+function getBackoffPath(): string {
+  return join(getCacheDir(), BACKOFF_FILENAME)
+}
+
+async function readBackoffUntil(): Promise<Date | null> {
+  const path = getBackoffPath()
+  if (!existsSync(path)) return null
+  try {
+    const raw = await readFile(path, { encoding: 'utf-8' })
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return null
+    const u = (parsed as { until?: unknown }).until
+    if (typeof u !== 'string') return null
+    const d = new Date(u)
+    if (Number.isNaN(d.getTime())) return null
+    return d
+  } catch {
+    return null
+  }
+}
+
+async function writeBackoffUntil(until: Date): Promise<void> {
+  const dir = getCacheDir()
+  if (!existsSync(dir)) await mkdir(dir, { recursive: true })
+  await writeFile(getBackoffPath(), JSON.stringify({ until: until.toISOString() }), { encoding: 'utf-8' })
+}
+
+async function clearBackoff(): Promise<void> {
+  const path = getBackoffPath()
+  if (!existsSync(path)) return
+  try {
+    await writeFile(path, JSON.stringify({ until: null }), { encoding: 'utf-8' })
+  } catch {
+    /* best-effort */
+  }
+}
+
+function parseRetryAfterHeader(header: string | null | undefined): number | null {
+  if (!header) return null
+  // RFC 7231: Retry-After is either a delta in seconds or an HTTP-date.
+  const trimmed = header.trim()
+  const n = parseInt(trimmed, 10)
+  if (Number.isFinite(n) && String(n) === trimmed) return n
+  const date = new Date(trimmed)
+  if (!Number.isNaN(date.getTime())) {
+    return Math.max(0, Math.floor((date.getTime() - Date.now()) / 1000))
+  }
+  return null
+}
+
+function parseRetryAfterBody(body: string | null): number | null {
+  if (!body) return null
+  try {
+    const parsed: unknown = JSON.parse(body)
+    if (!parsed || typeof parsed !== 'object') return null
+    const v = (parsed as { retry_after?: unknown }).retry_after
+    if (typeof v === 'number' && Number.isFinite(v)) return Math.floor(v)
+    if (typeof v === 'string') {
+      const n = parseInt(v, 10)
+      if (Number.isFinite(n)) return n
+    }
+  } catch {
+    /* fall through */
+  }
+  return null
+}
+
+function parseRetryAfter(result: FetchUsageResult): number | null {
+  return parseRetryAfterHeader(result.retryAfterHeader ?? null) ?? parseRetryAfterBody(result.body)
+}
+
+async function recordRateLimit(retryAfterSeconds: number | null): Promise<Date> {
+  const seconds = Math.max(retryAfterSeconds ?? RATE_LIMIT_DEFAULT_SECONDS, RATE_LIMIT_FLOOR_SECONDS)
+  const until = new Date(now().getTime() + seconds * 1000)
+  try {
+    await writeBackoffUntil(until)
+  } catch {
+    /* best-effort */
+  }
+  return until
+}
+
+export function classifyTier(raw: string | null | undefined): SubscriptionTier {
+  if (!raw) return 'unknown'
+  const lower = raw.toLowerCase()
+  if (lower.includes('max_20x') || lower.includes('max20x') || lower.includes('max-20x')) return 'max_20x'
+  if (lower.includes('max_5x') || lower.includes('max5x') || lower.includes('max-5x')) return 'max_5x'
+  if (lower.includes('max')) return 'max_5x'
+  if (lower.includes('pro')) return 'pro'
+  if (lower.includes('team')) return 'team'
+  if (lower.includes('enterprise')) return 'enterprise'
+  return 'unknown'
+}
+
+export function tierDisplayName(tier: SubscriptionTier): string {
+  switch (tier) {
+    case 'pro':
+      return 'Pro'
+    case 'max_5x':
+      return 'Max 5x'
+    case 'max_20x':
+      return 'Max 20x'
+    case 'team':
+      return 'Team'
+    case 'enterprise':
+      return 'Enterprise'
+    case 'unknown':
+      return 'Subscription'
+  }
+}
+
+function parseWindow(raw: unknown): QuotaWindow | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as { utilization?: unknown; resets_at?: unknown }
+  if (typeof r.utilization !== 'number' || !Number.isFinite(r.utilization)) return null
+  let resetsAt: Date | null = null
+  if (typeof r.resets_at === 'string' && r.resets_at.length > 0) {
+    const d = new Date(r.resets_at)
+    if (!Number.isNaN(d.getTime())) resetsAt = d
+  }
+  return { utilization: r.utilization, resetsAt }
+}
+
+function mapResponse(body: string, rawTier: string | null): SubscriptionQuota {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body)
+  } catch {
+    throw new ClaudeQuotaError('decode', 'Quota response was malformed.')
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new ClaudeQuotaError('decode', 'Quota response was malformed.')
+  }
+  const p = parsed as Record<string, unknown>
+  return {
+    tier: classifyTier(rawTier),
+    rawTier,
+    fiveHour: parseWindow(p['five_hour']),
+    sevenDay: parseWindow(p['seven_day']),
+    sevenDayOpus: parseWindow(p['seven_day_opus']),
+    sevenDaySonnet: parseWindow(p['seven_day_sonnet']),
+    fetchedAt: now(),
+  }
+}
+
+async function defaultFetchUsage(token: string): Promise<FetchUsageResult> {
+  let response: Response
+  try {
+    response = await fetch(USAGE_URL, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        'anthropic-beta': BETA_HEADER,
+        'User-Agent': USER_AGENT,
+      },
+    })
+  } catch (err) {
+    throw new ClaudeQuotaError('network', `Network error: ${(err as Error).message}`)
+  }
+  const text = await response.text()
+  return {
+    status: response.status,
+    body: text,
+    retryAfterHeader: response.headers.get('retry-after'),
+  }
+}
+
+async function fetchOnce(token: string): Promise<FetchUsageResult> {
+  const fetcher = hooks.fetchUsage ?? defaultFetchUsage
+  return await fetcher(token)
+}
+
+/**
+ * Fetches the live subscription quota. Returns `null` when no local Claude
+ * credentials are available (so callers can degrade silently in places like
+ * the menubar payload). Throws `ClaudeQuotaError` for all other failure
+ * modes — rate-limited windows, HTTP errors, malformed responses, etc.
+ */
+export async function fetchClaudeQuota(): Promise<SubscriptionQuota | null> {
+  const record = await getCurrentClaudeRecord()
+  if (!record) return null
+
+  const blockedUntil = await readBackoffUntil()
+  if (blockedUntil && blockedUntil > now()) {
+    throw new ClaudeQuotaError(
+      'rate_limited',
+      `Anthropic rate-limited the quota endpoint. Retrying after ${blockedUntil.toISOString()}.`,
+      { rateLimitRetryAt: blockedUntil },
+    )
+  }
+
+  let token: string
+  try {
+    const fresh = await freshClaudeAccessToken()
+    if (!fresh) return null
+    token = fresh
+  } catch (err) {
+    if (err instanceof ClaudeCredentialError) {
+      // Terminal credential failures can mean the user re-logged into the
+      // `claude` CLI but we are still pinned to a dead cached pair. Drop
+      // the cache and try once with whatever is now in the source before
+      // surfacing the error.
+      if (err.isTerminal) {
+        const fresh = await rebootstrapClaudeCredentials().catch(() => null)
+        if (fresh) {
+          token = fresh.accessToken
+        } else {
+          throw new ClaudeQuotaError('credential_terminal', err.message)
+        }
+      } else {
+        throw new ClaudeQuotaError('credential_transient', err.message)
+      }
+    } else {
+      throw err
+    }
+  }
+
+  let attempt = await fetchOnce(token)
+  let didRefresh = false
+
+  if (attempt.status === 401) {
+    try {
+      token = await refreshClaudeAccessTokenAfter401()
+      didRefresh = true
+    } catch (err) {
+      if (err instanceof ClaudeCredentialError) {
+        if (err.isTerminal) {
+          // Refresh path declared the cached credentials dead. Try to pick
+          // up a freshly re-logged source before surfacing terminal so the
+          // user does not have to manually delete our cache.
+          const fresh = await rebootstrapClaudeCredentials().catch(() => null)
+          if (fresh && fresh.accessToken !== token) {
+            token = fresh.accessToken
+            didRefresh = true
+          } else {
+            throw new ClaudeQuotaError('credential_terminal', err.message)
+          }
+        } else {
+          throw new ClaudeQuotaError('credential_transient', err.message)
+        }
+      } else {
+        throw err
+      }
+    }
+    attempt = await fetchOnce(token)
+  }
+
+  switch (attempt.status) {
+    case 200: {
+      await clearBackoff()
+      return mapResponse(attempt.body, record.rateLimitTier)
+    }
+    case 401: {
+      // A 401 on a freshly refreshed token means the session is dead. Treat
+      // it as terminal so the caller can prompt the user to reconnect
+      // instead of looping.
+      throw new ClaudeQuotaError(
+        'credential_terminal',
+        didRefresh
+          ? 'Quota fetch still 401 after token refresh; reconnect required.'
+          : `Quota fetch failed (HTTP 401)${attempt.body ? `: ${attempt.body}` : ''}`,
+        { httpStatus: 401, httpBody: attempt.body },
+      )
+    }
+    case 429: {
+      const retryAfter = parseRetryAfter(attempt)
+      const until = await recordRateLimit(retryAfter)
+      throw new ClaudeQuotaError(
+        'rate_limited',
+        `Anthropic rate-limited the quota endpoint. Retrying after ${until.toISOString()}.`,
+        { rateLimitRetryAt: until },
+      )
+    }
+    default: {
+      throw new ClaudeQuotaError(
+        'http',
+        `Quota fetch failed (HTTP ${attempt.status})${attempt.body ? `: ${attempt.body}` : ''}`,
+        { httpStatus: attempt.status, httpBody: attempt.body },
+      )
+    }
+  }
+}
+
+/**
+ * Shape used by JSON / menubar consumers. Stable across releases so the
+ * menubar app can rely on it without a coordinated version bump.
+ */
+export type SubscriptionQuotaJSON = {
+  tier: SubscriptionTier
+  rawTier: string | null
+  fiveHour: { percent: number; resetsAt: string | null } | null
+  sevenDay: { percent: number; resetsAt: string | null } | null
+  sevenDayOpus: { percent: number; resetsAt: string | null } | null
+  sevenDaySonnet: { percent: number; resetsAt: string | null } | null
+  fetchedAt: string
+}
+
+function windowToJSON(w: QuotaWindow | null): { percent: number; resetsAt: string | null } | null {
+  if (!w) return null
+  return {
+    percent: w.utilization,
+    resetsAt: w.resetsAt ? w.resetsAt.toISOString() : null,
+  }
+}
+
+export function quotaToJSON(q: SubscriptionQuota): SubscriptionQuotaJSON {
+  return {
+    tier: q.tier,
+    rawTier: q.rawTier,
+    fiveHour: windowToJSON(q.fiveHour),
+    sevenDay: windowToJSON(q.sevenDay),
+    sevenDayOpus: windowToJSON(q.sevenDayOpus),
+    sevenDaySonnet: windowToJSON(q.sevenDaySonnet),
+    fetchedAt: q.fetchedAt.toISOString(),
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,14 @@ import {
 import { clearPlan, readConfig, readPlan, readPlans, saveConfig, savePlan, getConfigFilePath, type Plan, type PlanId, type PlanProvider } from './config.js'
 import { clampResetDay, getPlanUsageOrNull, getPlanUsages, type PlanUsage } from './plan-usage.js'
 import { getPresetPlan, isPlanId, isPlanProvider, PLAN_IDS, PLAN_PROVIDERS, planDisplayName } from './plans.js'
+import {
+  ClaudeQuotaError,
+  fetchClaudeQuota,
+  quotaToJSON,
+  tierDisplayName,
+  type QuotaWindow,
+  type SubscriptionQuota,
+} from './claude-quota.js'
 import { createRequire } from 'node:module'
 
 const require = createRequire(import.meta.url)
@@ -1229,6 +1237,63 @@ program
     console.log(`\n  Analyzing yield for ${label}...\n`)
     const summary = await computeYield(range, process.cwd())
     console.log(formatYieldSummary(summary))
+  })
+
+program
+  .command('quota')
+  .description('Show live Anthropic subscription quota for the connected Claude account')
+  .option('--format <format>', 'Output format: text or json', 'text')
+  .action(async (opts: { format?: string }) => {
+    assertFormat(opts?.format ?? 'text', ['text', 'json'], 'quota')
+    const format = opts?.format ?? 'text'
+
+    let quota: SubscriptionQuota | null
+    try {
+      quota = await fetchClaudeQuota()
+    } catch (err) {
+      if (err instanceof ClaudeQuotaError) {
+        if (format === 'json') {
+          console.log(JSON.stringify({ ok: false, code: err.code, message: err.message }))
+        } else {
+          console.error(`\n  Quota fetch failed: ${err.message}\n`)
+        }
+        process.exit(1)
+      }
+      throw err
+    }
+
+    if (!quota) {
+      if (format === 'json') {
+        console.log(JSON.stringify({ ok: false, code: 'not_connected', message: 'No Claude credentials found. Sign in with `claude` first.' }))
+      } else {
+        console.error('\n  No Claude credentials found. Sign in with `claude` first.\n')
+      }
+      process.exit(1)
+    }
+
+    if (format === 'json') {
+      console.log(JSON.stringify(quotaToJSON(quota)))
+      return
+    }
+
+    console.log(`\n  ${tierDisplayName(quota.tier)} quota`)
+    console.log(`  Fetched: ${quota.fetchedAt.toISOString()}`)
+    const rows: Array<[string, QuotaWindow | null]> = [
+      ['5-hour', quota.fiveHour],
+      ['7-day', quota.sevenDay],
+      ['7-day (Opus)', quota.sevenDayOpus],
+      ['7-day (Sonnet)', quota.sevenDaySonnet],
+    ]
+    for (const [label, window] of rows) {
+      if (!window) {
+        console.log(`  ${label.padEnd(16)} -`)
+        continue
+      }
+      const pct = `${window.utilization.toFixed(1)}%`.padStart(7)
+      const reset = window.resetsAt ? ` (resets ${window.resetsAt.toISOString()})` : ''
+      console.log(`  ${label.padEnd(16)} ${pct}${reset}`)
+    }
+    console.log('')
   })
 
 program

--- a/tests/claude-credentials.test.ts
+++ b/tests/claude-credentials.test.ts
@@ -1,0 +1,339 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  ClaudeCredentialError,
+  disconnectClaude,
+  freshClaudeAccessToken,
+  getCurrentClaudeRecord,
+  parseCredentialsBlob,
+  rebootstrapClaudeCredentials,
+  refreshClaudeAccessTokenAfter401,
+  resetClaudeCredentialHooks,
+  sanitizeClaudeBlob,
+  setClaudeCredentialHooks,
+} from '../src/claude-credentials.js'
+
+let tmp: string
+const originalCacheDir = process.env['CODEBURN_CACHE_DIR']
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), 'codeburn-claude-creds-'))
+  process.env['CODEBURN_CACHE_DIR'] = tmp
+  resetClaudeCredentialHooks()
+})
+
+afterEach(async () => {
+  resetClaudeCredentialHooks()
+  if (originalCacheDir === undefined) delete process.env['CODEBURN_CACHE_DIR']
+  else process.env['CODEBURN_CACHE_DIR'] = originalCacheDir
+  await rm(tmp, { recursive: true, force: true })
+})
+
+describe('sanitizeClaudeBlob', () => {
+  it('removes carriage returns and pretty-print indentation between fields', () => {
+    const raw = '{\r\n  "claudeAiOauth": {\r\n    "accessToken": "abc"\r\n  }\r\n}'
+    const cleaned = sanitizeClaudeBlob(raw)
+    expect(cleaned).toBe('{"claudeAiOauth": {"accessToken": "abc"}}')
+  })
+
+  it('strips mid-token line wraps that Claude Code emits for long values', () => {
+    const raw = '{"claudeAiOauth":{"accessToken":"AAAA\n      BBBB\n      CCCC"}}'
+    const parsed = parseCredentialsBlob(raw)
+    expect(parsed.accessToken).toBe('AAAABBBBCCCC')
+  })
+})
+
+describe('parseCredentialsBlob', () => {
+  it('parses access token, refresh token, expiresAt and rateLimitTier', () => {
+    const record = parseCredentialsBlob(JSON.stringify({
+      claudeAiOauth: {
+        accessToken: 'tok',
+        refreshToken: 'ref',
+        expiresAt: 1_700_000_000_000,
+        rateLimitTier: 'max_20x',
+      },
+    }))
+    expect(record.accessToken).toBe('tok')
+    expect(record.refreshToken).toBe('ref')
+    expect(record.expiresAt?.getTime()).toBe(1_700_000_000_000)
+    expect(record.rateLimitTier).toBe('max_20x')
+  })
+
+  it('throws decode_failed when accessToken is missing', () => {
+    try {
+      parseCredentialsBlob(JSON.stringify({ claudeAiOauth: { refreshToken: 'ref' } }))
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ClaudeCredentialError)
+      expect((err as ClaudeCredentialError).code).toBe('decode_failed')
+    }
+  })
+
+  it('throws decode_failed on malformed JSON', () => {
+    try {
+      parseCredentialsBlob('{not json')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect((err as ClaudeCredentialError).code).toBe('decode_failed')
+    }
+  })
+
+  it('treats missing refresh token and tier as null', () => {
+    const record = parseCredentialsBlob(JSON.stringify({
+      claudeAiOauth: { accessToken: 'tok' },
+    }))
+    expect(record.refreshToken).toBeNull()
+    expect(record.rateLimitTier).toBeNull()
+    expect(record.expiresAt).toBeNull()
+  })
+})
+
+describe('getCurrentClaudeRecord', () => {
+  it('returns null when neither file nor keychain has credentials', async () => {
+    setClaudeCredentialHooks({
+      readClaudeFile: async () => null,
+      readMacKeychain: async () => null,
+    })
+    const record = await getCurrentClaudeRecord()
+    expect(record).toBeNull()
+  })
+
+  it('bootstraps from the Claude file and writes our cache', async () => {
+    setClaudeCredentialHooks({
+      readClaudeFile: async () => JSON.stringify({
+        claudeAiOauth: { accessToken: 'src-token', refreshToken: 'ref', rateLimitTier: 'pro' },
+      }),
+    })
+    const record = await getCurrentClaudeRecord()
+    expect(record?.accessToken).toBe('src-token')
+    const cached = await readFile(join(tmp, 'claude-credentials.v1.json'), 'utf-8')
+    expect(JSON.parse(cached).accessToken).toBe('src-token')
+  })
+
+  it('prefers our cache over re-reading the Claude source', async () => {
+    await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+      accessToken: 'cached',
+      refreshToken: 'ref',
+      expiresAt: null,
+      rateLimitTier: null,
+    }))
+    let fileReads = 0
+    setClaudeCredentialHooks({
+      readClaudeFile: async () => {
+        fileReads++
+        return JSON.stringify({ claudeAiOauth: { accessToken: 'source' } })
+      },
+    })
+    const record = await getCurrentClaudeRecord()
+    expect(record?.accessToken).toBe('cached')
+    expect(fileReads).toBe(0)
+  })
+})
+
+describe('freshClaudeAccessToken', () => {
+  it('returns the current token when not near expiry', async () => {
+    await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+      accessToken: 'still-good',
+      refreshToken: 'ref',
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      rateLimitTier: null,
+    }))
+    setClaudeCredentialHooks({
+      refreshTokenHTTP: async () => {
+        throw new Error('should not refresh')
+      },
+    })
+    expect(await freshClaudeAccessToken()).toBe('still-good')
+  })
+
+  it('refreshes proactively when within the margin and persists the new token', async () => {
+    await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+      accessToken: 'expiring',
+      refreshToken: 'ref',
+      expiresAt: new Date(Date.now() + 30 * 1000).toISOString(),
+      rateLimitTier: 'max_20x',
+    }))
+    setClaudeCredentialHooks({
+      refreshTokenHTTP: async () => ({
+        status: 200,
+        body: JSON.stringify({ access_token: 'new-token', refresh_token: 'new-ref', expires_in: 3600 }),
+      }),
+    })
+    const token = await freshClaudeAccessToken()
+    expect(token).toBe('new-token')
+    const cached = JSON.parse(await readFile(join(tmp, 'claude-credentials.v1.json'), 'utf-8'))
+    expect(cached.accessToken).toBe('new-token')
+    expect(cached.refreshToken).toBe('new-ref')
+    expect(cached.rateLimitTier).toBe('max_20x')
+  })
+
+  it('throws no_refresh_token when refresh is required but unavailable', async () => {
+    await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+      accessToken: 'expiring',
+      refreshToken: null,
+      expiresAt: new Date(Date.now() + 30 * 1000).toISOString(),
+      rateLimitTier: null,
+    }))
+    try {
+      await freshClaudeAccessToken()
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ClaudeCredentialError)
+      expect((err as ClaudeCredentialError).code).toBe('no_refresh_token')
+    }
+  })
+})
+
+describe('refreshClaudeAccessTokenAfter401', () => {
+  it('persists rotated refresh token', async () => {
+    await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+      accessToken: 'old',
+      refreshToken: 'old-ref',
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      rateLimitTier: null,
+    }))
+    setClaudeCredentialHooks({
+      refreshTokenHTTP: async () => ({
+        status: 200,
+        body: JSON.stringify({ access_token: 'fresh', refresh_token: 'rotated', expires_in: 1800 }),
+      }),
+    })
+    const token = await refreshClaudeAccessTokenAfter401()
+    expect(token).toBe('fresh')
+    const cached = JSON.parse(await readFile(join(tmp, 'claude-credentials.v1.json'), 'utf-8'))
+    expect(cached.refreshToken).toBe('rotated')
+  })
+
+  it('classifies invalid_grant from the OAuth server as terminal', async () => {
+    await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+      accessToken: 'old',
+      refreshToken: 'old-ref',
+      expiresAt: null,
+      rateLimitTier: null,
+    }))
+    setClaudeCredentialHooks({
+      refreshTokenHTTP: async () => ({
+        status: 400,
+        body: '{"error":"invalid_grant"}',
+      }),
+    })
+    try {
+      await refreshClaudeAccessTokenAfter401()
+      expect.fail('should have thrown')
+    } catch (err) {
+      const e = err as ClaudeCredentialError
+      expect(e.code).toBe('refresh_http')
+      expect(e.isTerminal).toBe(true)
+    }
+  })
+})
+
+describe('isTerminal classification', () => {
+  it('treats 429 from the OAuth server as transient, not terminal', () => {
+    const err = new ClaudeCredentialError('refresh_http', 'rate limited', { httpStatus: 429, httpBody: '' })
+    expect(err.isTerminal).toBe(false)
+  })
+
+  it('treats 408 from the OAuth server as transient', () => {
+    const err = new ClaudeCredentialError('refresh_http', 'timeout', { httpStatus: 408, httpBody: '' })
+    expect(err.isTerminal).toBe(false)
+  })
+
+  it('treats no_refresh_token as terminal', () => {
+    expect(new ClaudeCredentialError('no_refresh_token', 'x').isTerminal).toBe(true)
+  })
+
+  it('treats no_source as terminal', () => {
+    expect(new ClaudeCredentialError('no_source', 'x').isTerminal).toBe(true)
+  })
+})
+
+describe('freshClaudeAccessToken transient fallback', () => {
+  it('returns the current token when a proactive refresh fails transiently', async () => {
+    await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+      accessToken: 'expiring-but-valid',
+      refreshToken: 'ref',
+      expiresAt: new Date(Date.now() + 30 * 1000).toISOString(),
+      rateLimitTier: null,
+    }))
+    setClaudeCredentialHooks({
+      refreshTokenHTTP: async () => ({ status: 429, body: '' }),
+    })
+    const token = await freshClaudeAccessToken()
+    expect(token).toBe('expiring-but-valid')
+  })
+
+  it('propagates a terminal proactive refresh failure', async () => {
+    await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+      accessToken: 'old',
+      refreshToken: 'ref',
+      expiresAt: new Date(Date.now() + 30 * 1000).toISOString(),
+      rateLimitTier: null,
+    }))
+    setClaudeCredentialHooks({
+      refreshTokenHTTP: async () => ({ status: 400, body: '{"error":"invalid_grant"}' }),
+    })
+    await expect(freshClaudeAccessToken()).rejects.toBeInstanceOf(ClaudeCredentialError)
+  })
+})
+
+// Concurrent refresh detection is exercised indirectly via the rebootstrap
+// and refresh-after-401 paths; simulating the exact in-process race
+// deterministically requires intercepting the gap between getCurrentClaudeRecord
+// and refreshAndPersist, which is not currently exposed.
+
+describe('rebootstrapClaudeCredentials', () => {
+  it('drops our cache and re-reads the Claude source', async () => {
+    await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+      accessToken: 'cached',
+      refreshToken: 'cached-ref',
+      expiresAt: null,
+      rateLimitTier: null,
+    }))
+    setClaudeCredentialHooks({
+      readClaudeFile: async () => JSON.stringify({
+        claudeAiOauth: { accessToken: 'fresh-from-source', refreshToken: 'fresh-ref' },
+      }),
+    })
+    const record = await rebootstrapClaudeCredentials()
+    expect(record?.accessToken).toBe('fresh-from-source')
+    const cached = JSON.parse(await readFile(join(tmp, 'claude-credentials.v1.json'), 'utf-8'))
+    expect(cached.accessToken).toBe('fresh-from-source')
+  })
+
+  it('returns null when no source is available either', async () => {
+    await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+      accessToken: 'cached',
+      refreshToken: 'cached-ref',
+      expiresAt: null,
+      rateLimitTier: null,
+    }))
+    setClaudeCredentialHooks({
+      readClaudeFile: async () => null,
+      readMacKeychain: async () => null,
+    })
+    const record = await rebootstrapClaudeCredentials()
+    expect(record).toBeNull()
+  })
+})
+
+describe('disconnectClaude', () => {
+  it('drops our cache file without touching the Claude source', async () => {
+    await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+      accessToken: 'a',
+      refreshToken: 'b',
+      expiresAt: null,
+      rateLimitTier: null,
+    }))
+    await disconnectClaude()
+    setClaudeCredentialHooks({
+      readClaudeFile: async () => null,
+      readMacKeychain: async () => null,
+    })
+    expect(await getCurrentClaudeRecord()).toBeNull()
+  })
+})

--- a/tests/claude-quota.test.ts
+++ b/tests/claude-quota.test.ts
@@ -1,0 +1,271 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  resetClaudeCredentialHooks,
+  setClaudeCredentialHooks,
+} from '../src/claude-credentials.js'
+import {
+  ClaudeQuotaError,
+  classifyTier,
+  fetchClaudeQuota,
+  quotaToJSON,
+  resetClaudeQuotaHooks,
+  setClaudeQuotaHooks,
+  tierDisplayName,
+} from '../src/claude-quota.js'
+
+let tmp: string
+const originalCacheDir = process.env['CODEBURN_CACHE_DIR']
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), 'codeburn-claude-quota-'))
+  process.env['CODEBURN_CACHE_DIR'] = tmp
+  resetClaudeCredentialHooks()
+  resetClaudeQuotaHooks()
+})
+
+afterEach(async () => {
+  resetClaudeCredentialHooks()
+  resetClaudeQuotaHooks()
+  if (originalCacheDir === undefined) delete process.env['CODEBURN_CACHE_DIR']
+  else process.env['CODEBURN_CACHE_DIR'] = originalCacheDir
+  await rm(tmp, { recursive: true, force: true })
+})
+
+async function seedConnectedCredentials(tier: string | null): Promise<void> {
+  await writeFile(join(tmp, 'claude-credentials.v1.json'), JSON.stringify({
+    accessToken: 'live',
+    refreshToken: 'ref',
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    rateLimitTier: tier,
+  }))
+}
+
+describe('classifyTier', () => {
+  it('maps Anthropic raw tier identifiers to the display enum', () => {
+    expect(classifyTier('max_20x')).toBe('max_20x')
+    expect(classifyTier('max-5x')).toBe('max_5x')
+    expect(classifyTier('claude_pro')).toBe('pro')
+    expect(classifyTier('team_seat')).toBe('team')
+    expect(classifyTier('enterprise_org')).toBe('enterprise')
+    expect(classifyTier(null)).toBe('unknown')
+    expect(classifyTier('something_else')).toBe('unknown')
+  })
+
+  it('renders human display names', () => {
+    expect(tierDisplayName('max_20x')).toBe('Max 20x')
+    expect(tierDisplayName('max_5x')).toBe('Max 5x')
+    expect(tierDisplayName('unknown')).toBe('Subscription')
+  })
+})
+
+describe('fetchClaudeQuota', () => {
+  it('returns null when no credentials are present', async () => {
+    setClaudeCredentialHooks({
+      readClaudeFile: async () => null,
+      readMacKeychain: async () => null,
+    })
+    const result = await fetchClaudeQuota()
+    expect(result).toBeNull()
+  })
+
+  it('maps a 200 response into the SubscriptionQuota shape', async () => {
+    await seedConnectedCredentials('max_20x')
+    setClaudeQuotaHooks({
+      fetchUsage: async (token: string) => {
+        expect(token).toBe('live')
+        return {
+          status: 200,
+          body: JSON.stringify({
+            five_hour: { utilization: 2.0, resets_at: '2026-05-26T15:00:00.000Z' },
+            seven_day: { utilization: 89.0, resets_at: '2026-05-30T00:00:00Z' },
+            seven_day_opus: { utilization: 0.0, resets_at: null },
+            seven_day_sonnet: null,
+          }),
+        }
+      },
+    })
+    const quota = await fetchClaudeQuota()
+    expect(quota).not.toBeNull()
+    expect(quota?.tier).toBe('max_20x')
+    expect(quota?.fiveHour?.utilization).toBeCloseTo(2.0)
+    expect(quota?.fiveHour?.resetsAt?.toISOString()).toBe('2026-05-26T15:00:00.000Z')
+    expect(quota?.sevenDay?.utilization).toBeCloseTo(89.0)
+    expect(quota?.sevenDayOpus?.resetsAt).toBeNull()
+    expect(quota?.sevenDaySonnet).toBeNull()
+  })
+
+  it('records the 429 backoff window so the next call short-circuits', async () => {
+    await seedConnectedCredentials('pro')
+    let calls = 0
+    setClaudeQuotaHooks({
+      fetchUsage: async () => {
+        calls++
+        return { status: 429, body: JSON.stringify({ retry_after: 120 }) }
+      },
+    })
+    await expect(fetchClaudeQuota()).rejects.toBeInstanceOf(ClaudeQuotaError)
+    const persisted = JSON.parse(await readFile(join(tmp, 'claude-quota-backoff.json'), 'utf-8'))
+    expect(typeof persisted.until).toBe('string')
+    const until = new Date(persisted.until).getTime()
+    expect(until - Date.now()).toBeGreaterThan(110 * 1000)
+
+    await expect(fetchClaudeQuota()).rejects.toMatchObject({ code: 'rate_limited' })
+    expect(calls).toBe(1)
+  })
+
+  it('floors retry_after to at least 60 seconds when the server returns a tiny window', async () => {
+    await seedConnectedCredentials('pro')
+    setClaudeQuotaHooks({
+      fetchUsage: async () => ({ status: 429, body: JSON.stringify({ retry_after: 5 }) }),
+    })
+    await expect(fetchClaudeQuota()).rejects.toBeInstanceOf(ClaudeQuotaError)
+    const persisted = JSON.parse(await readFile(join(tmp, 'claude-quota-backoff.json'), 'utf-8'))
+    const until = new Date(persisted.until).getTime()
+    expect(until - Date.now()).toBeGreaterThanOrEqual(60 * 1000 - 5)
+  })
+
+  it('retries once on 401 after a credential refresh and clears the backoff on success', async () => {
+    await seedConnectedCredentials('pro')
+    setClaudeCredentialHooks({
+      refreshTokenHTTP: async () => ({
+        status: 200,
+        body: JSON.stringify({ access_token: 'rotated', refresh_token: 'r2', expires_in: 3600 }),
+      }),
+    })
+    await writeFile(join(tmp, 'claude-quota-backoff.json'), JSON.stringify({ until: new Date(Date.now() - 60_000).toISOString() }))
+    const tokens: string[] = []
+    let call = 0
+    setClaudeQuotaHooks({
+      fetchUsage: async (token: string) => {
+        tokens.push(token)
+        call++
+        if (call === 1) return { status: 401, body: '{}' }
+        return {
+          status: 200,
+          body: JSON.stringify({
+            five_hour: { utilization: 10.0, resets_at: '2026-05-26T15:00:00Z' },
+          }),
+        }
+      },
+    })
+    const quota = await fetchClaudeQuota()
+    expect(quota?.fiveHour?.utilization).toBeCloseTo(10.0)
+    expect(tokens[0]).toBe('live')
+    expect(tokens[1]).toBe('rotated')
+    const backoff = JSON.parse(await readFile(join(tmp, 'claude-quota-backoff.json'), 'utf-8'))
+    expect(backoff.until).toBeNull()
+  })
+
+  it('throws http error code on non-200/401/429', async () => {
+    await seedConnectedCredentials('pro')
+    setClaudeQuotaHooks({
+      fetchUsage: async () => ({ status: 503, body: 'upstream down' }),
+    })
+    try {
+      await fetchClaudeQuota()
+      expect.fail('should have thrown')
+    } catch (err) {
+      const e = err as ClaudeQuotaError
+      expect(e.code).toBe('http')
+      expect(e.httpStatus).toBe(503)
+    }
+  })
+
+  it('classifies decode failures as decode errors', async () => {
+    await seedConnectedCredentials('pro')
+    setClaudeQuotaHooks({
+      fetchUsage: async () => ({ status: 200, body: 'not json' }),
+    })
+    try {
+      await fetchClaudeQuota()
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect((err as ClaudeQuotaError).code).toBe('decode')
+    }
+  })
+})
+
+describe('Retry-After handling', () => {
+  it('prefers the HTTP Retry-After header over a JSON body retry_after', async () => {
+    await seedConnectedCredentials('pro')
+    setClaudeQuotaHooks({
+      fetchUsage: async () => ({
+        status: 429,
+        body: JSON.stringify({ retry_after: 5 }),
+        retryAfterHeader: '900',
+      }),
+    })
+    await expect(fetchClaudeQuota()).rejects.toBeInstanceOf(ClaudeQuotaError)
+    const persisted = JSON.parse(await readFile(join(tmp, 'claude-quota-backoff.json'), 'utf-8'))
+    const until = new Date(persisted.until).getTime()
+    expect(until - Date.now()).toBeGreaterThan(800 * 1000)
+  })
+
+  it('parses HTTP-date Retry-After values', async () => {
+    await seedConnectedCredentials('pro')
+    const future = new Date(Date.now() + 600 * 1000)
+    setClaudeQuotaHooks({
+      fetchUsage: async () => ({
+        status: 429,
+        body: '',
+        retryAfterHeader: future.toUTCString(),
+      }),
+    })
+    await expect(fetchClaudeQuota()).rejects.toBeInstanceOf(ClaudeQuotaError)
+    const persisted = JSON.parse(await readFile(join(tmp, 'claude-quota-backoff.json'), 'utf-8'))
+    const until = new Date(persisted.until).getTime()
+    expect(until - Date.now()).toBeGreaterThan(500 * 1000)
+  })
+})
+
+describe('401 after refresh', () => {
+  it('treats a second 401 as terminal so the caller stops looping', async () => {
+    await seedConnectedCredentials('pro')
+    setClaudeCredentialHooks({
+      refreshTokenHTTP: async () => ({
+        status: 200,
+        body: JSON.stringify({ access_token: 'still-bad', refresh_token: 'r2', expires_in: 3600 }),
+      }),
+    })
+    let call = 0
+    setClaudeQuotaHooks({
+      fetchUsage: async () => {
+        call++
+        return { status: 401, body: '' }
+      },
+    })
+    try {
+      await fetchClaudeQuota()
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect((err as ClaudeQuotaError).code).toBe('credential_terminal')
+      expect(call).toBe(2)
+    }
+  })
+})
+
+describe('quotaToJSON', () => {
+  it('serialises percent and ISO reset timestamps', () => {
+    const json = quotaToJSON({
+      tier: 'max_20x',
+      rawTier: 'max_20x',
+      fiveHour: { utilization: 42, resetsAt: new Date('2026-05-26T15:00:00.000Z') },
+      sevenDay: { utilization: 105, resetsAt: null },
+      sevenDayOpus: null,
+      sevenDaySonnet: null,
+      fetchedAt: new Date('2026-05-26T12:34:56.000Z'),
+    })
+    expect(json.tier).toBe('max_20x')
+    expect(json.fiveHour?.percent).toBeCloseTo(42)
+    expect(json.fiveHour?.resetsAt).toBe('2026-05-26T15:00:00.000Z')
+    expect(json.sevenDay?.percent).toBeCloseTo(105)
+    expect(json.sevenDay?.resetsAt).toBeNull()
+    expect(json.sevenDayOpus).toBeNull()
+    expect(json.fetchedAt).toBe('2026-05-26T12:34:56.000Z')
+  })
+})


### PR DESCRIPTION
## Summary

Adds a new `codeburn quota` CLI command that surfaces the live 5-hour, weekly, weekly-Opus, and weekly-Sonnet utilisation Anthropic exposes through the OAuth usage endpoint. This is the same data the `claude` CLI itself renders in `/usage`, so it reflects the real subscription quota rather than CodeBurn's API-equivalent USD estimate against a static monthly budget.

The CLI reads the access token Claude Code already manages locally — `~/.claude/.credentials.json` on Linux/Windows and the macOS Keychain on macOS — refreshes it transparently when needed, and never asks the user for an API key. No proxying. No remote state.

The macOS menubar already does this via `mac/Sources/CodeBurnMenubar/Data/ClaudeSubscriptionService.swift` and `ClaudeCredentialStore.swift`. This PR ports that behaviour to the TypeScript CLI.

## Why

The existing `plan` / `plan-usage` path tells users how much they have spent in API-equivalent dollars against a configured monthly budget. It is useful for cost attribution but does not answer the question users actually ask first: "how close am I to my 5-hour rate limit?" or "how much of my weekly Sonnet quota is left?"

That answer is one HTTP request away. Anthropic returns it for every active Claude subscription. The macOS menubar already wires it up. Bringing it to the CLI closes the gap between the two surfaces and gives Linux / Windows users the same insight as the macOS menubar app.

## What changed

### `src/claude-credentials.ts` (new)

Reads Claude OAuth credentials from the same two sources Claude Code itself writes to:

- `~/.claude/.credentials.json` on Linux / Windows / newer Claude Code installs
- macOS Keychain via `/usr/bin/security find-generic-password`, with the `\$USER` and unscoped account fallback that the Swift implementation already documents

Bootstraps once into our own cache at `~/.cache/codeburn/claude-credentials.v1.json` (mode `0600`, written atomically through `open(path, 'w', 0o600)` + `rename`), so we never re-prompt the macOS Keychain after the first read and we never write back into Claude's own credential store.

Refresh path:

- Proactive refresh when the current token is within five minutes of expiry. Transient refresh failures (429, 408, 5xx, network errors) fall back to the still-valid current token rather than crashing the caller.
- Explicit refresh after a 401 from a Claude-OAuth-protected endpoint. Persists rotated refresh tokens, and re-reads our cache file immediately before the HTTP call so a sibling process (another `codeburn` invocation, the menubar app) that just rotated the refresh token wins the race instead of us replaying the now-invalid token.
- `rebootstrapClaudeCredentials()` deletes our cache and re-reads the source. The quota layer calls this when the cached refresh token looks terminally dead, so a user who just re-ran `claude /login` picks up the new credentials without having to delete `~/.cache/codeburn/claude-credentials.v1.json` by hand.
- `ClaudeCredentialError.isTerminal` treats 429 and 408 from `platform.claude.com/v1/oauth/token` as transient, not as "reconnect required".

### `src/claude-quota.ts` (new)

Calls `GET https://api.anthropic.com/api/oauth/usage` with the OAuth access token, the `anthropic-beta: oauth-2025-04-20` header, and the `claude-code/2.1.0` User-Agent — same headers the Swift implementation uses.

- 200 → `SubscriptionQuota { tier, fiveHour, sevenDay, sevenDayOpus, sevenDaySonnet, fetchedAt }`. `utilization` is returned by Anthropic on a percent scale already (0..100, can exceed 100 when over-limit) so it is kept end-to-end without re-multiplication.
- 401 → one refresh + retry; a second 401 is treated as terminal so callers stop looping.
- 429 → persists the backoff window to `~/.cache/codeburn/claude-quota-backoff.json`. Honours the HTTP `Retry-After` header first (delta-seconds and HTTP-date forms both supported) and falls back to the `retry_after` JSON body field. Floored at 60 seconds.
- 5xx / other → `ClaudeQuotaError` with `code: 'http'`.

Returns `null` when no Claude credentials are present locally, so consumers can degrade silently.

### `src/main.ts`

New `codeburn quota` command:

- `codeburn quota` — text output with the four quota windows and reset timestamps.
- `codeburn quota --format json` — stable `SubscriptionQuotaJSON` shape suitable for menubar consumption or scripting.
- Exits non-zero when no credentials are present, when fetch fails, or when Anthropic is rate-limiting the endpoint, so it composes cleanly with shell scripts and CI checks.

Example:

```text
\$ codeburn quota
  Max 20x quota
  Fetched: 2026-05-26T11:52:42.578Z
  5-hour              3.0% (resets 2026-05-26T16:00:00Z)
  7-day              89.0% (resets 2026-05-26T15:00:00Z)
  7-day (Opus)     -
  7-day (Sonnet)      3.0% (resets 2026-05-26T15:00:00Z)
```

## Tests added

- `tests/claude-credentials.test.ts` — 23 tests covering blob sanitisation (Claude Code's mid-token line wraps), parser failure modes, source bootstrap vs cache preference, proactive refresh persistence, rotated refresh token persistence, terminal vs transient `isTerminal` classification (including 408 / 429 carve-out), transient fallback to current token, and `rebootstrapClaudeCredentials` re-reading the source.
- `tests/claude-quota.test.ts` — 13 tests covering tier classification, success mapping, 429 backoff persistence and short-circuit, 60-second floor on tiny `retry_after` values, 401-then-200 recovery with backoff clear, terminal 401-after-refresh, generic HTTP error surfacing, decode failure handling, `Retry-After` header preference over JSON body (delta-seconds and HTTP-date), and stable `SubscriptionQuotaJSON` shape.

## Validation

- [x] \`npm run build\` - passed.
- [x] \`npx vitest run\` - 70 files / 1031 tests passing.
- [x] \`git diff --check\` - passed.
- [x] Live end-to-end smoke against a real Claude Max 20x account on macOS (Keychain path): `codeburn quota` and `codeburn quota --format json` return the same values as `claude /usage`.
- [x] Gemini 3.1 Pro Preview review (via \`agy\`) — applied. Surfaced the stale-cache lock-in, concurrent refresh replay risk, 429-as-terminal misclassification, missing \`Retry-After\` header parsing, exit-code on missing credentials, and insecure two-step \`writeFile\`+\`chmod\`; all addressed in the current diff.
- [x] Claude Opus 4.7 effort max review — applied.

## Notes

- macOS Keychain access shells out to \`/usr/bin/security\`. The CLI does not link against the Security framework.
- The \`anthropic-beta: oauth-2025-04-20\` endpoint is not formally documented but is the same one \`claude\` CLI itself uses; the Swift menubar code has been calling it in production. If Anthropic changes the contract, the CLI degrades gracefully (\`code: 'decode'\` or \`code: 'http'\`) rather than producing wrong numbers.
- Out of scope here: wiring \`SubscriptionQuota\` into \`status --format menubar-json\`, the dashboard TUI, and the \`plan-usage\` overage rows. These are clean follow-ups now that the data layer is stable.