### PR TITLE
chore(release): 0.9.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## 0.9.14 - 2026-06-22
+
+### Added (CLI)
+- **Browser dashboard.** `codeburn web` serves a local React dashboard in your
+  browser with the same task, model, tool, and project breakdowns as the TUI,
+  plus charts. Data is read locally and the server binds to localhost. (#531, #533)
+- **Combine usage across your devices.** `codeburn share` exposes one device's
+  usage over your local network (PIN-paired), and `codeburn devices` shows
+  combined totals by machine. Devices can also be discovered and paired from the
+  browser dashboard. (#532, #534, #536)
+- **New providers:** Grok Build (#521), ZCode (z.ai GLM-5.2) (#537), Hermes Agent
+  (#544), Kiro CLI sessions (#502), and zerostack (#519, thanks @kevinpauer).
+- **`codeburn overview`.** Plain-text monthly usage summary that is
+  copy-pasteable, with `--no-color` and `--from`/`--to`. (#528, #535)
+- **Codex credit usage.** Compute and surface Codex credit consumption alongside
+  dollar cost. (#408, #495, #510)
+- **MCP server usage in exports.** `codeburn export` now includes per-MCP-server
+  usage in both JSON and CSV. (#496, #514)
+- **JSON output for `optimize` and `yield`.** (#492, #500)
+- **Claude-scoped agent-type breakdown** in the report.
+- **OpenCode 1.1+ file-based JSON sessions.** (#523)
+- **Copilot OTel cache-token parsing.** (#477, thanks @steelp02; #498)
+
+### Fixed (CLI)
+- **Model names in reports.** Models priced through a sibling alias no longer
+  show their internal pricing key: ZCode/Hermes GLM-5.2 and Grok Build display
+  their real names, gpt-5.5 labels as GPT-5.5, and gpt-5.3-codex-spark is
+  distinguished from base GPT-5.3 Codex. (#548, #550, #539 thanks @ozymandiashh)
+- **Hermes lowercase glm-5.2** prices the same as GLM-5.2. (#545, thanks @ozymandiashh)
+- **Daily cache** purges cached today/future entries on hydration and is bumped
+  to v9 so newly supported providers backfill across history without a manual
+  cache clear. (#550)
+- **Cursor** scans the requested window instead of a blind 250k ROWID cap. (#482, #512)
+- **cursor-agent** ingests the workspace-less CLI transcript layout. (#542, thanks @ozymandiashh)
+- **Claude Code project names** no longer collapse to a parent folder, and stray
+  `.git` directories no longer over-group projects. (#540, thanks @ozymandiashh)
+- **Copilot** shell commands and skills/agents display correctly. (#527, thanks @jonjozwiak)
+- **Codex** attributes MCP calls emitted as `event_msg`/`mcp_tool_call_end`. (#513)
+- **Antigravity** reads the current `agy` CLI on-disk layout. (#541, thanks @ozymandiashh)
+- Workflow/ultracode subagent usage is now counted. (#470)
+- `--provider` is validated and the non-TTY report is deterministic. (#501)
+- The dashboard plan banner is scoped to its own provider tab. (#524)
+- Test isolation and environment-collision fixes. (#530, thanks @tvcsantos)
+
+### Added (macOS menubar)
+- **Custom daily budget.** Set a custom daily budget amount; the alert respects
+  the display metric (Cost or Tokens). (#497, #505, #506)
+- **Agent tabs** show every active agent for the selected range, ordered by
+  usage. (#549)
+- Polished status-item menu and About tab (Star and Sponsor links). (#509)
+
+### Fixed (macOS menubar)
+- **Keychain prompts.** Stop repeated keychain prompts on token refresh; read the
+  Claude keychain via the `security` CLI on silent refresh. (#490, #491)
+- Restore the right-click status-item menu on macOS 27. (#472, thanks @theparlor)
+- Support installer HTTP proxies. (#475, thanks @sleicht)
+- Surface the CLI's stdout/stderr on a decode failure so a stray banner is
+  self-diagnosing. (#515, #547)
+- Reduce repeated status parsing and guard against clock skew. (#486, #499)
+- The cost budget stays in USD and an empty custom budget is flagged. (#508)
+- Drop the ` tok` suffix from the Total Tokens metric. (#511)
+
 ## 0.9.12 - 2026-06-09
 
 ### Added (CLI)

--- a/README.md
+++ b/README.md
@@ -176,6 +176,35 @@ Did the spend actually ship? `codeburn yield` correlates AI sessions with git co
 
 Requires a git repository. Run from your project directory.
 
+## Browser dashboard
+
+```bash
+codeburn web                    # opens http://localhost:4747 in your browser
+codeburn web -p 30days          # start on a different period
+codeburn web --port 8080        # pick a port (falls back to a free one if taken)
+codeburn web --no-open          # start the server without opening a browser
+```
+
+A local web dashboard with the same task, model, tool, and project breakdowns as the TUI, rendered with charts. Everything is read from disk on your machine and the server binds to localhost; nothing is uploaded.
+
+### Combine usage across your devices
+
+See one total across your laptop, desktop, and work machine on the same network. On each other device, share its usage:
+
+```bash
+codeburn share --pair           # opens a pairing window and prints a PIN
+```
+
+Then add it once from your main device (the PIN authorizes the pairing):
+
+```bash
+codeburn devices add            # find nearby devices and pair, or: add <host> --pin <pin>
+codeburn devices                # combined totals by machine
+codeburn devices rm <name>      # forget a device
+```
+
+Pairing is PIN-authorized and stays on your local network. You can also discover and pair devices straight from the browser dashboard.
+
 ## Menu bar
 
 ```bash
@@ -248,7 +277,7 @@ If multiple providers have session data on disk, press `p` in the dashboard to t
 
 Each provider doc lists the exact data location, storage format, and known quirks. Linux and Windows paths are detected automatically. If a path has changed or is wrong, please [open an issue](https://github.com/getagentseal/codeburn/issues).
 
-The `--provider` flag filters any command to a single provider: `codeburn report --provider claude`, `codeburn today --provider codex`, `codeburn export --provider cursor`. Works on all commands: `report`, `today`, `month`, `overview`, `status`, `export`, `optimize`, `compare`, `yield`.
+The `--provider` flag filters any command to a single provider: `codeburn report --provider claude`, `codeburn today --provider codex`, `codeburn export --provider cursor`. Works on all commands: `report`, `today`, `month`, `overview`, `status`, `export`, `web`, `optimize`, `compare`, `yield`.
 
 Adding a new provider is a single file. See `src/providers/codex.ts` for an example.
 
@@ -281,6 +310,15 @@ Run `codeburn` for the dashboard, or use a subcommand below. Most commands also 
 | `codeburn status --format json` | The same totals as JSON |
 | `codeburn export` | CSV covering today, 7 days, and 30 days |
 | `codeburn export -f json` | Export as JSON instead of CSV |
+
+**Web & devices**
+
+| Command | What it does |
+|---------|--------------|
+| `codeburn web` | Local browser dashboard with charts (http://localhost:4747) |
+| `codeburn share --pair` | Share this device's usage to your other devices (PIN pairing) |
+| `codeburn devices add` | Find and pair a nearby device |
+| `codeburn devices` | Combined usage totals across your paired devices |
 
 **Analysis**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeburn",
-  "version": "0.9.12",
+  "version": "0.9.14",
   "description": "See where your AI spend goes - by task, tool, model, and project",
   "type": "module",
   "main": "./dist/cli.js",


### PR DESCRIPTION
Release **0.9.14**. Adds the CHANGELOG entry, documents the new browser dashboard and device sharing in the README, and bumps the package version.

## Highlights since 0.9.12
- **Browser dashboard** (`codeburn web`): local React dashboard with charts, plus in-browser device discovery.
- **Combine usage across your devices** (`codeburn share` / `codeburn devices`): PIN-paired over the local network.
- **New providers:** Grok Build, ZCode (z.ai GLM-5.2), Hermes Agent, Kiro CLI sessions, zerostack.
- **Codex credit usage**, **MCP server usage in exports**, **JSON output for `optimize`/`yield`**.
- CLI and menubar fixes: model-name display (no pricing-alias leaks), daily-cache v9 backfill, custom daily budget, fewer keychain prompts, agent tabs ordered by usage, and more.

## Contributors
Thanks @ozymandiashh, @jonjozwiak, @kevinpauer, @tvcsantos, @steelp02, @sleicht, and @theparlor. Full per-change credits are in the CHANGELOG.

## After merge
Manual `npm publish` (no publish CI). `prepublishOnly` rebuilds with fresh pricing data.
