### PR TITLE
fix(codex): content-address fork dedupe key to stop undercounting divergent events

### DIFF
--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -529,7 +529,21 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
           const model = resolveModel(entry.payload, sessionModel)
           const timestamp = entry.timestamp ?? ''
-          const dedupKey = `codex:${forkedFromId || sessionId}:${cumulativeTotal}`
+          // Forked sessions copy the parent's entire token_count history
+          // (re-timestamped), so replays must collide with the parent's events
+          // and drop to avoid double-counting -- hence the parent namespace
+          // (forkedFromId) and the deliberate omission of the per-session id.
+          // But cumulativeTotal alone is too coarse a discriminator: a genuine
+          // post-divergence fork event whose running total coincidentally equals
+          // some parent total would also collide and be lost (undercount). So we
+          // also key on the cumulative token breakdown, which a fork replays
+          // verbatim from the parent -- a true replay collides exactly, while
+          // genuinely different work at the same total stays distinct. We use the
+          // CUMULATIVE figures (not the per-event deltas) on purpose: the deltas
+          // are computed against a running `prev` that the fork advances
+          // differently once the 5s cutoff skips some replays, so a delta-based
+          // key would spuriously diverge on a replay and double-count it.
+          const dedupKey = `codex:${forkedFromId || sessionId}:${cumulativeTotal}:${total?.input_tokens ?? 0}:${total?.cached_input_tokens ?? 0}:${total?.output_tokens ?? 0}:${total?.reasoning_output_tokens ?? 0}`
 
           if (seenKeys.has(dedupKey)) continue
           seenKeys.add(dedupKey)

--- a/tests/providers/codex.test.ts
+++ b/tests/providers/codex.test.ts
@@ -16,15 +16,16 @@ afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true })
 })
 
-function sessionMeta(opts: { cwd?: string; originator?: string; session_id?: string; model?: string } = {}) {
+function sessionMeta(opts: { cwd?: string; originator?: string; session_id?: string; model?: string; forked_from_id?: string; timestamp?: string } = {}) {
   return JSON.stringify({
     type: 'session_meta',
-    timestamp: '2026-04-14T10:00:00Z',
+    timestamp: opts.timestamp ?? '2026-04-14T10:00:00Z',
     payload: {
       cwd: opts.cwd ?? '/Users/test/myproject',
       originator: opts.originator ?? 'codex-cli',
       session_id: opts.session_id ?? 'sess-001',
       model: opts.model ?? 'gpt-5.3-codex',
+      ...(opts.forked_from_id ? { forked_from_id: opts.forked_from_id } : {}),
     },
   })
 }
@@ -396,5 +397,99 @@ describe('codex provider - JSONL parsing', () => {
       calls.push(call)
     }
     expect(calls).toHaveLength(1)
+  })
+})
+
+describe('codex provider - forked session dedupe', () => {
+  // Aggregate every discovered session through ONE shared seenKeys, exactly as
+  // the real provider report does, then sum the global token total.
+  async function aggregateTokens(dir: string): Promise<{ tokens: number; calls: number }> {
+    const provider = createCodexProvider(dir)
+    const sessions = (await provider.discoverSessions()).sort((a, b) => (a.path < b.path ? -1 : 1))
+    const seenKeys = new Set<string>()
+    let tokens = 0
+    let calls = 0
+    for (const s of sessions) {
+      for await (const c of provider.createSessionParser(s, seenKeys).parse()) {
+        calls++
+        tokens += c.inputTokens + c.outputTokens + c.cachedInputTokens + c.reasoningTokens
+      }
+    }
+    return { tokens, calls }
+  }
+
+  it('does not double-count a fork that replays the parent past the 5s cutoff', async () => {
+    // Parent does 1100 tokens of real work. The fork replays both events with
+    // timestamps well beyond the 5s fork cutoff, then adds one genuine event
+    // (+400). The replays must collide with the parent and drop, so the global
+    // total is 1500 -- not 2600 (which keying on the fork's own session id would
+    // produce by double-counting the replayed history).
+    await writeSession(tmpDir, '2026-04-14', 'rollout-1-parent.jsonl', [
+      sessionMeta({ session_id: 'sess-parent' }),
+      tokenCount({ timestamp: '2026-04-14T10:00:01Z', last: { input: 700 }, total: { total: 700 } }),
+      tokenCount({ timestamp: '2026-04-14T10:00:02Z', last: { input: 400 }, total: { total: 1100 } }),
+    ])
+    await writeSession(tmpDir, '2026-04-14', 'rollout-2-fork.jsonl', [
+      sessionMeta({ session_id: 'sess-fork', forked_from_id: 'sess-parent' }),
+      tokenCount({ timestamp: '2026-04-14T10:00:10Z', last: { input: 700 }, total: { total: 700 } }),
+      tokenCount({ timestamp: '2026-04-14T10:00:11Z', last: { input: 400 }, total: { total: 1100 } }),
+      tokenCount({ timestamp: '2026-04-14T10:00:12Z', last: { input: 400 }, total: { total: 1500 } }),
+    ])
+
+    const { tokens } = await aggregateTokens(tmpDir)
+    expect(tokens).toBe(1500)
+  })
+
+  it('keeps a genuine divergent fork event that shares a cumulative total with the parent', async () => {
+    // Parent reaches cumulative 1600 via input (last input 500). The fork replays
+    // 700 and 1100, then does genuinely different work that also reaches
+    // cumulative 1600 but via OUTPUT (last output 500). Keying on cumulativeTotal
+    // alone would collide the fork's 1600 with the parent's 1600 and drop it
+    // (undercount, losing 500). The content-addressed key keeps both.
+    await writeSession(tmpDir, '2026-04-14', 'rollout-1-parent.jsonl', [
+      sessionMeta({ session_id: 'sess-parent' }),
+      tokenCount({ timestamp: '2026-04-14T10:00:01Z', last: { input: 700 }, total: { total: 700 } }),
+      tokenCount({ timestamp: '2026-04-14T10:00:02Z', last: { input: 400 }, total: { total: 1100 } }),
+      tokenCount({ timestamp: '2026-04-14T10:00:03Z', last: { input: 500 }, total: { input: 1600, total: 1600 } }),
+    ])
+    await writeSession(tmpDir, '2026-04-14', 'rollout-2-fork.jsonl', [
+      sessionMeta({ session_id: 'sess-fork', forked_from_id: 'sess-parent' }),
+      tokenCount({ timestamp: '2026-04-14T10:00:10Z', last: { input: 700 }, total: { total: 700 } }),
+      tokenCount({ timestamp: '2026-04-14T10:00:11Z', last: { input: 400 }, total: { total: 1100 } }),
+      tokenCount({ timestamp: '2026-04-14T10:00:12Z', last: { output: 500 }, total: { input: 1100, output: 500, total: 1600 } }),
+    ])
+
+    const { tokens } = await aggregateTokens(tmpDir)
+    // parent 1600 + fork's genuine +500 = 2100; replays (700, 1100) dropped.
+    expect(tokens).toBe(2100)
+  })
+
+  it('does not overcount a total-only fork whose replay straddles the 5s cutoff', async () => {
+    // The dedupe key must be derived from the cumulative token breakdown, not
+    // per-event deltas. In the fallback branch (events with total_token_usage
+    // but no last_token_usage), the delta is computed against a running `prev`.
+    // A fork skips replays within 5s of the fork (prev NOT advanced), so a
+    // replay kept just past the cutoff would compute a different delta than the
+    // parent did and, with a delta-based key, fail to dedupe -> double-count.
+    // The cumulative totals are copied verbatim, so a cumulative-based key
+    // collides regardless of the cutoff. Parent does 300 tokens; the fork is a
+    // pure replay (no new work), so the global total must stay 300.
+    await writeSession(tmpDir, '2026-04-14', 'rollout-1-parent.jsonl', [
+      sessionMeta({ session_id: 'sess-parent' }),
+      tokenCount({ timestamp: '2026-04-14T10:00:01Z', total: { input: 100, total: 100 } }),
+      tokenCount({ timestamp: '2026-04-14T10:00:02Z', total: { input: 200, total: 200 } }),
+      tokenCount({ timestamp: '2026-04-14T10:00:03Z', total: { input: 300, total: 300 } }),
+    ])
+    await writeSession(tmpDir, '2026-04-14', 'rollout-2-fork.jsonl', [
+      sessionMeta({ session_id: 'sess-fork', forked_from_id: 'sess-parent' }),
+      // 10:00:01 is within the 5s cutoff -> skipped (prev not advanced).
+      tokenCount({ timestamp: '2026-04-14T10:00:01Z', total: { input: 100, total: 100 } }),
+      // These land past the cutoff and replay the parent's cumulative totals.
+      tokenCount({ timestamp: '2026-04-14T10:00:08Z', total: { input: 200, total: 200 } }),
+      tokenCount({ timestamp: '2026-04-14T10:00:09Z', total: { input: 300, total: 300 } }),
+    ])
+
+    const { tokens } = await aggregateTokens(tmpDir)
+    expect(tokens).toBe(300)
   })
 })


