### PR TITLE
feat(budget): spend budgets with overview display and scriptable --check

### DIFF
--- a/src/budget.ts
+++ b/src/budget.ts
@@ -1,0 +1,62 @@
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export type BudgetTier = 'daily' | 'weekly' | 'monthly'
+export type BudgetState = 'under' | 'warn' | 'over'
+
+export type BudgetStatus = {
+  spent: number
+  budget: number
+  pct: number
+  projected: number
+  state: BudgetState
+}
+
+export type BudgetStatusInput = {
+  spent: number
+  budget: number
+  elapsedDays: number
+  totalDays: number
+}
+
+function requireFinitePositive(name: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RangeError(`${name} must be a finite number greater than 0`)
+  }
+}
+
+function requireFiniteNonNegative(name: string, value: number): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${name} must be a finite number greater than or equal to 0`)
+  }
+}
+
+function toDayIndex(d: Date): number {
+  return Math.floor(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()) / MS_PER_DAY)
+}
+
+export function diffCalendarDays(from: Date, to: Date): number {
+  return toDayIndex(to) - toDayIndex(from)
+}
+
+export function daysInMonth(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate()
+}
+
+export function computeBudgetStatus(input: BudgetStatusInput): BudgetStatus {
+  requireFiniteNonNegative('spent', input.spent)
+  requireFinitePositive('budget', input.budget)
+  requireFinitePositive('elapsedDays', input.elapsedDays)
+  requireFinitePositive('totalDays', input.totalDays)
+
+  const pct = (input.spent / input.budget) * 100
+  const projected = input.spent * input.totalDays / input.elapsedDays
+  const state: BudgetState = pct >= 100 ? 'over' : pct >= 80 ? 'warn' : 'under'
+
+  return {
+    spent: input.spent,
+    budget: input.budget,
+    pct,
+    projected,
+    state,
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,12 @@ export type CodeburnConfig = {
   // can show "saved $X by running locally". Distinct from modelAliases which
   // rewrites actual spend.
   localModelSavings?: Record<string, string>
+  // Spend budgets are stored in the configured display currency, not USD.
+  budget?: {
+    daily?: number
+    weekly?: number
+    monthly?: number
+  }
   // Absolute directory prefixes whose Claude Code sessions are routed through a
   // subscription-backed LLM proxy (e.g. GitHub Copilot via ANTHROPIC_BASE_URL;
   // tools like claude-code-over-github-copilot / claudegate). The JSONL records

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { exportCsv, exportJson, type PeriodExport } from './export.js'
 import { findUnpricedModels, loadPricing, setModelAliases, setPriceOverrides, setLocalModelSavings, setProxyPaths, normalizeProxyPath } from './models.js'
 import { parseAllSessions, filterProjectsByName, filterProjectsByDateRange, clearSessionCache } from './parser.js'
 import { allProviderNames, getAllProviders } from './providers/index.js'
-import { convertCost } from './currency.js'
+import { convertCost, formatCost } from './currency.js'
 import { renderStatusBar } from './format.js'
 import { toDateString } from './daily-cache.js'
 import { dateKey } from './day-aggregator.js'
@@ -32,6 +32,7 @@ import { registerGuardCommands } from './guard/cli.js'
 import { registerSyncCommands } from './sync/cli.js'
 import { runContextCommand } from './context-tree.js'
 import { renderCompare } from './compare.js'
+import { computeBudgetStatus, daysInMonth, diffCalendarDays, type BudgetStatus, type BudgetTier } from './budget.js'
 import {
   installAntigravityStatusLineHook,
   runAgyStatusLineHook,
@@ -142,6 +143,29 @@ function toJsonPlanSummary(planUsage: PlanUsage): JsonPlanSummary {
 
 type JsonPlanSummaryMap = Partial<Record<PlanProvider, JsonPlanSummary>>
 
+type BudgetCommandOpts = {
+  daily?: number
+  weekly?: number
+  monthly?: number
+  list?: boolean
+  remove?: string
+  check?: boolean
+}
+
+type OverviewBudget = {
+  tier: BudgetTier
+  status: BudgetStatus
+  inProgress: boolean
+}
+
+type BudgetPeriodInfo = {
+  tier: BudgetTier
+  range: DateRange
+  elapsedDays: number
+  totalDays: number
+  inProgress: boolean
+}
+
 function toJsonPlanSummaryMap(planUsages: PlanUsage[]): JsonPlanSummaryMap {
   const summaries: JsonPlanSummaryMap = {}
   for (const usage of planUsages) {
@@ -165,6 +189,174 @@ async function attachPlanSummaries<T extends object>(payload: T): Promise<T & { 
 function planLabel(plan: Plan): string {
   const name = planDisplayName(plan.id)
   return plan.id === 'custom' ? `${name} (${plan.provider})` : name
+}
+
+function formatDisplayCurrencyAmount(amount: number): string {
+  const { rate } = getCurrency()
+  return formatCost(rate > 0 ? amount / rate : amount)
+}
+
+function isValidBudgetAmount(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function configuredBudgetEntries(budget: CodeburnConfig['budget']): Array<{ tier: BudgetTier; amount: number }> {
+  const entries: Array<{ tier: BudgetTier; amount: number }> = []
+  const daily = budget?.daily
+  const weekly = budget?.weekly
+  const monthly = budget?.monthly
+  if (isValidBudgetAmount(daily)) entries.push({ tier: 'daily', amount: daily })
+  if (isValidBudgetAmount(weekly)) entries.push({ tier: 'weekly', amount: weekly })
+  if (isValidBudgetAmount(monthly)) entries.push({ tier: 'monthly', amount: monthly })
+  return entries
+}
+
+function budgetTierForOverview(period: Period | undefined, customRange: DateRange | null): BudgetTier | undefined {
+  if (customRange) return undefined
+  if (period === 'today') return 'daily'
+  if (period === 'week') return 'weekly'
+  if (period === 'month') return 'monthly'
+  return undefined
+}
+
+function budgetAmountForTier(budget: CodeburnConfig['budget'], tier: BudgetTier): number | undefined {
+  const amount = tier === 'daily'
+    ? budget?.daily
+    : tier === 'weekly'
+      ? budget?.weekly
+      : budget?.monthly
+  return isValidBudgetAmount(amount) ? amount : undefined
+}
+
+function periodForBudgetTier(tier: BudgetTier): Extract<Period, 'today' | 'week' | 'month'> {
+  if (tier === 'daily') return 'today'
+  if (tier === 'weekly') return 'week'
+  return 'month'
+}
+
+function getBudgetPeriodInfo(tier: BudgetTier): BudgetPeriodInfo {
+  const { range } = getDateRange(periodForBudgetTier(tier))
+  const progress = getOverviewBudgetProgress(tier, range)
+  return { tier, range, ...progress }
+}
+
+function getOverviewBudgetProgress(tier: BudgetTier, range: DateRange, today = new Date()): Pick<BudgetPeriodInfo, 'elapsedDays' | 'totalDays' | 'inProgress'> {
+  if (tier === 'daily') return { elapsedDays: 1, totalDays: 1, inProgress: false }
+  if (tier === 'weekly') return { elapsedDays: 7, totalDays: 7, inProgress: false }
+
+  const totalDays = daysInMonth(today)
+  const elapsedDays = Math.max(1, Math.min(totalDays, diffCalendarDays(range.start, today) + 1))
+  return { elapsedDays, totalDays, inProgress: elapsedDays < totalDays }
+}
+
+function totalProjectCostUSD(projects: ProjectSummary[]): number {
+  return projects.reduce((sum, project) => sum + project.totalCostUSD, 0)
+}
+
+function buildOverviewBudget(projects: ProjectSummary[], budget: CodeburnConfig['budget'], tier: BudgetTier | undefined, range: DateRange): OverviewBudget | undefined {
+  if (!tier) return undefined
+  const amount = budgetAmountForTier(budget, tier)
+  if (amount === undefined) return undefined
+  const progress = getOverviewBudgetProgress(tier, range)
+  return {
+    tier,
+    status: computeBudgetStatus({
+      spent: convertCost(totalProjectCostUSD(projects)),
+      budget: amount,
+      elapsedDays: progress.elapsedDays,
+      totalDays: progress.totalDays,
+    }),
+    inProgress: progress.inProgress,
+  }
+}
+
+function isOverviewBudgetFilterActive(opts: { provider: string; project: string[]; exclude: string[] }): boolean {
+  return opts.provider !== 'all' || opts.project.length > 0 || opts.exclude.length > 0
+}
+
+function printBudgetList(budget: CodeburnConfig['budget']): void {
+  const entries = configuredBudgetEntries(budget)
+  if (entries.length === 0) {
+    console.log('\n  No budgets configured.')
+    console.log(`  Config: ${getConfigFilePath()}`)
+    console.log('  Add one with: codeburn budget --monthly <amount>\n')
+    return
+  }
+
+  console.log('\n  Budgets:')
+  for (const entry of entries) {
+    console.log(`    ${entry.tier}: ${formatDisplayCurrencyAmount(entry.amount)}`)
+  }
+  console.log(`  Config: ${getConfigFilePath()}\n`)
+}
+
+function validateBudgetSetters(opts: BudgetCommandOpts): boolean {
+  const invalid: Array<{ flag: string; value: number | undefined }> = []
+  if (opts.daily !== undefined && !isValidBudgetAmount(opts.daily)) invalid.push({ flag: '--daily', value: opts.daily })
+  if (opts.weekly !== undefined && !isValidBudgetAmount(opts.weekly)) invalid.push({ flag: '--weekly', value: opts.weekly })
+  if (opts.monthly !== undefined && !isValidBudgetAmount(opts.monthly)) invalid.push({ flag: '--monthly', value: opts.monthly })
+
+  if (invalid.length === 0) return true
+
+  for (const item of invalid) {
+    console.error(`\n  ${item.flag} must be a finite number greater than 0 (got: ${String(item.value)}).\n`)
+  }
+  process.exitCode = 1
+  return false
+}
+
+function assignBudgetSetters(config: CodeburnConfig, opts: BudgetCommandOpts): void {
+  const budget = { ...(config.budget ?? {}) }
+  if (opts.daily !== undefined) budget.daily = opts.daily
+  if (opts.weekly !== undefined) budget.weekly = opts.weekly
+  if (opts.monthly !== undefined) budget.monthly = opts.monthly
+  config.budget = budget
+}
+
+function removeBudget(config: CodeburnConfig, tier: string): boolean {
+  if (tier !== 'daily' && tier !== 'weekly' && tier !== 'monthly') {
+    console.error(`\n  Unknown budget period: ${tier}. Use daily, weekly, or monthly.\n`)
+    process.exitCode = 1
+    return false
+  }
+
+  const budget = { ...(config.budget ?? {}) }
+  if (tier === 'daily') delete budget.daily
+  if (tier === 'weekly') delete budget.weekly
+  if (tier === 'monthly') delete budget.monthly
+  config.budget = configuredBudgetEntries(budget).length > 0 ? budget : undefined
+  return true
+}
+
+async function runBudgetCheck(budget: CodeburnConfig['budget']): Promise<void> {
+  const entries = configuredBudgetEntries(budget)
+  if (entries.length === 0) {
+    console.log('\n  No budgets configured.')
+    console.log('  Add one with: codeburn budget --monthly <amount>\n')
+    return
+  }
+
+  await loadPricing()
+
+  let over = false
+  console.log('')
+  for (const entry of entries) {
+    const period = getBudgetPeriodInfo(entry.tier)
+    const projects = await parseAllSessions(period.range, 'all')
+    const status = computeBudgetStatus({
+      spent: convertCost(totalProjectCostUSD(projects)),
+      budget: entry.amount,
+      elapsedDays: period.elapsedDays,
+      totalDays: period.totalDays,
+    })
+    const label = status.state === 'over' ? 'OVER' : status.state === 'warn' ? 'WARN' : 'OK'
+    if (status.state === 'over') over = true
+    console.log(`  ${entry.tier}: ${formatDisplayCurrencyAmount(status.spent)} of ${formatDisplayCurrencyAmount(status.budget)} (${Math.floor(status.pct)}%) [${label}]`)
+    clearSessionCache()
+  }
+  console.log('')
+
+  if (over) process.exitCode = 1
 }
 
 function toPlanDisplay(plan: Plan) {
@@ -724,11 +916,54 @@ program
       console.error(`\n  Error: ${err instanceof Error ? err.message : String(err)}\n`)
       process.exit(1)
     }
+    const period = customRange ? undefined : toPeriod(opts.period)
     const { range, label } = customRange
       ? { range: customRange, label: formatDateRangeLabel(opts.from, opts.to) }
-      : getDateRange(toPeriod(opts.period))
+      : getDateRange(period!)
     const projects = filterProjectsByName(await parseAllSessions(range, opts.provider), opts.project, opts.exclude)
-    process.stdout.write(renderOverview(projects, { label, color: opts.color }))
+    const config = await readConfig()
+    const budget = isOverviewBudgetFilterActive(opts)
+      ? undefined
+      : buildOverviewBudget(projects, config.budget, budgetTierForOverview(period, customRange), range)
+    process.stdout.write(renderOverview(projects, { label, color: opts.color, budget }))
+  })
+
+program
+  .command('budget')
+  .description('Set spend budgets and check current spend against them')
+  .option('--daily <amt>', 'Set daily spend budget in the active display currency', parseNumber)
+  .option('--weekly <amt>', 'Set weekly spend budget in the active display currency', parseNumber)
+  .option('--monthly <amt>', 'Set monthly spend budget in the active display currency', parseNumber)
+  .option('--list', 'List configured spend budgets')
+  .option('--remove <period>', 'Remove one budget: daily, weekly, or monthly')
+  .option('--check', 'Check current spend and exit 1 if any configured budget is over')
+  .action(async (opts: BudgetCommandOpts) => {
+    const config = await readConfig()
+    const hasSetter = opts.daily !== undefined || opts.weekly !== undefined || opts.monthly !== undefined
+
+    if (opts.list || (!hasSetter && !opts.remove && !opts.check)) {
+      printBudgetList(config.budget)
+      return
+    }
+
+    if (opts.remove) {
+      if (!removeBudget(config, opts.remove)) return
+      await saveConfig(config)
+      console.log(`\n  Removed ${opts.remove} budget.`)
+      console.log(`  Config: ${getConfigFilePath()}\n`)
+      return
+    }
+
+    if (opts.check) {
+      await runBudgetCheck(config.budget)
+      return
+    }
+
+    if (!validateBudgetSetters(opts)) return
+    assignBudgetSetters(config, opts)
+    await saveConfig(config)
+    console.log('\n  Budget saved.')
+    printBudgetList(config.budget)
   })
 
 program

--- a/src/overview.ts
+++ b/src/overview.ts
@@ -3,15 +3,20 @@ import { Chalk, type ChalkInstance } from 'chalk'
 import { homedir } from 'os'
 
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory } from './types.js'
-import { formatCost as baseCost } from './currency.js'
+import { formatCost as baseCost, getCurrency } from './currency.js'
 import { findUnpricedModels, getShortModelName } from './models.js'
 import { dateKey } from './day-aggregator.js'
+import type { BudgetStatus, BudgetTier } from './budget.js'
 
 // Display-only helpers. The shared formatters omit thousands separators and
 // abbreviate; here we show full, comma-grouped numbers so the tables read like
 // a precise statement. Aggregation uses raw numbers; these only affect render.
 function formatCost(usd: number): string {
   return baseCost(usd).replace(/(\d)(?=(\d{3})+(\.|$))/g, '$1,')
+}
+function formatDisplayCost(amount: number): string {
+  const { rate } = getCurrency()
+  return formatCost(rate > 0 ? amount / rate : amount)
 }
 function formatTokens(n: number): string {
   // Pin the locale so grouping is deterministic regardless of the host's
@@ -38,6 +43,11 @@ function projectName(p: ProjectSummary): string {
 }
 
 type Col = { header: string; right?: boolean }
+type OverviewBudget = {
+  tier: BudgetTier
+  status: BudgetStatus
+  inProgress: boolean
+}
 
 // Visible width, ignoring ANSI color codes, so padding stays aligned.
 function vlen(s: string): number {
@@ -74,7 +84,7 @@ function renderTable(c: ChalkInstance, cols: Col[], rows: string[][]): string {
 
 export function renderOverview(
   projects: ProjectSummary[],
-  opts: { label: string; color: boolean },
+  opts: { label: string; color: boolean; budget?: OverviewBudget },
 ): string {
   const c = new Chalk(opts.color ? {} : { level: 0 })
   const heading = (text: string): string => c.cyan.bold(text)
@@ -170,6 +180,20 @@ export function renderOverview(
     const more = unpriced.length > 3 ? ` +${unpriced.length - 3} more` : ''
     out.push(kv('Unpriced', c.yellow(`${unpriced.length} model${unpriced.length === 1 ? '' : 's'} at $0: `) + shown + more))
     out.push(kv('', c.dim('Fix: codeburn model-alias "<model>" <known-model>')))
+  }
+  if (opts.budget) {
+    const label = opts.budget.tier === 'daily'
+      ? 'Daily'
+      : opts.budget.tier === 'weekly'
+        ? 'Weekly'
+        : 'Monthly'
+    const status = opts.budget.status
+    const pct = `${Math.floor(status.pct)}%`
+    const statusColor = status.state === 'over' ? c.red : status.state === 'warn' ? c.yellow : c.green
+    const projected = opts.budget.inProgress
+      ? c.dim(`  projected ${formatDisplayCost(status.projected)} by ${opts.budget.tier === 'monthly' ? 'month' : opts.budget.tier === 'weekly' ? 'week' : 'day'} end`)
+      : ''
+    out.push('  ' + statusColor(`${label} budget: ${formatDisplayCost(status.spent)} of ${formatDisplayCost(status.budget)} (${pct})`) + projected)
   }
   out.push('')
 

--- a/tests/budget.test.ts
+++ b/tests/budget.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeBudgetStatus } from '../src/budget.js'
+
+describe('computeBudgetStatus', () => {
+  it('classifies under, warn, and over at the threshold boundaries', () => {
+    expect(computeBudgetStatus({ spent: 79.99, budget: 100, elapsedDays: 1, totalDays: 1 }).state).toBe('under')
+    expect(computeBudgetStatus({ spent: 80, budget: 100, elapsedDays: 1, totalDays: 1 }).state).toBe('warn')
+    expect(computeBudgetStatus({ spent: 99.99, budget: 100, elapsedDays: 1, totalDays: 1 }).state).toBe('warn')
+    expect(computeBudgetStatus({ spent: 100, budget: 100, elapsedDays: 1, totalDays: 1 }).state).toBe('over')
+  })
+
+  it('computes percent and linear projection from elapsed and total days', () => {
+    const status = computeBudgetStatus({ spent: 30, budget: 120, elapsedDays: 10, totalDays: 30 })
+
+    expect(status.pct).toBe(25)
+    expect(status.projected).toBe(90)
+  })
+
+  it('rejects invalid numeric inputs', () => {
+    expect(() => computeBudgetStatus({ spent: -1, budget: 100, elapsedDays: 1, totalDays: 1 })).toThrow(/spent/)
+    expect(() => computeBudgetStatus({ spent: 1, budget: 0, elapsedDays: 1, totalDays: 1 })).toThrow(/budget/)
+    expect(() => computeBudgetStatus({ spent: 1, budget: 100, elapsedDays: 0, totalDays: 1 })).toThrow(/elapsedDays/)
+    expect(() => computeBudgetStatus({ spent: 1, budget: 100, elapsedDays: 1, totalDays: -1 })).toThrow(/totalDays/)
+    expect(() => computeBudgetStatus({ spent: Number.POSITIVE_INFINITY, budget: 100, elapsedDays: 1, totalDays: 1 })).toThrow(/spent/)
+  })
+})

--- a/tests/cli-budget.test.ts
+++ b/tests/cli-budget.test.ts
@@ -1,0 +1,237 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+import { describe, expect, it } from 'vitest'
+
+import { getDateRange } from '../src/cli-date.js'
+
+const CLI_TIMEOUT_MS = 30_000
+
+function runCli(args: string[], home: string) {
+  return spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      CLAUDE_CONFIG_DIR: join(home, '.claude'),
+      HOME: home,
+      USERPROFILE: home,
+      HOMEPATH: home,
+      HOMEDRIVE: '',
+      TZ: 'UTC',
+    },
+    encoding: 'utf-8',
+    timeout: CLI_TIMEOUT_MS,
+  })
+}
+
+async function readConfig(home: string): Promise<{ budget?: { daily?: number; weekly?: number; monthly?: number } }> {
+  const raw = await readFile(join(home, '.config', 'codeburn', 'config.json'), 'utf-8')
+  return JSON.parse(raw) as { budget?: { daily?: number; weekly?: number; monthly?: number } }
+}
+
+function timestampFromDate(date: Date, offsetMinutes = 0): string {
+  return new Date(date.getTime() + offsetMinutes * 60_000)
+    .toISOString()
+    .replace(/\.\d+Z$/, 'Z')
+}
+
+function currentMonthTimestamp(offsetMinutes: number): string {
+  const now = new Date()
+  const base = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12, 0, 0))
+  return timestampFromDate(base, offsetMinutes)
+}
+
+function userLine(sessionId: string, timestamp: string): string {
+  return JSON.stringify({
+    type: 'user',
+    sessionId,
+    timestamp,
+    cwd: '/tmp/codeburn-budget-app',
+    message: { role: 'user', content: 'ship budget check' },
+  })
+}
+
+function assistantLine(sessionId: string, timestamp: string): string {
+  return JSON.stringify({
+    type: 'assistant',
+    sessionId,
+    timestamp,
+    cwd: '/tmp/codeburn-budget-app',
+    message: {
+      id: `msg-${sessionId}`,
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [{ type: 'text', text: 'done' }],
+      usage: {
+        input_tokens: 1_000_000,
+        output_tokens: 100_000,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  })
+}
+
+async function seedClaudeSpend(home: string, opts: { sessionId: string; timestamp: string }): Promise<void> {
+  const projectDir = join(home, '.claude', 'projects', 'budget-app')
+  await mkdir(projectDir, { recursive: true })
+  await writeFile(
+    join(projectDir, `${opts.sessionId}.jsonl`),
+    [
+      userLine(opts.sessionId, opts.timestamp),
+      assistantLine(opts.sessionId, timestampFromDate(new Date(opts.timestamp), 1)),
+    ].join('\n') + '\n',
+    'utf-8',
+  )
+}
+
+async function seedCurrentMonthSpend(home: string): Promise<void> {
+  await seedClaudeSpend(home, { sessionId: 'budget-session', timestamp: currentMonthTimestamp(0) })
+}
+
+describe('codeburn budget command', () => {
+  it('saves, lists, and removes a monthly budget', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    try {
+      const set = runCli(['budget', '--monthly', '123.45'], home)
+      expect(set.status, `stderr: ${set.stderr}`).toBe(0)
+      expect(set.stdout).toContain('monthly')
+
+      const saved = await readConfig(home)
+      expect(saved.budget?.monthly).toBe(123.45)
+
+      const list = runCli(['budget', '--list'], home)
+      expect(list.status).toBe(0)
+      expect(list.stdout).toContain('monthly')
+      expect(list.stdout).toContain('$123.45')
+
+      const remove = runCli(['budget', '--remove', 'monthly'], home)
+      expect(remove.status).toBe(0)
+
+      const after = await readConfig(home)
+      expect(after.budget).toBeUndefined()
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  }, CLI_TIMEOUT_MS)
+
+  it('rejects an invalid amount without writing a budget', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    try {
+      const result = runCli(['budget', '--daily', '0'], home)
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('--daily must be a finite number greater than 0')
+
+      const list = runCli(['budget', '--list'], home)
+      expect(list.status).toBe(0)
+      expect(list.stdout).toContain('No budgets configured')
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  }, CLI_TIMEOUT_MS)
+
+  it('exits 1 when the current month is over budget', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    try {
+      await seedCurrentMonthSpend(home)
+      expect(runCli(['budget', '--monthly', '0.01'], home).status).toBe(0)
+
+      const result = runCli(['budget', '--check'], home)
+      expect(result.status, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(1)
+      expect(result.stdout).toContain('monthly:')
+      expect(result.stdout).toContain('[OVER]')
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  }, CLI_TIMEOUT_MS)
+
+  it('floors a 99.x percent budget check without reporting over', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    try {
+      await seedCurrentMonthSpend(home)
+      expect(runCli(['budget', '--monthly', '4.52'], home).status).toBe(0)
+
+      const result = runCli(['budget', '--check'], home)
+      expect(result.status, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0)
+      expect(result.stdout).toContain('(99%) [WARN]')
+      expect(result.stdout).not.toContain('(100%)')
+      expect(result.stdout).not.toContain('[OVER]')
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  }, CLI_TIMEOUT_MS)
+
+  it('exits 0 when the current month is under budget or no budget is configured', async () => {
+    const noneHome = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    const underHome = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    try {
+      const none = runCli(['budget', '--check'], noneHome)
+      expect(none.status).toBe(0)
+      expect(none.stdout).toContain('No budgets configured')
+
+      await seedCurrentMonthSpend(underHome)
+      expect(runCli(['budget', '--monthly', '100000'], underHome).status).toBe(0)
+
+      const under = runCli(['budget', '--check'], underHome)
+      expect(under.status, `stdout: ${under.stdout}\nstderr: ${under.stderr}`).toBe(0)
+      expect(under.stdout).toContain('monthly:')
+      expect(under.stdout).toContain('[OK]')
+    } finally {
+      await rm(noneHome, { recursive: true, force: true })
+      await rm(underHome, { recursive: true, force: true })
+    }
+  }, CLI_TIMEOUT_MS)
+
+  it('keeps overview budget lines only on unfiltered overviews', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    try {
+      await seedCurrentMonthSpend(home)
+      expect(runCli(['budget', '--monthly', '100000'], home).status).toBe(0)
+
+      const unfiltered = runCli(['overview', '-p', 'month', '--no-color'], home)
+      expect(unfiltered.status, `stdout: ${unfiltered.stdout}\nstderr: ${unfiltered.stderr}`).toBe(0)
+      expect(unfiltered.stdout).toContain('Monthly budget:')
+
+      for (const filterArgs of [
+        ['--provider', 'claude'],
+        ['--project', 'budget-app'],
+        ['--exclude', 'not-the-budget-app'],
+      ]) {
+        const filtered = runCli(['overview', '-p', 'month', '--no-color', ...filterArgs], home)
+        expect(filtered.status, `args: ${filterArgs.join(' ')}\nstdout: ${filtered.stdout}\nstderr: ${filtered.stderr}`).toBe(0)
+        expect(filtered.stdout).toContain('Totals')
+        expect(filtered.stdout).not.toMatch(/\b(?:Daily|Weekly|Monthly) budget:/)
+      }
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  }, CLI_TIMEOUT_MS)
+
+  it('uses the same weekly spend window for budget --check and overview -p week', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-budget-'))
+    try {
+      const weekStart = getDateRange('week').range.start
+      await seedClaudeSpend(home, {
+        sessionId: 'weekly-boundary-session',
+        timestamp: timestampFromDate(weekStart, 1),
+      })
+      expect(runCli(['budget', '--weekly', '100000'], home).status).toBe(0)
+
+      const overview = runCli(['overview', '-p', 'week', '--no-color'], home)
+      expect(overview.status, `stdout: ${overview.stdout}\nstderr: ${overview.stderr}`).toBe(0)
+      const overviewSpent = overview.stdout.match(/Weekly budget: (\$[0-9,]+\.\d{2}) of/)
+      expect(overviewSpent?.[1]).toBeDefined()
+      expect(overviewSpent?.[1]).not.toBe('$0.00')
+
+      const check = runCli(['budget', '--check'], home)
+      expect(check.status, `stdout: ${check.stdout}\nstderr: ${check.stderr}`).toBe(0)
+      const checkSpent = check.stdout.match(/weekly:\s+(\$[0-9,]+\.\d{2}) of/)
+      expect(checkSpent?.[1]).toBe(overviewSpent?.[1])
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  }, CLI_TIMEOUT_MS)
+})

--- a/tests/overview.test.ts
+++ b/tests/overview.test.ts
@@ -101,6 +101,78 @@ describe('renderOverview', () => {
     expect(out).toContain('No usage found for June 2026')
   })
 
+  it('does not render a budget line when no budget is provided', () => {
+    const out = renderOverview([makeProject({
+      project: 'myproject',
+      projectPath: '/Users/test/myproject',
+      cost: 12.5,
+      calls: 3,
+      model: 'claude-opus-4-8',
+      provider: 'claude',
+      tokens: { input: 1000, output: 200, cacheR: 5000, cacheW: 100 },
+    })], { label: 'June 2026', color: false })
+
+    expect(out).not.toContain('budget:')
+  })
+
+  it('renders a configured monthly budget line with percent and projection', () => {
+    const out = renderOverview([makeProject({
+      project: 'myproject',
+      projectPath: '/Users/test/myproject',
+      cost: 80,
+      calls: 3,
+      model: 'claude-opus-4-8',
+      provider: 'claude',
+      tokens: { input: 1000, output: 200, cacheR: 5000, cacheW: 100 },
+    })], {
+      label: 'June 2026',
+      color: false,
+      budget: {
+        tier: 'monthly',
+        inProgress: true,
+        status: {
+          spent: 80,
+          budget: 120,
+          pct: 66.6666666667,
+          projected: 160,
+          state: 'under',
+        },
+      },
+    })
+
+    expect(out).toContain('Monthly budget: $80.00 of $120.00 (66%)')
+    expect(out).toContain('projected $160.00 by month end')
+  })
+
+  it('does not display 100 percent while the raw state is warn at 99.6 percent', () => {
+    const out = renderOverview([makeProject({
+      project: 'myproject',
+      projectPath: '/Users/test/myproject',
+      cost: 99.6,
+      calls: 3,
+      model: 'claude-opus-4-8',
+      provider: 'claude',
+      tokens: { input: 1000, output: 200, cacheR: 5000, cacheW: 100 },
+    })], {
+      label: 'June 2026',
+      color: false,
+      budget: {
+        tier: 'monthly',
+        inProgress: false,
+        status: {
+          spent: 99.6,
+          budget: 100,
+          pct: 99.6,
+          projected: 99.6,
+          state: 'warn',
+        },
+      },
+    })
+
+    expect(out).toContain('Monthly budget: $99.60 of $100.00 (99%)')
+    expect(out).not.toContain('(100%)')
+  })
+
   it('does not split a slug-only Claude project path into fake path segments', () => {
     const out = renderOverview([makeProject({
       project: 'Projects-Content-OS',


### PR DESCRIPTION

Implements #561.

## What this adds

A spend-budget feature, so codeburn does not just show where AI spend goes but lets you act on it: set a daily/weekly/monthly budget, see budget usage with a run-rate projection in `overview`, and get a scriptable over-budget signal from `budget --check`. There is no spend-budget feature today (`context-budget.ts` is the model context window, unrelated).

```bash
codeburn budget --monthly 100      # also --weekly / --daily, in your display currency
codeburn budget --list
codeburn budget --remove monthly
codeburn budget --check            # exits non-zero if any configured budget is over


