### PR TITLE
test(cli-proxy-path): fix load-timeout flake by raising the test timeout

### DIFF
--- a/tests/cli-proxy-path.test.ts
+++ b/tests/cli-proxy-path.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Each test spawns `tsx src/cli.ts` several times, which re-transpiles the CLI
+// on every spawn. Under full-suite parallel load those spawns contend for CPU
+// and can exceed the 5s default, so give this spawn-based file a timeout that
+// matches the per-spawn cap below. The slowest test runs ~1.7s in isolation.
+vi.setConfig({ testTimeout: 30_000 })
 
 let homes: string[] = []
 


### PR DESCRIPTION
## Problem
`tests/cli-proxy-path.test.ts` spawns `tsx src/cli.ts` several times per test, which re-transpiles the CLI on every spawn. Under full-suite parallel load those spawns contend for CPU, so the slowest test occasionally exceeded the 5s default test timeout, even though it runs in ~1.7s in isolation and each `spawnSync` already allows 30s.

## Fix
Set the file-level `testTimeout` to 30s (via `vi.setConfig`), matching the existing per-spawn cap. Spawn-based integration tests are inherently slower than unit tests and shouldn't be held to the 5s default. No test logic changed.

## Verification
- File solo: 6/6 pass.
- Full suite: 1194/1194 across two consecutive runs (previously `cli-proxy-path` intermittently timed out under load).