### PR TITLE
fix(models): price Hermes lowercase glm-5.2 the same as GLM-5.2

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -325,6 +325,10 @@ const BUILTIN_ALIASES: Record<string, string> = {
   // ZCode runs GLM-5.2 through z.ai's start-plan subscription; it isn't in
   // LiteLLM yet. Price as the nearest released sibling (GLM-5.1) until it is.
   'GLM-5.2':                        'glm-5p1',
+  // Hermes Agent stores the same model id lowercased (`glm-5.2`) in its
+  // sessions table, so it misses the capitalized alias above and goes
+  // unpriced. Map the lowercase spelling to the same sibling.
+  'glm-5.2':                        'glm-5p1',
 }
 
 let userAliases: Record<string, string> = {}

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -32,6 +32,15 @@ describe('getModelCosts', () => {
     expect(costs).not.toBeNull()
     expect(costs!.inputCostPerToken).toBe(5e-6)
   })
+
+  it('prices lowercase glm-5.2 (Hermes spelling) the same as capitalized GLM-5.2', () => {
+    const lower = getModelCosts('glm-5.2')
+    const upper = getModelCosts('GLM-5.2')
+    expect(lower).not.toBeNull()
+    expect(upper).not.toBeNull()
+    expect(lower!.inputCostPerToken).toBe(upper!.inputCostPerToken)
+    expect(lower!.outputCostPerToken).toBe(upper!.outputCostPerToken)
+  })
 })
 
 describe('getShortModelName', () => {


### PR DESCRIPTION
Follow-up to the maintainer's note on #543. The merged Hermes provider (#544) reads `sessions.model` and passes it straight to `calculateCost`, but Hermes stores GLM-5.2 lowercased as `glm-5.2`, while `BUILTIN_ALIASES` only carries the capitalized `GLM-5.2` (added for ZCode). As a result GLM-5.2 sessions logged by Hermes resolve to no pricing and report €0.

This adds the lowercase `glm-5.2` alias pointing to the same `glm-5p1` sibling, plus a regression test asserting the lowercase and capitalized spellings price identically. Verified against a real `~/.hermes/state.db` whose only GLM model id is `glm-5.2`.
