### PR TITLE
test(usage-aggregator): fix timeout flake by building against an empty HOME

### DIFF
--- a/tests/usage-aggregator.test.ts
+++ b/tests/usage-aggregator.test.ts
@@ -1,10 +1,38 @@
-import { describe, expect, it, beforeAll } from 'vitest'
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { buildMenubarPayloadForRange } from '../src/usage-aggregator.js'
 import { getDateRange } from '../src/cli-date.js'
 import { loadPricing } from '../src/models.js'
 
 describe('buildMenubarPayloadForRange', () => {
-  beforeAll(async () => { await loadPricing() })
+  // Point HOME / config at an empty temp dir so the payload is built from an
+  // empty dataset. This keeps the test deterministic and fast regardless of how
+  // much real session data the developer's machine has for "today" (parsing a
+  // heavy day previously pushed this past its timeout).
+  const saved: Record<string, string | undefined> = {}
+  let tmp: string
+
+  beforeAll(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'codeburn-agg-test-'))
+    for (const key of ['HOME', 'CLAUDE_CONFIG_DIR', 'XDG_CONFIG_HOME', 'CODEBURN_CACHE_DIR']) {
+      saved[key] = process.env[key]
+    }
+    process.env['HOME'] = tmp
+    process.env['CLAUDE_CONFIG_DIR'] = join(tmp, '.claude')
+    process.env['XDG_CONFIG_HOME'] = join(tmp, '.config')
+    process.env['CODEBURN_CACHE_DIR'] = join(tmp, 'cache')
+    await loadPricing()
+  })
+
+  afterAll(async () => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+    await rm(tmp, { recursive: true, force: true })
+  })
 
   it('returns a valid payload and skips optimize findings when optimize:false', async () => {
     const payload = await buildMenubarPayloadForRange(getDateRange('today'), { provider: 'all', optimize: false })


### PR DESCRIPTION
## Problem
`tests/usage-aggregator.test.ts` calls `buildMenubarPayloadForRange(getDateRange('today'), ...)`, which parses the developer's real on-disk session data for today against a fixed 5s timeout. On a heavy-usage day this exceeds the timeout and the test fails locally. It stays green on CI because CI has no real session data.

## Fix
Point `HOME`, `CLAUDE_CONFIG_DIR`, `XDG_CONFIG_HOME`, and `CODEBURN_CACHE_DIR` at an empty temp dir for this test so the payload is built from an empty dataset. The test still asserts the payload shape and the `optimize:false` short-circuit, but now runs deterministically in ~0.3s (was timing out at 5s). Env is saved/restored in beforeAll/afterAll; vitest's default forks pool isolates the file in its own process, and the daily-cache test already uses the same env-override pattern.

## Verification
- The test passes in ~330ms across repeated runs (was a 5s timeout).
- Full suite: the previously-failing `usage-aggregator` test now passes; no other test regressed (the env override is confined to this file).