### PR TITLE
fix(menubar): drop ' tok' suffix from Total Tokens metric (#497)

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -734,7 +734,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 valueText = compact ? "↑\(out)↓\(inp)\(suffix)" : " ↑\(out) ↓\(inp)\(suffix)"
             } else if store.displayMetric == .totalTokens, let p = menubarPayload?.current {
                 let total = formatTokensMenubar(Double(p.inputTokens + p.outputTokens))
-                valueText = compact ? "\(total)\(suffix)" : " \(total) tok\(suffix)"
+                valueText = compact ? "\(total)\(suffix)" : " \(total)\(suffix)"
             } else if store.displayMetric == .credits, let p = menubarPayload?.current {
                 let credits = formatTokensMenubar((p.codexCredits ?? 0).rounded())
                 valueText = compact ? "\(credits)cr\(suffix)" : " \(credits) credits\(suffix)"


### PR DESCRIPTION
Follow-up from #497: with the **Total Tokens** metric selected, the menu bar showed e.g. `🔥 0 tok`. The reporter asked to drop the ` tok` unit — the user explicitly chose the metric, and the flame already disambiguates it from a dollar amount.

Change: the wide rendering now shows ` <total><periodSuffix>` instead of ` <total> tok<periodSuffix>`. Compact mode already had no unit. The Credits metric keeps its `cr`/`credits` marker (it would otherwise be indistinguishable from total tokens).

`swift build` passes.