### PR TITLE
feat(menubar): configure CLAUDE_CONFIG_DIRS via Settings

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Data/CLIClaudeConfig.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CLIClaudeConfig.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Reads and writes the CLI's `claudeConfigDirs` list in
+/// `~/.config/codeburn/config.json`. The menubar is a GUI app that doesn't
+/// inherit the user's shell environment, so it can't rely on `CLAUDE_CONFIG_DIRS`
+/// to aggregate usage across multiple Claude config directories (work / personal
+/// accounts). Persisting to the shared config file instead means every `codeburn`
+/// invocation honors the list — whether the menubar spawns it directly or the
+/// user launches `codeburn report` in a terminal — without injecting environment
+/// variables through the shell/AppleScript paths (which only accept a strict
+/// metacharacter-free allowlist that arbitrary directory paths can't satisfy).
+///
+/// Shares the same on-disk flock as `CLICurrencyConfig` so a concurrent
+/// `codeburn` write from a terminal can't race the menubar and drop the other's
+/// changes (TOCTOU on config.json).
+enum CLIClaudeConfig {
+    private static var configDir: String {
+        (NSHomeDirectory() as NSString).appendingPathComponent(".config/codeburn")
+    }
+    private static var configPath: String {
+        (configDir as NSString).appendingPathComponent("config.json")
+    }
+    private static var lockPath: String {
+        (configDir as NSString).appendingPathComponent(".config.lock")
+    }
+
+    /// Returns the persisted config directories, or an empty array when none are
+    /// set (the CLI then falls back to `~/.claude`).
+    static func load() -> [String] {
+        guard
+            let data = try? SafeFile.read(from: configPath),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let dirs = json["claudeConfigDirs"] as? [Any]
+        else {
+            return []
+        }
+        return dirs.compactMap { $0 as? String }.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+    }
+
+    /// Persists the given directories. An empty list removes the key entirely so
+    /// the CLI reverts to its default `~/.claude` behavior. Entries are trimmed
+    /// and blanks dropped; order is preserved.
+    static func persist(dirs: [String]) {
+        let cleaned = dirs
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        do {
+            try SafeFile.withExclusiveLock(at: lockPath) {
+                var existing: [String: Any] = [:]
+                if let data = try? SafeFile.read(from: configPath),
+                   let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                    existing = parsed
+                }
+
+                if cleaned.isEmpty {
+                    existing.removeValue(forKey: "claudeConfigDirs")
+                } else {
+                    existing["claudeConfigDirs"] = cleaned
+                }
+
+                guard let data = try? JSONSerialization.data(
+                    withJSONObject: existing,
+                    options: [.prettyPrinted, .sortedKeys]
+                ) else {
+                    return
+                }
+                try SafeFile.write(data, to: configPath, mode: 0o600)
+            }
+        } catch {
+            NSLog("CodeBurn: failed to persist claudeConfigDirs config: \(error)")
+        }
+    }
+}

