### PR TITLE
fix(menubar): cost budget stays USD; flag empty custom budget

### DIFF
--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -85,9 +85,11 @@ final class AppStore {
         return total >= activeDailyBudget
     }
 
-    /// The active daily-budget threshold formatted for display (currency or tokens).
+    /// The active daily-budget threshold formatted for display (tokens, or USD).
+    /// The cost budget is defined in USD (matching the "$" presets and field), so
+    /// it is not run through the display-currency conversion here.
     var dailyBudgetLabel: String {
-        isTokenMetric ? "\(activeDailyBudget.asCompactTokens()) tokens" : activeDailyBudget.asCurrency()
+        isTokenMetric ? "\(activeDailyBudget.asCompactTokens()) tokens" : activeDailyBudget.asUSD()
     }
 
     var isLoading: Bool { loadingCountsByKey.values.contains { $0 > 0 } }
@@ -1267,6 +1269,12 @@ private let thousandsFormatter: NumberFormatter = {
         if n >= 1_000_000 { return String(format: "%.1fM", n / 1_000_000) }
         if n >= 1_000 { return String(format: "%.0fK", n / 1_000) }
         return String(format: "%.0f", n)
+    }
+
+    /// Formats a raw USD amount with a "$" and grouping, without applying the
+    /// display-currency rate. Used for the USD-denominated daily budget.
+    func asUSD() -> String {
+        "$" + (groupedDecimalFormatter.string(from: NSNumber(value: self)) ?? "\(Int(self))")
     }
 }
 

--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -57,6 +57,17 @@ private struct GeneralSettingsTab: View {
         v == v.rounded() ? String(Int(v)) : String(v)
     }
 
+    // Help text under the budget picker. When "Custom…" is selected but no amount
+    // has been entered, the budget is effectively 0 (off); call that out so the
+    // alert does not look armed when it isn't.
+    private var alertHelpText: String {
+        let customEmpty = store.isTokenMetric
+            ? (tokenCustom && store.dailyTokenBudget == 0)
+            : (costCustom && store.dailyBudget == 0)
+        if customEmpty { return "Enter an amount above, or the alert stays off." }
+        return "Flame icon turns yellow when today's \(store.isTokenMetric ? "tokens" : "cost") pass the daily budget."
+    }
+
     var body: some View {
         Form {
             Section("Display") {
@@ -162,7 +173,7 @@ private struct GeneralSettingsTab: View {
                         }
                     }
                 }
-                Text("Flame icon turns yellow when today's \(store.isTokenMetric ? "tokens" : "cost") pass the daily budget.")
+                Text(alertHelpText)
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }


### PR DESCRIPTION
Two small follow-ups from the multi-agent validation of the daily-budget work (#505/#506).

## 1. Currency consistency
The daily cost budget is defined in USD (presets are `$25…$500`, the custom field shows `$`), but the "exceeded" banner ran the value through the display-currency rate (`asCurrency()`), so a non-USD user saw the field and banner disagree, e.g. field "$100" but banner "€92" for the same threshold. This was pre-existing (the `asCurrency()` label predates #505), surfaced more by the custom field.

Fix: render the budget label in USD via a new `asUSD()` helper (no FX conversion), so the picker, the field, and the banner all agree. The over-budget comparison was already USD-vs-USD (`current.cost` vs `dailyBudget`) and is unchanged. Full display-currency budgets would mean converting presets (ugly, non-round), so the budget stays USD-denominated.

## 2. Empty custom cue
Selecting "Custom…" and leaving the field blank stores 0, which silently disables the alert while the picker still shows "Custom…". The help text now reads "Enter an amount above, or the alert stays off." in that state, so it doesn't look armed when it isn't.

## Verification
- `swift build` passes.
- macOS app (not covered by the JS suite). Runtime check: in a non-USD currency, set a $ budget and confirm field/banner match; select Custom with an empty field and confirm the hint shows and no flame fires.