### PR TITLE
Add CNY currency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Subscription tracking for Claude Pro, Claude Max, Cursor Pro, and custom provide
 codeburn currency GBP          # set to British Pounds
 codeburn currency AUD          # set to Australian Dollars
 codeburn currency JPY          # set to Japanese Yen
+codeburn currency CNY          # set to Chinese Yuan
 codeburn currency              # show current setting
 codeburn currency --reset      # back to USD
 ```

--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -991,7 +991,7 @@ final class AppStore {
 }
 
 enum SupportedCurrency: String, CaseIterable, Identifiable {
-    case USD, GBP, EUR, AUD, CAD, NZD, JPY, CHF, INR, BRL, SEK, SGD, HKD, KRW, MXN, ZAR, DKK
+    case USD, GBP, EUR, AUD, CAD, NZD, JPY, CNY, CHF, INR, BRL, SEK, SGD, HKD, KRW, MXN, ZAR, DKK
     var id: String { rawValue }
     var displayName: String {
         switch self {
@@ -1002,6 +1002,7 @@ enum SupportedCurrency: String, CaseIterable, Identifiable {
         case .CAD: "Canadian Dollar"
         case .NZD: "New Zealand Dollar"
         case .JPY: "Japanese Yen"
+        case .CNY: "Chinese Yuan"
         case .CHF: "Swiss Franc"
         case .INR: "Indian Rupee"
         case .BRL: "Brazilian Real"

--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -36,7 +36,7 @@ private struct GeneralSettingsTab: View {
                     get: { store.currency },
                     set: { applyCurrency(code: $0) }
                 )) {
-                    ForEach(["USD", "EUR", "GBP", "INR", "JPY", "AUD", "CAD"], id: \.self) { code in
+                    ForEach(["USD", "EUR", "GBP", "INR", "JPY", "CNY", "AUD", "CAD"], id: \.self) { code in
                         Text(code).tag(code)
                     }
                 }

--- a/src/currency.ts
+++ b/src/currency.ts
@@ -27,6 +27,9 @@ function isValidRate(value: unknown): value is number {
 let active: CurrencyState = { code: 'USD', rate: 1, symbol: '$' }
 
 const USD: CurrencyState = { code: 'USD', rate: 1, symbol: '$' }
+const SYMBOL_OVERRIDES: Record<string, string> = {
+  CNY: '¥',
+}
 
 // Intl.NumberFormat throws on invalid ISO 4217 codes, so we use it as a validator
 export function isValidCurrencyCode(code: string): boolean {
@@ -39,6 +42,8 @@ export function isValidCurrencyCode(code: string): boolean {
 }
 
 function resolveSymbol(code: string): string {
+  if (SYMBOL_OVERRIDES[code]) return SYMBOL_OVERRIDES[code]
+
   const parts = new Intl.NumberFormat('en', {
     style: 'currency',
     currency: code,

--- a/tests/currency-rounding.test.ts
+++ b/tests/currency-rounding.test.ts
@@ -100,5 +100,6 @@ describe('getFractionDigits', () => {
     expect(getFractionDigits('EUR')).toBe(2)
     expect(getFractionDigits('GBP')).toBe(2)
     expect(getFractionDigits('INR')).toBe(2)
+    expect(getFractionDigits('CNY')).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary
- add CNY to the macOS menubar currency picker and settings picker
- normalize CNY display to ¥ in the CLI currency formatter
- document `codeburn currency CNY` and cover CNY fraction digits in tests

## Related issue
- Supports part of #422 by adding Chinese Yuan / CNY currency support for Chinese users. This does not attempt full Chinese localization.

## Tests
- `npm test -- currency-rounding`
- `npm run build`
- `cd mac && swift test`