## How it surfaces

1. **`overview`** shows one line under the totals when the period matches a configured cadence (today -> daily, last-7-days -> weekly, this-month -> monthly):

   ```
   Monthly budget: €67.40 of €100.00 (67%)  projected €98.20 by month end
   ```

   green under 80%, amber from 80%, red at 100%+, with a linear run-rate projection for the in-progress period.

2. **`budget --check`** prints each configured budget's status and exits 1 if any is over budget. It is well suited to cron or CI:

   ```bash
   codeburn budget --check || notify-send "Over AI budget"
   ```

   It can also be used in pre-commit hooks or a shell prompt, but each configured tier reruns discovery, so a frequently rendered prompt may be expensive.

## Design decisions

- **The alert is the `--check` exit code**, not a notification daemon. That keeps the feature small and composable and leaves the choice of how to be notified to the user.
- **Budgets are in the display currency** (the one `currency` sets and `overview` shows). Spend is summed in USD and converted once via `convertCost` before comparison, so the line reads in the same units the user typed.
- **Budgets count the full would-be API cost, including subscription-proxied spend.** They use `project.totalCostUSD`, without subtracting `totalProxiedCostUSD`, which is consistent with the overview Cost total.
- **The overview budget line is suppressed when a filter is active** (`--provider`, `--project`, `--exclude`). A global budget shown next to a filtered subset would read as falsely-green, so it is hidden rather than misleading.
- **Projection applies to the monthly tier only.** The daily and weekly windows are rolling and complete by definition (today, last 7 days), so a run-rate projection is meaningless there; only the in-progress calendar month projects.
- **`budget --check` uses the same date-range source as `overview`** per cadence (daily -> `today`, weekly -> `week`, monthly -> `month`), so the spend window and the numbers agree between the two surfaces.
- **Default behavior is unchanged.** With no budget configured, `overview` output and every other command are byte-for-byte identical. The feature is purely additive.

