### PR TITLE
fix(menubar): surface CLI stdout/stderr on decode failure (#515)

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Data/DataClient.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/DataClient.swift
@@ -17,6 +17,26 @@ enum DataClientError: Error {
     case outputTooLarge
 }
 
+/// Wraps a `MenubarPayload` decode failure with a bounded snippet of what the CLI
+/// actually wrote to stdout (plus stderr), so a malformed-output failure — for
+/// example a stray Node banner landing on stdout ahead of the JSON (see #515) —
+/// is self-diagnosing in logs and the UI instead of an opaque "not valid JSON".
+struct CLIDecodeFailure: Error, CustomStringConvertible {
+    let underlying: Error
+    let stdoutByteCount: Int
+    let stdoutSnippet: String
+    let stderr: String
+
+    var description: String {
+        var parts = [
+            "decode failed: \(underlying)",
+            "stdout (\(stdoutByteCount) bytes): \(stdoutSnippet.isEmpty ? "<empty>" : stdoutSnippet)",
+        ]
+        if !stderr.isEmpty { parts.append("stderr: \(stderr)") }
+        return parts.joined(separator: " | ")
+    }
+}
+
 /// Runs the CLI via argv (no shell interpretation). See `CodeburnCLI` for why we never route
 /// commands through `/bin/zsh -c` anymore.
 struct DataClient {
@@ -46,7 +66,13 @@ struct DataClient {
         do {
             return try JSONDecoder().decode(MenubarPayload.self, from: result.stdout)
         } catch {
-            throw DataClientError.decode(error)
+            let snippet = String(decoding: result.stdout.prefix(2048), as: UTF8.self)
+            throw DataClientError.decode(CLIDecodeFailure(
+                underlying: error,
+                stdoutByteCount: result.stdout.count,
+                stdoutSnippet: snippet,
+                stderr: result.stderr
+            ))
         }
     }
 

--- a/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
@@ -14,6 +14,7 @@ private func menubarPayload(cost: Double) -> MenubarPayload {
             inputTokens: 1,
             outputTokens: 1,
             cacheHitPercent: 0,
+            codexCredits: nil,
             topActivities: [],
             topModels: [],
             localModelSavings: LocalModelSavings(totalUSD: 0, calls: 0, byModel: [], byProvider: []),

--- a/mac/Tests/CodeBurnMenubarTests/DataClientProcessTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/DataClientProcessTests.swift
@@ -38,6 +38,31 @@ final class DataClientProcessTests: XCTestCase {
                        "runProcess deadlocked: \(count) concurrent CLIs starved the cooperative pool")
     }
 
+    /// A decode failure surfaces the CLI's actual stdout/stderr so a stray banner
+    /// on stdout (see #515) is self-diagnosing instead of an opaque "not valid JSON".
+    func testDecodeFailureSurfacesOutput() {
+        struct Boom: Error {}
+        let failure = CLIDecodeFailure(
+            underlying: Boom(),
+            stdoutByteCount: 13,
+            stdoutSnippet: "(node) banner",
+            stderr: "warn: x"
+        )
+        let text = String(describing: failure)
+        XCTAssertTrue(text.contains("(node) banner"), "should include the stdout snippet")
+        XCTAssertTrue(text.contains("13 bytes"), "should include the stdout byte count")
+        XCTAssertTrue(text.contains("warn: x"), "should include stderr")
+    }
+
+    /// Empty stdout is reported distinctly (the JSONDecoder-on-empty-Data case).
+    func testDecodeFailureWithEmptyStdout() {
+        struct Boom: Error {}
+        let failure = CLIDecodeFailure(underlying: Boom(), stdoutByteCount: 0, stdoutSnippet: "", stderr: "")
+        let text = String(describing: failure)
+        XCTAssertTrue(text.contains("0 bytes"))
+        XCTAssertTrue(text.contains("<empty>"))
+    }
+
     /// A normally-exiting process returns its real output and exit code through
     /// the off-pool wait path.
     func testProcessReturnsOutputAndExitCode() async throws {

--- a/mac/Tests/CodeBurnMenubarTests/MenubarStatusCacheTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/MenubarStatusCacheTests.swift
@@ -16,6 +16,7 @@ struct MenubarStatusCacheTests {
             current: CurrentBlock(
                 label: "Today", cost: cost, calls: 1, sessions: 1, oneShotRate: nil,
                 inputTokens: 1, outputTokens: 1, cacheHitPercent: 0,
+                codexCredits: nil,
                 topActivities: [], topModels: [], localModelSavings: LocalModelSavings(totalUSD: 0, calls: 0, byModel: [], byProvider: []), providers: ["claude": cost],
                 topProjects: [], modelEfficiency: [], topSessions: [],
                 retryTax: RetryTax(totalUSD: 0, retries: 0, editTurns: 0, byModel: []),


### PR DESCRIPTION
## Summary

Addresses #515 (menubar showing "Couldn't load Today / dataCorrupted: not valid JSON").

The reporter's actual failure is already resolved: the root cause was a Node v25-specific banner landing on stdout ahead of the JSON the menubar reads, and it stopped reproducing after they upgraded to Node v26 (they captured a clean exit 0, empty stderr, valid JSON payload). The CLI's `status --format menubar-json` writes only `JSON.stringify(payload)` to stdout, so there is no CLI app-code bug; the pollution was the Node runtime.

What this PR adds is the hardening both contributors on the issue agreed on, so a future stdout banner is self-diagnosing instead of an opaque error.

## Change

`DataClient.fetch` previously threw `DataClientError.decode(error)`, which surfaced only "not valid JSON" with no context (AppStore renders it via `String(describing:)`). This wraps the failure in a `CLIDecodeFailure` that carries:

- a bounded (2KB) UTF-8 snippet of what the CLI actually wrote to stdout,
- the total stdout byte count (so empty stdout is distinct from a non-JSON prefix),
- stderr.

So the error now reads, for example, `decode failed: ... | stdout (37 bytes): (node) <banner> {"generated":... | stderr: ...` instead of a bare decode error. The snippet is the user's own local usage output (no secrets) and is bounded.

## Also (second commit)

The Swift test target did not compile on `main`: two tests built `CurrentBlock` without the `codexCredits` parameter added in #510 (CI does not run the Swift tests, so it went unnoticed). Added `codexCredits: nil` to both so the suite builds.

## Validation

- `swift build` clean.
- `swift test`: 40 tests across 12 suites pass, including two new tests asserting the decode error surfaces the stdout snippet, byte count, and stderr (plus the distinct empty-stdout case).
