### PR TITLE
fix(network): add timeouts to critical-path fetches (#445)

### DIFF
--- a/src/currency.ts
+++ b/src/currency.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { homedir } from 'os'
 
 import { readConfig } from './config.js'
+import { fetchWithTimeout } from './fetch-utils.js'
 
 type CurrencyState = {
   code: string
@@ -79,7 +80,9 @@ function getRateCachePath(): string {
 }
 
 async function fetchRate(code: string): Promise<number> {
-  const response = await fetch(`${FRANKFURTER_URL}${code}`)
+  // Bounded so a stalled network can't hang the daily refresh for non-USD users
+  // (same wedge as the pricing fetch); callers fall back to USD / cached rate.
+  const response = await fetchWithTimeout(`${FRANKFURTER_URL}${code}`)
   if (!response.ok) throw new Error(`HTTP ${response.status}`)
   const data = await response.json() as { rates?: Record<string, unknown> }
   const rate = data.rates?.[code]

--- a/src/fetch-utils.ts
+++ b/src/fetch-utils.ts
@@ -1,0 +1,22 @@
+// Default ceiling for outbound HTTP. Every CLI command awaits loadPricing(),
+// and the macOS menubar shells out to the CLI and blocks on its exit — so an
+// unbounded fetch() on a half-open network (e.g. Wi-Fi/DNS not yet up after
+// wake-from-sleep) wedges the menubar on its loading spinner indefinitely.
+// 8s is generous for these small JSON endpoints while still failing fast.
+export const DEFAULT_FETCH_TIMEOUT_MS = 8000
+
+/// fetch() with a hard timeout. On timeout the returned promise rejects with a
+/// TimeoutError (an AbortError subtype), which callers already handle via their
+/// existing try/catch + bundled-snapshot fallback. A caller-supplied signal is
+/// combined with the timeout so either can abort the request.
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs)
+  const signal = init.signal
+    ? AbortSignal.any([init.signal, timeoutSignal])
+    : timeoutSignal
+  return fetch(url, { ...init, signal })
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir } from 'fs/promises'
 import { join } from 'path'
 import { homedir } from 'os'
 import snapshotData from './data/litellm-snapshot.json'
+import { fetchWithTimeout } from './fetch-utils.js'
 
 export type ModelCosts = {
   inputCostPerToken: number
@@ -94,7 +95,11 @@ function parseLiteLLMEntry(entry: LiteLLMEntry): ModelCosts | null {
 }
 
 async function fetchAndCachePricing(): Promise<Map<string, ModelCosts>> {
-  const response = await fetch(LITELLM_URL)
+  // Bounded: runs on every CLI invocation (the menubar shells out and blocks on
+  // it). Without a timeout a half-open network after wake-from-sleep makes
+  // fetch() hang forever, wedging the menubar's loading spinner. On timeout the
+  // caller's catch falls back to the bundled price snapshot.
+  const response = await fetchWithTimeout(LITELLM_URL)
   if (!response.ok) throw new Error(`HTTP ${response.status}`)
   const data = await response.json() as Record<string, LiteLLMEntry>
   const pricing = new Map<string, ModelCosts>()

--- a/tests/fetch-utils.test.ts
+++ b/tests/fetch-utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { createServer, type Server } from 'node:http'
+import { type AddressInfo } from 'node:net'
+
+import { fetchWithTimeout } from '../src/fetch-utils.js'
+
+let server: Server
+
+afterEach(async () => {
+  await new Promise<void>(resolve => server?.close(() => resolve()))
+})
+
+function listen(handler: (respond: () => void) => void): Promise<string> {
+  return new Promise(resolve => {
+    server = createServer((_req, res) => handler(() => res.end('{"ok":true}')))
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo
+      resolve(`http://127.0.0.1:${port}/`)
+    })
+  })
+}
+
+describe('fetchWithTimeout', () => {
+  it('aborts when the server never responds, within the timeout window', async () => {
+    // Accept the request but never reply — the half-open-network case.
+    const url = await listen(() => { /* never respond */ })
+
+    const start = Date.now()
+    await expect(fetchWithTimeout(url, {}, 150)).rejects.toMatchObject({ name: 'TimeoutError' })
+    const elapsed = Date.now() - start
+
+    // Fails fast at ~the timeout, not hanging indefinitely.
+    expect(elapsed).toBeLessThan(2000)
+  })
+
+  it('returns the response when the server replies before the timeout', async () => {
+    const url = await listen(respond => respond())
+
+    const res = await fetchWithTimeout(url, {}, 2000)
+    expect(res.ok).toBe(true)
+    expect(await res.json()).toEqual({ ok: true })
+  })
+
+  it('still aborts on timeout when the caller also passes a signal', async () => {
+    const url = await listen(() => { /* never respond */ })
+    const controller = new AbortController()
+
+    await expect(fetchWithTimeout(url, { signal: controller.signal }, 150))
+      .rejects.toMatchObject({ name: 'TimeoutError' })
+  })
+})


### PR DESCRIPTION
Fixes #445.

## Problem

The menubar hangs forever on the loading spinner (~once a day, typically the first open after the Mac sleeps overnight). Root cause, as diagnosed in the issue:

- Every CLI command awaits `loadPricing()`, and the macOS menubar shells out to the CLI and blocks on `Process.waitUntilExit`.
- Once the 24h pricing cache (`litellm-pricing.json`) expires, `loadPricing()` is forced to call `fetchAndCachePricing()` → `fetch(LITELLM_URL)`.
- That `fetch()` had **no timeout**. A half-open network after wake-from-sleep (accepts the connection, never replies) makes it hang forever. The existing `try/catch` only handles *rejections*; a hang never resolves or rejects, so `loadPricing()` awaits indefinitely and the CLI never prints or exits → the menubar's `waitUntilExit` blocks until relaunch.

## Fix

A shared `fetchWithTimeout` helper (`src/fetch-utils.ts`, 8s default via `AbortSignal.timeout`), applied to the two daily-critical-path fetches:

- `fetchAndCachePricing` (`models.ts`) — the proven culprit, on every invocation
- `fetchRate` (`currency.ts`) — same daily-refresh path for non-USD users

On timeout the request rejects with a `TimeoutError`, which the callers' existing `catch` already handles — pricing falls back to the **bundled snapshot**, currency to the cached/USD rate. So the timeout is safe: no behavior change on a healthy network, graceful degradation on a stalled one.

Scope: the always-on critical path. The release-installer fetches in `menubar-installer.ts` also lack timeouts but only run during install/update (not the daily hang path) — left for a separate change.

## Proof (reproduced on `main`)

Stale pricing cache + the LiteLLM host black-holed (accepts, never replies):

| | Result |
|---|---|
| `main` (no timeout) | hangs the full 20s wall-clock, killed (exit 124), no output |
| with this fix | aborts at ~8s, falls back to the snapshot, renders the dashboard (exit 0) |

## Testing

- New `tests/fetch-utils.test.ts` — aborts on a hanging server within the window, passes through a responsive one, and still aborts when the caller also supplies a signal.
- `models.test.ts` (100) + `currency-rounding.test.ts` (10) + `fetch-utils.test.ts` (3) all pass. `tsc --noEmit` clean.

## Follow-up (not in this PR)

The reporter's second finding — the Swift menubar never respawns a child after a hung load (↻ refresh is a no-op) — is a separate app-side recovery defect worth its own change.