### PR TITLE
fix(models-report): stop double-counting cache reads

### DIFF
--- a/src/models-report.ts
+++ b/src/models-report.ts
@@ -89,7 +89,11 @@ export async function aggregateModels(projects: ProjectSummary[], opts: Aggregat
           bucket.inputTokens += call.usage.inputTokens
           bucket.outputTokens += call.usage.outputTokens + call.usage.reasoningTokens
           bucket.cacheWriteTokens += call.usage.cacheCreationInputTokens
-          bucket.cacheReadTokens += call.usage.cacheReadInputTokens + call.usage.cachedInputTokens
+          // cacheReadInputTokens (Anthropic vocab) and cachedInputTokens (OpenAI vocab)
+          // are two names for the same thing. Providers populate one or set both to the
+          // same value, so take the max — summing double-counts cache reads for every
+          // provider that fills both fields.
+          bucket.cacheReadTokens += Math.max(call.usage.cacheReadInputTokens, call.usage.cachedInputTokens)
           bucket.costUSD += call.costUSD
           bucket.calls += 1
 

--- a/tests/models-report.test.ts
+++ b/tests/models-report.test.ts
@@ -125,6 +125,17 @@ describe('aggregateModels', () => {
     expect(claudeRow.totalTokens).toBe(1800 + 300 + 800 + 13000)
   })
 
+  it('does not double-count cache reads when a provider sets both cache fields', async () => {
+    // Providers like codex/mux/codebuff populate cacheReadInputTokens AND
+    // cachedInputTokens with the same value (Anthropic vs OpenAI vocabulary for
+    // the same tokens). The report must count them once, not sum them.
+    const call = makeCall({ provider: 'mux', model: 'claude-opus-4-8', input: 100, output: 50, cacheRead: 4000, costUSD: 2.0 })
+    call.usage.cachedInputTokens = 4000 // mirrors cacheReadInputTokens, as those providers do
+
+    const rows = await aggregateModels([makeProject([makeTurn('feature', [call])])])
+    expect(rows[0]!.cacheReadTokens).toBe(4000) // not 8000
+  })
+
   it('reports the dominant task type with its cost share in default mode', async () => {
     const project = makeProject([
       makeTurn('feature', [makeCall({ provider: 'claude', model: 'claude-sonnet-4-6', costUSD: 6.0, input: 100, output: 20 })]),


### PR DESCRIPTION
## Problem

`models-report.ts` summed the two cache-read token fields:

```ts
bucket.cacheReadTokens += call.usage.cacheReadInputTokens + call.usage.cachedInputTokens
```

But `cacheReadInputTokens` (Anthropic vocabulary) and `cachedInputTokens` (OpenAI vocabulary) name the **same** tokens — input served from cache. ~11 providers (codex, codebuff, droid, gemini, kimi, mux, openclaw, pi, qwen, and the shared sqlite/vscode parsers) populate **both** fields with the same value, so the sum doubled the cache-read token figure in the `codeburn models` report for all of them.

## Fix

Take the max instead of summing:

```ts
bucket.cacheReadTokens += Math.max(call.usage.cacheReadInputTokens, call.usage.cachedInputTokens)
```

Verified across all ~25 providers: each either sets both fields equal or sets `cachedInputTokens: 0` — none set them to *different* non-zero values, so `max` is always the correct single value.

## Blast radius

- **Cost: unaffected** — `calculateCost` takes the cache-read count once via its own argument, never the sum.
- **Cache-hit %, dashboard: unaffected** — line 92 was the only place that summed the two fields.
- **Only effect:** the cache-read token column in `codeburn models` corrects to its true (un-doubled) value for the affected providers.

## Testing

- New regression test in `models-report.test.ts` exercising the both-fields-set case (would fail under the old summing code: 8000 vs 4000).
- `tests/models-report.test.ts` — 20/20 pass. `tsc --noEmit` clean.