--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// macOS-standard tabbed Settings window. New per-provider sections (Codex,
@@ -114,6 +115,15 @@ private struct ClaudeSettingsTab: View {
         Form {
             Section("Connection") {
                 ClaudeConnectionRow()
+            }
+            Section {
+                ClaudeConfigDirsSection()
+            } header: {
+                Text("Config Directories")
+            } footer: {
+                Text("Aggregate usage across multiple Claude config directories (e.g. work and personal accounts). Leave empty to track just the default `~/.claude`. The `CLAUDE_CONFIG_DIRS` environment variable, if set, overrides this list.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
             }
             Section("Quota Refresh") {
                 Picker("Update every", selection: Binding(
@@ -240,6 +250,85 @@ private struct ClaudeConnectionRow: View {
         case .bootstrapping:
             ProgressView().controlSize(.small)
         }
+    }
+}
+
+// MARK: - Claude config directories
+
+private struct ClaudeConfigDirsSection: View {
+    @Environment(AppStore.self) private var store
+    @State private var dirs: [String] = CLIClaudeConfig.load()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if dirs.isEmpty {
+                Text("No extra directories — tracking the default `~/.claude`.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(Array(dirs.enumerated()), id: \.offset) { index, dir in
+                    HStack(spacing: 8) {
+                        Image(systemName: "folder")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                        Text(dir)
+                            .font(.system(size: 12))
+                            .truncationMode(.middle)
+                            .lineLimit(1)
+                            .help(dir)
+                        Spacer()
+                        Button {
+                            remove(at: index)
+                        } label: {
+                            Image(systemName: "minus.circle.fill")
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Remove")
+                    }
+                }
+            }
+
+            Button {
+                addDirectory()
+            } label: {
+                Label("Add Directory…", systemImage: "plus")
+            }
+            .controlSize(.small)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func addDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = true
+        panel.prompt = "Add"
+        panel.message = "Choose one or more Claude config directories (each containing a `projects` folder)."
+        guard panel.runModal() == .OK else { return }
+
+        let added = panel.urls.map { $0.path }
+        var next = dirs
+        for path in added where !next.contains(path) {
+            next.append(path)
+        }
+        apply(next)
+    }
+
+    private func remove(at index: Int) {
+        guard dirs.indices.contains(index) else { return }
+        var next = dirs
+        next.remove(at: index)
+        apply(next)
+    }
+
+    /// Persists the new list and kicks a forced refresh so the dashboard
+    /// reflects the changed aggregation immediately.
+    private func apply(_ next: [String]) {
+        dirs = next
+        CLIClaudeConfig.persist(dirs: next)
+        Task { await store.refresh(includeOptimize: false, force: true, showLoading: true) }
     }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,12 @@ export type CodeburnConfig = {
   plan?: Plan
   plans?: PlanConfigMap
   modelAliases?: Record<string, string>
+  // Extra Claude config directories to aggregate usage across (e.g. work /
+  // personal accounts). Honored by getClaudeConfigDirs() below the
+  // CLAUDE_CONFIG_DIRS/CLAUDE_CONFIG_DIR env vars. Lets the macOS menubar — a
+  // GUI app that doesn't inherit the user's shell env — configure multi-account
+  // aggregation without injecting env into every spawned subprocess.
+  claudeConfigDirs?: string[]
 }
 
 function getConfigDir(): string {

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -4,6 +4,7 @@ import { homedir } from 'os'
 
 import type { Provider, SessionSource, SessionParser } from './types.js'
 import { getShortModelName } from '../models.js'
+import { readConfig } from '../config.js'
 
 function expandHome(p: string): string {
   if (p === '~') return homedir()
@@ -11,14 +12,28 @@ function expandHome(p: string): string {
   return p
 }
 
+function dedupeResolved(paths: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const p of paths) {
+    if (!seen.has(p)) {
+      seen.add(p)
+      out.push(p)
+    }
+  }
+  return out
+}
+
 /// Returns every Claude config dir to scan, in priority order with duplicates
 /// removed (resolved-path equality). Precedence: `CLAUDE_CONFIG_DIRS` (a
 /// `path.delimiter`-separated list, ":" on POSIX, ";" on Windows), then
-/// `CLAUDE_CONFIG_DIR` (single dir), then `~/.claude`. Sessions from every
-/// returned dir are merged into one ProjectSummary per project name in
-/// `src/parser.ts:scanProjectDirs`, so two dirs holding the same sanitized
-/// project slug naturally aggregate (issue #208 option 1).
-function getClaudeConfigDirs(): string[] {
+/// `CLAUDE_CONFIG_DIR` (single dir), then the `claudeConfigDirs` array in
+/// `~/.config/codeburn/config.json` (how the macOS menubar configures
+/// multi-account aggregation, since a GUI app can't inherit the shell env),
+/// then `~/.claude`. Sessions from every returned dir are merged into one
+/// ProjectSummary per project name in `src/parser.ts:scanProjectDirs`, so two
+/// dirs holding the same sanitized project slug naturally aggregate (#208).
+async function getClaudeConfigDirs(): Promise<string[]> {
   const multi = process.env['CLAUDE_CONFIG_DIRS']
   if (multi !== undefined && multi !== '') {
     const dirs = multi
@@ -26,20 +41,22 @@ function getClaudeConfigDirs(): string[] {
       .map(s => s.trim())
       .filter(s => s.length > 0)
       .map(s => resolve(expandHome(s)))
-    if (dirs.length > 0) {
-      const seen = new Set<string>()
-      const out: string[] = []
-      for (const d of dirs) {
-        if (!seen.has(d)) {
-          seen.add(d)
-          out.push(d)
-        }
-      }
-      return out
-    }
+    if (dirs.length > 0) return dedupeResolved(dirs)
   }
   const single = process.env['CLAUDE_CONFIG_DIR']
   if (single !== undefined && single !== '') return [resolve(expandHome(single))]
+
+  // Config-file fallback (menubar-driven). Env vars always win so a power user
+  // can still override per-shell. A non-array or empty value falls through to
+  // the ~/.claude default, matching the "unset" behavior.
+  const config = await readConfig()
+  if (Array.isArray(config.claudeConfigDirs)) {
+    const dirs = config.claudeConfigDirs
+      .filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+      .map(s => resolve(expandHome(s.trim())))
+    if (dirs.length > 0) return dedupeResolved(dirs)
+  }
+
   return [join(homedir(), '.claude')]
 }
 
@@ -157,7 +174,7 @@ export const claude: Provider = {
   async discoverSessions(): Promise<SessionSource[]> {
     const sources: SessionSource[] = []
     const seenProjectDirs = new Set<string>()
-    const configDirs = getClaudeConfigDirs()
+    const configDirs = await getClaudeConfigDirs()
     let anyDirReadable = false
 
     for (const claudeDir of configDirs) {

--- a/tests/providers/claude-config-dirs.test.ts
+++ b/tests/providers/claude-config-dirs.test.ts
@@ -197,6 +197,82 @@ describe('claude provider — CLAUDE_CONFIG_DIRS discovery', () => {
   })
 })
 
+describe('claude provider — config.json claudeConfigDirs (menubar-driven)', () => {
+  async function writeConfigJson(value: unknown): Promise<void> {
+    const dir = join(process.env['HOME']!, '.config', 'codeburn')
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, 'config.json'), JSON.stringify({ claudeConfigDirs: value }))
+  }
+
+  it('honors claudeConfigDirs from config.json when no env var is set', async () => {
+    const work = await makeConfigDir('claude-work', ['-Users-you-app'])
+    const personal = await makeConfigDir('claude-personal', ['-Users-you-app'])
+    await writeConfigJson([work, personal])
+
+    const sources = await claude.discoverSessions()
+    const paths = sources.map(s => s.path)
+    expect(paths).toContain(join(work, 'projects', '-Users-you-app'))
+    expect(paths).toContain(join(personal, 'projects', '-Users-you-app'))
+  })
+
+  it('lets env CLAUDE_CONFIG_DIRS override config.json', async () => {
+    const fromEnv = await makeConfigDir('claude-env', ['-Users-you-app'])
+    const fromFile = await makeConfigDir('claude-file', ['-Users-you-app'])
+    await writeConfigJson([fromFile])
+    process.env['CLAUDE_CONFIG_DIRS'] = fromEnv
+
+    const sources = await claude.discoverSessions()
+    expect(sources.some(s => s.path === join(fromEnv, 'projects', '-Users-you-app'))).toBe(true)
+    expect(sources.every(s => !s.path.startsWith(fromFile))).toBe(true)
+  })
+
+  it('lets env CLAUDE_CONFIG_DIR override config.json', async () => {
+    const fromEnv = await makeConfigDir('claude-env', ['-Users-you-app'])
+    const fromFile = await makeConfigDir('claude-file', ['-Users-you-app'])
+    await writeConfigJson([fromFile])
+    process.env['CLAUDE_CONFIG_DIR'] = fromEnv
+
+    const sources = await claude.discoverSessions()
+    expect(sources.some(s => s.path === join(fromEnv, 'projects', '-Users-you-app'))).toBe(true)
+    expect(sources.every(s => !s.path.startsWith(fromFile))).toBe(true)
+  })
+
+  it('falls back to ~/.claude when config.json claudeConfigDirs is empty', async () => {
+    const homeDir = process.env['HOME']!
+    await mkdir(join(homeDir, '.claude', 'projects', '-Users-you-app'), { recursive: true })
+    await writeConfigJson([])
+
+    const sources = await claude.discoverSessions()
+    expect(sources.some(s => s.path === join(homeDir, '.claude', 'projects', '-Users-you-app'))).toBe(true)
+  })
+
+  it('expands ~ in config.json entries', async () => {
+    const homeDir = process.env['HOME']!
+    await mkdir(join(homeDir, 'cfg-claude', 'projects', '-Users-you-app'), { recursive: true })
+    await writeConfigJson(['~/cfg-claude'])
+
+    const sources = await claude.discoverSessions()
+    expect(sources.some(s => s.path === join(homeDir, 'cfg-claude', 'projects', '-Users-you-app'))).toBe(true)
+  })
+
+  it('ignores non-string and blank entries in config.json', async () => {
+    const real = await makeConfigDir('claude-real', ['-Users-you-app'])
+    await writeConfigJson([real, 42, '', '   ', null])
+
+    const sources = await claude.discoverSessions()
+    expect(sources.some(s => s.path === join(real, 'projects', '-Users-you-app'))).toBe(true)
+  })
+
+  it('falls back to ~/.claude when claudeConfigDirs is not an array', async () => {
+    const homeDir = process.env['HOME']!
+    await mkdir(join(homeDir, '.claude', 'projects', '-Users-you-app'), { recursive: true })
+    await writeConfigJson('not-an-array')
+
+    const sources = await claude.discoverSessions()
+    expect(sources.some(s => s.path === join(homeDir, '.claude', 'projects', '-Users-you-app'))).toBe(true)
+  })
+})
+
 describe('claude parser — multi-dir aggregation (issue #208 option 1)', () => {
   it('merges sessions from two config dirs into a single ProjectSummary when the canonical cwd matches', async () => {
     const work = await makeConfigDir('claude-work', [])


### PR DESCRIPTION
Closes #434.

## Summary

Adds a **Config Directories** section under the Claude tab in the macOS menubar Settings, so users can aggregate usage across multiple Claude config directories (e.g. work / personal accounts) from the GUI. The menubar is an accessory app that doesn't inherit the user's shell environment, so `CLAUDE_CONFIG_DIRS` was previously unreachable from the app.

## Approach: config file, not env injection

The original proposal in #434 was to inject `CLAUDE_CONFIG_DIRS` as an env var into every spawned subprocess, including the Terminal-launched `report`/`optimize` path. That path (`TerminalLauncher` → AppleScript `do script`) relies on a strict allowlist that excludes shell metacharacters — and arbitrary directory paths (`/Users/me/My $tuff/.claude`) can't satisfy it. Escaping arbitrary paths through AppleScript + shell is exactly the injection surface that code was written to close.

Instead, the list is persisted to the shared `~/.config/codeburn/config.json` (the same file the currency setting uses). The CLI reads it regardless of how it's launched, so **both** the menubar's data refresh **and** terminal-launched commands honor it consistently — with zero env injection into the shell/AppleScript paths.

## Changes

**CLI**
- `getClaudeConfigDirs()` now reads a `claudeConfigDirs` array from config.json as a fallback tier. Precedence: `CLAUDE_CONFIG_DIRS` env → `CLAUDE_CONFIG_DIR` env → **config.json** → `~/.claude`. Env still wins for per-shell overrides.
- `claudeConfigDirs?: string[]` added to the `CodeburnConfig` type.

**Menubar**
- `CLIClaudeConfig` mirrors `CLICurrencyConfig`'s flock-guarded write (shares the same lock, so a concurrent terminal `codeburn` write can't race the menubar).
- Settings UI: add/remove list with a native folder picker; forces a refresh on edit.

## Relationship to #251

This is intentionally the minimal "merge totals across dirs" approach (#208 option 1), preserving existing merge behavior. It does **not** add per-account attribution — that's #251's larger track. The config.json field is a clean seam #251's richer account model can build on; the #434 author explicitly designed this to be compatible with both.

## Testing

- 7 new tests in `tests/providers/claude-config-dirs.test.ts` (config.json precedence, `~` expansion, empty/non-array/non-string handling).
- Full suite: **1024 CLI tests + 31 Swift tests pass**. `tsc --noEmit` clean, both builds clean.