## Implementation

- `src/budget.ts` (new): a pure `computeBudgetStatus` returning `{ spent, budget, pct, projected, state }`, where `projected = spent * totalDays / elapsedDays` and `state` is `under` (<80%), `warn` (>=80%), or `over` (>=100%). No I/O, fully unit-tested.
- `src/config.ts`: a new optional `budget` field (`{ daily?, weekly?, monthly? }`, display-currency amounts).
- `src/main.ts`: the `budget` command (set with finite > 0 validation, `--list`, `--remove`, `--check` that aggregates current-period spend via the existing session pipeline) and the overview wiring that builds the budget status for the matching tier.
- `src/overview.ts`: the budget line in `renderOverview`, colored by state, with the projection only while the period is in progress. Whole-number percentages are floored so the display cannot read 100% before the raw state is over.

## Verification

- Unit tests (`tests/budget.test.ts`): threshold boundaries, exact projection math, invalid-input guards.
- CLI tests (`tests/cli-budget.test.ts`, isolated HOME): set/list/remove; invalid amount exits 1; `--check` exits 1 over and 0 under-or-none; 99.x% floors to 99% with WARN and exit 0; the budget line is suppressed under filters; `--check` and `overview -p week` report the same weekly spend window.
- Render tests (`tests/overview.test.ts`): the line appears with the right percent and projection when a budget is set, is absent otherwise, and 99.6% displays as 99% while state remains warn.
- `npx vitest run tests/budget.test.ts tests/cli-budget.test.ts tests/overview.test.ts` passes with 19 tests. `npx tsc --noEmit` is clean.
- Full `npx vitest run` reaches 1,749 passing tests and 5 skipped tests, but the existing `tests/cli-status-menubar.test.ts` selected-config-source case exceeds its 5-second timeout under full parallel load. That file passes all 13 tests in isolation, including the same case in 3,496ms.

