### PR TITLE
Add contribution heatmap insight

### DIFF
--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -1108,8 +1108,8 @@ enum DisplayMetric: String {
 enum InsightMode: String, CaseIterable, Identifiable {
     case plan = "Plan"
     case trend = "Trend"
-    case calendar = "Calendar"
     case forecast = "Forecast"
+    case calendar = "Calendar"
     case pulse = "Pulse"
     case stats = "Stats"
     case optimize = "Optimize"

--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -1108,6 +1108,7 @@ enum DisplayMetric: String {
 enum InsightMode: String, CaseIterable, Identifiable {
     case plan = "Plan"
     case trend = "Trend"
+    case calendar = "Calendar"
     case forecast = "Forecast"
     case pulse = "Pulse"
     case stats = "Stats"

--- a/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
@@ -538,7 +538,7 @@ private struct ContributionHeatmapInsight: View {
 
     private let cellSize: CGFloat = 8
     private let cellGap: CGFloat = 3
-    private let weekdayLabelWidth: CGFloat = 18
+    private let weekdayLabelWidth: CGFloat = 26
     @State private var hoveredDayID: ContributionDay.ID?
 
     var body: some View {
@@ -605,7 +605,7 @@ private struct ContributionHeatmapInsight: View {
                 }
             }
         }
-        .frame(height: 198)
+        .frame(height: 216)
     }
 
     private func adaptiveWeekCount(for width: CGFloat) -> Int {
@@ -619,6 +619,7 @@ private struct ContributionHeatmapInsight: View {
         case 0: return "Mon"
         case 2: return "Wed"
         case 4: return "Fri"
+        case 6: return "Sun"
         default: return ""
         }
     }
@@ -694,14 +695,15 @@ private struct ContributionDayDetail: View {
     }
 
     private var title: String {
-        guard let day else { return "Hover a day" }
+        // The header already shows the period total and active-day count, so
+        // the resting state is a short hover hint — not a duplicate of those
+        // (and not the full sentence that previously overflowed and truncated).
+        guard let day else { return "Daily detail" }
         return prettyDate(day.date)
     }
 
     private var value: String {
-        guard let day else {
-            return "\(fallbackStats.activeDays) active days, \(fallbackStats.total.asCompactCurrency()) total"
-        }
+        guard let day else { return "Hover a day" }
         if day.isFuture { return "Future day" }
         if day.cost <= 0 && day.calls == 0 { return "No tracked usage" }
         return day.cost.asCompactCurrency()

--- a/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
@@ -9,6 +9,7 @@ private let trendChartHeight: CGFloat = 90
 private let yyyymmdd: DateFormatter = {
     let f = DateFormatter()
     f.dateFormat = "yyyy-MM-dd"
+    f.locale = Locale(identifier: "en_US_POSIX")
     f.timeZone = .current
     return f
 }()
@@ -16,12 +17,14 @@ private let yyyymmdd: DateFormatter = {
 private let prettyDayFormat: DateFormatter = {
     let f = DateFormatter()
     f.dateFormat = "EEE MMM d"
+    f.locale = Locale(identifier: "en_US_POSIX")
     return f
 }()
 
 private let mmmDayFormat: DateFormatter = {
     let f = DateFormatter()
     f.dateFormat = "MMM d"
+    f.locale = Locale(identifier: "en_US_POSIX")
     f.timeZone = .current
     return f
 }()
@@ -32,8 +35,8 @@ private let gregorianCalendar: Calendar = {
     return c
 }()
 
-/// Three switchable insight visualizations: Calendar (this month), Forecast (burn rate),
-/// Pulse (efficiency KPIs). Pills at top toggle between them.
+/// Switchable insight visualizations: trend, calendar, forecast, pulse, stats,
+/// optimize, plus provider-specific plan views.
 struct HeatmapSection: View {
     @Environment(AppStore.self) private var store
 
@@ -80,6 +83,7 @@ struct HeatmapSection: View {
                 PlanInsight(usage: store.subscription)
             }
         case .trend: TrendInsight(days: store.payload.history.daily, period: store.trendPeriod)
+        case .calendar: ContributionHeatmapInsight(days: store.payload.history.daily)
         case .forecast: ForecastInsight(days: store.payload.history.daily)
         case .pulse: PulseInsight(payload: store.payload)
         case .stats: StatsInsight(payload: store.payload)
@@ -525,6 +529,354 @@ private func computeTrendStats(bars: [TrendBar], allDays: [DailyHistoryEntry], d
         deltaPercent: deltaPercent,
         yesterdayBar: yesterdayBar
     )
+}
+
+// MARK: - Calendar
+
+private struct ContributionHeatmapInsight: View {
+    let days: [DailyHistoryEntry]
+
+    private let cellSize: CGFloat = 8
+    private let cellGap: CGFloat = 3
+    private let weekdayLabelWidth: CGFloat = 18
+    @State private var hoveredDayID: ContributionDay.ID?
+
+    var body: some View {
+        GeometryReader { geo in
+            let weekCount = adaptiveWeekCount(for: geo.size.width)
+            let weeks = buildContributionWeeks(from: days, weekCount: weekCount)
+            let stats = computeContributionStats(weeks: weeks)
+            let hoveredDay = weeks.flatMap(\.days).first { $0.id == hoveredDayID }
+
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .firstTextBaseline) {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Daily activity")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(.tertiary)
+                        Text(stats.total.asCurrency())
+                            .font(.system(size: 18, weight: .semibold, design: .rounded))
+                            .monospacedDigit()
+                            .foregroundStyle(.primary)
+                    }
+                    Spacer()
+                    Text("\(stats.activeDays) active days")
+                        .font(.system(size: 10.5, weight: .medium))
+                        .monospacedDigit()
+                        .foregroundStyle(Theme.brandAccent)
+                }
+
+                HStack(alignment: .top, spacing: 6) {
+                    VStack(alignment: .trailing, spacing: cellGap) {
+                        ForEach(0..<7, id: \.self) { idx in
+                            Text(weekdayLabel(for: idx))
+                                .font(.system(size: 8.5, weight: .medium))
+                                .foregroundStyle(.tertiary)
+                                .frame(width: weekdayLabelWidth, height: cellSize, alignment: .trailing)
+                        }
+                    }
+
+                    HStack(alignment: .top, spacing: cellGap) {
+                        ForEach(weeks) { week in
+                            VStack(spacing: cellGap) {
+                                ForEach(week.days) { day in
+                                    ContributionCell(
+                                        day: day,
+                                        size: cellSize,
+                                        isHovered: hoveredDayID == day.id
+                                    )
+                                    .onHover { hovering in
+                                        hoveredDayID = hovering ? day.id : (hoveredDayID == day.id ? nil : hoveredDayID)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+
+                ContributionDayDetail(day: hoveredDay, fallbackStats: stats)
+                    .animation(.easeInOut(duration: 0.12), value: hoveredDayID)
+
+                HStack(spacing: 14) {
+                    MiniStat(label: "Peak day", value: stats.peakLabel)
+                    MiniStat(label: "Avg active", value: stats.avgActive.asCompactCurrency())
+                    MiniStat(label: "Streak", value: "\(stats.currentStreak)d")
+                }
+            }
+        }
+        .frame(height: 198)
+    }
+
+    private func adaptiveWeekCount(for width: CGFloat) -> Int {
+        let available = max(0, width - weekdayLabelWidth - 10)
+        let raw = Int(floor((available + cellGap) / (cellSize + cellGap)))
+        return min(max(raw, 1), 52)
+    }
+
+    private func weekdayLabel(for index: Int) -> String {
+        switch index {
+        case 0: return "Mon"
+        case 2: return "Wed"
+        case 4: return "Fri"
+        default: return ""
+        }
+    }
+}
+
+private struct ContributionCell: View {
+    let day: ContributionDay
+    let size: CGFloat
+    let isHovered: Bool
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 2)
+            .fill(fillColor)
+            .frame(width: size, height: size)
+            .overlay(
+                RoundedRectangle(cornerRadius: 2)
+                    .stroke(strokeColor, lineWidth: isHovered || day.isToday ? 1 : 0)
+            )
+            .scaleEffect(isHovered ? 1.35 : 1.0)
+            .animation(.easeOut(duration: 0.10), value: isHovered)
+            .help(day.helpText)
+            .accessibilityLabel(day.helpText)
+    }
+
+    private var strokeColor: Color {
+        if isHovered { return Theme.brandAccent.opacity(0.95) }
+        if day.isToday { return Theme.brandAccent.opacity(0.95) }
+        return Color.clear
+    }
+
+    private var fillColor: Color {
+        if day.isFuture { return Color.secondary.opacity(0.06) }
+        if isHovered { return Theme.brandAccent.opacity(0.95) }
+        switch day.level {
+        case 0: return Color.secondary.opacity(0.14)
+        case 1: return Theme.brandAccent.opacity(0.30)
+        case 2: return Theme.brandAccent.opacity(0.48)
+        case 3: return Theme.brandAccent.opacity(0.66)
+        default: return Theme.brandAccent.opacity(0.88)
+        }
+    }
+}
+
+private struct ContributionDayDetail: View {
+    let day: ContributionDay?
+    let fallbackStats: ContributionStats
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.tertiary)
+                Text(value)
+                    .font(.system(size: 13, weight: .semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+
+            DetailMetric(label: "Calls", value: calls)
+            DetailMetric(label: "Tokens", value: tokens)
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 7)
+        .frame(maxWidth: .infinity, minHeight: 42, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color(nsColor: .separatorColor).opacity(0.25))
+        )
+    }
+
+    private var title: String {
+        guard let day else { return "Hover a day" }
+        return prettyDate(day.date)
+    }
+
+    private var value: String {
+        guard let day else {
+            return "\(fallbackStats.activeDays) active days, \(fallbackStats.total.asCompactCurrency()) total"
+        }
+        if day.isFuture { return "Future day" }
+        if day.cost <= 0 && day.calls == 0 { return "No tracked usage" }
+        return day.cost.asCompactCurrency()
+    }
+
+    private var calls: String {
+        guard let day, !day.isFuture else { return "—" }
+        return "\(day.calls)"
+    }
+
+    private var tokens: String {
+        guard let day, !day.isFuture else { return "—" }
+        return formatTokensForContribution(day.totalTokens)
+    }
+}
+
+private struct DetailMetric: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            Text(label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.tertiary)
+            Text(value)
+                .font(.codeMono(size: 11, weight: .semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+        }
+        .frame(minWidth: 42, alignment: .trailing)
+    }
+}
+
+struct ContributionWeek: Identifiable, Equatable {
+    let startDate: String
+    let days: [ContributionDay]
+
+    var id: String { startDate }
+}
+
+struct ContributionDay: Identifiable, Equatable {
+    let date: String
+    let cost: Double
+    let calls: Int
+    let inputTokens: Int
+    let outputTokens: Int
+    let level: Int
+    let isToday: Bool
+    let isFuture: Bool
+
+    var id: String { date }
+    var totalTokens: Int { inputTokens + outputTokens }
+
+    @MainActor var helpText: String {
+        if isFuture { return "\(prettyDate(date)): future day" }
+        if cost <= 0 && calls == 0 { return "\(prettyDate(date)): no tracked usage" }
+        return "\(prettyDate(date)): \(cost.asCompactCurrency()), \(calls) calls, \(formatTokensForContribution(totalTokens)) tokens"
+    }
+}
+
+struct ContributionStats: Equatable {
+    let total: Double
+    let activeDays: Int
+    let avgActive: Double
+    let peakLabel: String
+    let currentStreak: Int
+}
+
+func contributionLevel(value: Double, maxValue: Double) -> Int {
+    guard value > 0, maxValue > 0 else { return 0 }
+    let ratio = min(max(value / maxValue, 0), 1)
+    if ratio < 0.25 { return 1 }
+    if ratio < 0.50 { return 2 }
+    if ratio < 0.75 { return 3 }
+    return 4
+}
+
+func buildContributionWeeks(
+    from days: [DailyHistoryEntry],
+    weekCount: Int,
+    now: Date = Date(),
+    calendar: Calendar = gregorianCalendar,
+    formatter: DateFormatter = yyyymmdd
+) -> [ContributionWeek] {
+    let today = calendar.startOfDay(for: now)
+    let todayKey = formatter.string(from: today)
+    let visibleWeekCount = min(max(weekCount, 1), 52)
+    let entryByDate = Dictionary(days.map { ($0.date, $0) }, uniquingKeysWith: { _, new in new })
+    guard
+        let thisWeekStart = startOfContributionWeek(containing: today, calendar: calendar),
+        let firstWeekStart = calendar.date(byAdding: .weekOfYear, value: -(visibleWeekCount - 1), to: thisWeekStart)
+    else {
+        return []
+    }
+
+    var visibleKeys: [String] = []
+    for offset in 0..<(visibleWeekCount * 7) {
+        guard let date = calendar.date(byAdding: .day, value: offset, to: firstWeekStart) else { continue }
+        if date <= today { visibleKeys.append(formatter.string(from: date)) }
+    }
+    let maxCost = visibleKeys.compactMap { entryByDate[$0]?.cost }.max() ?? 0
+
+    var weeks: [ContributionWeek] = []
+    for weekOffset in 0..<visibleWeekCount {
+        guard let weekStart = calendar.date(byAdding: .weekOfYear, value: weekOffset, to: firstWeekStart) else { continue }
+        let weekStartKey = formatter.string(from: weekStart)
+        var contributionDays: [ContributionDay] = []
+
+        for dayOffset in 0..<7 {
+            guard let date = calendar.date(byAdding: .day, value: dayOffset, to: weekStart) else { continue }
+            let key = formatter.string(from: date)
+            let entry = entryByDate[key]
+            let isFuture = date > today
+            let cost = isFuture ? 0 : (entry?.cost ?? 0)
+            contributionDays.append(ContributionDay(
+                date: key,
+                cost: cost,
+                calls: isFuture ? 0 : (entry?.calls ?? 0),
+                inputTokens: isFuture ? 0 : (entry?.inputTokens ?? 0),
+                outputTokens: isFuture ? 0 : (entry?.outputTokens ?? 0),
+                level: isFuture ? 0 : contributionLevel(value: cost, maxValue: maxCost),
+                isToday: key == todayKey,
+                isFuture: isFuture
+            ))
+        }
+
+        weeks.append(ContributionWeek(startDate: weekStartKey, days: contributionDays))
+    }
+
+    return weeks
+}
+
+@MainActor func computeContributionStats(weeks: [ContributionWeek]) -> ContributionStats {
+    let days = weeks.flatMap(\.days).filter { !$0.isFuture }
+    let active = days.filter { $0.cost > 0 }
+    let total = active.reduce(0.0) { $0 + $1.cost }
+    let avg = active.isEmpty ? 0 : total / Double(active.count)
+    let peak = active.max(by: { $0.cost < $1.cost })
+    let peakLabel = peak.map { "\($0.cost.asCompactCurrency()) on \(shortContributionDate($0.date))" } ?? "—"
+
+    var streak = 0
+    for day in days.reversed() {
+        if day.cost > 0 {
+            streak += 1
+        } else {
+            break
+        }
+    }
+
+    return ContributionStats(
+        total: total,
+        activeDays: active.count,
+        avgActive: avg,
+        peakLabel: peakLabel,
+        currentStreak: streak
+    )
+}
+
+private func startOfContributionWeek(containing date: Date, calendar: Calendar) -> Date? {
+    let start = calendar.startOfDay(for: date)
+    let weekday = calendar.component(.weekday, from: start)
+    let daysFromMonday = (weekday + 5) % 7
+    return calendar.date(byAdding: .day, value: -daysFromMonday, to: start)
+}
+
+private func shortContributionDate(_ ymd: String) -> String {
+    guard let date = yyyymmdd.date(from: ymd) else { return ymd }
+    return mmmDayFormat.string(from: date)
+}
+
+private func formatTokensForContribution(_ n: Int) -> String {
+    if n >= 1_000_000 { return String(format: "%.1fM", Double(n) / 1_000_000) }
+    if n >= 1_000 { return String(format: "%.0fK", Double(n) / 1_000) }
+    return "\(n)"
 }
 
 // MARK: - Forecast

--- a/mac/Tests/CodeBurnMenubarTests/ContributionHeatmapTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/ContributionHeatmapTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import CodeBurnMenubar
+
+private let heatmapNow: Date = {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    return calendar.date(from: DateComponents(year: 2026, month: 6, day: 3, hour: 12))!
+}()
+
+private let heatmapCalendar: Calendar = {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    return calendar
+}()
+
+private let heatmapFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)!
+    return formatter
+}()
+
+private func historyEntry(
+    _ date: String,
+    cost: Double,
+    calls: Int = 1,
+    inputTokens: Int = 100,
+    outputTokens: Int = 20
+) -> DailyHistoryEntry {
+    DailyHistoryEntry(
+        date: date,
+        cost: cost,
+        calls: calls,
+        inputTokens: inputTokens,
+        outputTokens: outputTokens,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        topModels: []
+    )
+}
+
+@Suite("Contribution heatmap")
+struct ContributionHeatmapTests {
+    @Test("builds Monday-start weeks ending with the current week")
+    func buildsMondayStartWeeks() {
+        let weeks = buildContributionWeeks(
+            from: [historyEntry("2026-06-03", cost: 10)],
+            weekCount: 2,
+            now: heatmapNow,
+            calendar: heatmapCalendar,
+            formatter: heatmapFormatter
+        )
+
+        #expect(weeks.map(\.startDate) == ["2026-05-25", "2026-06-01"])
+        #expect(weeks.allSatisfy { $0.days.count == 7 })
+        #expect(weeks[1].days[0].date == "2026-06-01")
+        #expect(weeks[1].days[2].date == "2026-06-03")
+        #expect(weeks[1].days[2].isToday)
+    }
+
+    @Test("marks future cells after today")
+    func marksFutureCells() {
+        let weeks = buildContributionWeeks(
+            from: [
+                historyEntry("2026-06-03", cost: 10),
+                historyEntry("2026-06-04", cost: 99),
+            ],
+            weekCount: 1,
+            now: heatmapNow,
+            calendar: heatmapCalendar,
+            formatter: heatmapFormatter
+        )
+
+        let currentWeek = weeks[0].days
+        #expect(currentWeek[2].date == "2026-06-03")
+        #expect(currentWeek[2].cost == 10)
+        #expect(!currentWeek[2].isFuture)
+        #expect(currentWeek[3].date == "2026-06-04")
+        #expect(currentWeek[3].cost == 0)
+        #expect(currentWeek[3].isFuture)
+    }
+
+    @Test("maps costs to four nonzero intensity levels")
+    func mapsIntensityLevels() {
+        #expect(contributionLevel(value: 0, maxValue: 100) == 0)
+        #expect(contributionLevel(value: 10, maxValue: 100) == 1)
+        #expect(contributionLevel(value: 25, maxValue: 100) == 2)
+        #expect(contributionLevel(value: 50, maxValue: 100) == 3)
+        #expect(contributionLevel(value: 75, maxValue: 100) == 4)
+        #expect(contributionLevel(value: 100, maxValue: 100) == 4)
+    }
+
+    @MainActor
+    @Test("computes total, active days, average, and current streak")
+    func computesStats() {
+        let weeks = buildContributionWeeks(
+            from: [
+                historyEntry("2026-06-01", cost: 3),
+                historyEntry("2026-06-02", cost: 0),
+                historyEntry("2026-06-03", cost: 9),
+            ],
+            weekCount: 1,
+            now: heatmapNow,
+            calendar: heatmapCalendar,
+            formatter: heatmapFormatter
+        )
+
+        let stats = computeContributionStats(weeks: weeks)
+        #expect(stats.total == 12)
+        #expect(stats.activeDays == 2)
+        #expect(stats.avgActive == 6)
+        #expect(stats.currentStreak == 1)
+        #expect(stats.peakLabel.contains("Jun 3"))
+    }
+}


### PR DESCRIPTION
## Summary
- add a Calendar insight tab to the macOS menubar
- render a width-adaptive GitHub-style contribution heatmap from daily history
- show per-day hover details for spend, calls, and tokens
- add Swift tests for week layout, future days, intensity levels, and summary stats

## Related issue
Closes #431

## Conflict check
- Fetched `getagentseal/codeburn` main
- `git merge-tree --write-tree HEAD FETCH_HEAD` completed successfully with no conflicts

## Tests
- `cd mac && swift test`
