### PR TITLE
chore(dev): silence the tsx module.register deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "bundle-litellm": "node scripts/bundle-litellm.mjs",
     "build": "node scripts/bundle-litellm.mjs && tsup && node -e \"const fs=require('fs'); fs.copyFileSync('src/cli.ts','dist/cli.js'); fs.chmodSync('dist/cli.js',0o755)\"",
-    "dev": "tsx src/cli.ts",
+    "dev": "NODE_OPTIONS=--no-deprecation tsx src/cli.ts",
     "test": "vitest",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
Node 26 flags tsx's loader use of `module.register()` as deprecated (DEP0205), which prints on every `npm run dev`. Run the `dev` script with `NODE_OPTIONS=--no-deprecation` so source-checkout output stays clean.

Dev-only: end users run the built `dist` via `npx` / `npm i -g` and never touch the `dev` script, so the shipped CLI is unaffected.