### PR TITLE
refactor(mux): drop dead openai reasoning fallback

### DIFF
--- a/src/providers/mux.ts
+++ b/src/providers/mux.ts
@@ -183,14 +183,15 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
         const pm = meta.providerMetadata ?? {}
         const anthropic = asRecord(pm['anthropic'])
-        const openai = asRecord(pm['openai'])
 
         // mux reports inputTokens inclusive of cache read+creation and
         // outputTokens inclusive of reasoning; decompose to codeburn's
         // cache/reasoning-exclusive convention. Cache creation is Anthropic-only.
+        // The AI SDK v6 normalizes reasoning into usage.reasoningTokens across
+        // every provider family, so that field is the single source of truth.
         const cacheRead = num(usage['cachedInputTokens'])
         const cacheCreate = num(anthropic?.['cacheCreationInputTokens'])
-        const reasoning = num(usage['reasoningTokens']) || num(openai?.['reasoningTokens'])
+        const reasoning = num(usage['reasoningTokens'])
         const inputTokens = Math.max(0, num(usage['inputTokens']) - cacheRead - cacheCreate)
         const outputTokens = Math.max(0, num(usage['outputTokens']) - reasoning)
 


### PR DESCRIPTION
Fast-follow cleanup on #438 (coder/mux provider).

## What

The mux provider had a reasoning-token fallback:

```ts
const openai = asRecord(pm['openai'])
const reasoning = num(usage['reasoningTokens']) || num(openai?.['reasoningTokens'])
```

The AI SDK v6 (which mux uses) normalizes reasoning into `usage.reasoningTokens` across every provider family, so the left operand of the `||` always wins and the `providerMetadata.openai` branch never fires. Dropped it and the now-unused `openai` extraction.

## Why separate from #438

The PR came from the `coder/codeburn` org fork, which I can't push to. Merged #438 as-is (the dead branch was harmless) and applied this cleanup on main.

## Testing

- `tsc --noEmit` clean
- `tests/providers/mux.test.ts` — 21/21 pass (no behavior change; the removed branch was unreachable)