### PR TITLE
feat(opencode): read file-based JSON sessions (OpenCode 1.1+)

### DIFF
--- a/src/providers/opencode-file-parser.ts
+++ b/src/providers/opencode-file-parser.ts
@@ -1,0 +1,154 @@
+import { readdir, readFile } from 'fs/promises'
+import { join } from 'path'
+
+import { buildAssistantCall, sanitize, type MessageData, type PartData } from './session-message.js'
+import type { SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+
+// OpenCode 1.1+ stores sessions as file-based JSON instead of a SQLite DB:
+//   storage/session/<projectID>/<sessionID>.json   session metadata
+//   storage/message/<sessionID>/<messageID>.json    one file per message
+//   storage/part/<messageID>/<partID>.json          one file per part
+// The message/part shape matches the SQLite layout, so the per-message build
+// logic is shared via buildAssistantCall.
+
+type SessionMeta = {
+  id?: string
+  directory?: string
+  title?: string
+  time?: { created?: number }
+}
+
+type FileMessageData = MessageData & {
+  id?: string
+  time?: { created?: number }
+}
+
+async function readJson<T>(path: string): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(path, 'utf8')) as T
+  } catch {
+    return null
+  }
+}
+
+async function readParts(dataDir: string, messageId: string): Promise<PartData[]> {
+  const dir = join(dataDir, 'storage', 'part', messageId)
+  let files: string[]
+  try {
+    files = (await readdir(dir)).sort()
+  } catch {
+    return []
+  }
+  const parts: PartData[] = []
+  for (const f of files) {
+    if (!f.endsWith('.json')) continue
+    const part = await readJson<PartData>(join(dir, f))
+    if (part) parts.push(part)
+  }
+  return parts
+}
+
+export async function discoverOpenCodeFileSessions(
+  dataDir: string,
+  providerName: string,
+): Promise<SessionSource[]> {
+  const sessionRoot = join(dataDir, 'storage', 'session')
+  let projectDirs: string[]
+  try {
+    projectDirs = await readdir(sessionRoot)
+  } catch {
+    return []
+  }
+
+  const sources: SessionSource[] = []
+  for (const project of projectDirs) {
+    let files: string[]
+    try {
+      files = await readdir(join(sessionRoot, project))
+    } catch {
+      continue
+    }
+    for (const f of files) {
+      if (!f.endsWith('.json')) continue
+      const path = join(sessionRoot, project, f)
+      const meta = await readJson<SessionMeta>(path)
+      if (!meta?.id) continue
+      sources.push({
+        path,
+        project: sanitize(meta.directory || meta.title || ''),
+        provider: providerName,
+      })
+    }
+  }
+  return sources
+}
+
+export function createOpenCodeFileSessionParser(
+  source: SessionSource,
+  seenKeys: Set<string>,
+  dataDir: string,
+  providerName: string,
+): SessionParser {
+  return {
+    async *parse(): AsyncGenerator<ParsedProviderCall> {
+      const meta = await readJson<SessionMeta>(source.path)
+      if (!meta?.id) return
+      const sessionId = meta.id
+
+      const messageDir = join(dataDir, 'storage', 'message', sessionId)
+      let messageFiles: string[]
+      try {
+        messageFiles = await readdir(messageDir)
+      } catch {
+        return
+      }
+
+      const messages: Array<{ id: string; data: FileMessageData }> = []
+      for (const f of messageFiles) {
+        if (!f.endsWith('.json')) continue
+        const data = await readJson<FileMessageData>(join(messageDir, f))
+        if (!data) continue
+        messages.push({ id: data.id ?? f.replace(/\.json$/, ''), data })
+      }
+      messages.sort((a, b) => {
+        const byTime = (a.data.time?.created ?? 0) - (b.data.time?.created ?? 0)
+        if (byTime !== 0) return byTime
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+      })
+
+      let currentUserMessage = ''
+      for (const { id, data } of messages) {
+        if (data.role === 'user') {
+          const parts = await readParts(dataDir, id)
+          const text = parts
+            .filter((p) => p.type === 'text')
+            .map((p) => p.text ?? '')
+            .filter(Boolean)
+            .join(' ')
+          if (text) currentUserMessage = text
+          continue
+        }
+
+        if (data.role !== 'assistant' && data.role !== 'model') continue
+
+        const dedupKey = `${providerName}:${sessionId}:${id}`
+        if (seenKeys.has(dedupKey)) continue
+
+        const parts = await readParts(dataDir, id)
+        const call = buildAssistantCall({
+          providerName,
+          dedupKey,
+          sessionId,
+          data,
+          parts,
+          timeCreatedMs: data.time?.created ?? meta.time?.created ?? 0,
+          userMessage: currentUserMessage,
+        })
+        if (!call) continue
+
+        seenKeys.add(dedupKey)
+        yield call
+      }
+    },
+  }
+}

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -3,6 +3,7 @@ import { homedir } from 'os'
 
 import { getShortModelName } from '../models.js'
 import { discoverSqliteSessions, createSqliteSessionParser, type SqliteProviderConfig } from './sqlite-session-parser.js'
