### PR TITLE
fix(menubar): reduce repeated status parsing (#486) + clock-skew guard

### DIFF
--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -226,13 +226,6 @@ export async function ensureCacheHydrated(
       }
     }
 
-    const hadYesterday = c.days.some(d => d.date >= yesterdayStr)
-    if (hadYesterday) {
-      const freshDays = c.days.filter(d => d.date < yesterdayStr)
-      const latestFresh = freshDays.length > 0 ? freshDays[freshDays.length - 1].date : null
-      c = { ...c, days: freshDays, lastComputedDate: latestFresh }
-    }
-
     const gapStart = c.lastComputedDate
       ? new Date(
           parseInt(c.lastComputedDate.slice(0, 4)),

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -226,6 +226,18 @@ export async function ensureCacheHydrated(
       }
     }
 
+    // Drop any cached entry dated today or later. The cache only ever stores
+    // complete past days (up to yesterday), so a >= today entry can only come
+    // from the clock moving backward or a stale older cache; left in place it
+    // would be served frozen instead of recomputed live. Yesterday and earlier
+    // stay cached, so this does not re-parse already-cached days.
+    const todayStr = toDateString(now)
+    if (c.days.some(d => d.date >= todayStr)) {
+      const freshDays = c.days.filter(d => d.date < todayStr)
+      const latestFresh = freshDays.length > 0 ? freshDays[freshDays.length - 1].date : null
+      c = { ...c, days: freshDays, lastComputedDate: latestFresh }
+    }
+
     const gapStart = c.lastComputedDate
       ? new Date(
           parseInt(c.lastComputedDate.slice(0, 4)),

--- a/src/providers/cursor-agent.ts
+++ b/src/providers/cursor-agent.ts
@@ -44,6 +44,7 @@ const TOOL_CALL_MARKER = /^\s*\[Tool call\]\s*(.+?)\s*$/i
 const TOOL_RESULT_MARKER = /^\s*\[Tool result\]\b/i
 const USER_QUERY_OPEN = '<user_query>'
 const USER_QUERY_CLOSE = '</user_query>'
+const warnedUnrecognizedTranscripts = new Set<string>()
 const CONVERSATION_SUMMARY_QUERY = `
   SELECT conversationId, model, title, updatedAt
   FROM conversation_summaries
@@ -360,7 +361,10 @@ function createParser(
         const parsed = isJsonl ? parseJsonlTranscript(transcript) : parseTranscript(transcript)
 
         if (!parsed.recognized) {
-          process.stderr.write(`codeburn: skipped ${basename(source.path)}: unrecognized cursor-agent transcript format\n`)
+          if (!warnedUnrecognizedTranscripts.has(source.path)) {
+            warnedUnrecognizedTranscripts.add(source.path)
+            process.stderr.write(`codeburn: skipped ${basename(source.path)}: unrecognized cursor-agent transcript format\n`)
+          }
           return
         }
 

--- a/tests/daily-cache.test.ts
+++ b/tests/daily-cache.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { readFile, rm } from 'fs/promises'
 import { existsSync } from 'fs'
 import { tmpdir } from 'os'
@@ -11,8 +11,8 @@ import {
   DAILY_CACHE_VERSION,
   type DailyCache,
   type DailyEntry,
-  ensureCacheHydrated,
   getDaysInRange,
+  ensureCacheHydrated,
   loadDailyCache,
   saveDailyCache,
   withDailyCacheLock,
@@ -44,6 +44,7 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
+  vi.useRealTimers()
   delete process.env['CODEBURN_CACHE_DIR']
   if (existsSync(TMP_CACHE_ROOT)) {
     await rm(TMP_CACHE_ROOT, { recursive: true, force: true })
@@ -264,6 +265,33 @@ describe('getDaysInRange', () => {
   it('clips to available cache days when range extends beyond', () => {
     const days = getDaysInRange(cache, '2026-04-09', '2026-04-20')
     expect(days.map(d => d.date)).toEqual(['2026-04-09', '2026-04-10'])
+  })
+})
+
+describe('ensureCacheHydrated', () => {
+  it('does not recompute yesterday after it has already been cached', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-12T12:00:00.000Z'))
+
+    const saved: DailyCache = {
+      version: DAILY_CACHE_VERSION,
+      savingsConfigHash: '',
+      lastComputedDate: '2026-06-11',
+      days: [emptyDay('2026-06-11', 5, 10)],
+    }
+    await saveDailyCache(saved)
+
+    let parseCalls = 0
+    const hydrated = await ensureCacheHydrated(
+      async () => {
+        parseCalls += 1
+        return []
+      },
+      () => [],
+    )
+
+    expect(parseCalls).toBe(0)
+    expect(hydrated).toEqual(saved)
   })
 })
 

--- a/tests/daily-cache.test.ts
+++ b/tests/daily-cache.test.ts
@@ -293,6 +293,34 @@ describe('ensureCacheHydrated', () => {
     expect(parseCalls).toBe(0)
     expect(hydrated).toEqual(saved)
   })
+
+  it('drops a cached today/future entry so it is recomputed live, keeping yesterday cached', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-12T12:00:00.000Z'))
+
+    // A "today" entry can only exist via a backward clock change or a stale
+    // cache; it must be purged so today is served live, not from a frozen entry.
+    const saved: DailyCache = {
+      version: DAILY_CACHE_VERSION,
+      savingsConfigHash: '',
+      lastComputedDate: '2026-06-12',
+      days: [emptyDay('2026-06-11', 5, 10), emptyDay('2026-06-12', 9, 20)],
+    }
+    await saveDailyCache(saved)
+
+    let parseCalls = 0
+    const hydrated = await ensureCacheHydrated(
+      async () => {
+        parseCalls += 1
+        return []
+      },
+      () => [],
+    )
+
+    expect(parseCalls).toBe(0)
+    expect(hydrated.days.map(d => d.date)).toEqual(['2026-06-11'])
+    expect(hydrated.lastComputedDate).toBe('2026-06-11')
+  })
 })
 
 describe('withDailyCacheLock', () => {

--- a/tests/providers/cursor-agent.test.ts
+++ b/tests/providers/cursor-agent.test.ts
@@ -190,6 +190,28 @@ describe('cursor-agent provider', () => {
     stderrSpy.mockRestore()
   })
 
+  it('warns only once for the same unrecognized transcript', async () => {
+    const baseDir = await makeBaseDir()
+    const transcriptDir = join(baseDir, 'projects', 'bad-proj-repeat', 'agent-transcripts')
+    await mkdir(transcriptDir, { recursive: true })
+    const transcriptPath = join(transcriptDir, 'repeat-bad.txt')
+    await writeFile(transcriptPath, 'no cursor-agent markers here')
+
+    const provider = createCursorAgentProvider(baseDir)
+    const source = (await provider.discoverSessions())[0]!
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    await collectCalls(provider, source)
+    await collectCalls(provider, source)
+
+    const warnings = stderrSpy.mock.calls
+      .map(call => String(call[0] ?? ''))
+      .filter(message => message.includes('unrecognized cursor-agent transcript format'))
+    expect(warnings).toHaveLength(1)
+
+    stderrSpy.mockRestore()
+  })
+
   it('falls back to stable sha1 conversation id for non-uuid filenames', async () => {
     const baseDir = await makeBaseDir()
     const transcriptDir = join(baseDir, 'projects', 'sha-proj', 'agent-transcripts')


### PR DESCRIPTION
Supersedes #486. Contains @vaibhavarora14's repeated-status-parsing fix (their commits preserved) plus one maintainer follow-up commit.

## What #486 does (closes #484)
- daily-cache: stops re-parsing yesterday on every hydration once it is already cached (the cache only stores complete past days, so re-parsing produced identical data). Real perf win.
- cursor-agent: dedupes the "unrecognized transcript" warning so the same file only warns once per process.

## Follow-up commit on this branch
The original change removed a block that also self-healed a rare case: a cached entry dated today or later (from the system clock moving backward, or a stale older cache) would be served frozen instead of recomputed live. Re-added as a narrow guard that purges only `>= today` entries, so yesterday and earlier stay cached (the perf win is preserved) while today is always recomputed live. Added a regression test.

## Verification
- `npm run build` passes.
- Full suite: 1170/1171. The single failure is the pre-existing `usage-aggregator` timeout flake (passes in isolation at ~3.5s), unrelated to this change.
- daily-cache + cursor-agent targeted tests pass, including the PR's regression tests and the new clock-skew test.