### PR TITLE
fix(menubar): stop repeated keychain prompts on token refresh (#490)

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Data/ClaudeCredentialStore.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/ClaudeCredentialStore.swift
@@ -1,5 +1,4 @@
 import Foundation
-import LocalAuthentication
 import Security
 
 /// Owns the lifecycle of Claude OAuth credentials, mirroring CodexBar's pattern:
@@ -201,18 +200,30 @@ enum ClaudeCredentialStore {
     /// entries under different account names — older versions used "agentseal"
     /// (a hardcoded company-style identifier) while Claude Code 2.1.x writes
     /// under `$USER` (NSUserName()). After a user re-runs `/login`, both
-    /// entries can coexist and `SecItemCopyMatching` with kSecMatchLimitOne
-    /// often returns the older stale one. We try the user-keyed entry first
-    /// (the modern format), then fall back to the unscoped query for older
-    /// installations.
+    /// entries can coexist and a service-only lookup often returns the older
+    /// stale one. We try the user-keyed entry first (the modern format), then
+    /// fall back to the unscoped query for older installations.
+    ///
+    /// Silent background reads go through the `security` CLI rather than the
+    /// Security framework. The Apple-signed `security` binary sits in the
+    /// keychain item's `apple-tool:` partition, so it never raises the
+    /// partition-list prompt. The framework API does — and re-prompts every
+    /// time Claude Code rotates its credential and resets the item's partition
+    /// list, dropping our app from the allowed set (issue #490). Only the
+    /// user-initiated bootstrap still reads through the framework, where a
+    /// single consent prompt is expected.
     private static func readClaudeKeychain(allowUI: Bool) throws -> CredentialRecord? {
-        if let record = try readClaudeKeychain(account: NSUserName(), allowUI: allowUI) {
+        if !allowUI {
+            return readClaudeKeychainSilently(account: NSUserName())
+                ?? readClaudeKeychainSilently(account: nil)
+        }
+        if let record = try readClaudeKeychainPrompting(account: NSUserName()) {
             return record
         }
-        return try readClaudeKeychain(account: nil, allowUI: allowUI)
+        return try readClaudeKeychainPrompting(account: nil)
     }
 
-    private static func readClaudeKeychain(account: String?, allowUI: Bool) throws -> CredentialRecord? {
+    private static func readClaudeKeychainPrompting(account: String?) throws -> CredentialRecord? {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: claudeKeychainService,
@@ -220,24 +231,38 @@ enum ClaudeCredentialStore {
             kSecReturnData as String: true,
         ]
         if let account { query[kSecAttrAccount as String] = account }
-        if !allowUI {
-            // Background refresh cycles must never raise a keychain prompt. Fail
-            // the read instead. Relies on the user having granted "Always Allow"
-            // on the one-time bootstrap prompt.
-            let context = LAContext()
-            context.interactionNotAllowed = true
-            query[kSecUseAuthenticationContext as String] = context
-        }
         var result: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound { return nil }
-        // Silent read that would need interaction: treat as "no fresher token
-        // available", not an error. The caller falls back to the cached token.
-        if !allowUI, status == errSecInteractionNotAllowed { return nil }
         guard status == errSecSuccess, let data = result as? Data else {
             throw StoreError.keychainReadFailed(status)
         }
         return try parseClaudeBlob(data: sanitizeClaudeBlob(data))
+    }
+
+    /// Reads Claude's keychain entry via `/usr/bin/security`, which never raises
+    /// the partition-list prompt. Returns nil on any failure so the caller falls
+    /// back to the cached token.
+    private static func readClaudeKeychainSilently(account: String?) -> CredentialRecord? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        var args = ["find-generic-password", "-s", claudeKeychainService]
+        if let account { args += ["-a", account] }
+        args.append("-w")
+        process.arguments = args
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return try? parseClaudeBlob(data: sanitizeClaudeBlob(data))
+        } catch {
+            return nil
+        }
     }
 
     /// Claude Code's keychain writer line-wraps long values (newline + leading


### PR DESCRIPTION
Fixes #490.

## Problem
The menubar re-reads the `Claude Code-credentials` keychain item on every silent token refresh (proactive near-expiry refresh and post-401 retry) via the Security framework. On macOS Sierra+, access to a generic-password item is governed by its **partition list**, not the legacy "Always Allow" ACL shown in Keychain Access. Claude Code resets that partition list each time it rotates its OAuth credential, which drops the menubar's code identity from the allowed set. The next read then raises a fresh keychain password prompt. On a heavy Claude Code day this fires dozens of times.

The `LAContext.interactionNotAllowed` flag the code relied on does not suppress the partition-list prompt for a plain generic-password item, so the "silent" path was not actually silent.

## Fix
Route the silent read path through `/usr/bin/security find-generic-password ... -w`. The Apple-signed `security` binary sits in the item's `apple-tool:` partition, so it reads the secret without ever prompting and without depending on the user's ACL grant. It is read-only and never spends the shared refresh token, so the existing invariant (the Claude CLI owns the grant; we never refresh it ourselves) is preserved.

The user-initiated bootstrap keeps the framework read, where a single consent prompt is expected. Removes the now-unused `LocalAuthentication` import and the ineffective `interactionNotAllowed` branch.

Did not implement the issue's suggested Option A (refresh via the Anthropic OAuth API using the cached refresh token): Claude's refresh token is single-use and shared with the CLI, so spending it would invalidate the user's `claude` login. Option B (this change) avoids that.

## Scope
Menubar app only (`mac/Sources/CodeBurnMenubar/`). No CLI changes.

## Verification
- `swift build` passes.
- Confirmed `security find-generic-password -s "Claude Code-credentials" -a "$USER" -w` returns the valid `claudeAiOauth` JSON with no prompt on macOS.
- Not reproduced end to end: the original symptom requires Claude Code rotating its credential and resetting the partition list over hours of use.

## Release
Ship as `mac-v0.9.13` (not a re-upload of 0.9.12): the in-app updater only offers an update when the release version is strictly greater than the installed version, so reusing 0.9.12 would never reach existing users.