### PR TITLE
docs(changelog): credit @vaibhavarora14 for #486

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 - Support installer HTTP proxies. (#475, thanks @sleicht)
 - Surface the CLI's stdout/stderr on a decode failure so a stray banner is
   self-diagnosing. (#515, #547)
-- Reduce repeated status parsing and guard against clock skew. (#486, #499)
+- Reduce repeated status parsing and guard against clock skew. (#486, thanks @vaibhavarora14; #499)
 - The cost budget stays in USD and an empty custom budget is flagged. (#508)
 - Drop the ` tok` suffix from the Total Tokens metric. (#511)
 


### PR DESCRIPTION
The 0.9.14 changelog referenced #486 but did not credit its author. The v0.9.14 release notes already credit @vaibhavarora14; this keeps CHANGELOG.md consistent.