### PR TITLE
feat(kiro): add Kiro CLI session support

### DIFF
--- a/docs/providers/kiro.md
+++ b/docs/providers/kiro.md
@@ -1,12 +1,14 @@
 # Kiro
 
-Kiro IDE chat history.
+Kiro IDE and CLI chat history.
 
 - **Source:** `src/providers/kiro.ts`
 - **Loading:** eager (`src/providers/index.ts:7`)
 - **Test:** `tests/providers/kiro.test.ts`
 
 ## Where it reads from
+
+### Kiro IDE
 
 VS Code-style globalStorage at `kiro.kiroagent`:
 
@@ -22,14 +24,34 @@ Sessions are under hash-named workspace subdirectories. Discovery keeps backward
 - `<workspace-hash>/<session-hash>` extensionless session index files
 - `<workspace-hash>/<session-hash>/<execution-hash>` extensionless execution files inside session directories
 
+### Kiro CLI
+
+JSONL session files at:
+
+| Platform | Path |
+|---|---|
+| macOS / Linux / WSL | `~/.kiro/sessions/cli/` |
+| Windows | `%USERPROFILE%\.kiro\sessions\cli\` |
+
+Each session has two files:
+- `<session-id>.json` — metadata (session_id, cwd, timestamps, model info)
+- `<session-id>.jsonl` — conversation (one JSON object per line: Prompt, AssistantMessage, ToolResults)
+
+Project name is derived from the `cwd` field in the metadata file.
+
 ## Storage format
 
-Kiro has two known JSON formats:
+Kiro has three known formats:
 
 - Legacy `.chat` files with `{ chat, metadata, executionId }`
 - Modern extensionless execution files with identifiers/timestamps at the top level plus conversation fields such as `messages`, `conversation`, `chat`, `transcript`, `entries`, `events`, or direct prompt/response fields
+- CLI JSONL files with line-delimited entries: `{ version, kind: "Prompt"|"AssistantMessage"|"ToolResults", data: { content: [...] } }`
 
 Session index files with `{ executions: [...] }` are discovered but skipped during parsing because they do not contain conversation content.
+
+## MCP tool detection (CLI)
+
+The CLI parser distinguishes built-in tools (`read`, `write`, `shell`, `grep`, `glob`, `web_search`, `web_fetch`, `code`, `subagent`, `knowledge`, `todo_list`, `introspect`, `summary`, `switch_to_execution`, `dummy`) from MCP tools. Any tool name not in the built-in set is prefixed as `mcp__<server>__<tool>`. The MCP server name is read from `~/.kiro/settings/mcp.json`.
 
 ## Caching
 
@@ -37,13 +59,16 @@ None.
 
 ## Deduplication
 
-Modern files deduplicate per session/execution pair. Legacy `.chat` files deduplicate per workflow/execution pair.
+- Modern IDE files deduplicate per session/execution pair.
+- Legacy `.chat` files deduplicate per workflow/execution pair.
+- CLI sessions deduplicate per session ID.
 
 ## Quirks
 
 - **Workspace hash resolution** is non-trivial. The parser tries `workspace.json` first; if that fails, it base64-decodes the directory name to recover the workspace path.
 - **Model ID normalization.** Kiro stores models like `claude-1.2`; the parser rewrites the dot to a hyphen so they match `claude-1-2` in the pricing snapshot. Add new versions here when Kiro ships them.
 - **Tool name extraction accepts text and structured calls.** Kiro can embed tool calls inside message text as `<tool_use><name>...</name>` or expose structured `toolCalls` / `tool_calls` / `tools` entries.
+- **CLI model is always `auto`.** The CLI does not expose the underlying model, so sessions are labeled `kiro-auto` and costed at Sonnet rates.
 - Token counts are estimated via char count (`CHARS_PER_TOKEN = 4`).
 
 ## When fixing a bug here
@@ -51,3 +76,5 @@ Modern files deduplicate per session/execution pair. Legacy `.chat` files dedupl
 1. If the bug is "wrong workspace", check the base64 fallback path. Some users name their workspaces with characters that are not valid base64.
 2. If the bug is "missing model in pricing", add the model to the normalization map and verify against `tests/providers/kiro.test.ts`.
 3. If the bug is "tools missing", check both text-envelope extraction and structured tool-call extraction. Kiro changes its envelope occasionally.
+4. If the bug is "CLI sessions not found", verify `~/.kiro/sessions/cli/` exists and contains `.jsonl` files with matching `.json` metadata files.
+5. If the bug is "MCP tools not detected from CLI", check `~/.kiro/settings/mcp.json` and the `CLI_BUILTIN_TOOLS` set.

--- a/src/providers/kiro.ts
+++ b/src/providers/kiro.ts
@@ -1,9 +1,9 @@
 import type { Dirent } from 'fs'
-import { readdir, readFile } from 'fs/promises'
+import { readdir, readFile, stat } from 'fs/promises'
 import { basename, dirname, extname, join } from 'path'
 import { homedir } from 'os'
 
-import { readSessionFile } from '../fs-utils.js'
+import { readSessionFile, readSessionLines } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
 import type { ToolCall } from '../types.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
@@ -50,6 +50,226 @@ const toolNameMap: Record<string, string> = {
 type KiroChatMessage = {
   role: 'human' | 'bot' | 'tool'
   content: string
+}
+
+// --- Kiro CLI support ---
+
+/** Built-in tools in Kiro CLI; anything else is assumed to be an MCP tool. */
+const CLI_BUILTIN_TOOLS = new Set([
+  'code', 'glob', 'grep', 'introspect', 'knowledge', 'read', 'shell',
+  'subagent', 'summary', 'switch_to_execution', 'todo_list', 'web_fetch',
+  'web_search', 'write', 'dummy',
+])
+
+/** Map Kiro CLI built-in tool names to CodeBurn canonical names. */
+const cliToolNameMap: Record<string, string> = {
+  read: 'Read',
+  write: 'Edit',
+  shell: 'Bash',
+  grep: 'Grep',
+  glob: 'Glob',
+  web_search: 'WebSearch',
+  web_fetch: 'WebFetch',
+  code: 'Read',
+  subagent: 'Agent',
+}
+
+type CliJsonlEntry = {
+  version?: string
+  kind: string
+  data?: {
+    message_id?: string
+    content?: Array<{ kind: string; data?: unknown }>
+  }
+}
+
+type CliSessionMeta = {
+  session_id: string
+  cwd?: string
+  created_at?: string
+  updated_at?: string
+  title?: string
+  session_state?: {
+    rts_model_state?: {
+      model_info?: { model_id?: string }
+    }
+  }
+}
+
+function getKiroCliSessionsDir(override?: string): string {
+  if (override) return override
+  return join(homedir(), '.kiro', 'sessions', 'cli')
+}
+
+async function loadCliMcpServerName(): Promise<string> {
+  const mcpPath = join(homedir(), '.kiro', 'settings', 'mcp.json')
+  try {
+    const raw = await readFile(mcpPath, 'utf-8')
+    const data = JSON.parse(raw) as { mcpServers?: Record<string, unknown> }
+    const servers = Object.keys(data.mcpServers ?? {})
+    if (servers.length > 0) return servers[0]!
+  } catch {}
+  return 'mcp-server'
+}
+
+function normalizeCliToolName(name: string, mcpServer: string): string {
+  if (CLI_BUILTIN_TOOLS.has(name)) {
+    return cliToolNameMap[name] ?? name
+  }
+  return `mcp__${mcpServer}__${name}`
+}
+
+function parseCliJsonlSession(
+  lines: string[],
+  sessionId: string,
+  project: string,
+  modelId: string,
+  timestamp: string,
+  mcpServer: string,
+  seenKeys: Set<string>,
+): ParsedProviderCall[] {
+  const results: ParsedProviderCall[] = []
+  const chat: Array<{ role: 'human' | 'bot'; content: string; tools: string[] }> = []
+
+  for (const line of lines) {
+    let entry: CliJsonlEntry
+    try { entry = JSON.parse(line) } catch { continue }
+
+    if (entry.kind === 'Prompt') {
+      const text = (entry.data?.content ?? [])
+        .filter(c => c.kind === 'text')
+        .map(c => c.data as string)
+        .join('\n')
+      if (text) chat.push({ role: 'human', content: text, tools: [] })
+    }
+
+    if (entry.kind === 'AssistantMessage') {
+      const parts = entry.data?.content ?? []
+      let text = ''
+      const tools: string[] = []
+      for (const part of parts) {
+        if (part.kind === 'text') text += part.data as string
+        else if (part.kind === 'toolUse') {
+          const toolData = part.data as { name?: string } | undefined
+          const rawName = toolData?.name ?? 'unknown'
+          tools.push(normalizeCliToolName(rawName, mcpServer))
+        }
+      }
+      if (text || tools.length > 0) chat.push({ role: 'bot', content: text, tools })
+    }
+  }
+
+  const botMessages = chat.filter(m => m.role === 'bot')
+  const totalOutputChars = botMessages.reduce((sum, m) => sum + m.content.length, 0)
+  const allTools = botMessages.flatMap(m => m.tools)
+  const hasActivity = totalOutputChars > 0 || allTools.length > 0
+  if (!hasActivity) return results
+
+  const dedupKey = `kiro-cli:${sessionId}`
+  if (seenKeys.has(dedupKey)) return results
+
+  const pendingUserMessage = chat.find(m => m.role === 'human')?.content.slice(0, 500) ?? ''
+  const inputChars = chat.filter(m => m.role === 'human').reduce((sum, m) => sum + m.content.length, 0)
+  const inputTokens = Math.ceil(inputChars / CHARS_PER_TOKEN)
+  const outputTokens = Math.ceil(totalOutputChars / CHARS_PER_TOKEN)
+
+  let resolvedModel = normalizeModelId(modelId)
+  if (resolvedModel === 'auto' || !resolvedModel) resolvedModel = 'kiro-auto'
+
+  const costUSD = calculateCost(resolvedModel, inputTokens, outputTokens, 0, 0, 0)
+  seenKeys.add(dedupKey)
+
+  const toolSequence: ToolCall[][] = botMessages
+    .filter(m => m.tools.length > 0)
+    .map(m => m.tools.map(t => ({ tool: t })))
+
+  results.push({
+    provider: 'kiro',
+    model: resolvedModel,
+    inputTokens,
+    outputTokens,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    cachedInputTokens: 0,
+    reasoningTokens: 0,
+    webSearchRequests: 0,
+    costUSD,
+    tools: [...new Set(allTools)],
+    bashCommands: [],
+    toolSequence: toolSequence.length > 1 ? toolSequence : undefined,
+    timestamp,
+    speed: 'standard',
+    deduplicationKey: dedupKey,
+    userMessage: pendingUserMessage,
+    sessionId,
+  })
+
+  return results
+}
+
+function createCliParser(source: SessionSource, seenKeys: Set<string>, mcpServerPromise: Promise<string>): SessionParser {
+  return {
+    async *parse(): AsyncGenerator<ParsedProviderCall> {
+      // source.path points to the .jsonl file; metadata is in the sibling .json
+      const jsonlPath = source.path
+      const jsonPath = jsonlPath.replace(/\.jsonl$/, '.json')
+
+      let meta: CliSessionMeta
+      try {
+        const raw = await readFile(jsonPath, 'utf-8')
+        meta = JSON.parse(raw)
+      } catch { return }
+
+      const sessionId = meta.session_id ?? basename(jsonlPath, '.jsonl')
+      const modelId = meta.session_state?.rts_model_state?.model_info?.model_id ?? 'auto'
+      const timestamp = meta.created_at ?? new Date().toISOString()
+
+      const tsDate = parseKiroTimestamp(timestamp)
+      if (!tsDate) return
+
+      const mcpServer = await mcpServerPromise
+
+      const lines: string[] = []
+      for await (const line of readSessionLines(jsonlPath)) {
+        lines.push(line)
+      }
+
+      const calls = parseCliJsonlSession(lines, sessionId, source.project, modelId, tsDate.toISOString(), mcpServer, seenKeys)
+      for (const call of calls) {
+        yield call
+      }
+    },
+  }
+}
+
+async function discoverCliSessions(cliDir: string): Promise<SessionSource[]> {
+  const sources: SessionSource[] = []
+
+  let files: string[]
+  try {
+    const entries = await readdir(cliDir)
+    files = entries.filter(f => f.endsWith('.jsonl'))
+  } catch { return sources }
+
+  for (const file of files) {
+    const sessionId = file.replace('.jsonl', '')
+    const jsonPath = join(cliDir, `${sessionId}.json`)
+
+    let meta: CliSessionMeta
+    try {
+      const raw = await readFile(jsonPath, 'utf-8')
+      meta = JSON.parse(raw)
+    } catch { continue }
+
+    const filePath = join(cliDir, file)
+    const s = await stat(filePath).catch(() => null)
+    if (!s?.isFile() || s.size === 0) continue
+
+    const project = meta.cwd ? basename(meta.cwd) : 'kiro-cli'
+    sources.push({ path: filePath, project, provider: 'kiro' })
+  }
+
+  return sources
 }
 
 type KiroChatFile = {
@@ -468,9 +688,11 @@ async function discoverSessions(agentDir: string, workspaceStorageDir: string): 
   return sources
 }
 
-export function createKiroProvider(agentDirOverride?: string, workspaceStorageDirOverride?: string): Provider {
+export function createKiroProvider(agentDirOverride?: string, workspaceStorageDirOverride?: string, cliDirOverride?: string): Provider {
   const agentDir = getKiroAgentDir(agentDirOverride)
   const wsDir = getKiroWorkspaceStorageDir(workspaceStorageDirOverride)
+  const cliDir = getKiroCliSessionsDir(cliDirOverride)
+  const mcpServerPromise = loadCliMcpServerName()
 
   return {
     name: 'kiro',
@@ -485,14 +707,22 @@ export function createKiroProvider(agentDirOverride?: string, workspaceStorageDi
     },
 
     toolDisplayName(rawTool: string): string {
+      if (rawTool.startsWith('mcp__')) return rawTool
       return toolNameMap[rawTool] ?? rawTool
     },
 
     async discoverSessions(): Promise<SessionSource[]> {
-      return discoverSessions(agentDir, wsDir)
+      const [ideSessions, cliSessions] = await Promise.all([
+        discoverSessions(agentDir, wsDir),
+        discoverCliSessions(cliDir),
+      ])
+      return [...ideSessions, ...cliSessions]
     },
 
     createSessionParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
+      if (source.path.endsWith('.jsonl')) {
+        return createCliParser(source, seenKeys, mcpServerPromise)
+      }
       return createParser(source, seenKeys)
     },
   }

--- a/tests/providers/kiro.test.ts
+++ b/tests/providers/kiro.test.ts
@@ -499,7 +499,7 @@ describe('kiro provider - discoverSessions', () => {
     await writeFile(join(wsDir, 'session1.chat'), makeChatFile({}))
     await writeFile(join(wsDir, 'session2.chat'), makeChatFile({}))
 
-    const provider = createKiroProvider(tmpDir, '/nonexistent/ws')
+    const provider = createKiroProvider(tmpDir, '/nonexistent/ws', '/nonexistent/cli')
     const sessions = await provider.discoverSessions()
 
     expect(sessions).toHaveLength(2)
@@ -520,7 +520,7 @@ describe('kiro provider - discoverSessions', () => {
     await writeFile(join(sessionDir, '.hidden'), 'ignored')
     await writeFile(join(sessionDir, 'ignored.txt'), 'hello')
 
-    const provider = createKiroProvider(tmpDir, '/nonexistent/ws')
+    const provider = createKiroProvider(tmpDir, '/nonexistent/ws', '/nonexistent/cli')
     const sessions = await provider.discoverSessions()
     const paths = sessions.map(s => s.path).sort()
 
@@ -542,7 +542,7 @@ describe('kiro provider - discoverSessions', () => {
     await mkdir(wsStorageEntry, { recursive: true })
     await writeFile(join(wsStorageEntry, 'workspace.json'), JSON.stringify({ folder: 'file:///home/user/myapp' }))
 
-    const provider = createKiroProvider(tmpDir, workspaceStorageDir)
+    const provider = createKiroProvider(tmpDir, workspaceStorageDir, '/nonexistent/cli')
     const sessions = await provider.discoverSessions()
 
     expect(sessions).toHaveLength(1)
@@ -550,7 +550,7 @@ describe('kiro provider - discoverSessions', () => {
   })
 
   it('returns empty when directory does not exist', async () => {
-    const provider = createKiroProvider('/nonexistent/agent', '/nonexistent/ws')
+    const provider = createKiroProvider('/nonexistent/agent', '/nonexistent/ws', '/nonexistent/cli')
     const sessions = await provider.discoverSessions()
     expect(sessions).toHaveLength(0)
   })
@@ -560,7 +560,7 @@ describe('kiro provider - discoverSessions', () => {
     await mkdir(shortDir, { recursive: true })
     await writeFile(join(shortDir, 'test.chat'), makeChatFile({}))
 
-    const provider = createKiroProvider(tmpDir, '/nonexistent/ws')
+    const provider = createKiroProvider(tmpDir, '/nonexistent/ws', '/nonexistent/cli')
     const sessions = await provider.discoverSessions()
     expect(sessions).toHaveLength(0)
   })
@@ -572,7 +572,7 @@ describe('kiro provider - discoverSessions', () => {
     await writeFile(join(wsDir, 'index.json'), '{}')
     await writeFile(join(wsDir, 'notes.txt'), 'hello')
 
-    const provider = createKiroProvider(tmpDir, '/nonexistent/ws')
+    const provider = createKiroProvider(tmpDir, '/nonexistent/ws', '/nonexistent/cli')
     const sessions = await provider.discoverSessions()
     expect(sessions).toHaveLength(0)
   })
@@ -602,5 +602,160 @@ describe('kiro provider - metadata', () => {
   it('longest-prefix match for versioned model IDs', () => {
     expect(kiro.modelDisplayName('claude-sonnet-4-5-20260101')).toBe('Sonnet 4.5')
     expect(kiro.modelDisplayName('claude-haiku-4-5-20260101')).toBe('Haiku 4.5')
+  })
+})
+
+describe('kiro provider - CLI session parsing', () => {
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'kiro-cli-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  function makeCliSessionMeta(opts: {
+    sessionId?: string
+    cwd?: string
+    createdAt?: string
+    modelId?: string
+  }) {
+    return JSON.stringify({
+      session_id: opts.sessionId ?? 'cli-session-001',
+      cwd: opts.cwd ?? '/home/user/myproject',
+      created_at: opts.createdAt ?? '2026-05-20T14:00:00.000Z',
+      updated_at: '2026-05-20T15:00:00.000Z',
+      title: 'Test session',
+      session_state: {
+        rts_model_state: {
+          model_info: { model_id: opts.modelId ?? 'auto' },
+        },
+      },
+    })
+  }
+
+  function makeCliSessionJsonl(messages: Array<{ kind: string; content?: Array<{ kind: string; data?: unknown }> }>) {
+    return messages.map(m => JSON.stringify({
+      version: 'v1',
+      kind: m.kind,
+      data: { message_id: 'msg-' + Math.random().toString(36).slice(2), content: m.content ?? [] },
+    })).join('\n')
+  }
+
+  it('parses a basic CLI JSONL session', async () => {
+    const sessionId = 'cli-basic-001'
+    await writeFile(join(tmpDir, `${sessionId}.json`), makeCliSessionMeta({ sessionId }))
+    await writeFile(join(tmpDir, `${sessionId}.jsonl`), makeCliSessionJsonl([
+      { kind: 'Prompt', content: [{ kind: 'text', data: 'explain the code' }] },
+      { kind: 'AssistantMessage', content: [{ kind: 'text', data: 'Here is an explanation of the code.' }] },
+    ]))
+
+    const provider = createKiroProvider('/nonexistent/agent', '/nonexistent/ws', tmpDir)
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.project).toBe('myproject')
+
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(sessions[0]!, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.provider).toBe('kiro')
+    expect(calls[0]!.model).toBe('kiro-auto')
+    expect(calls[0]!.userMessage).toBe('explain the code')
+    expect(calls[0]!.outputTokens).toBeGreaterThan(0)
+    expect(calls[0]!.timestamp).toBe('2026-05-20T14:00:00.000Z')
+  })
+
+  it('detects built-in tools', async () => {
+    const sessionId = 'cli-tools-001'
+    await writeFile(join(tmpDir, `${sessionId}.json`), makeCliSessionMeta({ sessionId }))
+    await writeFile(join(tmpDir, `${sessionId}.jsonl`), makeCliSessionJsonl([
+      { kind: 'Prompt', content: [{ kind: 'text', data: 'read the file' }] },
+      { kind: 'AssistantMessage', content: [
+        { kind: 'text', data: 'Reading...' },
+        { kind: 'toolUse', data: { name: 'read', toolUseId: 't1', input: {} } },
+      ] },
+      { kind: 'AssistantMessage', content: [
+        { kind: 'text', data: 'Done.' },
+        { kind: 'toolUse', data: { name: 'shell', toolUseId: 't2', input: {} } },
+      ] },
+    ]))
+
+    const provider = createKiroProvider('/nonexistent/agent', '/nonexistent/ws', tmpDir)
+    const sessions = await provider.discoverSessions()
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(sessions[0]!, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.tools).toContain('Read')
+    expect(calls[0]!.tools).toContain('Bash')
+  })
+
+  it('detects MCP tools with mcp__ prefix', async () => {
+    const sessionId = 'cli-mcp-001'
+    await writeFile(join(tmpDir, `${sessionId}.json`), makeCliSessionMeta({ sessionId }))
+    await writeFile(join(tmpDir, `${sessionId}.jsonl`), makeCliSessionJsonl([
+      { kind: 'Prompt', content: [{ kind: 'text', data: 'search jira' }] },
+      { kind: 'AssistantMessage', content: [
+        { kind: 'text', data: 'Searching...' },
+        { kind: 'toolUse', data: { name: 'searchJiraIssuesUsingJql', toolUseId: 't1', input: {} } },
+      ] },
+    ]))
+
+    const provider = createKiroProvider('/nonexistent/agent', '/nonexistent/ws', tmpDir)
+    const sessions = await provider.discoverSessions()
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(sessions[0]!, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.tools.some(t => t.startsWith('mcp__'))).toBe(true)
+    expect(calls[0]!.tools.some(t => t.includes('searchJiraIssuesUsingJql'))).toBe(true)
+  })
+
+  it('skips empty JSONL files', async () => {
+    const sessionId = 'cli-empty-001'
+    await writeFile(join(tmpDir, `${sessionId}.json`), makeCliSessionMeta({ sessionId }))
+    await writeFile(join(tmpDir, `${sessionId}.jsonl`), '')
+
+    const provider = createKiroProvider('/nonexistent/agent', '/nonexistent/ws', tmpDir)
+    const sessions = await provider.discoverSessions()
+    expect(sessions).toHaveLength(0) // stat.size === 0 is skipped
+  })
+
+  it('deduplicates CLI sessions', async () => {
+    const sessionId = 'cli-dedup-001'
+    await writeFile(join(tmpDir, `${sessionId}.json`), makeCliSessionMeta({ sessionId }))
+    await writeFile(join(tmpDir, `${sessionId}.jsonl`), makeCliSessionJsonl([
+      { kind: 'Prompt', content: [{ kind: 'text', data: 'hello' }] },
+      { kind: 'AssistantMessage', content: [{ kind: 'text', data: 'hi there' }] },
+    ]))
+
+    const provider = createKiroProvider('/nonexistent/agent', '/nonexistent/ws', tmpDir)
+    const sessions = await provider.discoverSessions()
+    const seenKeys = new Set<string>()
+
+    const calls1: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(sessions[0]!, seenKeys).parse()) calls1.push(call)
+    const calls2: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(sessions[0]!, seenKeys).parse()) calls2.push(call)
+
+    expect(calls1).toHaveLength(1)
+    expect(calls2).toHaveLength(0)
+  })
+
+  it('uses cwd basename as project name', async () => {
+    const sessionId = 'cli-project-001'
+    await writeFile(join(tmpDir, `${sessionId}.json`), makeCliSessionMeta({
+      sessionId,
+      cwd: '/home/user/workspace/my-cool-app',
+    }))
+    await writeFile(join(tmpDir, `${sessionId}.jsonl`), makeCliSessionJsonl([
+      { kind: 'Prompt', content: [{ kind: 'text', data: 'test' }] },
+      { kind: 'AssistantMessage', content: [{ kind: 'text', data: 'ok' }] },
+    ]))
+
+    const provider = createKiroProvider('/nonexistent/agent', '/nonexistent/ws', tmpDir)
+    const sessions = await provider.discoverSessions()
+    expect(sessions[0]!.project).toBe('my-cool-app')
   })
 })


### PR DESCRIPTION
## Summary

Extends the existing Kiro provider to read sessions from **Kiro CLI** (`~/.kiro/sessions/cli/`), in addition to the existing Kiro IDE support.

## Changes

- **Discovery:** scans `~/.kiro/sessions/cli/*.jsonl` for CLI sessions
- **Parser:** new JSONL parser for the CLI format (`Prompt`, `AssistantMessage`, `ToolResults` entries)
- **MCP detection:** tools not in the built-in set are prefixed as `mcp__<server>__<tool>` (server name read from `~/.kiro/settings/mcp.json`)
- **Project resolution:** uses `cwd` from session metadata
- **Tests:** 6 new tests covering CLI parsing, tool detection, MCP, dedup, and project naming
- **Docs:** updated `docs/providers/kiro.md`

## How Kiro CLI stores data

```
~/.kiro/sessions/cli/
├── <session-id>.json   # metadata (session_id, cwd, timestamps, model)
└── <session-id>.jsonl  # conversation (line-delimited Prompt/AssistantMessage/ToolResults)
```

## Testing

```bash
npx vitest run tests/providers/kiro.test.ts  # 38 tests pass (32 existing + 6 new)
npx tsc --noEmit                              # clean
```