### PR TITLE
docs(copilot): clarify token-estimate vs metered billing (interim for #443)

### DIFF
--- a/docs/providers/copilot.md
+++ b/docs/providers/copilot.md
@@ -36,6 +36,15 @@ Copilot does not always tag the model on each message. The parser infers it from
 
 See `copilot.ts:176-213`.
 
+## Pricing (read this before comparing to the GitHub dashboard)
+
+**CodeBurn's Copilot cost is a token-based estimate and will not match your GitHub Copilot bill.** They measure different things:
+
+- **CodeBurn** prices Copilot usage as `tokens × the underlying model's API rate`. Copilot's logs don't record a billed amount and often don't tag the model, so the parser infers the model family from the tool-call-ID prefix (see Model inference) and prices the tokens at Anthropic/OpenAI **API** rates. Calls are flagged `costIsEstimated`.
+- **GitHub** bills by **metered usage**, not tokens: the legacy **premium-request** model (`requests × per-model multiplier × $0.04`, against a monthly allowance) for annual Pro/Pro+ plans, or the newer **usage-based AI Credits** model (1 credit = $0.01) that GitHub moved to on 2026-06-01 for everyone else.
+
+Because a token estimate and a request-multiplier / credit charge are different units, the two figures diverge — and the gap widened with metered billing. Treat the Copilot number as a relative token-spend signal, not a dollar-accurate bill. Modeling GitHub's metered billing directly is tracked separately; the multiplier table has changed silently in the past, so it needs per-plan calibration against a real dashboard.
+
 ## Quirks
 
 - `toolRequests` can be missing or non-array on older sessions; the parser guards against that (`copilot.ts:126`, `:260`).

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -173,6 +173,10 @@ function parseLegacyEvents(content: string, sessionId: string, seenKeys: Set<str
         reasoningTokens: 0,
         webSearchRequests: 0,
         costUSD,
+        // Copilot doesn't record a billed amount; this is a token-based API-rate
+        // estimate of the inferred model, which does NOT match GitHub's
+        // premium-request / AI-Credits metered billing. See docs/providers/copilot.md.
+        costIsEstimated: true,
         tools,
         bashCommands: [],
         timestamp: event.timestamp ?? '',
@@ -306,6 +310,9 @@ function parseTranscriptEvents(content: string, sessionId: string, seenKeys: Set
         reasoningTokens,
         webSearchRequests: 0,
         costUSD,
+        // Token-based API-rate estimate of the inferred model — not GitHub's
+        // metered premium-request / AI-Credits billing. See docs/providers/copilot.md.
+        costIsEstimated: true,
         tools,
         bashCommands: [],
         timestamp: event.timestamp ?? '',


### PR DESCRIPTION
Interim baseline for #443 — **not** the full metered-billing cost model (that's gated on reporter calibration; see below).

## What this does
- Adds a **Pricing** section to `docs/providers/copilot.md` explaining why codeburn's Copilot number won't match the GitHub dashboard: codeburn estimates `tokens × underlying-model API rate`, while GitHub bills by metered **premium requests** (legacy, annual plans) or **AI Credits** (the usage-based model GitHub moved to on 2026-06-01).
- Sets `costIsEstimated: true` on Copilot calls (both parsers).

## Why it's only a baseline
The real fix — modeling GitHub's metered billing so the dollar figure matches the dashboard — can't be done blind:
- GitHub switched billing systems **5 days ago** (premium-request → AI Credits). We don't yet know which system the reporter is on.
- The premium-request multiplier table has **changed silently** in the past (Sonnet 1×→9×, Opus 10×→27×), so there's no stable spec to test against except a real user's dashboard.
- Making a Copilot-specific cost survive the cache round-trip needs changes to the core cost-authority path (`parser.ts` drops + recomputes provider cost), which warrants its own careful PR.

So we asked the reporter (and the subagent commenter) for their plan + billing system + a calibration data point on #443. Once we have that, the real metered-billing model gets built **on their numbers** and they validate the branch before merge.

## Status
Draft / **do not merge yet** — kept open as the honest-labeling baseline. tsc clean; `copilot.test.ts` 25/25 pass.