## Files

- `src/budget.ts` (new), `src/config.ts`, `src/main.ts`, `src/overview.ts`
- `tests/budget.test.ts` (new), `tests/cli-budget.test.ts` (new), `tests/overview.test.ts`


## Architect follow-up gates

### npx tsc --noEmit

```text
$ perl -e '$seconds = shift @ARGV; alarm $seconds; exec @ARGV' 600 npx tsc --noEmit
exit: 0


### npx vitest run tests/budget.test.ts tests/cli-budget.test.ts tests/overview.test.ts

```text
$ perl -e '$seconds = shift @ARGV; alarm $seconds; exec @ARGV' 300 npx vitest run tests/budget.test.ts tests/cli-budget.test.ts tests/overview.test.ts
exit: 0

 RUN  v3.2.6 /Users/husamsoboh/codeburn/.architect/wt/fix0716-02

 ✓ tests/budget.test.ts (3 tests) 3ms
 ✓ tests/overview.test.ts (9 tests) 41ms
 ✓ tests/cli-budget.test.ts (7 tests) 15241ms
   ✓ codeburn budget command > saves, lists, and removes a monthly budget  2617ms
   ✓ codeburn budget command > rejects an invalid amount without writing a budget  1440ms
   ✓ codeburn budget command > exits 1 when the current month is over budget  1794ms
   ✓ codeburn budget command > floors a 99.x percent budget check without reporting over  1468ms
   ✓ codeburn budget command > exits 0 when the current month is under budget or no budget is configured  2496ms
   ✓ codeburn budget command > keeps overview budget lines only on unfiltered overviews  3264ms
   ✓ codeburn budget command > uses the same weekly spend window for budget --check and overview -p week  2161ms

 Test Files  3 passed (3)
      Tests  19 passed (19)
   Start at  18:55:09
   Duration  16.20s (transform 319ms, setup 65ms, collect 428ms, tests 15.29s, environment 1ms, prepare 364ms)


