### PR TITLE
fix(menubar): use SupportedCurrency enum in settings picker

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -36,8 +36,8 @@ private struct GeneralSettingsTab: View {
                     get: { store.currency },
                     set: { applyCurrency(code: $0) }
                 )) {
-                    ForEach(["USD", "EUR", "GBP", "INR", "JPY", "CNY", "AUD", "CAD"], id: \.self) { code in
-                        Text(code).tag(code)
+                    ForEach(SupportedCurrency.allCases) { currency in
+                        Text("\(currency.rawValue) — \(currency.displayName)").tag(currency.rawValue)
                     }
                 }
                 Picker("Metric", selection: Binding(


### PR DESCRIPTION
## Summary
- Replace hardcoded 8-currency array in SettingsView picker with `SupportedCurrency.allCases`
- All 18 currencies now appear automatically; future enum additions need no separate SettingsView edit
- Picker labels now show `"USD — US Dollar"` style for clarity

## Context
Follow-up to #430 (CNY support). The picker was a hardcoded subset that drifted out of sync with the `SupportedCurrency` enum — a pre-existing issue surfaced during review.

## Test plan
- [x] `swift build` passes
- [x] Verified `SupportedCurrency` conforms to `CaseIterable` + `Identifiable`