### PR TITLE
fix(menubar): explicit observation dependency for the budget flame

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -590,6 +590,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             _ = self.store.displayMetric
             _ = self.store.dailyBudget
             _ = self.store.dailyTokenBudget
+            // Read the derived flag so the flame re-tints when today's usage
+            // crosses the budget, not only when the budget value itself changes.
+            // This also makes the dependency on todayPayload explicit instead of
+            // relying on payload/menubarPayload happening to touch the same cache.
+            _ = self.store.isOverDailyBudget
             // Track the live-quota state too so the flame icon re-tints on
             // every subscription / codex usage update, not just every 30s.
             _ = self.store.subscription


### PR DESCRIPTION
Follow-up hardening from an independent multi-agent validation of #505/#506.

## What
The menubar `withObservationTracking` block read `displayMetric`, `dailyBudget`, and `dailyTokenBudget`, but not the derived `isOverDailyBudget` (which also depends on `todayPayload`). Today it still works because `payload`/`menubarPayload` register a dependency on the same underlying `cache` storage, so a today-usage write fires the re-tint. But that is incidental: if the cache is ever refactored or `todayPayload` memoized separately, the flame would silently stop updating on budget crossings.

This reads `isOverDailyBudget` in the tracking block, making the dependency explicit and intent-proof.

## Validation context
Three independent validators reviewed #505/#506: build clean, quota-over-budget tint precedence preserved, no leftover cost-only comparisons, token units consistent, sentinel/parsing/persistence correct, no SwiftUI focus-loss or feedback loop, no metric-switch desync. This was the one low-risk robustness gap they converged on. Remaining items they noted are pre-existing or minor UX (see PR discussion).

## Verification
- `swift build` passes.