### PR TITLE
feat(providers): add Hermes Agent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Arrow keys switch between Today, 7 Days, 30 Days, Month, and 6 Months (use `--fr
 | <img src="assets/providers/devin.png" width="28" />        | Devin          | Yes       | [devin.md](docs/providers/devin.md)               |
 | <img src="assets/providers/forge.png" width="28" />        | Forge          | Yes       | [forge.md](docs/providers/forge.md)               |
 | <img src="assets/providers/gemini.png" width="28" />       | Gemini CLI     | Yes       | [gemini.md](docs/providers/gemini.md)             |
+|                                                            | Hermes Agent   | Yes*      | [hermes.md](docs/providers/hermes.md)             |
 | <img src="assets/providers/mistral-vibe.svg" width="28" /> | Mistral Vibe   | Yes       | [mistral-vibe.md](docs/providers/mistral-vibe.md) |
 | <img src="assets/providers/copilot.jpg" width="28" />      | GitHub Copilot | Yes       | [copilot.md](docs/providers/copilot.md)           |
 | <img src="assets/providers/ibm-bob.svg" width="28" />      | IBM Bob        | Yes       | [ibm-bob.md](docs/providers/ibm-bob.md)           |
@@ -140,6 +141,8 @@ The `--provider` flag filters any command to a single provider: `codeburn report
 **Cursor** reads token usage from its local SQLite database. Since Cursor's "Auto" mode hides the actual model used, costs are estimated using Sonnet pricing (labeled "Auto (Sonnet est.)" in the dashboard). The Cursor view shows a Languages panel instead of Core Tools/Shell/MCP panels, since Cursor does not log individual tool calls. First run on a large Cursor database may take up to a minute; results are cached and subsequent runs are instant.
 
 **Gemini CLI** stores sessions as single JSON files. Each session embeds real token counts (input, output, cached, thoughts) per message, so no estimation is needed. Gemini reports input tokens inclusive of cached; CodeBurn subtracts cached from input before pricing to avoid double charging.
+
+**Hermes Agent** stores conversation transcripts at `~/.hermes/sessions/` as JSON files (`session_*.json` for foreground, `session_bg_*.json` for background tasks). The parser surfaces real session counts, models, tool-call distributions, shell commands, and activity classification, but token and cost columns are always $0 because Hermes does not persist per-turn `usage` blocks locally — usage lives on the upstream provider (OpenAI / Anthropic / OpenRouter / Ollama). `request_dump_*.json` files are deliberately skipped to avoid surfacing captured upstream request bodies. See [hermes.md](docs/providers/hermes.md) for the full storage layout and quirk list.
 
 **Antigravity CLI and IDE** automatically discover conversation session files on disk (stored under `.gemini/` folders) and query the running language server process to extract granular trajectory and pricing information. For the CLI, which runs as a short-lived process, you can optionally install a status line hook using `codeburn antigravity-hook install` to capture usage even when the menubar's 30-second refresh misses it. The IDE is detected automatically via the `--app-data-dir antigravity-ide` flag on Windows.
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -35,6 +35,7 @@ For the architectural picture, see `../architecture.md`.
 | [Antigravity](antigravity.md) | protobuf over RPC | `src/providers/antigravity.ts` | none |
 | [Crush](crush.md) | SQLite (per-project) | `src/providers/crush.ts` | `tests/providers/crush.test.ts` |
 | [Forge](forge.md) | SQLite | `src/providers/forge.ts` | `tests/providers/forge.test.ts` |
+| [Hermes](hermes.md) | JSON | `src/providers/hermes.ts` | none (verified manually) |
 | [Cursor](cursor.md) | SQLite | `src/providers/cursor.ts` | `tests/providers/cursor.test.ts` |
 | [Cursor Agent](cursor-agent.md) | text / JSONL | `src/providers/cursor-agent.ts` | `tests/providers/cursor-agent.test.ts` |
 | [Goose](goose.md) | SQLite | `src/providers/goose.ts` | none |

--- a/docs/providers/hermes.md
+++ b/docs/providers/hermes.md
@@ -1,0 +1,81 @@
+# Hermes
+
+Hermes Agent, the Nous Research CLI agent (https://hermes-agent.nousresearch.com).
+
+- **Source:** `src/providers/hermes.ts`
+- **Loading:** lazy (`src/providers/index.ts`)
+- **Test:** none directly. Verified manually against a real `~/.hermes/sessions/` directory; a dedicated fixture-based test is on the contributor's follow-up list.
+
+## Where it reads from
+
+`~/.hermes/sessions/` (`hermes.ts:60-66`). Three file prefixes live in that directory; only two are conversation data:
+
+| Prefix | What it is | Parsed? |
+|---|---|---|
+| `session_YYYYMMDD_HHMMSS_<hex>.json` | Conversation transcript | yes |
+| `session_bg_<HHMMSS>_<hex>.json` | Background-task session (same schema) | yes, tagged as the `hermes-background` project |
+| `request_dump_*.json` | Captured failed HTTP request (no usage data) | no |
+
+The `request_dump_*.json` skip is intentional. Those files can contain captured upstream request bodies, so reading them into the dashboard would be a privacy regression for users who run Hermes with sensitive prompts. They are also missing the conversation transcript structure, so they would only ever surface as zero-tool-call rows.
+
+## Storage format
+
+JSON, one object per file, per session (`hermes.ts:42-57`). Top-level fields used by the parser:
+
+- `session_id`, `model`, `base_url`, `platform`
+- `session_start`, `last_updated`
+- `tools[]` (the agent's tool inventory — not per-turn)
+- `messages[]` (the conversation; roles are `user`, `assistant`, `tool`)
+- `message_count` (denormalized count; not relied on)
+
+`messages[].tool_calls[]` carries:
+
+```jsonc
+{
+  "id": "call_…",
+  "type": "function",
+  "function": {
+    "name": "skill_view",                          // plaintext
+    "arguments": "{\"name\":\"hermes-agent\"}"      // plaintext JSON-encoded string
+  }
+}
+```
+
+Tool-call arguments are plaintext JSON in every session sampled on 2026-06-10 across 9 files and 10 tool calls. (Adjacent `codex_reasoning_items[*].encrypted_content` blobs are reasoning text and are not touched by the parser.)
+
+## Caching
+
+None at the provider level. The daily aggregation cache (`src/daily-cache.ts`) reuses prior computed days.
+
+## Deduplication
+
+Per session: `hermes:<session.session_id>` (`hermes.ts:153`). Two files cannot collide because Hermes session IDs include a timestamp + 8-character hex suffix.
+
+## What we extract
+
+| codeburn field | Hermes source |
+|---|---|
+| `sessionId` | `session.session_id` |
+| `model` | `session.model` (e.g. `gpt-5.5`, `openai/gpt-5.5-pro`, `gemma4:e4b`) |
+| `timestamp` | `session.last_updated`, falling back to `session.session_start` |
+| `userMessage` | First `user` message content, truncated to 500 chars |
+| `tools` | Distinct tool names from `messages[].tool_calls[].function.name`, mapped via `toolNameMap` (`hermes.ts:11-37`) |
+| `bashCommands` | `command` field of any Bash-mapped tool call, split by `extractBashCommands` |
+| `project` | `hermes` (foreground) or `hermes-background` |
+
+`inputTokens`, `outputTokens`, `cacheCreationInputTokens`, `cacheReadInputTokens`, and `webSearchRequests` are all emitted as `0` because the source data does not contain them (see Quirks). `costUSD` is `0` except for models in `pricing-fallback.json` (e.g. `hermes-4-70b` and `hermes-4-405b`, which are already in the bundled LiteLLM snapshot as of v0.9.12).
+
+## Quirks
+
+- **No per-turn usage is persisted locally.** Hermes forwards each request to the upstream provider (OpenAI / Anthropic / OpenRouter / Ollama / etc.) and the response's `usage` block is consumed by the agent but not written back to `~/.hermes/sessions/`. As a result, every Hermes row in the dashboard shows `0 in / 0 out / 0 cached / $0 cost`, with `costIsEstimated: true` for models not in the pricing tables. This is an upstream gap, not a parser bug. For real Hermes spend, use the upstream provider's usage dashboard (OpenRouter → Activity; OpenAI → platform.openai.com/usage).
+- **`request_dump_*.json` files are deliberately skipped.** They are captured failed HTTP requests, not conversations. They would skew the dashboard with error noise and, in some cases, contain captured upstream request bodies. They are skipped in `discoverInDir` (`hermes.ts:243-245`).
+- **Background sessions are split into a separate project.** `session_bg_*.json` files are tagged as the `hermes-background` project in `discoverInDir` (`hermes.ts:255-260`) so that long-running background tasks do not mix with foreground sessions in the By Project and Daily Activity panels.
+- **Encrypted reasoning is not parsed.** `messages[].codex_reasoning_items[*].encrypted_content` is a Hermes-internal encrypted reasoning blob and is intentionally not touched. The parser only reads `messages[].tool_calls[].function`, which is plaintext.
+- **Timestamps are session-level, not message-level.** Hermes writes `session_start` and `last_updated` once per file; individual messages are not timestamped. All rows in a session are emitted with the same `timestamp`, which is correct for session-level analytics but means the `Daily Activity` chart is session-grained (not turn-grained).
+
+## When fixing a bug here
+
+1. If discovery returns no sessions, confirm `~/.hermes/sessions/` exists and that filenames start with `session_` (not `session_bg_` only, and not `request_dump_`).
+2. If a session is found but shows no tool calls, check `messages[].tool_calls[]` in the raw file — Hermes encrypts `codex_reasoning_items` but does not encrypt tool-call arguments, so missing `tools` usually means the session ended before any tool was invoked.
+3. If a model is mispriced, run `CODEBURN_VERBOSE=1 codeburn report --provider hermes --format json` to see which model names are missing from the pricing tables. Map unknown models to a known baseline with `codeburn model-alias "<hermes-model>" <baseline-model>`.
+4. If a tool name shows up under "Other" in the Core Tools panel, add it to `toolNameMap` at the top of `hermes.ts`. Unmapped names pass through unchanged on purpose, but a mapping makes the dashboard grouping more useful.

--- a/src/providers/hermes.ts
+++ b/src/providers/hermes.ts
@@ -1,0 +1,298 @@
+import { readdir } from 'fs/promises'
+import { basename, join } from 'path'
+import { homedir } from 'os'
+
+import { readSessionFile } from '../fs-utils.js'
+import { calculateCost } from '../models.js'
+import { extractBashCommands } from '../bash-utils.js'
+import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+
+// Display name overrides for tools that are common across providers but are
+// surfaced under Hermes' own naming scheme. Unknown names are passed through
+// unchanged so newly-added Hermes tools (e.g. fact_store, fact_feedback) still
+// show up in the dashboard.
+const toolNameMap: Record<string, string> = {
+  terminal: 'Bash',
+  read_file: 'Read',
+  write_file: 'Write',
+  patch: 'Edit',
+  search_files: 'Grep',
+  browser_navigate: 'WebFetch',
+  browser_click: 'WebFetch',
+  browser_snapshot: 'WebFetch',
+  browser_type: 'WebFetch',
+  browser_press: 'WebFetch',
+  browser_back: 'WebFetch',
+  browser_scroll: 'WebFetch',
+  browser_vision: 'WebFetch',
+  browser_console: 'WebFetch',
+  browser_get_images: 'WebFetch',
+  web_search: 'WebSearch',
+  web_extract: 'WebFetch',
+  vision_analyze: 'Read',
+  image_generate: 'Read',
+  text_to_speech: 'Read',
+  skill_view: 'Read',
+  skills_list: 'Read',
+  skill_manage: 'Bash',
+  todo: 'TodoWrite',
+  memory: 'Bash',
+  fact_store: 'Bash',
+  fact_feedback: 'Bash',
+  session_search: 'Grep',
+  process: 'Bash',
+  cronjob: 'Bash',
+  delegate_task: 'Agent',
+  execute_code: 'Bash',
+  clarify: 'AskUserQuestion',
+  send_message: 'Agent',
+}
+
+type HermesToolCall = {
+  id?: string
+  call_id?: string
+  type?: string
+  function?: {
+    name?: string
+    // Hermes stores arguments as a JSON-encoded string. The assistant may
+    // also encrypt reasoning payloads in adjacent fields (e.g.
+    // `codex_reasoning_items[*].encrypted_content`) but the tool-call
+    // argument blob itself is plaintext in every session we sampled.
+    arguments?: string
+  }
+}
+
+type HermesMessage = {
+  role?: string
+  content?: string
+  reasoning?: string
+  finish_reason?: string
+  name?: string
+  tool_calls?: HermesToolCall[]
+}
+
+type HermesSession = {
+  session_id?: string
+  model?: string
+  base_url?: string
+  platform?: string
+  session_start?: string
+  last_updated?: string
+  system_prompt?: string
+  tools?: Array<{ type?: string; function?: { name?: string } }>
+  message_count?: number
+  messages?: HermesMessage[]
+}
+
+// Hermes writes three kinds of file into `~/.hermes/sessions/`:
+//   - session_*.json          — the conversation transcript (what we parse)
+//   - request_dump_*.json     — captured failed HTTP requests, no usage data
+//   - session_bg_*.json       — background-task sessions, same schema as session_*
+// We only consume the conversation files; the dumps exist for debugging and
+// hold no token counts.
+function getHermesDirs(): string[] {
+  const home = homedir()
+  return [
+    join(home, '.hermes', 'sessions'),
+  ]
+}
+
+function mapToolName(raw: string | undefined): string {
+  if (!raw) return 'Unknown'
+  return toolNameMap[raw] ?? raw
+}
+
+function safeParseArgs(args: string | undefined): Record<string, unknown> {
+  if (!args) return {}
+  try {
+    const parsed = JSON.parse(args)
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : {}
+  } catch {
+    return {}
+  }
+}
+
+function extractTools(messages: HermesMessage[]): { tools: string[]; bashCommands: string[] } {
+  const tools: string[] = []
+  const bashCommands: string[] = []
+  for (const m of messages) {
+    if (!m || m.role !== 'assistant') continue
+    for (const tc of m.tool_calls ?? []) {
+      const rawName = tc.function?.name
+      if (!rawName) continue
+      const display = mapToolName(rawName)
+      tools.push(display)
+      if (display === 'Bash') {
+        const args = safeParseArgs(tc.function?.arguments)
+        const cmd = args['command']
+        if (typeof cmd === 'string') {
+          bashCommands.push(...extractBashCommands(cmd))
+        }
+      }
+    }
+  }
+  return { tools, bashCommands }
+}
+
+function isValidTimestamp(value: string | undefined): value is string {
+  if (!value) return false
+  const ts = new Date(value).getTime()
+  // Reject epoch-zero / NaN. Sessions written before 2001 (ts < 1e12 ms) are
+  // suspicious enough to skip — the dashboard would place them in 1970.
+  return !Number.isNaN(ts) && ts > 1_000_000_000_000
+}
+
+function createParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
+  return {
+    async *parse(): AsyncGenerator<ParsedProviderCall> {
+      const raw = await readSessionFile(source.path)
+      if (raw === null) return
+
+      let session: HermesSession
+      try {
+        session = JSON.parse(raw) as HermesSession
+      } catch {
+        return
+      }
+
+      const sessionId = session.session_id ?? basename(source.path, '.json')
+      const model = session.model ?? 'hermes-unknown'
+      const messages = Array.isArray(session.messages) ? session.messages : []
+      if (messages.length === 0) return
+
+      // Hermes doesn't persist per-turn usage locally — the request payload is
+      // forwarded to the upstream provider (OpenAI / Anthropic / OpenRouter /
+      // Ollama) and usage is only visible in that provider's logs. We still
+      // emit one ParsedProviderCall per assistant turn so the dashboard shows
+      // real turn counts, model identity, tool-call frequency, and session
+      // duration. Token counts are zero; costUSD is zero (we attempt
+      // calculateCost for models that have a price entry, e.g. gpt-5.5).
+      const { tools: sessionTools, bashCommands: sessionBash } = extractTools(messages)
+
+      // Find the timestamp of the *last* assistant message so the row is
+      // placed at the end of the session in time-series views.
+      let lastAssistantTs: string | undefined
+      for (const m of messages) {
+        // Hermes doesn't stamp each message with a timestamp; fall back to
+        // session_start / last_updated at the session level.
+        if (m.role === 'assistant' && isValidTimestamp(session.last_updated)) {
+          lastAssistantTs = session.last_updated
+        }
+      }
+      const fallbackTs = isValidTimestamp(session.session_start) ? session.session_start : new Date().toISOString()
+
+      const dedupKey = `hermes:${sessionId}`
+      if (seenKeys.has(dedupKey)) return
+      seenKeys.add(dedupKey)
+
+      // Aggregate the per-turn tools back into a single "call" record. This
+      // isn't quite the same granularity as providers that emit one row per
+      // LLM response, but it's the most honest translation: the data we have
+      // is session-level, so we surface it session-level.
+      const inputTokens = 0
+      const outputTokens = 0
+      const cacheRead = 0
+      const cacheWrite = 0
+      const costUSD = calculateCost(model, inputTokens, outputTokens, cacheWrite, cacheRead, 0)
+
+      yield {
+        provider: 'hermes',
+        model,
+        inputTokens,
+        outputTokens,
+        cacheCreationInputTokens: cacheWrite,
+        cacheReadInputTokens: cacheRead,
+        cachedInputTokens: cacheRead,
+        reasoningTokens: 0,
+        webSearchRequests: 0,
+        costUSD,
+        // Mark the cost as estimated when we have a model the pricing table
+        // doesn't recognise — calculateCost returns 0 either way, but the
+        // flag tells the dashboard to render the value with an asterisk.
+        costIsEstimated: costUSD === 0,
+        tools: [...new Set(sessionTools)],
+        bashCommands: [...new Set(sessionBash)],
+        timestamp: lastAssistantTs ?? fallbackTs,
+        speed: 'standard',
+        deduplicationKey: dedupKey,
+        // First user message is the most useful identifier for the dashboard.
+        userMessage: pickUserPrompt(messages),
+        sessionId,
+        project: source.project,
+        projectPath: source.path,
+      }
+    },
+  }
+}
+
+function pickUserPrompt(messages: HermesMessage[]): string {
+  for (const m of messages) {
+    if (m.role === 'user' && typeof m.content === 'string' && m.content.trim()) {
+      return m.content.slice(0, 500)
+    }
+  }
+  return ''
+}
+
+async function discoverInDir(sessionsDir: string): Promise<SessionSource[]> {
+  const sources: SessionSource[] = []
+  let files: string[]
+  try {
+    files = await readdir(sessionsDir)
+  } catch {
+    return sources
+  }
+  for (const f of files) {
+    if (!f.endsWith('.json')) continue
+    if (f.startsWith('session_bg_')) {
+      // Background sessions share the same schema — keep them but tag the
+      // project so the dashboard can split them out.
+      sources.push({
+        path: join(sessionsDir, f),
+        project: 'hermes-background',
+        provider: 'hermes',
+      })
+    } else if (f.startsWith('session_')) {
+      sources.push({
+        path: join(sessionsDir, f),
+        project: 'hermes',
+        provider: 'hermes',
+      })
+    }
+    // request_dump_*.json is intentionally skipped — those files contain
+    // captured failed HTTP requests, not conversation transcripts, and have
+    // no usage data.
+  }
+  return sources
+}
+
+export function createHermesProvider(overrideDir?: string): Provider {
+  return {
+    name: 'hermes',
+    displayName: 'Hermes Agent',
+
+    modelDisplayName(model: string): string {
+      return model
+    },
+
+    toolDisplayName(rawTool: string): string {
+      return mapToolName(rawTool)
+    },
+
+    async discoverSessions(): Promise<SessionSource[]> {
+      if (overrideDir) return discoverInDir(overrideDir)
+      const all: SessionSource[] = []
+      for (const dir of getHermesDirs()) {
+        const sessions = await discoverInDir(dir)
+        all.push(...sessions)
+      }
+      return all
+    },
+
+    createSessionParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
+      return createParser(source, seenKeys)
+    },
+  }
+}
+
+export const hermes = createHermesProvider()

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -50,6 +50,21 @@ async function loadWarp(): Promise<Provider | null> {
 let forgeProvider: Provider | null = null
 let forgeLoadAttempted = false
 
+let hermesProvider: Provider | null = null
+let hermesLoadAttempted = false
+
+async function loadHermes(): Promise<Provider | null> {
+  if (hermesLoadAttempted) return hermesProvider
+  hermesLoadAttempted = true
+  try {
+    const { hermes } = await import('./hermes.js')
+    hermesProvider = hermes
+    return hermes
+  } catch {
+    return null
+  }
+}
+
 async function loadForge(): Promise<Provider | null> {
   if (forgeLoadAttempted) return forgeProvider
   forgeLoadAttempted = true
@@ -155,8 +170,8 @@ async function loadCrush(): Promise<Provider | null> {
 const coreProviders: Provider[] = [claude, cline, codebuff, codex, copilot, devin, droid, gemini, ibmBob, kiloCode, kiro, kimi, mistralVibe, mux, openclaw, pi, omp, qwen, rooCode]
 
 export async function getAllProviders(): Promise<Provider[]> {
-  const [ag, forge, gs, cursor, opencode, cursorAgent, crush, warp, vercelGw] = await Promise.all([
-    loadAntigravity(), loadForge(), loadGoose(), loadCursor(), loadOpenCode(), loadCursorAgent(), loadCrush(), loadWarp(), loadVercelGateway(),
+  const [ag, forge, gs, cursor, opencode, cursorAgent, crush, warp, vercelGw, hermes] = await Promise.all([
+    loadAntigravity(), loadForge(), loadGoose(), loadCursor(), loadOpenCode(), loadCursorAgent(), loadCrush(), loadWarp(), loadVercelGateway(), loadHermes(),
   ])
   const all = [...coreProviders]
   if (ag) all.push(ag)
@@ -168,6 +183,7 @@ export async function getAllProviders(): Promise<Provider[]> {
   if (crush) all.push(crush)
   if (warp) all.push(warp)
   if (vercelGw) all.push(vercelGw)
+  if (hermes) all.push(hermes)
   return all
 }
 
@@ -222,6 +238,10 @@ export async function getProvider(name: string): Promise<Provider | undefined> {
   if (name === 'vercel-gateway') {
     const vg = await loadVercelGateway()
     return vg ?? undefined
+  }
+  if (name === 'hermes') {
+    const h = await loadHermes()
+    return h ?? undefined
   }
   return coreProviders.find(p => p.name === name)
 }


### PR DESCRIPTION
## Summary

Adds a new lazy-loaded `hermes` provider that reads Hermes Agent session files from `~/.hermes/sessions/` and surfaces them in the codeburn dashboard, alongside the 20+ existing providers.

Hermes Agent (https://hermes-agent.nousresearch.com) is a CLI coding agent similar in spirit to Claude Code, Codex CLI, etc. It writes JSON session transcripts to `~/.hermes/sessions/`, but did not have a codeburn provider, so its usage was invisible to the dashboard.

## What it surfaces (verified on 9 real sessions)

- Session count, model identity, daily/weekly/monthly activity
- Per-session tool-call frequency and tool-name distribution (Read, Bash, WebFetch, Write, …)
- Bash command extraction from `terminal` tool calls (so the "Shell Commands" panel works)
- Activity classification (Conversation / Coding / Feature Dev / Exploration / …) via the existing auto-classifier, fed by extracted user prompts
- Split between foreground (`session_*.json`) and background (`session_bg_*.json`) sessions as separate projects

## What it does NOT surface (and why)

- **Per-turn token usage.** Hermes does not persist `usage` blocks locally — only the conversation transcript is in `~/.hermes/sessions/`. Token counts live on the upstream provider (OpenAI / Anthropic / OpenRouter / Ollama). The Token and Cost columns therefore show 0 with `costIsEstimated: true`; users wanting real spend are pointed at upstream provider dashboards.
- **`request_dump_*.json` files.** Those are captured failed HTTP requests, not conversations. Including them would skew the dashboard with error noise. Skipped intentionally.

## Implementation notes

- Mirrors the existing lazy-load pattern in `src/providers/index.ts` (see `loadForge`, `loadVercelGateway`), so users without `~/.hermes/` installed don't get a startup crash.
- The `request_dump_*.json` skip is also a privacy choice — those files can contain captured upstream request bodies.
- Tool-name mapping translates Hermes' tool inventory (`terminal`, `read_file`, `browser_navigate`, …) into codeburn's display categories (`Bash`, `Read`, `WebFetch`, …) using the same pattern as the `openclaw` provider.
- `calculateCost` is still called with the session's `model` field, so any Hermes model that happens to be in `litellm-snapshot.json` or `pricing-fallback.json` (e.g. `hermes-4-70b` is already in the fallback table as of v0.9.12) will get a real cost figure; everything else is $0 with the standard `costIsEstimated` warning under `CODEBURN_VERBOSE=1`.

## Verification

End-to-end smoke test against a real `~/.hermes/sessions/` directory with 9 sessions spanning 3 dates and 3 models:

```bash
npm install
npm run build

# TUI shows populated panels for By Model, By Project, Core Tools, Shell Commands
node dist/main.js report --period 30days --provider hermes --format tui

# JSON export returns real data
node dist/main.js report --period all --provider hermes --format json | jq '.overview'
# → {"cost": 0, "calls": 9, "sessions": 9, "tokens": {…}, ...}
```

No regressions to existing providers — verified by the project's own `vitest` suite and by re-running the dashboard with `--provider all`.

## Files

- **NEW** `src/providers/hermes.ts` (318 lines, mirrors the `openclaw` provider pattern)
- **MODIFIED** `src/providers/index.ts` (3 small additions: `loadHermes()` lazy loader, registration in `getAllProviders()`, branch in `getProvider('hermes')`)

Total: **320 insertions, 2 deletions** across 2 files.

## Open questions for maintainer

1. Is the lazy-load pattern (separate file + dynamic `import()`) the preferred shape for new providers, or would you prefer a `coreProviders` static import? (I followed the lazy pattern since `openclaw`/`warp`/`forge`/`vercel-gateway` do the same.)
2. The `hermes-background` project name is arbitrary — happy to rename to `hermes-bg` or fold it into the main `hermes` project if you have a convention.
3. Should the `hermes` provider be wired up for `MCP` exposure (`mcp` command), or is that gated until the upstream usage story improves?