+import { discoverOpenCodeFileSessions, createOpenCodeFileSessionParser } from './opencode-file-parser.js'
 import type { Provider, SessionSource, SessionParser } from './types.js'
 
 const toolNameMap: Record<string, string> = {
@@ -39,6 +40,7 @@ function getSqliteConfig(dataDir?: string): SqliteProviderConfig {
 
 export function createOpenCodeProvider(dataDir?: string): Provider {
   const sqliteConfig = getSqliteConfig(dataDir)
+  const resolvedDataDir = getDataDir(dataDir)
 
   return {
     name: 'opencode',
@@ -53,11 +55,19 @@ export function createOpenCodeProvider(dataDir?: string): Provider {
       return toolNameMap[rawTool] ?? rawTool
     },
 
+    // OpenCode 1.1+ stores sessions as file-based JSON; older builds used a
+    // SQLite DB. Prefer file-based when present, otherwise fall back to the DB
+    // so pre-migration installs keep reporting.
     async discoverSessions(): Promise<SessionSource[]> {
+      const fileSessions = await discoverOpenCodeFileSessions(resolvedDataDir, 'opencode')
+      if (fileSessions.length > 0) return fileSessions
       return discoverSqliteSessions(sqliteConfig)
     },
 
     createSessionParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
+      if (source.path.endsWith('.json')) {
+        return createOpenCodeFileSessionParser(source, seenKeys, resolvedDataDir, 'opencode')
+      }
       return createSqliteSessionParser(source, seenKeys, sqliteConfig)
     },
   }

--- a/src/providers/session-message.ts
+++ b/src/providers/session-message.ts
@@ -1,0 +1,153 @@
+import { calculateCost } from '../models.js'
+import { extractBashCommands } from '../bash-utils.js'
+import type { ParsedProviderCall } from './types.js'
+
+// The message/part shape shared by OpenCode-style stores (OpenCode SQLite, the
+// OpenCode file-based JSON layout, and Kilo Code). Token-bearing assistant
+// messages carry either the normalized `tokens` object or a raw `usage` block.
+export type MessageData = {
+  role: string
+  modelID?: string
+  model?: string
+  cost?: number
+  tokens?: {
+    input?: number
+    output?: number
+    reasoning?: number
+    cache?: { read?: number; write?: number }
+  }
+  usage?: {
+    input_tokens?: number
+    output_tokens?: number
+    cache_creation_input_tokens?: number
+    cache_read_input_tokens?: number
+  }
+}
+
+export type PartData = {
+  type: string
+  text?: string
+  tool?: string
+  state?: { input?: { command?: string } }
+}
+
+const toolNameMap: Record<string, string> = {
+  bash: 'Bash',
+  read: 'Read',
+  edit: 'Edit',
+  write: 'Write',
+  glob: 'Glob',
+  grep: 'Grep',
+  task: 'Agent',
+  fetch: 'WebFetch',
+  search: 'WebSearch',
+  todo: 'TodoWrite',
+  skill: 'Skill',
+  patch: 'Patch',
+}
+
+export function normalizeToolName(rawTool?: string): string {
+  if (!rawTool) return ''
+  if (rawTool.startsWith('mcp__')) return rawTool
+  const builtIn = toolNameMap[rawTool]
+  if (builtIn) return builtIn
+  const serverSeparator = rawTool.indexOf('_')
+  if (serverSeparator > 0 && serverSeparator < rawTool.length - 1) {
+    const server = rawTool.slice(0, serverSeparator)
+    const tool = rawTool.slice(serverSeparator + 1)
+    return `mcp__${server}__${tool}`
+  }
+  return rawTool
+}
+
+export function sanitize(dir: string): string {
+  return dir.replace(/^\//, '').replace(/\//g, '-')
+}
+
+export function parseTimestamp(raw: number): string {
+  const ms = raw < 1e12 ? raw * 1000 : raw
+  return new Date(ms).toISOString()
+}
+
+// Build a ParsedProviderCall from one assistant message and its parts. Returns
+// null when the message has no tokens, no cost, and no substantive parts (an
+// empty or errored turn worth skipping). Shared by the SQLite and file-based
+// OpenCode parsers so both attribute tokens, tools, and cost identically.
+export function buildAssistantCall(opts: {
+  providerName: string
+  dedupKey: string
+  sessionId: string
+  data: MessageData
+  parts: PartData[]
+  timeCreatedMs: number
+  userMessage: string
+}): ParsedProviderCall | null {
+  const { data, parts } = opts
+
+  const tokens = {
+    input: data.tokens?.input ?? data.usage?.input_tokens ?? 0,
+    output: data.tokens?.output ?? data.usage?.output_tokens ?? 0,
+    reasoning: data.tokens?.reasoning ?? 0,
+    cacheRead: data.tokens?.cache?.read ?? data.usage?.cache_read_input_tokens ?? 0,
+    cacheWrite: data.tokens?.cache?.write ?? data.usage?.cache_creation_input_tokens ?? 0,
+  }
+
+  const toolParts = parts.filter((p) => (p.type === 'tool' || p.type === 'tool-call' || p.type === 'tool_call') && normalizeToolName(p.tool))
+  const hasTextOutput = parts.some((p) => p.type === 'text' && typeof p.text === 'string' && p.text.trim().length > 0)
+  const hasToolOrTextParts = hasTextOutput || toolParts.length > 0
+  const hasAnySubstantiveParts = parts.some((p) =>
+    p.type === 'text' || p.type === 'tool' || p.type === 'tool-call' || p.type === 'tool_call' ||
+    p.type === 'tool-result' || p.type === 'tool_result' || p.type === 'reasoning' || p.type === 'file'
+  )
+  const hasActivity = hasToolOrTextParts || hasAnySubstantiveParts
+
+  const allZero =
+    tokens.input === 0 &&
+    tokens.output === 0 &&
+    tokens.reasoning === 0 &&
+    tokens.cacheRead === 0 &&
+    tokens.cacheWrite === 0
+  if (allZero && (data.cost ?? 0) === 0 && !hasActivity) return null
+
+  const tools = toolParts
+    .map((p) => normalizeToolName(p.tool))
+    .filter(Boolean)
+
+  const bashCommands = toolParts
+    .filter((p) => p.tool === 'bash' && typeof p.state?.input?.command === 'string')
+    .flatMap((p) => extractBashCommands(p.state!.input!.command!))
+
+  const model = data.modelID ?? data.model ?? 'unknown'
+  let costUSD = calculateCost(
+    model,
+    tokens.input,
+    tokens.output + tokens.reasoning,
+    tokens.cacheWrite,
+    tokens.cacheRead,
+    0,
+  )
+
+  if (costUSD === 0 && typeof data.cost === 'number' && data.cost > 0) {
+    costUSD = data.cost
+  }
+
+  return {
+    provider: opts.providerName,
+    model,
+    inputTokens: tokens.input,
+    outputTokens: tokens.output,
+    cacheCreationInputTokens: tokens.cacheWrite,
+    cacheReadInputTokens: tokens.cacheRead,
+    cachedInputTokens: tokens.cacheRead,
+    reasoningTokens: tokens.reasoning,
+    webSearchRequests: 0,
+    costUSD,
+    tools,
+    bashCommands,
+    timestamp: parseTimestamp(opts.timeCreatedMs),
+    speed: 'standard',
+    deduplicationKey: opts.dedupKey,
+    userMessage: opts.userMessage,
+    sessionId: opts.sessionId,
+  }
+}

--- a/src/providers/sqlite-session-parser.ts
+++ b/src/providers/sqlite-session-parser.ts
@@ -2,8 +2,8 @@ import { readdir } from 'fs/promises'
 import { join } from 'path'
 
 import { calculateCost } from '../models.js'
-import { extractBashCommands } from '../bash-utils.js'
 import { isSqliteAvailable, getSqliteLoadError, openDatabase, blobToText, isSqliteBusyError, type SqliteDatabase } from '../sqlite.js'
+import { buildAssistantCall, parseTimestamp, sanitize, type MessageData, type PartData } from './session-message.js'
 import type {
   SessionSource,
   SessionParser,
@@ -29,32 +29,6 @@ type SessionRow = {
   time_created: number
 }
 
-type MessageData = {
-  role: string
-  modelID?: string
-  model?: string
-  cost?: number
-  tokens?: {
-    input?: number
-    output?: number
-    reasoning?: number
-    cache?: { read?: number; write?: number }
-  }
-  usage?: {
-    input_tokens?: number
-    output_tokens?: number
-    cache_creation_input_tokens?: number
-    cache_read_input_tokens?: number
-  }
-}
-
-type PartData = {
-  type: string
-  text?: string
-  tool?: string
-  state?: { input?: { command?: string } }
-}
-
 type SessionTokenRow = {
   cost?: number
   tokens_input?: number
@@ -63,44 +37,6 @@ type SessionTokenRow = {
   tokens_cache_read?: number
   tokens_cache_write?: number
   model_id?: string
-}
-
-const toolNameMap: Record<string, string> = {
-  bash: 'Bash',
-  read: 'Read',
-  edit: 'Edit',
-  write: 'Write',
-  glob: 'Glob',
-  grep: 'Grep',
-  task: 'Agent',
-  fetch: 'WebFetch',
-  search: 'WebSearch',
-  todo: 'TodoWrite',
-  skill: 'Skill',
-  patch: 'Patch',
-}
-
-function normalizeToolName(rawTool?: string): string {
-  if (!rawTool) return ''
-  if (rawTool.startsWith('mcp__')) return rawTool
-  const builtIn = toolNameMap[rawTool]
-  if (builtIn) return builtIn
-  const serverSeparator = rawTool.indexOf('_')
-  if (serverSeparator > 0 && serverSeparator < rawTool.length - 1) {
-    const server = rawTool.slice(0, serverSeparator)
-    const tool = rawTool.slice(serverSeparator + 1)
-    return `mcp__${server}__${tool}`
-  }
-  return rawTool
-}
-
-function sanitize(dir: string): string {
-  return dir.replace(/^\//, '').replace(/\//g, '-')
-}
-
-function parseTimestamp(raw: number): string {
-  const ms = raw < 1e12 ? raw * 1000 : raw
-  return new Date(ms).toISOString()
 }
 
 function tryQuerySessionTokens(db: SqliteDatabase, sessionId: string): {
@@ -270,78 +206,23 @@ export function createSqliteSessionParser(
             continue
           }
 
-          const tokens = {
-            input: data.tokens?.input ?? data.usage?.input_tokens ?? 0,
-            output: data.tokens?.output ?? data.usage?.output_tokens ?? 0,
-            reasoning: data.tokens?.reasoning ?? 0,
-            cacheRead: data.tokens?.cache?.read ?? data.usage?.cache_read_input_tokens ?? 0,
-            cacheWrite: data.tokens?.cache?.write ?? data.usage?.cache_creation_input_tokens ?? 0,
-          }
-
-          const msgParts = partsByMsg.get(msg.id) ?? []
-          const toolParts = msgParts.filter((p) => (p.type === 'tool' || p.type === 'tool-call' || p.type === 'tool_call') && normalizeToolName(p.tool))
-          const hasTextOutput = msgParts.some((p) => p.type === 'text' && typeof p.text === 'string' && p.text.trim().length > 0)
-          const hasToolOrTextParts = hasTextOutput || toolParts.length > 0
-          const hasAnySubstantiveParts = msgParts.some((p) =>
-            p.type === 'text' || p.type === 'tool' || p.type === 'tool-call' || p.type === 'tool_call' ||
-            p.type === 'tool-result' || p.type === 'tool_result' || p.type === 'reasoning' || p.type === 'file'
-          )
-          const hasActivity = hasToolOrTextParts || hasAnySubstantiveParts
-
-          const allZero =
-            tokens.input === 0 &&
-            tokens.output === 0 &&
-            tokens.reasoning === 0 &&
-            tokens.cacheRead === 0 &&
-            tokens.cacheWrite === 0
-          if (allZero && (data.cost ?? 0) === 0 && !hasActivity) continue
-
-          const tools = toolParts
-            .map((p) => normalizeToolName(p.tool))
-            .filter(Boolean)
-
-          const bashCommands = toolParts
-            .filter((p) => p.tool === 'bash' && typeof p.state?.input?.command === 'string')
-            .flatMap((p) => extractBashCommands(p.state!.input!.command!))
-
           const dedupKey = `${config.providerName}:${msg.session_id}:${msg.id}`
           if (seenKeys.has(dedupKey)) continue
-          seenKeys.add(dedupKey)
 
-          const model = data.modelID ?? data.model ?? 'unknown'
-          let costUSD = calculateCost(
-            model,
-            tokens.input,
-            tokens.output + tokens.reasoning,
-            tokens.cacheWrite,
-            tokens.cacheRead,
-            0,
-          )
-
-          if (costUSD === 0 && typeof data.cost === 'number' && data.cost > 0) {
-            costUSD = data.cost
-          }
-
-          yieldCount++
-          yield {
-            provider: config.providerName,
-            model,
-            inputTokens: tokens.input,
-            outputTokens: tokens.output,
-            cacheCreationInputTokens: tokens.cacheWrite,
-            cacheReadInputTokens: tokens.cacheRead,
-            cachedInputTokens: tokens.cacheRead,
-            reasoningTokens: tokens.reasoning,
-            webSearchRequests: 0,
-            costUSD,
-            tools,
-            bashCommands,
-            timestamp: parseTimestamp(msg.time_created),
-            speed: 'standard',
-            deduplicationKey: dedupKey,
-            userMessage: currentUserMessageBySession.get(msg.session_id) ?? '',
+          const call = buildAssistantCall({
+            providerName: config.providerName,
+            dedupKey,
             sessionId,
-          }
+            data,
+            parts: partsByMsg.get(msg.id) ?? [],
+            timeCreatedMs: msg.time_created,
+            userMessage: currentUserMessageBySession.get(msg.session_id) ?? '',
+          })
+          if (!call) continue
+
+          seenKeys.add(dedupKey)
+          yieldCount++
+          yield call
         }
 
         if (yieldCount === 0 && messages.length > 0) {

--- a/tests/providers/opencode-file.test.ts
+++ b/tests/providers/opencode-file.test.ts
@@ -1,0 +1,202 @@
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+import { createOpenCodeProvider } from '../../src/providers/opencode.js'
+import type { ParsedProviderCall } from '../../src/providers/types.js'
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'opencode-file-test-'))
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+type Msg = { id: string; data: Record<string, unknown>; parts?: Array<Record<string, unknown>> }
+
+// Mirrors the OpenCode 1.1+ on-disk layout under <dataDir>/storage/.
+async function writeSession(opts: {
+  sessionId?: string
+  projectId?: string
+  directory?: string
+  title?: string
+  messages: Msg[]
+}) {
+  const storage = join(tmpDir, 'opencode', 'storage')
+  const sessionId = opts.sessionId ?? 'ses_test1'
+  const projectId = opts.projectId ?? 'global'
+
+  const sessionDir = join(storage, 'session', projectId)
+  await mkdir(sessionDir, { recursive: true })
+  await writeFile(join(sessionDir, `${sessionId}.json`), JSON.stringify({
+    id: sessionId,
+    slug: 'cosmic-engine',
+    version: '1.1.65',
+    projectID: projectId,
+    directory: opts.directory ?? '/Users/test/myproject',
+    title: opts.title ?? 'Test session',
+    time: { created: 1781886356809, updated: 1781886683506 },
+  }))
+
+  const messageDir = join(storage, 'message', sessionId)
+  await mkdir(messageDir, { recursive: true })
+  for (const m of opts.messages) {
+    await writeFile(join(messageDir, `${m.id}.json`), JSON.stringify({ id: m.id, sessionID: sessionId, ...m.data }))
+    if (m.parts?.length) {
+      const partDir = join(storage, 'part', m.id)
+      await mkdir(partDir, { recursive: true })
+      let i = 0
+      for (const p of m.parts) {
+        await writeFile(join(partDir, `prt_${m.id}_${String(i++).padStart(3, '0')}.json`), JSON.stringify(p))
+      }
+    }
+  }
+  return { sessionId }
+}
+
+async function parseAll(seen = new Set<string>()): Promise<ParsedProviderCall[]> {
+  const provider = createOpenCodeProvider(tmpDir)
+  const sources = await provider.discoverSessions()
+  const calls: ParsedProviderCall[] = []
+  for (const source of sources) {
+    for await (const call of provider.createSessionParser(source, seen).parse()) calls.push(call)
+  }
+  return calls
+}
+
+describe('opencode file-based provider - discovery', () => {
+  it('discovers a file-based session and derives the project from directory', async () => {
+    await writeSession({
+      directory: '/Users/test/myproject',
+      messages: [{
+        id: 'msg_a',
+        data: {
+          role: 'assistant', modelID: 'gpt-5.3-codex-spark', cost: 0,
+          tokens: { input: 1000, output: 200, reasoning: 50, cache: { read: 5000, write: 0 } },
+          time: { created: 1781886356900 },
+        },
+        parts: [{ type: 'text', text: 'hello' }],
+      }],
+    })
+    const provider = createOpenCodeProvider(tmpDir)
+    const sources = await provider.discoverSessions()
+    expect(sources).toHaveLength(1)
+    expect(sources[0]!.provider).toBe('opencode')
+    expect(sources[0]!.project).toBe('Users-test-myproject')
+    expect(sources[0]!.path.endsWith('.json')).toBe(true)
+  })
+
+  it('returns nothing when neither file storage nor a DB exists', async () => {
+    const provider = createOpenCodeProvider(tmpDir)
+    expect(await provider.discoverSessions()).toEqual([])
+  })
+})
+
+describe('opencode file-based provider - parsing', () => {
+  it('extracts tokens, tools, bash commands, and the preceding user message', async () => {
+    await writeSession({
+      messages: [
+        {
+          id: 'msg_user',
+          data: { role: 'user', time: { created: 1 } },
+          parts: [{ type: 'text', text: 'find the git repos' }],
+        },
+        {
+          id: 'msg_a',
+          data: {
+            role: 'assistant', modelID: 'gpt-5.3-codex-spark', cost: 0,
+            tokens: { input: 1200, output: 300, reasoning: 100, cache: { read: 8000, write: 0 } },
+            time: { created: 2 },
+          },
+          parts: [
+            { type: 'reasoning' },
+            { type: 'tool', tool: 'bash', state: { status: 'completed', input: { command: 'git status' } } },
+            { type: 'tool', tool: 'read', state: { input: { filePath: '/x' } } },
+            { type: 'text', text: 'done' },
+          ],
+        },
+      ],
+    })
+    const calls = await parseAll()
+    expect(calls).toHaveLength(1)
+    const c = calls[0]!
+    expect(c.provider).toBe('opencode')
+    expect(c.model).toBe('gpt-5.3-codex-spark')
+    expect(c.inputTokens).toBe(1200)
+    expect(c.outputTokens).toBe(300)
+    expect(c.reasoningTokens).toBe(100)
+    expect(c.cacheReadInputTokens).toBe(8000)
+    expect(c.cachedInputTokens).toBe(8000)
+    expect(c.tools).toEqual(['Bash', 'Read'])
+    expect(c.bashCommands).toContain('git')
+    expect(c.userMessage).toBe('find the git repos')
+    expect(c.deduplicationKey).toBe('opencode:ses_test1:msg_a')
+  })
+
+  it('skips an errored or empty assistant turn (all-zero tokens, no parts)', async () => {
+    await writeSession({
+      messages: [{
+        id: 'msg_err',
+        data: {
+          role: 'assistant', modelID: 'gpt-5.3-codex', cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: 1 },
+        },
+      }],
+    })
+    expect(await parseAll()).toHaveLength(0)
+  })
+
+  it('falls back to message.cost when the model has no price table', async () => {
+    await writeSession({
+      messages: [{
+        id: 'msg_a',
+        data: {
+          role: 'assistant', modelID: 'totally-unknown-model-xyz', cost: 0.42,
+          tokens: { input: 100, output: 20, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: 1 },
+        },
+        parts: [{ type: 'text', text: 'x' }],
+      }],
+    })
+    const calls = await parseAll()
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.costUSD).toBeCloseTo(0.42)
+  })
+
+  it('deduplicates across repeated parses', async () => {
+    await writeSession({
+      messages: [{
+        id: 'msg_a',
+        data: {
+          role: 'assistant', modelID: 'gpt-5.3-codex-spark',
+          tokens: { input: 100, output: 20, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: 1 },
+        },
+        parts: [{ type: 'text', text: 'x' }],
+      }],
+    })
+    const seen = new Set<string>()
+    expect(await parseAll(seen)).toHaveLength(1)
+    expect(await parseAll(seen)).toHaveLength(0)
+  })
+
+  it('reads sessions across multiple project folders', async () => {
+    await writeSession({
+      sessionId: 'ses_one', projectId: 'global', directory: '/Users/test/a',
+      messages: [{ id: 'm1', data: { role: 'assistant', modelID: 'gpt-5.3-codex-spark', tokens: { input: 10, output: 2 }, time: { created: 1 } }, parts: [{ type: 'text', text: 'x' }] }],
+    })
+    await writeSession({
+      sessionId: 'ses_two', projectId: 'proj_hash', directory: '/Users/test/b',
+      messages: [{ id: 'm2', data: { role: 'assistant', modelID: 'gpt-5.3-codex-spark', tokens: { input: 20, output: 4 }, time: { created: 1 } }, parts: [{ type: 'text', text: 'y' }] }],
+    })
+    const calls = await parseAll()
+    expect(calls).toHaveLength(2)
+    expect(calls.map((c) => c.sessionId).sort()).toEqual(['ses_one', 'ses_two'])
+  })
+})


### PR DESCRIPTION
## Problem
OpenCode 1.1+ stores sessions as file-based JSON under `~/.local/share/opencode/storage/{session,message,part}/` instead of a SQLite database. The provider only globbed for `opencode*.db`, so on a current OpenCode install it discovered zero sessions and reported no usage at all. Confirmed locally: a live OpenCode 1.1.65 session with ~67K tokens of context was completely invisible to CodeBurn (0 sessions discovered).

## Change
- New `opencode-file-parser.ts`: file-based discovery and parsing. Reads sessions from `storage/session/**/*.json`, tokens, cost, and model from `storage/message/<id>/*.json`, and tools and bash commands from `storage/part/<id>/*.json`. No SQLite dependency.
- `opencode.ts` prefers file-based storage when present and falls back to the SQLite DB so pre-migration installs keep reporting.
- Shared message-to-call logic (token extraction, tool and bash parsing, cost, skip rules) extracted into `session-message.ts`, so the file path, the SQLite path, and Kilo Code all behave identically.

## Verification
- Against a live OpenCode 1.1.65 session: 0 to 3 sessions, 33 calls, 87K input/output/reasoning tokens plus 1.17M cache reads, $0.56 estimated, model gpt-5.3-codex-spark, tools Bash/Glob/Read, user messages captured. Errored turns (such as a rejected model request) are correctly skipped.
- 7 new file-based tests. Existing OpenCode (43) and Kilo Code (4) SQLite tests pass unchanged.
- Full suite 1239/1239, tsc clean.

Related to #414. That issue also covers a narrower gap (no tokens for non-GPT Azure Foundry models in the SQLite path); this PR fixes the broader case where current OpenCode is not read at all. The SQLite fallback path is unchanged.
