### PR TITLE
fix(menubar): reduce repeated status parsing

### DIFF
--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -226,13 +226,6 @@ export async function ensureCacheHydrated(
       }
     }
 
-    const hadYesterday = c.days.some(d => d.date >= yesterdayStr)
-    if (hadYesterday) {
-      const freshDays = c.days.filter(d => d.date < yesterdayStr)
-      const latestFresh = freshDays.length > 0 ? freshDays[freshDays.length - 1].date : null
-      c = { ...c, days: freshDays, lastComputedDate: latestFresh }
-    }
-
     const gapStart = c.lastComputedDate
       ? new Date(
           parseInt(c.lastComputedDate.slice(0, 4)),

--- a/src/providers/cursor-agent.ts
+++ b/src/providers/cursor-agent.ts
@@ -44,6 +44,7 @@ const TOOL_CALL_MARKER = /^\s*\[Tool call\]\s*(.+?)\s*$/i
 const TOOL_RESULT_MARKER = /^\s*\[Tool result\]\b/i
 const USER_QUERY_OPEN = '<user_query>'
 const USER_QUERY_CLOSE = '</user_query>'
+const warnedUnrecognizedTranscripts = new Set<string>()
 const CONVERSATION_SUMMARY_QUERY = `
   SELECT conversationId, model, title, updatedAt
   FROM conversation_summaries
@@ -360,7 +361,10 @@ function createParser(
         const parsed = isJsonl ? parseJsonlTranscript(transcript) : parseTranscript(transcript)
 
         if (!parsed.recognized) {
-          process.stderr.write(`codeburn: skipped ${basename(source.path)}: unrecognized cursor-agent transcript format\n`)
+          if (!warnedUnrecognizedTranscripts.has(source.path)) {
+            warnedUnrecognizedTranscripts.add(source.path)
+            process.stderr.write(`codeburn: skipped ${basename(source.path)}: unrecognized cursor-agent transcript format\n`)
+          }
           return
         }
 

--- a/tests/daily-cache.test.ts
+++ b/tests/daily-cache.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { readFile, rm } from 'fs/promises'
 import { existsSync } from 'fs'
 import { tmpdir } from 'os'
@@ -11,8 +11,8 @@ import {
   DAILY_CACHE_VERSION,
   type DailyCache,
   type DailyEntry,
-  ensureCacheHydrated,
   getDaysInRange,
+  ensureCacheHydrated,
   loadDailyCache,
   saveDailyCache,
   withDailyCacheLock,
@@ -44,6 +44,7 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
+  vi.useRealTimers()
   delete process.env['CODEBURN_CACHE_DIR']
   if (existsSync(TMP_CACHE_ROOT)) {
     await rm(TMP_CACHE_ROOT, { recursive: true, force: true })
@@ -264,6 +265,33 @@ describe('getDaysInRange', () => {
   it('clips to available cache days when range extends beyond', () => {
     const days = getDaysInRange(cache, '2026-04-09', '2026-04-20')
     expect(days.map(d => d.date)).toEqual(['2026-04-09', '2026-04-10'])
+  })
+})
+
+describe('ensureCacheHydrated', () => {
+  it('does not recompute yesterday after it has already been cached', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-12T12:00:00.000Z'))
+
+    const saved: DailyCache = {
+      version: DAILY_CACHE_VERSION,
+      savingsConfigHash: '',
+      lastComputedDate: '2026-06-11',
+      days: [emptyDay('2026-06-11', 5, 10)],
+    }
+    await saveDailyCache(saved)
+
+    let parseCalls = 0
+    const hydrated = await ensureCacheHydrated(
+      async () => {
+        parseCalls += 1
+        return []
+      },
+      () => [],
+    )
+
+    expect(parseCalls).toBe(0)
+    expect(hydrated).toEqual(saved)
   })
 })
 

--- a/tests/providers/cursor-agent.test.ts
+++ b/tests/providers/cursor-agent.test.ts
@@ -190,6 +190,28 @@ describe('cursor-agent provider', () => {
     stderrSpy.mockRestore()
   })
 
+  it('warns only once for the same unrecognized transcript', async () => {
+    const baseDir = await makeBaseDir()
+    const transcriptDir = join(baseDir, 'projects', 'bad-proj-repeat', 'agent-transcripts')
+    await mkdir(transcriptDir, { recursive: true })
+    const transcriptPath = join(transcriptDir, 'repeat-bad.txt')
+    await writeFile(transcriptPath, 'no cursor-agent markers here')
+
+    const provider = createCursorAgentProvider(baseDir)
+    const source = (await provider.discoverSessions())[0]!
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    await collectCalls(provider, source)
+    await collectCalls(provider, source)
+
+    const warnings = stderrSpy.mock.calls
+      .map(call => String(call[0] ?? ''))
+      .filter(message => message.includes('unrecognized cursor-agent transcript format'))
+    expect(warnings).toHaveLength(1)
+
+    stderrSpy.mockRestore()
+  })
+
   it('falls back to stable sha1 conversation id for non-uuid filenames', async () => {
     const baseDir = await makeBaseDir()
     const transcriptDir = join(baseDir, 'projects', 'sha-proj', 'agent-transcripts')


### PR DESCRIPTION
## Summary

- Keeps cached daily data for yesterday instead of forcing a repeat hydration parse once it is already cached.
- Suppresses duplicate warnings when the same unrecognized Cursor agent transcript is parsed repeatedly.
- Adds regression coverage for both repeated-cache hydration and repeated transcript warnings.

## Target issues

Closes #484

## Testing

- [x] `npm test -- --run tests/daily-cache.test.ts tests/providers/cursor-agent.test.ts`
- [ ] I have tested this locally against real data (not just unit tests)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds


Made with [Cursor](https://cursor.com)