### PR TITLE
Distinguish gpt-5.3-codex-spark from base GPT-5.3 Codex label

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -621,6 +621,7 @@ const SHORT_NAMES: Record<string, string> = {
   'gpt-5.4-nano': 'GPT-5.4 Nano',
   'gpt-5.4-mini': 'GPT-5.4 Mini',
   'gpt-5.4': 'GPT-5.4',
+  'gpt-5.3-codex-spark': 'GPT-5.3 Codex Spark',
   'gpt-5.3-codex': 'GPT-5.3 Codex',
   'gpt-5.3': 'GPT-5.3',
   'gpt-5.2-pro': 'GPT-5.2 Pro',

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -16,6 +16,7 @@ const modelDisplayNames: Record<string, string> = {
   'gpt-5.5': 'GPT-5.5',
   'gpt-5.4-mini': 'GPT-5.4 Mini',
   'gpt-5.4': 'GPT-5.4',
+  'gpt-5.3-codex-spark': 'GPT-5.3 Codex Spark',
   'gpt-5.3-codex': 'GPT-5.3 Codex',
   'gpt-5.2-low': 'GPT-5.2 Low',
   'gpt-5.2': 'GPT-5.2',

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -51,6 +51,18 @@ describe('getShortModelName', () => {
     expect(getShortModelName('gpt-5.4-mini')).toBe('GPT-5.4 Mini')
   })
 
+  // Regression for #461: spark is a distinct variant, not a reasoning suffix.
+  it('maps gpt-5.3-codex-spark to its own label (not GPT-5.3 Codex)', () => {
+    const name = getShortModelName('gpt-5.3-codex-spark')
+    expect(name).not.toBe('GPT-5.3 Codex')
+    expect(name).toBe('GPT-5.3 Codex Spark')
+  })
+
+  it('maps gpt-5.3-codex reasoning suffixes to the base label', () => {
+    expect(getShortModelName('gpt-5.3-codex-high')).toBe('GPT-5.3 Codex')
+    expect(getShortModelName('gpt-5.3-codex-low')).toBe('GPT-5.3 Codex')
+  })
+
   it('maps claude-opus-4-6 with date suffix', () => {
     expect(getShortModelName('claude-opus-4-6-20260205')).toBe('Opus 4.6')
   })

--- a/tests/providers/codex.test.ts
+++ b/tests/providers/codex.test.ts
@@ -105,6 +105,21 @@ async function writeSession(dir: string, date: string, filename: string, lines: 
   return filePath
 }
 
+describe('codex provider - model display names', () => {
+  it('maps gpt-5.3-codex-spark to its own label', () => {
+    const provider = createCodexProvider(tmpDir)
+    const name = provider.modelDisplayName('gpt-5.3-codex-spark')
+    expect(name).not.toBe('GPT-5.3 Codex')
+    expect(name).toBe('GPT-5.3 Codex Spark')
+  })
+
+  it('maps gpt-5.3-codex reasoning suffixes to the base label', () => {
+    const provider = createCodexProvider(tmpDir)
+    expect(provider.modelDisplayName('gpt-5.3-codex-high')).toBe('GPT-5.3 Codex')
+    expect(provider.modelDisplayName('gpt-5.3-codex-low')).toBe('GPT-5.3 Codex')
+  })
+})
+
 describe('codex provider - session discovery', () => {
   it('discovers sessions in YYYY/MM/DD structure', async () => {
     await writeSession(tmpDir, '2026-04-14', 'rollout-abc123.jsonl', [


### PR DESCRIPTION
## Summary

Closes #461 by giving `gpt-5.3-codex-spark` its own display label instead of collapsing it onto the retired base `GPT-5.3 Codex` in `today`/`models`/`status` output.

## Root cause

`getShortModelName` (`src/models.ts`) and the Codex provider's `modelDisplayName` (`src/providers/codex.ts`) resolve display names with a longest-key-first `startsWith(key + "-")` match. That match is intended for reasoning-effort suffixes (`-high`/`-low`), which should fold onto the base label. But `-spark` is a distinct model variant, not a reasoning suffix, and there was no explicit entry for it, so it was swept onto `gpt-5.3-codex` and rendered as `GPT-5.3 Codex`. On usage/billing dashboards this makes a distinct, active model look like the retired base and muddies spend attribution.

As confirmed on the issue, pricing was never wrong: LiteLLM has no `gpt-5.3-codex-spark` entry, so `getModelCosts` falls back to the base `gpt-5.3-codex` rate. This is a display-label-only defect.

## What changed

- Add an explicit display entry `gpt-5.3-codex-spark` -> `GPT-5.3 Codex Spark` to `SHORT_NAMES` in `src/models.ts`.
- Add the matching entry to `modelDisplayNames` in `src/providers/codex.ts`.

Both tables are evaluated longest-key-first (`SORTED_SHORT_NAMES` in `src/models.ts`, `modelDisplayEntries` in `src/providers/codex.ts`), so the longer, more specific key wins for the exact variant while `-high`/`-low` continue to fall through to the base. The change is purely additive: no other model label or code path is touched.

## Validation

Concrete before/after via the real `getShortModelName` resolver:

```text
// origin/main (5fd1160)
gpt-5.3-codex-spark => GPT-5.3 Codex
gpt-5.3-codex-high  => GPT-5.3 Codex
gpt-5.3-codex-low   => GPT-5.3 Codex
gpt-5.3-codex       => GPT-5.3 Codex

// this branch
gpt-5.3-codex-spark => GPT-5.3 Codex Spark
gpt-5.3-codex-high  => GPT-5.3 Codex
gpt-5.3-codex-low   => GPT-5.3 Codex
gpt-5.3-codex       => GPT-5.3 Codex
```

Only `gpt-5.3-codex-spark` changes; the reasoning suffixes and the base are untouched.

Checks run (en_US locale):

```text
npm test -- --run tests/models.test.ts tests/providers/codex.test.ts   - 128 tests passed
npm test -- --run                                                      - 1276 tests passed
npx semgrep --config .semgrep/rules/no-bracket-assign-hot-paths.yml src/  - 0 findings (37 files)
npm run build (bundle-litellm + tsup)                                  - build success
Gemini 3.1 Pro (High) review - PASS (sort is order-independent; no collateral relabel:
  `-sparkle` falls through, `-spark-high` maps to Spark; pricing unaffected; no orphaned display paths)
```

New regression coverage:
- `tests/models.test.ts`: `gpt-5.3-codex-spark` -> distinct label; `-high`/`-low` -> base.
- `tests/providers/codex.test.ts`: same two assertions through the Codex provider's `modelDisplayName`.

## Notes

- Pricing/cost is unchanged by design (no LiteLLM key for the variant; base-rate fallback preserved).
- `npm run build` regenerated `src/data/litellm-snapshot.json` and `src/data/pricing-fallback.json`; both were restored because they are unrelated to this fix. The diff is the two source entries plus tests.
