### PR TITLE
fix(codex): attribute MCP calls emitted as event_msg/mcp_tool_call_end (#478)

### DIFF
--- a/src/codex-cache.ts
+++ b/src/codex-cache.ts
@@ -6,7 +6,9 @@ import { homedir } from 'os'
 
 import type { ParsedProviderCall } from './providers/types.js'
 
-const CODEX_CACHE_VERSION = 3
+// v4: attribute MCP calls emitted as event_msg/mcp_tool_call_end (issue #478).
+// Recent Codex sessions cached under v3 dropped these, so force a re-parse.
+const CODEX_CACHE_VERSION = 4
 const CACHE_FILE = 'codex-results.json'
 
 type FileFingerprint = { mtimeMs: number; sizeBytes: number }

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -405,6 +405,22 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           continue
         }
 
+        // Recent Codex emits MCP calls as `event_msg`/`mcp_tool_call_end`
+        // instead of a `function_call` response_item, so the call was never
+        // attributed. Rebuild the canonical `mcp__<server>__<tool>` name the
+        // classifier recognizes.
+        if (entry.type === 'event_msg' && entry.payload?.type === 'mcp_tool_call_end') {
+          const inv = (entry.payload as Record<string, unknown>)['invocation'] as Record<string, unknown> | undefined
+          const server = typeof inv?.['server'] === 'string' ? inv['server'] as string : ''
+          const tool = typeof inv?.['tool'] === 'string' ? inv['tool'] as string : ''
+          if (server && tool) {
+            const name = `mcp__${server}__${tool}`
+            pendingTools.push(name)
+            pendingToolSequence.push([{ tool: name }])
+          }
+          continue
+        }
+
         if (entry.type === 'response_item' && entry.payload?.type === 'message' && entry.payload?.role === 'user') {
           const texts = normalizeContentBlocks(entry.payload.content)
             .filter(c => c.type === 'input_text')

--- a/tests/providers/codex.test.ts
+++ b/tests/providers/codex.test.ts
@@ -70,6 +70,20 @@ function functionCall(name: string, timestamp?: string) {
   })
 }
 
+function mcpToolCallEnd(server: string, tool: string, timestamp?: string) {
+  return JSON.stringify({
+    type: 'event_msg',
+    timestamp: timestamp ?? '2026-04-14T10:00:30Z',
+    payload: {
+      type: 'mcp_tool_call_end',
+      call_id: 'call-1',
+      invocation: { server, tool, arguments: {} },
+      duration: '1.2s',
+      result: { Ok: { content: [] } },
+    },
+  })
+}
+
 function userMessage(text: string, timestamp?: string) {
   return JSON.stringify({
     type: 'response_item',
@@ -277,6 +291,30 @@ describe('codex provider - JSONL parsing', () => {
     expect(call.sessionId).toBe('sess-parse')
     expect(call.costUSD).toBeGreaterThan(0)
     expect(call.deduplicationKey).toContain('codex:')
+  })
+
+  it('attributes MCP calls emitted as event_msg/mcp_tool_call_end', async () => {
+    const filePath = await writeSession(tmpDir, '2026-04-14', 'rollout-mcp.jsonl', [
+      sessionMeta({ session_id: 'sess-mcp', model: 'gpt-5.5' }),
+      userMessage('look up the issue'),
+      mcpToolCallEnd('github', 'get_issue'),
+      tokenCount({
+        timestamp: '2026-04-14T10:01:00Z',
+        last: { input: 300, output: 100 },
+        total: { total: 400 },
+      }),
+    ])
+
+    const provider = createCodexProvider(tmpDir)
+    const source = { path: filePath, project: 'test', provider: 'codex' }
+    const parser = provider.createSessionParser(source, new Set())
+    const calls: ParsedProviderCall[] = []
+    for await (const call of parser.parse()) {
+      calls.push(call)
+    }
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.tools).toEqual(['mcp__github__get_issue'])
   })
 
   it('normalizes Codex subagent tool calls to Agent', async () => {


### PR DESCRIPTION
## Problem

Codex MCP usage shows up in long lookback windows but not in recent ones (`today`, `week`, `month`). Reported in #478.

Recent Codex sessions report a completed MCP tool call as an `event_msg` with `type: "mcp_tool_call_end"` instead of a `function_call` response_item. The provider only built its tool list (`pendingTools`) from `function_call` and `patch_apply_end` events, and MCP is recognized purely by the `mcp__<server>__<tool>` naming convention reaching that list (`classifier.ts:45`, `parser.ts:965`). So these calls were never attributed: token usage was still counted, but the MCP tool itself was dropped. Older sessions emitted MCP as `function_call` items carrying the `mcp__` prefix, which is why long windows still showed it.

## Fix

- Add a handler for `event_msg` / `mcp_tool_call_end` that reads `invocation.server` and `invocation.tool` and rebuilds the canonical `mcp__<server>__<tool>` name. Verified against the Codex source event shape (`McpToolCallEndEvent` -> `{ type, call_id, invocation: { server, tool, arguments }, ... }`). Uses `_end` so each call is counted once after it completes; empty server/tool are skipped so a malformed event can't produce an invalid name.
- Bump the Codex result cache to v4. The cache is keyed on file fingerprint, not parser version, so without this bump existing users would keep serving the stale (pre-fix) attribution until session files changed. v4 forces a one-time re-parse.

## Validation on real local data

| | parsed calls | MCP attributed |
|---|---|---|
| before | 1383 | none |
| after | 1383 | `mcp__node_repl__js` x5 |

Matches ground truth: the raw JSONL holds exactly 5 genuine `mcp_tool_call_end` events across two recent sessions, all dropped before and all attributed after. Total call count unchanged (no double-counting; token totals untouched).

New test `attributes MCP calls emitted as event_msg/mcp_tool_call_end` asserts the reconstructed name. Full codex suite 18/18, `tsc --noEmit` clean.

Fixes #478