### PR TITLE
feat!: rename mac app name to CodeBurn

### DIFF
--- a/.github/workflows/release-menubar.yml
+++ b/.github/workflows/release-menubar.yml
@@ -44,10 +44,10 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: CodeBurnMenubar-${{ steps.version.outputs.value }}
+          name: CodeBurn-${{ steps.version.outputs.value }}
           path: |
-            mac/.build/dist/CodeBurnMenubar-${{ steps.version.outputs.value }}.zip
-            mac/.build/dist/CodeBurnMenubar-${{ steps.version.outputs.value }}.zip.sha256
+            mac/.build/dist/CodeBurn-${{ steps.version.outputs.value }}.zip
+            mac/.build/dist/CodeBurn-${{ steps.version.outputs.value }}.zip.sha256
           if-no-files-found: error
 
       - name: Create / update GitHub Release
@@ -70,6 +70,6 @@ jobs:
             the zip from this page directly and macOS shows "cannot verify developer",
             right-click the app in Finder and pick Open to whitelist it once.
           files: |
-            mac/.build/dist/CodeBurnMenubar-${{ steps.version.outputs.value }}.zip
-            mac/.build/dist/CodeBurnMenubar-${{ steps.version.outputs.value }}.zip.sha256
+            mac/.build/dist/CodeBurn-${{ steps.version.outputs.value }}.zip
+            mac/.build/dist/CodeBurn-${{ steps.version.outputs.value }}.zip.sha256
           fail_on_unmatched_files: true

--- a/mac/Scripts/package-app.sh
+++ b/mac/Scripts/package-app.sh
@@ -102,7 +102,7 @@ else
 fi
 codesign --verify --deep --strict "${BUNDLE}"
 
-ZIP_NAME="CodeBurnMenubar-${ASSET_VERSION}.zip"
+ZIP_NAME="CodeBurn-${ASSET_VERSION}.zip"
 ZIP_PATH="${DIST_DIR}/${ZIP_NAME}"
 echo "▸ Packaging ${ZIP_NAME}..."
 (cd "${DIST_DIR}" && COPYFILE_DISABLE=1 /usr/bin/ditto -c -k --norsrc --keepParent "${BUNDLE_NAME}" "${ZIP_NAME}")

--- a/mac/Scripts/package-app.sh
+++ b/mac/Scripts/package-app.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Builds a universal CodeBurnMenubar.app bundle from the SwiftPM target and drops a
+# Builds a universal CodeBurn.app bundle from the SwiftPM target and drops a
 # distributable zip alongside. Used by the GitHub release workflow; also runnable locally.
 #
 # Usage:
@@ -11,7 +11,7 @@ set -euo pipefail
 VERSION="${1:-dev}"
 ASSET_VERSION="${VERSION#mac-}"
 BUNDLE_VERSION="${ASSET_VERSION#v}"
-BUNDLE_NAME="CodeBurnMenubar.app"
+BUNDLE_NAME="CodeBurn.app"
 BUNDLE_ID="org.agentseal.codeburn-menubar"
 EXECUTABLE_NAME="CodeBurnMenubar"
 MIN_MACOS="14.0"
@@ -54,7 +54,7 @@ cat > "${BUNDLE}/Contents/Info.plist" <<PLIST
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleDisplayName</key>
-    <string>CodeBurn Menubar</string>
+    <string>CodeBurn</string>
     <key>CFBundleExecutable</key>
     <string>${EXECUTABLE_NAME}</string>
     <key>CFBundleIconFile</key>
@@ -64,7 +64,7 @@ cat > "${BUNDLE}/Contents/Info.plist" <<PLIST
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
-    <string>${EXECUTABLE_NAME}</string>
+    <string>CodeBurn</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>

--- a/mac/Sources/CodeBurnMenubar/Data/UpdateChecker.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/UpdateChecker.swift
@@ -95,7 +95,7 @@ final class UpdateChecker {
             }
 
             let version = resolved.asset.name
-                .replacingOccurrences(of: "CodeBurnMenubar-", with: "")
+                .replacingOccurrences(of: "CodeBurn-", with: "")
                 .replacingOccurrences(of: ".zip", with: "")
 
             let cliVersion = Self.resolveLatestCliVersion(in: releases)
