### PR TITLE
fix(codex): attribute MCP tool-call end events

### DIFF
--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -40,6 +40,36 @@ const toolNameMap: Record<string, string> = {
   read_dir: 'Glob',
 }
 
+function normalizeMcpSegment(segment: string): string {
+  return segment
+    .replace(/[^a-zA-Z0-9_]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+}
+
+function mcpToolName(server: string, tool: string): string | null {
+  const normalizedServer = normalizeMcpSegment(server)
+  const normalizedTool = normalizeMcpSegment(tool)
+  if (!normalizedServer || !normalizedTool) return null
+  return `mcp__${normalizedServer}__${normalizedTool}`
+}
+
+function codexFunctionCallToolName(payload: CodexEntry['payload']): string {
+  const rawName = payload?.name ?? ''
+  const namespace = payload?.namespace
+  if (typeof namespace === 'string' && namespace.startsWith('mcp__')) {
+    return mcpToolName(namespace.slice('mcp__'.length), rawName) ?? rawName
+  }
+  return toolNameMap[rawName] ?? rawName
+}
+
+function codexMcpToolEndName(entry: CodexEntry): string | null {
+  if (entry.type !== 'event_msg' || entry.payload?.type !== 'mcp_tool_call_end') return null
+  const invocation = entry.payload.invocation
+  if (typeof invocation?.server !== 'string' || typeof invocation.tool !== 'string') return null
+  return mcpToolName(invocation.server, invocation.tool)
+}
+
 type CodexEntry = {
   type: string
   timestamp?: string
@@ -53,7 +83,13 @@ type CodexEntry = {
     forked_from_id?: string
     model?: string
     name?: string
+    namespace?: string
+    call_id?: string
     content?: Array<{ type?: string; text?: string }>
+    invocation?: {
+      server?: string
+      tool?: string
+    }
     info?: {
       model?: string
       model_name?: string
@@ -234,6 +270,8 @@ function parseCodexLine(line: string | Buffer): CodexEntry | null {
       forked_from_id: getRawJsonStringField(pHead, 'forked_from_id'),
       model: getRawJsonStringField(pHead, 'model'),
       name: getRawJsonStringField(pHead, 'name'),
+      namespace: getRawJsonStringField(pHead, 'namespace'),
+      call_id: getRawJsonStringField(pHead, 'call_id'),
     },
   }
 
@@ -338,6 +376,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       let prevReasoning = 0
       let pendingTools: string[] = []
       let pendingToolSequence: ToolCall[][] = []
+      const mcpFunctionCallIds = new Set<string>()
       let pendingUserMessage = ''
       let pendingOutputChars = 0
       let estCounter = 0
@@ -372,8 +411,10 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         }
 
         if (entry.type === 'response_item' && entry.payload?.type === 'function_call') {
-          const rawName = entry.payload.name ?? ''
-          const mapped = toolNameMap[rawName] ?? rawName
+          const mapped = codexFunctionCallToolName(entry.payload)
+          if (mapped.startsWith('mcp__') && entry.payload.call_id) {
+            mcpFunctionCallIds.add(entry.payload.call_id)
+          }
           pendingTools.push(mapped)
           const call: ToolCall = { tool: mapped }
           const rawArgs = (entry.payload as Record<string, unknown>)['arguments']
@@ -387,6 +428,14 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             if (typeof cmd === 'string') call.command = cmd
           }
           pendingToolSequence.push([call])
+          continue
+        }
+
+        const mcpTool = codexMcpToolEndName(entry)
+        if (mcpTool) {
+          if (entry.payload?.call_id && mcpFunctionCallIds.has(entry.payload.call_id)) continue
+          pendingTools.push(mcpTool)
+          pendingToolSequence.push([{ tool: mcpTool }])
           continue
         }
 

--- a/tests/providers/codex.test.ts
+++ b/tests/providers/codex.test.ts
@@ -70,6 +70,31 @@ function functionCall(name: string, timestamp?: string) {
   })
 }
 
