### PR TITLE
fix(models): keep gpt-5.3-codex-spark on its own display line (fix #461)

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -617,6 +617,7 @@ const SHORT_NAMES: Record<string, string> = {
   'gpt-5.4-nano': 'GPT-5.4 Nano',
   'gpt-5.4-mini': 'GPT-5.4 Mini',
   'gpt-5.4': 'GPT-5.4',
+  'gpt-5.3-codex-spark': 'GPT-5.3 Codex Spark',
   'gpt-5.3-codex': 'GPT-5.3 Codex',
   'gpt-5.3': 'GPT-5.3',
   'gpt-5.2-pro': 'GPT-5.2 Pro',

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -16,6 +16,7 @@ const modelDisplayNames: Record<string, string> = {
   'gpt-5.5': 'GPT-5.5',
   'gpt-5.4-mini': 'GPT-5.4 Mini',
   'gpt-5.4': 'GPT-5.4',
+  'gpt-5.3-codex-spark': 'GPT-5.3 Codex Spark',
   'gpt-5.3-codex': 'GPT-5.3 Codex',
   'gpt-5.2-low': 'GPT-5.2 Low',
   'gpt-5.2': 'GPT-5.2',

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -61,6 +61,12 @@ describe('getShortModelName', () => {
     expect(getShortModelName('claude-opus-4-8')).toBe('Opus 4.8')
   })
 
+  // Regression for #461: gpt-5.3-codex-spark must keep its own display name
+  // rather than collapsing into the shorter gpt-5.3-codex bucket.
+  it('maps gpt-5.3-codex-spark to its own line (not GPT-5.3 Codex)', () => {
+    expect(getShortModelName('gpt-5.3-codex-spark')).toBe('GPT-5.3 Codex Spark')
+  })
+
   // A future version is derived from the id with no hand-maintained entry.
   it('derives an unreleased claude version with no SHORT_NAMES entry', () => {
     expect(getShortModelName('claude-sonnet-5-2')).toBe('Sonnet 5.2')

--- a/tests/providers/codex.test.ts
+++ b/tests/providers/codex.test.ts
@@ -493,3 +493,15 @@ describe('codex provider - forked session dedupe', () => {
     expect(tokens).toBe(300)
   })
 })
+
+describe('codex provider - modelDisplayName', () => {
+  it('maps gpt-5.3-codex-spark to its own display name (not GPT-5.3 Codex) - fix #461', () => {
+    const provider = createCodexProvider('/nonexistent/path')
+    expect(provider.modelDisplayName('gpt-5.3-codex-spark')).toBe('GPT-5.3 Codex Spark')
+  })
+
+  it('still maps the base gpt-5.3-codex to GPT-5.3 Codex', () => {
+    const provider = createCodexProvider('/nonexistent/path')
+    expect(provider.modelDisplayName('gpt-5.3-codex')).toBe('GPT-5.3 Codex')
+  })
+})


### PR DESCRIPTION
## Summary
- `gpt-5.3-codex-spark` is a distinct Codex model variant, but both
  `getShortModelName()` and Codex's own `modelDisplayName()` collapsed
  it into the base `GPT-5.3 Codex` label via the longest-prefix
  fallback (longest-first sort + `key + '-'` boundary match).
- Add explicit `gpt-5.3-codex-spark` entries to both `SHORT_NAMES`
  and Codex's `modelDisplayNames`, sorted before `gpt-5.3-codex` so
  the more specific id wins.

## Repro (before fix)
```bash
CODEX_HOME=/path/to/fake codeburn today --provider codex --format json
# models: [{ "name": "GPT-5.3 Codex", "calls": 4, ... }]
# spark calls silently merged into the base line
```

After fix, the same fixture produces two independent line items:
```
{ "name": "GPT-5.3 Codex Spark", "calls": 2, "cost": ... }
{ "name": "GPT-5.3 Codex",       "calls": 2, "cost": ... }
```

## Changes
| File | +Lines | Purpose |
|---|---|---|
| `src/models.ts` | +1 | Add `gpt-5.3-codex-spark` to `SHORT_NAMES` (sorted longest-first, automatically wins) |
| `src/providers/codex.ts` | +1 | Add `gpt-5.3-codex-spark` to per-provider `modelDisplayNames` |
| `tests/models.test.ts` | +6 | Regression: `getShortModelName('gpt-5.3-codex-spark')` → `'GPT-5.3 Codex Spark'` |
| `tests/providers/codex.test.ts` | +12 | Regression: `provider.modelDisplayName('gpt-5.3-codex-spark')` → `'GPT-5.3 Codex Spark'` |

## Testing
- [x] `npm test -- tests/models.test.ts tests/providers/codex.test.ts` — 126/126 pass
- [x] E2E: wrote a fake `~/.codex/sessions/2026/06/12/rollout-*.jsonl` with
      `gpt-5.3-codex-spark` model and ran `codeburn today --provider codex
      --format json`; confirmed spark and base now appear as separate line
      items with correct per-model cost attribution
- [x] Verified the 4 pre-existing failures elsewhere in the suite
      (`usage-aggregator`, `cli-proxy-path`, `cli-json-daily`) also fail on
      `main` without this change — not introduced by this PR

## Fixes #461