### PR DESCRIPTION
Fixes #413.

## Problem

Forked Codex sessions copy the parent's entire `token_count` history (re-timestamped). Those replays are keyed into the parent's namespace (`forkedFromId`) so they dedupe against the parent and don't double-count its spend. But the key used `cumulativeTotal` alone, which is too coarse: a genuine post-divergence fork event whose running total *coincidentally* equals some parent total collided with it and was dropped, undercounting real spend.

## Why not the suggested one-liner

The issue suggests keying on the fork's own `sessionId`. That would stop replays from colliding with the parent and **double-count the entire replayed history** (in the reporter's numbers, ~11,760 events counted twice). The reported "undercount" is mostly replayed parent history being correctly credited to the parent, not lost.

## Fix

Add the **cumulative** token breakdown (input, cached, output, reasoning) to the dedupe key. A fork replays those cumulative figures verbatim, so a true replay still collides (no double-count), while genuinely different work that reaches the same cumulative total stays distinct (no undercount).

The breakdown must use the **cumulative** totals, not per-event deltas: deltas are computed against a running `prev` that the fork advances differently once the 5s replay cutoff skips some events, so a delta-based key spuriously diverges on a replay and double-counts it (in the total-only fallback branch).

## Validation

Four key designs were tested against three parent+fork scenarios (built as fixtures run through the real provider with a shared `seenKeys`); only the final design passes all three:

| key | no-double-count (replay) | keeps divergent event | no-overcount (cutoff straddle, total-only) |
|---|---|---|---|
| old `cumulativeTotal` | pass | fail (undercount) | pass |
| suggested `sessionId` | fail (overcount) | fail | fail |
| per-event deltas | pass | pass | fail (overcount) |
| **cumulative breakdown** | pass | pass | pass |

Three regression tests pin these invariants. Non-forked sessions are unaffected (the breakdown is a no-op for a single session's monotonic cumulative total). Full codex suite passes; `tsc --noEmit` clean.