### PR TITLE
fix(menubar): support installer HTTP proxies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ink": "^7.0.0",
         "react": "^19.2.5",
         "strip-ansi": "^7.2.0",
+        "undici": "^7.27.2",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -3431,6 +3432,15 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ink": "^7.0.0",
     "react": "^19.2.5",
     "strip-ansi": "^7.2.0",
+    "undici": "^7.27.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/menubar-installer.ts
+++ b/src/menubar-installer.ts
@@ -6,6 +6,7 @@ import { homedir, platform, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { Readable } from 'node:stream'
+import { ProxyAgent, fetch as undiciFetch } from 'undici'
 
 import {
   buildPersistentCodeburnLookupPath,
@@ -31,6 +32,34 @@ export type InstallResult = { installedPath: string; launched: boolean }
 export type ReleaseAsset = { name: string; browser_download_url: string }
 export type ReleaseResponse = { tag_name: string; assets: ReleaseAsset[] }
 export type ResolvedAssets = { release: ReleaseResponse; zip: ReleaseAsset; checksum: ReleaseAsset }
+type ProxyEnv = Partial<Record<'HTTPS_PROXY' | 'https_proxy' | 'HTTP_PROXY' | 'http_proxy' | 'NO_PROXY' | 'no_proxy', string>>
+type FetchOptions = Parameters<typeof undiciFetch>[1]
+
+export function resolveProxyUrlForUrl(url: string, env: ProxyEnv = process.env): string | undefined {
+  const target = new URL(url)
+  if (matchesNoProxy(target.hostname, env.NO_PROXY ?? env.no_proxy)) return undefined
+  if (target.protocol === 'https:') return env.HTTPS_PROXY ?? env.https_proxy ?? env.HTTP_PROXY ?? env.http_proxy
+  if (target.protocol === 'http:') return env.HTTP_PROXY ?? env.http_proxy
+  return undefined
+}
+
+function matchesNoProxy(hostname: string, noProxy?: string): boolean {
+  if (!noProxy) return false
+  const host = hostname.toLowerCase()
+  return noProxy.split(',').some(entry => {
+    const rule = entry.trim().toLowerCase().split(':')[0]
+    if (!rule) return false
+    if (rule === '*') return true
+    if (rule.startsWith('.')) return host === rule.slice(1) || host.endsWith(rule)
+    return host === rule || host.endsWith(`.${rule}`)
+  })
+}
+
+function fetchWithProxy(url: string, options: FetchOptions = {}) {
+  const proxyUrl = resolveProxyUrlForUrl(url)
+  const dispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined
+  return undiciFetch(url, dispatcher ? { ...options, dispatcher } : options)
+}
 
 export function resolveMenubarReleaseAssets(release: ReleaseResponse): ResolvedAssets {
   const zip = release.assets.find(a => VERSIONED_ASSET_PATTERN.test(a.name))
@@ -102,7 +131,7 @@ async function sysProductVersion(): Promise<string> {
 }
 
 async function fetchLatestReleaseAssets(): Promise<ResolvedAssets> {
-  const response = await fetch(RELEASE_API, {
+  const response = await fetchWithProxy(RELEASE_API, {
     headers: {
       'User-Agent': 'codeburn-menubar-installer',
       Accept: 'application/vnd.github+json',
@@ -116,7 +145,7 @@ async function fetchLatestReleaseAssets(): Promise<ResolvedAssets> {
 }
 
 async function verifyChecksum(archivePath: string, checksumUrl: string): Promise<void> {
-  const response = await fetch(checksumUrl, {
+  const response = await fetchWithProxy(checksumUrl, {
     headers: { 'User-Agent': 'codeburn-menubar-installer' },
     redirect: 'follow',
   })
@@ -138,7 +167,7 @@ async function verifyChecksum(archivePath: string, checksumUrl: string): Promise
 }
 
 async function downloadToFile(url: string, destPath: string): Promise<void> {
-  const response = await fetch(url, {
+  const response = await fetchWithProxy(url, {
     headers: { 'User-Agent': 'codeburn-menubar-installer' },
     redirect: 'follow',
   })

--- a/tests/menubar-installer.test.ts
+++ b/tests/menubar-installer.test.ts
@@ -4,6 +4,7 @@ import {
   resolveLatestMenubarReleaseAssets,
   resolveMenubarReleaseAssets,
   resolvePersistentCodeburnPathFromWhichOutput,
+  resolveProxyUrlForUrl,
   type ReleaseResponse,
 } from '../src/menubar-installer.js'
 
@@ -95,5 +96,22 @@ describe('resolveMenubarReleaseAssets', () => {
     expect(() => resolvePersistentCodeburnPathFromWhichOutput(
       '/Users/me/.npm/_npx/abcd/node_modules/.bin/codeburn'
     )).toThrow(/Install CodeBurn globally first/)
+  })
+
+  it('uses HTTPS proxy for GitHub HTTPS downloads', () => {
+    const proxyUrl = resolveProxyUrlForUrl('https://api.github.com/repos/getagentseal/codeburn/releases', {
+      HTTPS_PROXY: 'http://proxy.company.test:8080',
+    })
+
+    expect(proxyUrl).toBe('http://proxy.company.test:8080')
+  })
+
+  it('bypasses proxy when NO_PROXY matches the download host', () => {
+    const proxyUrl = resolveProxyUrlForUrl('https://api.github.com/repos/getagentseal/codeburn/releases', {
+      HTTPS_PROXY: 'http://proxy.company.test:8080',
+      NO_PROXY: '.github.com',
+    })
+
+    expect(proxyUrl).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
Add proxy-aware downloads to the menubar installer so corporate networks can install the macOS menubar app through standard proxy environment variables.

## Context
`codeburn menubar` downloads release metadata, the app zip, and checksum from GitHub. Company networks may block direct GitHub access and require traffic through an HTTP proxy.

Closes #473

## Changes
- Route menubar installer network calls through an Undici `ProxyAgent` when proxy env vars are set.
- Honour `HTTPS_PROXY` / `https_proxy` for HTTPS requests, falling back to `HTTP_PROXY` / `http_proxy`.
- Honour `NO_PROXY` / `no_proxy` for host and domain bypass.
- Add tests for proxy selection and `NO_PROXY` bypass.

## Key Implementation Details
The PR uses `undici@^7.27.2` rather than v8 because the project supports Node `>=22.13.0` and Undici v8 requires Node `>=22.19.0`.

## Testing
```bash
npm test -- run tests/menubar-installer.test.ts
npx tsc --noEmit
```

Both commands passed locally on the clean PR branch.

`npm run build` remains blocked in this environment by network failure in `scripts/bundle-litellm.mjs` before compilation.