### PR TITLE
fix(pi): label gpt-5.5 as GPT-5.5

### DIFF
--- a/src/providers/pi.ts
+++ b/src/providers/pi.ts
@@ -11,6 +11,7 @@ import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from 
 const modelDisplayNames: Record<string, string> = {
   'gpt-5.4': 'GPT-5.4',
   'gpt-5.4-mini': 'GPT-5.4 Mini',
+  'gpt-5.5': 'GPT-5.5',
   'gpt-5': 'GPT-5',
   'gpt-4o': 'GPT-4o',
   'gpt-4o-mini': 'GPT-4o Mini',


### PR DESCRIPTION
The pi provider's `modelDisplayName` matches on a `startsWith` prefix; with no `gpt-5.5` entry, `gpt-5.5` fell into the greedy `'gpt-5' -> 'GPT-5'` prefix and rendered as "GPT-5", while codex/hermes (via the global short-name table) render "GPT-5.5". Adds an explicit `gpt-5.5` entry so the exact, longer key wins.

Verified live: pi's gpt-5.5 now shows "GPT-5.5"; no row renders bare "GPT-5". tsc clean; pi tests 17/17 pass.

Found during the post-v0.9.12 full-CLI accuracy audit. The other audit cosmetics were by-design (web/menubar 6-month window, currency --reset, export counts projects-with-spend) or a deeper follow-up (report.models showing raw ids / the glm-5p1 pricing alias).