### PR TITLE
fix(parser): cache parse failures so broken files aren't re-read every run (#441 follow-up)

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1832,15 +1832,23 @@ function warnProviderReadFailureOnce(providerName: string, err: unknown): void {
   }
 }
 
-function warnProviderParseFailureOnce(providerName: string, sourcePath: string, err: unknown): void {
-  const key = `${providerName}:parse-failure`
-  if (warnedProviderReadFailures.has(key)) return
-  warnedProviderReadFailures.add(key)
+// Warn per offending file (so a systemic break surfaces more than one path),
+// but cap per provider per run to avoid a flood. Cached failure markers mean a
+// given broken file is only re-encountered when it changes, so this stays quiet
+// across refreshes.
+const parseFailureCounts = new Map<string, number>()
+const PARSE_FAILURE_WARN_CAP = 5
+
+function warnProviderParseFailure(providerName: string, sourcePath: string, err: unknown): void {
+  const n = (parseFailureCounts.get(providerName) ?? 0) + 1
+  parseFailureCounts.set(providerName, n)
+  if (n > PARSE_FAILURE_WARN_CAP) return
   const msg = err instanceof Error ? err.message : String(err)
+  const tail = n === PARSE_FAILURE_WARN_CAP
+    ? ` (further ${providerName} parse failures this run are suppressed)`
+    : ''
   process.stderr.write(
-    `codeburn: skipping ${providerName} session(s) that failed to parse (${msg}). ` +
-    `First offending file: ${sourcePath}. Further ${providerName} parse failures this run are suppressed; ` +
-    `other sessions still aggregate normally.\n`
+    `codeburn: skipped ${providerName} session that failed to parse: ${sourcePath} (${msg})${tail}\n`
   )
 }
 
@@ -1868,7 +1876,10 @@ async function parseProviderSources(
 
     const cached = section.files[source.path]
     const action = reconcileFile(fp, cached)
-    if (action.action === 'unchanged' && cached && !cachedFileNeedsProviderReparse(providerName, source.path, cached)) {
+    // A cached parse failure at this same fingerprint stays skipped — don't
+    // re-read a file that already threw and hasn't changed. It re-parses only
+    // when the file changes (then `reconcileFile` reports non-'unchanged').
+    if (action.action === 'unchanged' && cached && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))) {
       unchangedSources.push({ source, cached })
     } else {
       changedSources.push({ source, fp })
@@ -1919,9 +1930,13 @@ async function parseProviderSources(
         }
         // A single malformed session file must not abort the entire run — that
         // would silently empty the daily-cache backfill and wipe the trend /
-        // history (issue #441). Skip just this file (its stale cache entry was
-        // already cleared above, so it's excluded) and keep going.
-        warnProviderParseFailureOnce(providerName, source.path, err)
+        // history (issue #441). Record a negative-result marker keyed by the
+        // current fingerprint so we don't re-read + re-throw this unchanged file
+        // on every refresh; it re-parses only if it changes. Empty turns => no
+        // usage contributed.
+        section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns: [], failed: true }
+        ;(diskCache as { _dirty?: boolean })._dirty = true
+        warnProviderParseFailure(providerName, source.path, err)
         continue
       }
     }

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -57,6 +57,11 @@ export type CachedFile = {
   canonicalProjectName?: string
   mcpInventory: string[]
   turns: CachedTurn[]
+  // Negative-result marker: this file threw while parsing at the recorded
+  // fingerprint. Cached so we don't re-read + re-throw it on every refresh; it
+  // is re-parsed only when the file changes (fingerprint differs). Carries no
+  // turns, so it contributes no usage. (issue #441 follow-up)
+  failed?: boolean
 }
 
 export type ProviderSection = {

--- a/tests/session-cache.test.ts
+++ b/tests/session-cache.test.ts
@@ -112,6 +112,27 @@ describe('loadCache / saveCache', () => {
     expect(loaded).toEqual(cache)
   })
 
+  it('persists a failed-parse marker across save/load (negative-result cache)', async () => {
+    const cache: SessionCache = {
+      version: CACHE_VERSION,
+      providers: {
+        pi: {
+          envFingerprint: 'abc123',
+          files: {
+            '/path/to/bad.jsonl': makeCachedFile({ turns: [], failed: true }),
+          },
+        },
+      },
+    }
+
+    await saveCache(cache)
+    const loaded = await loadCache()
+    // The `failed` flag and empty turns survive validation + load, so the file
+    // stays skipped on the next run instead of being re-read and re-thrown.
+    expect(loaded.providers['pi']?.files['/path/to/bad.jsonl']?.failed).toBe(true)
+    expect(loaded.providers['pi']?.files['/path/to/bad.jsonl']?.turns).toEqual([])
+  })
+
   it('returns empty cache on version mismatch', async () => {
     const bad: SessionCache = { version: 999, providers: { claude: { envFingerprint: 'x', files: {} } } }
     await mkdir(TMP_DIR, { recursive: true })
@@ -259,6 +280,22 @@ describe('reconcileFile', () => {
     })
     const current: FileFingerprint = { dev: 1, ino: 200, mtimeMs: 2000, sizeBytes: 5000 }
     expect(reconcileFile(current, cached)).toEqual({ action: 'modified' })
+  })
+
+  it('a failed marker at the same fingerprint stays "unchanged" (not re-parsed)', () => {
+    const fp: FileFingerprint = { dev: 1, ino: 100, mtimeMs: 1000, sizeBytes: 5000 }
+    const marker = makeCachedFile({ fingerprint: { ...fp }, turns: [], failed: true })
+    expect(reconcileFile(fp, marker)).toEqual({ action: 'unchanged' })
+  })
+
+  it('a failed marker is re-parsed once the file changes', () => {
+    const marker = makeCachedFile({
+      fingerprint: { dev: 1, ino: 100, mtimeMs: 1000, sizeBytes: 5000 },
+      turns: [],
+      failed: true,
+    })
+    const changed: FileFingerprint = { dev: 1, ino: 100, mtimeMs: 2000, sizeBytes: 6000 }
+    expect(reconcileFile(changed, marker)).toEqual({ action: 'modified' })
   })
 
   it('returns "modified" when size shrank', () => {


### PR DESCRIPTION
Follow-up to #450 (issue #441). Addresses the two non-blocking items noted there.

## Problems
1. **Re-parse loop:** when a session file failed to parse, it was excluded but left **uncached**. Successfully-parsed files get a fingerprint cache entry and are skipped if unchanged, but a failed file had none — so every menubar refresh (~4×/min) re-read and re-parsed it, hitting the same throw. Bounded per file, but wasted I/O forever.
2. **Thin visibility:** the warning fired **once per provider per process**, naming only the first offending file. A systemic break (many bad files of one provider) surfaced as a single line, so the scope of what was skipped was invisible.

## Fix
- **Negative-result marker:** a failed file is now cached as `{ fingerprint, turns: [], failed: true }`. `reconcileFile` treats it as `unchanged` at the same fingerprint → it's skipped (no re-read) until the file actually changes (fingerprint differs → re-parsed/retried). Empty `turns` means it contributes no usage, same as before.
- **Per-file warnings, capped:** warn once per offending file (with its path), capped at 5 per provider per run, then suppressed with a note — instead of once-per-provider. Cached markers mean a given broken file isn't re-encountered across refreshes, so this stays quiet.

## Why it's safe
- A clean array still returns by reference; the marker only changes the failure path.
- The marker carries no turns, so query-time aggregation is unaffected (no undercount-as-zero — it's simply absent from totals, exactly as before).
- `validateCachedFile` accepts the optional `failed` field; markers round-trip through save/load.

## Testing
- New tests: marker persists through save/load; `reconcileFile` stays `unchanged` at the same fingerprint and returns `modified` once the file changes (retry).
- Full suite: **1060 tests pass**. `tsc --noEmit` clean.