+function mcpFunctionCall(server: string, tool: string, timestamp?: string, callId = 'call-mcp-1') {
+  return JSON.stringify({
+    type: 'response_item',
+    timestamp: timestamp ?? '2026-04-14T10:00:30Z',
+    payload: {
+      type: 'function_call',
+      name: tool,
+      namespace: `mcp__${server}`,
+      call_id: callId,
+    },
+  })
+}
+
+function mcpToolCallEnd(server: string, tool: string, timestamp?: string, callId = 'call-mcp-1') {
+  return JSON.stringify({
+    type: 'event_msg',
+    timestamp: timestamp ?? '2026-04-14T10:00:45Z',
+    payload: {
+      type: 'mcp_tool_call_end',
+      invocation: { server, tool },
+      call_id: callId,
+    },
+  })
+}
+
 function userMessage(text: string, timestamp?: string) {
   return JSON.stringify({
     type: 'response_item',
@@ -303,6 +328,56 @@ describe('codex provider - JSONL parsing', () => {
 
     expect(calls).toHaveLength(1)
     expect(calls[0]!.tools).toEqual(['Agent', 'Agent', 'Agent'])
+  })
+
+  it('attributes recent Codex MCP tool-call end events', async () => {
+    const filePath = await writeSession(tmpDir, '2026-04-14', 'rollout-mcp.jsonl', [
+      sessionMeta({ session_id: 'sess-mcp', model: 'gpt-5.5' }),
+      userMessage('inspect the browser'),
+      mcpFunctionCall('node_repl', 'js'),
+      mcpToolCallEnd('node_repl', 'js'),
+      tokenCount({
+        timestamp: '2026-04-14T10:01:00Z',
+        last: { input: 300, output: 100 },
+        total: { total: 400 },
+      }),
+    ])
+
+    const provider = createCodexProvider(tmpDir)
+    const source = { path: filePath, project: 'test', provider: 'codex' }
+    const parser = provider.createSessionParser(source, new Set())
+    const calls: ParsedProviderCall[] = []
+    for await (const call of parser.parse()) {
+      calls.push(call)
+    }
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.tools).toEqual(['mcp__node_repl__js'])
+    expect(calls[0]!.toolSequence).toEqual([[{ tool: 'mcp__node_repl__js' }]])
+  })
+
+  it('attributes MCP tool-call end events without a paired function call', async () => {
+    const filePath = await writeSession(tmpDir, '2026-04-14', 'rollout-mcp-end-only.jsonl', [
+      sessionMeta({ session_id: 'sess-mcp-end-only', model: 'gpt-5.5' }),
+      userMessage('inspect the browser'),
+      mcpToolCallEnd('node_repl', 'js'),
+      tokenCount({
+        timestamp: '2026-04-14T10:01:00Z',
+        last: { input: 300, output: 100 },
+        total: { total: 400 },
+      }),
+    ])
+
+    const provider = createCodexProvider(tmpDir)
+    const source = { path: filePath, project: 'test', provider: 'codex' }
+    const parser = provider.createSessionParser(source, new Set())
+    const calls: ParsedProviderCall[] = []
+    for await (const call of parser.parse()) {
+      calls.push(call)
+    }
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.tools).toEqual(['mcp__node_repl__js'])
   })
 
   it('skips duplicate token_count events', async () => {


### PR DESCRIPTION
## Summary

- Normalize recent Codex MCP `function_call` entries with `namespace: "mcp__..."` into CodeBurn's canonical `mcp__server__tool` tool names.
- Parse `event_msg` / `mcp_tool_call_end` events when Codex emits only the completion event, while de-duping paired events by `call_id` so one MCP invocation is not counted twice.
- Add Codex provider regression coverage for both paired `function_call` + `mcp_tool_call_end` logs and end-only logs.

## Target issues

Closes #478

## Testing

- [x] `npm test -- --run tests/providers/codex.test.ts`
- [x] `npx tsc --noEmit --pretty false`
- [x] Inspected a real local Codex JSONL sequence with `function_call` namespace + matching `mcp_tool_call_end` `call_id`
- [x] `npm test` passes
- [x] `npm run build` succeeds