@@ -138,7 +138,7 @@ final class UpdateChecker {
     nonisolated static func resolveLatestMenubarRelease(in releases: [GitHubRelease]) -> (release: GitHubRelease, asset: GitHubAsset)? {
         for release in releases where release.tag_name.hasPrefix("mac-v") {
             guard let asset = release.assets.first(where: {
-                $0.name.hasPrefix("CodeBurnMenubar-v") && $0.name.hasSuffix(".zip")
+                $0.name.hasPrefix("CodeBurn-v") && $0.name.hasSuffix(".zip")
             }) else { continue }
             guard release.assets.contains(where: { $0.name == "\(asset.name).sha256" }) else { continue }
             return (release, asset)

--- a/mac/Tests/CodeBurnMenubarTests/UpdateCheckerTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/UpdateCheckerTests.swift
@@ -13,8 +13,8 @@ struct UpdateCheckerTests {
             GitHubRelease(
                 tag_name: "mac-v0.9.8",
                 assets: [
-                    GitHubAsset(name: "CodeBurnMenubar-v0.9.8.zip", browser_download_url: "https://example.test/app"),
-                    GitHubAsset(name: "CodeBurnMenubar-v0.9.8.zip.sha256", browser_download_url: "https://example.test/app.sha256"),
+                    GitHubAsset(name: "CodeBurn-v0.9.8.zip", browser_download_url: "https://example.test/app"),
+                    GitHubAsset(name: "CodeBurn-v0.9.8.zip.sha256", browser_download_url: "https://example.test/app.sha256"),
                 ]
             ),
         ]
@@ -22,7 +22,7 @@ struct UpdateCheckerTests {
         let resolved = UpdateChecker.resolveLatestMenubarRelease(in: releases)
 
         #expect(resolved?.release.tag_name == "mac-v0.9.8")
-        #expect(resolved?.asset.name == "CodeBurnMenubar-v0.9.8.zip")
+        #expect(resolved?.asset.name == "CodeBurn-v0.9.8.zip")
     }
 
     @Test("ignores mac release missing checksum")
@@ -30,7 +30,7 @@ struct UpdateCheckerTests {
         let releases = [
             GitHubRelease(
                 tag_name: "mac-v0.9.8",
-                assets: [GitHubAsset(name: "CodeBurnMenubar-v0.9.8.zip", browser_download_url: "https://example.test/app")]
+                assets: [GitHubAsset(name: "CodeBurn-v0.9.8.zip", browser_download_url: "https://example.test/app")]
             ),
         ]
 

--- a/src/menubar-installer.ts
+++ b/src/menubar-installer.ts
@@ -16,7 +16,8 @@ import {
 /// the repository, so we scan recent releases and choose the newest `mac-v*` release
 /// that actually contains the menubar zip.
 const RELEASE_API = 'https://api.github.com/repos/getagentseal/codeburn/releases?per_page=20'
-const APP_BUNDLE_NAME = 'CodeBurnMenubar.app'
+const APP_BUNDLE_NAME = 'CodeBurn.app'
+const LEGACY_APP_BUNDLE_NAME = 'CodeBurnMenubar.app'
 const EXPECTED_BUNDLE_ID = 'org.agentseal.codeburn-menubar'
 const VERSIONED_ASSET_PATTERN = /^CodeBurnMenubar-v.+\.zip$/
 const APP_PROCESS_NAME = 'CodeBurnMenubar'
@@ -237,7 +238,9 @@ export async function installMenubarApp(options: { force?: boolean } = {}): Prom
 
   const appsDir = userApplicationsDir()
   const targetPath = join(appsDir, APP_BUNDLE_NAME)
+  const legacyPath = join(appsDir, LEGACY_APP_BUNDLE_NAME)
   const alreadyInstalled = await exists(targetPath)
+  const legacyInstalled = await exists(legacyPath)
 
   if (alreadyInstalled && !options.force) {
     if (!(await isAppRunning())) {
@@ -246,7 +249,7 @@ export async function installMenubarApp(options: { force?: boolean } = {}): Prom
     return { installedPath: targetPath, launched: true }
   }
 
-  console.log('Looking up the latest CodeBurn Menubar release...')
+  console.log('Looking up the latest CodeBurn release...')
   const { zip, checksum } = await fetchLatestReleaseAssets()
 
   const stagingDir = await mkdtemp(join(tmpdir(), 'codeburn-menubar-'))
@@ -275,15 +278,16 @@ export async function installMenubarApp(options: { force?: boolean } = {}): Prom
     await runCommand('/usr/bin/xattr', ['-dr', 'com.apple.quarantine', unpackedApp]).catch(() => {})
 
     await mkdir(appsDir, { recursive: true })
-    if (alreadyInstalled) {
+    if (alreadyInstalled || legacyInstalled) {
       // Kill the running copy before replacing its bundle so `mv` can proceed cleanly and the
       // user ends up on the new version.
       await killRunningApp()
       await rm(targetPath, { recursive: true, force: true })
+      await rm(legacyPath, { recursive: true, force: true })
     }
     await rename(unpackedApp, targetPath)
 
-    console.log('Launching CodeBurn Menubar...')
+    console.log('Launching CodeBurn...')
     await runCommand('/usr/bin/open', [targetPath])
     return { installedPath: targetPath, launched: true }
   } finally {

--- a/src/menubar-installer.ts
+++ b/src/menubar-installer.ts
@@ -19,7 +19,7 @@ const RELEASE_API = 'https://api.github.com/repos/getagentseal/codeburn/releases
 const APP_BUNDLE_NAME = 'CodeBurn.app'
 const LEGACY_APP_BUNDLE_NAME = 'CodeBurnMenubar.app'
 const EXPECTED_BUNDLE_ID = 'org.agentseal.codeburn-menubar'
-const VERSIONED_ASSET_PATTERN = /^CodeBurnMenubar-v.+\.zip$/
+const VERSIONED_ASSET_PATTERN = /^CodeBurn-v.+\.zip$/
 const APP_PROCESS_NAME = 'CodeBurnMenubar'
 const SUPPORTED_OS = 'darwin'
 const MIN_MACOS_MAJOR = 14
@@ -57,7 +57,7 @@ export function resolveLatestMenubarReleaseAssets(releases: ReleaseResponse[]): 
       continue
     }
   }
-  throw new Error('No mac-v* release with a CodeBurnMenubar-v*.zip and checksum was found.')
+  throw new Error('No mac-v* release with a CodeBurn-v*.zip and checksum was found.')
 }
 
 export {

--- a/tests/menubar-installer.test.ts
+++ b/tests/menubar-installer.test.ts
@@ -16,25 +16,25 @@ describe('resolveMenubarReleaseAssets', () => {
     const release: ReleaseResponse = {
       tag_name: 'mac-v0.9.8',
       assets: [
-        asset('CodeBurnMenubar-dev.zip'),
-        asset('CodeBurnMenubar-dev.zip.sha256'),
-        asset('CodeBurnMenubar-v0.9.8.zip'),
-        asset('CodeBurnMenubar-v0.9.8.zip.sha256'),
+        asset('CodeBurn-dev.zip'),
+        asset('CodeBurn-dev.zip.sha256'),
+        asset('CodeBurn-v0.9.8.zip'),
+        asset('CodeBurn-v0.9.8.zip.sha256'),
       ],
     }
 
     const resolved = resolveMenubarReleaseAssets(release)
 
-    expect(resolved.zip.name).toBe('CodeBurnMenubar-v0.9.8.zip')
-    expect(resolved.checksum?.name).toBe('CodeBurnMenubar-v0.9.8.zip.sha256')
+    expect(resolved.zip.name).toBe('CodeBurn-v0.9.8.zip')
+    expect(resolved.checksum?.name).toBe('CodeBurn-v0.9.8.zip.sha256')
   })
 
   it('fails when a release only contains dev assets', () => {
     const release: ReleaseResponse = {
       tag_name: 'mac-v0.9.8',
       assets: [
-        asset('CodeBurnMenubar-dev.zip'),
-        asset('CodeBurnMenubar-dev.zip.sha256'),
+        asset('CodeBurn-dev.zip'),
+        asset('CodeBurn-dev.zip.sha256'),
       ],
     }
 
@@ -45,7 +45,7 @@ describe('resolveMenubarReleaseAssets', () => {
     const release: ReleaseResponse = {
       tag_name: 'mac-v0.9.8',
       assets: [
-        asset('CodeBurnMenubar-v0.9.8.zip'),
+        asset('CodeBurn-v0.9.8.zip'),
       ],
     }
 
@@ -63,8 +63,8 @@ describe('resolveMenubarReleaseAssets', () => {
       {
         tag_name: 'mac-v0.9.8',
         assets: [
-          asset('CodeBurnMenubar-v0.9.8.zip'),
-          asset('CodeBurnMenubar-v0.9.8.zip.sha256'),
+          asset('CodeBurn-v0.9.8.zip'),
+          asset('CodeBurn-v0.9.8.zip.sha256'),
         ],
       },
     ]
@@ -72,7 +72,7 @@ describe('resolveMenubarReleaseAssets', () => {
     const resolved = resolveLatestMenubarReleaseAssets(releases)
 
     expect(resolved.release.tag_name).toBe('mac-v0.9.8')
-    expect(resolved.zip.name).toBe('CodeBurnMenubar-v0.9.8.zip')
+    expect(resolved.zip.name).toBe('CodeBurn-v0.9.8.zip')
   })
 
   it('preserves the caller PATH when building the persistent CLI lookup PATH', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "rootDir": "src",
     "declaration": true,
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## Summary

<!-- What does this PR do? 1-3 bullet points. -->

I want to propose a rename of the mac app name to just CodeBurn. This PR addresses that. Also since this is a breaking change, when installing the app we also remove and kill the old one.

Note: intentionally left the process name with menubar, in order to keep cli and app processes with different names

## Testing

- [x] I have tested this locally against real data (not just unit tests)
- [x] `npm test` passes
- [x] `npm run build` succeeds

### For new providers only:

- [ ] I installed the tool and generated real sessions by using it
- [ ] `npm run dev -- today` shows correct costs and session counts for this provider
- [ ] `npm run dev -- models --provider <name>` shows correct model names and pricing
- [ ] Screenshot or terminal output attached below proving it works with real data

<!-- Paste screenshot / terminal output here -->
