### PR TITLE
chore(ci): bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/block-claude-coauthor.yml
+++ b/.github/workflows/block-claude-coauthor.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   semgrep:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Semgrep
         run: pip install semgrep

--- a/.github/workflows/release-menubar.yml
+++ b/.github/workflows/release-menubar.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Resolve version label
         id: version
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload artifact (for manual runs)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: CodeBurnMenubar-${{ steps.version.outputs.value }}
           path: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create / update GitHub Release
         if: startsWith(github.ref, 'refs/tags/mac-v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: Menubar ${{ steps.version.outputs.value }}


### PR DESCRIPTION
GitHub forces Node 20 actions to Node 24 on **2026-06-16**; the v0.9.12 menubar release surfaced the deprecation warning. Bumps every Node-20 action to its current node24 runtime — inputs verified unchanged against each action's `action.yml`:

- `actions/checkout` v4 → v6 (×3: ci, block-coauthor, release-menubar)
- `actions/upload-artifact` v4 → v7 (release-menubar, manual-dispatch path)
- `softprops/action-gh-release` v2 → v3 (release-menubar; `tag_name`/`name`/`body`/`files`/`fail_on_unmatched_files` all still present)

`getagentseal/firstlook@main` is left as-is (org-owned, pinned to main). This PR's own CI exercises `checkout@v6` live.