### PR TITLE
feat(pricing): Fable 5 + Mythos 5 launch pricing + names

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -44,6 +44,20 @@ function loadSnapshot(): Map<string, ModelCosts> {
       fastMultiplier: fast ?? 1,
     })
   }
+  // TEMP (2026-06-09): Fable 5 / Mythos 5 launch pricing, $10/M input and $50/M output,
+  // until LiteLLM indexes them. Added as snapshot fallbacks so a real LiteLLM entry, once
+  // it exists, takes precedence (mergeSnapshotFallbacks only fills gaps). Remove then.
+  const tempLaunch: ModelCosts = {
+    inputCostPerToken: 0.00001,
+    outputCostPerToken: 0.00005,
+    cacheWriteCostPerToken: 0.0000125,
+    cacheReadCostPerToken: 0.000001,
+    webSearchCostPerRequest: WEB_SEARCH_COST,
+    fastMultiplier: 1,
+  }
+  for (const id of ['claude-fable-5', 'claude-mythos-5']) {
+    if (!map.has(id)) map.set(id, { ...tempLaunch })
+  }
   return map
 }
 
@@ -466,6 +480,9 @@ const autoModelNames: Record<string, string> = {
 }
 
 const SHORT_NAMES: Record<string, string> = {
+  // TEMP (2026-06-09): until deriveClaudeShortName or LiteLLM cover them.
+  'claude-fable-5': 'Fable 5',
+  'claude-mythos-5': 'Mythos 5',
   // Modern claude-<family>-<major>-<minor> ids are derived in deriveClaudeShortName.
   // Only the legacy 3.x ids (family-last) need explicit mapping.
   'claude-3-7-sonnet': 'Sonnet 3.7',

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -69,6 +69,19 @@ describe('getShortModelName', () => {
   })
 })
 
+describe('Fable 5 / Mythos 5 launch pricing (temporary)', () => {
+  it('prices fable-5 and mythos-5 at $10/M input, $50/M output', () => {
+    for (const id of ['claude-fable-5', 'claude-mythos-5']) {
+      expect(calculateCost(id, 1_000_000, 0, 0, 0, 0)).toBeCloseTo(10, 6)
+      expect(calculateCost(id, 0, 1_000_000, 0, 0, 0)).toBeCloseTo(50, 6)
+    }
+  })
+  it('gives them their own display names', () => {
+    expect(getShortModelName('claude-fable-5')).toBe('Fable 5')
+    expect(getShortModelName('claude-mythos-5')).toBe('Mythos 5')
+  })
+})
+
 describe('builtin aliases - getModelCosts', () => {
   it('resolves anthropic--claude-4.6-opus', () => {
     expect(getModelCosts('anthropic--claude-4.6-opus')).not.toBeNull()


### PR DESCRIPTION
Adds pricing and display names for `claude-fable-5` and `claude-mythos-5` (launch pricing: $10/M input, $50/M output).

Before this they priced at $0 (not in LiteLLM) and rendered as the raw id. Added as snapshot fallbacks, so a real LiteLLM entry overrides them automatically once it exists (`mergeSnapshotFallbacks` only fills gaps). Marked TEMP for removal once LiteLLM indexes them.

Test: both price at $10/$50 per M and resolve to names "Fable 5" / "Mythos 5".