### PR TITLE
fix(menubar-tests): compile fix for localModelSavings/savingsUSD

### DIFF
--- a/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
@@ -16,6 +16,7 @@ private func menubarPayload(cost: Double) -> MenubarPayload {
             cacheHitPercent: 0,
             topActivities: [],
             topModels: [],
+            localModelSavings: LocalModelSavings(totalUSD: 0, calls: 0, byModel: [], byProvider: []),
             providers: ["claude": cost],
             topProjects: [],
             modelEfficiency: [],

--- a/mac/Tests/CodeBurnMenubarTests/ContributionHeatmapTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/ContributionHeatmapTests.swift
@@ -31,6 +31,7 @@ private func historyEntry(
     DailyHistoryEntry(
         date: date,
         cost: cost,
+        savingsUSD: 0,
         calls: calls,
         inputTokens: inputTokens,
         outputTokens: outputTokens,

--- a/mac/Tests/CodeBurnMenubarTests/MenubarStatusCacheTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/MenubarStatusCacheTests.swift
@@ -16,7 +16,7 @@ struct MenubarStatusCacheTests {
             current: CurrentBlock(
                 label: "Today", cost: cost, calls: 1, sessions: 1, oneShotRate: nil,
                 inputTokens: 1, outputTokens: 1, cacheHitPercent: 0,
-                topActivities: [], topModels: [], providers: ["claude": cost],
+                topActivities: [], topModels: [], localModelSavings: LocalModelSavings(totalUSD: 0, calls: 0, byModel: [], byProvider: []), providers: ["claude": cost],
                 topProjects: [], modelEfficiency: [], topSessions: [],
                 retryTax: RetryTax(totalUSD: 0, retries: 0, editTurns: 0, byModel: []),
                 routingWaste: RoutingWaste(totalSavingsUSD: 0, baselineModel: "", baselineCostPerEdit: 0, byModel: []),


### PR DESCRIPTION
Three menubar test fixtures stopped compiling after `localModelSavings` (CurrentBlock) and `savingsUSD` (DailyHistoryEntry) were added to the payload structs, which blocked the whole swift test target. Adds the missing args (zero values). swift test is green again (35 swift-testing + 8 XCTest).