### PR TITLE
feat(export): surface MCP server usage in JSON and CSV exports (#496)

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -171,6 +171,25 @@ function buildToolRows(projects: ProjectSummary[]): Row[] {
     }))
 }
 
+function buildMcpRows(projects: ProjectSummary[]): Row[] {
+  const mcpTotals: Record<string, number> = {}
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      for (const [server, d] of Object.entries(session.mcpBreakdown)) {
+        mcpTotals[server] = (mcpTotals[server] ?? 0) + d.calls
+      }
+    }
+  }
+  const total = Object.values(mcpTotals).reduce((s, n) => s + n, 0)
+  return Object.entries(mcpTotals)
+    .sort(([, a], [, b]) => b - a)
+    .map(([server, calls]) => ({
+      Server: server,
+      Calls: calls,
+      'Share (%)': pct(calls, total),
+    }))
+}
+
 function buildBashRows(projects: ProjectSummary[]): Row[] {
   const bashTotals: Record<string, number> = {}
   for (const project of projects) {
@@ -270,6 +289,7 @@ function buildReadme(periods: PeriodExport[]): string {
     '  projects.csv          Spend per project folder for the selected detail period.',
     '  sessions.csv          One row per session for the selected detail period.',
     '  tools.csv             Tool invocations and share for the selected detail period.',
+    '  mcp.csv               MCP server invocations and share for the selected detail period.',
     '  shell-commands.csv    Shell commands executed via Bash tool for the selected detail period.',
     '',
     'Notes',
@@ -338,6 +358,7 @@ export async function exportCsv(periods: PeriodExport[], outputPath: string): Pr
   await writeFile(join(folder, 'projects.csv'), rowsToCsv(buildProjectRows(thirtyDayProjects)), 'utf-8')
   await writeFile(join(folder, 'sessions.csv'), rowsToCsv(buildSessionRows(thirtyDayProjects)), 'utf-8')
   await writeFile(join(folder, 'tools.csv'), rowsToCsv(buildToolRows(thirtyDayProjects)), 'utf-8')
+  await writeFile(join(folder, 'mcp.csv'), rowsToCsv(buildMcpRows(thirtyDayProjects)), 'utf-8')
   await writeFile(join(folder, 'shell-commands.csv'), rowsToCsv(buildBashRows(thirtyDayProjects)), 'utf-8')
 
   return folder
@@ -362,6 +383,7 @@ export async function exportJson(periods: PeriodExport[], outputPath: string): P
     projects: buildProjectRows(thirtyDayProjects),
     sessions: buildSessionRows(thirtyDayProjects),
     tools: buildToolRows(thirtyDayProjects),
+    mcp: buildMcpRows(thirtyDayProjects),
     shellCommands: buildBashRows(thirtyDayProjects),
   }
 

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, readdir, rm } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
-import { exportCsv, type PeriodExport } from '../src/export.js'
+import { exportCsv, exportJson, type PeriodExport } from '../src/export.js'
 import type { ProjectSummary } from '../src/types.js'
 
 let tmpDir: string
@@ -192,5 +192,35 @@ describe('exportCsv', () => {
 
     expect(readme).toContain('selected detail period')
     expect(readme).not.toContain('30-day window')
+  })
+
+  it('writes MCP server usage to mcp.csv', async () => {
+    const project = makeProject('app')
+    project.sessions[0]!.mcpBreakdown = { node_repl: { calls: 5 } }
+    const periods: PeriodExport[] = [{ label: '30 Days', projects: [project] }]
+
+    const folder = await exportCsv(periods, join(tmpDir, 'mcp.csv'))
+    const mcp = await readFile(join(folder, 'mcp.csv'), 'utf-8')
+
+    expect(mcp).toContain('Server,Calls,Share (%)')
+    expect(mcp).toContain('node_repl,5,100')
+  })
+})
+
+describe('exportJson', () => {
+  it('includes an mcp section with per-server usage', async () => {
+    const project = makeProject('app')
+    project.sessions[0]!.mcpBreakdown = { node_repl: { calls: 3 }, github: { calls: 1 } }
+    const periods: PeriodExport[] = [{ label: '30 Days', projects: [project] }]
+
+    const outputPath = join(tmpDir, 'export.json')
+    const saved = await exportJson(periods, outputPath)
+    const data = JSON.parse(await readFile(saved, 'utf-8'))
+
+    expect(Array.isArray(data.mcp)).toBe(true)
+    expect(data.mcp).toEqual([
+      { Server: 'node_repl', Calls: 3, 'Share (%)': 75 },
+      { Server: 'github', Calls: 1, 'Share (%)': 25 },
+    ])
   })
 })


### PR DESCRIPTION
## Problem

`codeburn export` never showed MCP usage even when sessions had MCP activity (#496). Two distinct gaps:

1. **MCP usage wasn't parsed** for recent Codex sessions (the `mcp_tool_call_end` event was unhandled). Fixed separately in #513, which now populates `session.mcpBreakdown`.
2. **The export schema never surfaced MCP at all** (this PR). `exportJson`/`exportCsv` emitted `tools` and `shell-commands` but no MCP section, and the `tools` list is built via `extractCoreTools`, which deliberately strips `mcp__` names. So even with `mcpBreakdown` populated, exports showed nothing MCP.

## Change

Add an `mcp` section (server -> calls, with share %) to the JSON export and an `mcp.csv` to the CSV export, sourced from `session.mcpBreakdown`. Mirrors the existing `tools` section; README updated.

Schema string stays `codeburn.export.v2` since this is purely additive (new keys, no changes to existing fields) and shouldn't break consumers pinned to v2.

## Validation on real local data

```
$ codeburn export --format json --provider codex (June)
mcp: [{"Server":"node_repl","Calls":5,"Share (%)":100}]
tools: [{"Tool":"Bash",...},{"Tool":"Edit",...}]   # MCP correctly excluded here
```

New tests: `exportJson` emits per-server `mcp` rows with correct shares; `exportCsv` writes `mcp.csv`. Full export + codex + export-date-range suites pass (26/26), `tsc --noEmit` clean.

## Out of scope

`mcpInventory` (which MCP/skill tools were *available*, vs *used*) is still empty for Codex because `extractMcpInventory` only understands Claude's `deferred_tools_delta` shape, not Codex `tool_search_output` events. Tracked as a follow-up.

Fixes #496