### PR TITLE
fix(dashboard): scope the plan banner to its own provider tab

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -734,9 +734,14 @@ function DashboardContent({ projects, period, columns, activeProvider, budgets, 
   if (projects.length === 0) return <Panel title="CodeBurn" color={ORANGE} width={dashWidth}><Text dimColor>No usage data found for {activeLabel}.</Text></Panel>
   const pw = wide ? halfWidth : dashWidth
   const days = dayMode ? 1 : period === 'all' ? undefined : (period === 'month' || period === '30days' ? 31 : 14)
+  // A provider-scoped plan (e.g. SuperGrok) only makes sense on its own
+  // provider tab, where the shown cost matches the plan's spend. Hide it on
+  // every other tab, including All, so its budget isn't compared to spend it
+  // doesn't cover.
+  const visiblePlanUsages = (planUsages ?? []).filter(p => p.plan.provider === (activeProvider ?? 'all'))
   return (
     <Box flexDirection="column" width={dashWidth}>
-      <Overview projects={projects} label={activeLabel} width={dashWidth} planUsages={planUsages} />
+      <Overview projects={projects} label={activeLabel} width={dashWidth} planUsages={visiblePlanUsages} />
       <Row wide={wide} width={dashWidth}><DailyActivity projects={projects} days={days} pw={pw} bw={barWidth} /><ProjectBreakdown projects={projects} pw={pw} bw={barWidth} budgets={budgets} rows={dayMode ? 8 : period === 'all' ? 14 : period === 'month' || period === '30days' ? 14 : 8} /></Row>
       <Row wide={wide} width={dashWidth}><ActivityBreakdown projects={projects} pw={pw} bw={barWidth} /><ModelBreakdown projects={projects} pw={pw} bw={barWidth} /></Row>
       {isCursor ? (


### PR DESCRIPTION
## Problem
A provider-scoped plan (e.g. SuperGrok, provider `grok`) was rendered on every dashboard tab including All, where its budget was compared against spend from providers it does not cover. On the All tab you would see "SuperGrok Heavy: $4.43 API-equivalent vs $300.00 plan" next to the combined all-provider total, which is misleading.

## Change
Filter plan usages by the active provider tab before rendering the banner, so each plan shows only on the tab whose provider matches it. An `all`-scoped plan still shows on the All tab.

## Verification
- tsc clean, full suite 1232/1232.
- The dashboard TUI has no render tests; the change is a single filter, `plan.provider === activeProvider`. SuperGrok now shows only on the grok tab and is hidden from All and the other tabs.
