### PR TITLE
Raise streaming session cap to 4GB so large Codex sessions are counted

### DIFF
--- a/src/fs-utils.ts
+++ b/src/fs-utils.ts
@@ -9,10 +9,11 @@ export const LARGE_STREAM_LINE_BYTES = 32 * 1024
 
 // Line-by-line streaming has bounded memory (one line at a time) and is not
 // constrained by V8's string limit, so it can safely handle multi-GB session
-// files. The cap here is purely a sanity check against pathological inputs;
-// real Codex sessions for heavy users have been observed at 250+ MB and will
-// continue to grow as context windows expand.
-export const MAX_STREAM_SESSION_FILE_BYTES = 2 * 1024 * 1024 * 1024
+// files. Heavy Codex sessions routinely reach several GB (image-heavy compacted
+// turns), so the cap is generous and exists only to guard against truly
+// pathological inputs. When a file IS skipped, notice() surfaces it (always on,
+// not verbose-gated) so a dropped session never silently understates usage.
+export const MAX_STREAM_SESSION_FILE_BYTES = 4 * 1024 * 1024 * 1024
 
 function verbose(): boolean {
   return process.env.CODEBURN_VERBOSE === '1'
@@ -20,6 +21,12 @@ function verbose(): boolean {
 
 function warn(msg: string): void {
   if (verbose()) process.stderr.write(`codeburn: ${msg}\n`)
+}
+
+// Always surfaced (not verbose-gated): dropping an entire session file silently
+// understates reported usage with no signal, so oversize skips use this.
+function notice(msg: string): void {
+  process.stderr.write(`codeburn: ${msg}\n`)
 }
 
 export async function readSessionFile(filePath: string): Promise<string | null> {
@@ -73,6 +80,7 @@ type ReadSessionLinesOptions = {
   largeLineThresholdBytes?: number
   startByteOffset?: number
   byteOffsetTracker?: { lastCompleteLineOffset: number }
+  maxBytes?: number
 }
 
 export function readSessionLines(
@@ -97,9 +105,10 @@ export async function* readSessionLines(
     return
   }
 
-  if (size > MAX_STREAM_SESSION_FILE_BYTES) {
-    warn(
-      `skipped oversize file ${filePath} (${size} bytes > stream cap ${MAX_STREAM_SESSION_FILE_BYTES})`,
+  const maxBytes = options.maxBytes ?? MAX_STREAM_SESSION_FILE_BYTES
+  if (size > maxBytes) {
+    notice(
+      `skipped oversize session ${filePath} (${size} bytes > cap ${maxBytes}); its usage is NOT counted`,
     )
     return
   }

--- a/tests/fs-utils.test.ts
+++ b/tests/fs-utils.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path'
 
 import {
   MAX_SESSION_FILE_BYTES,
+  MAX_STREAM_SESSION_FILE_BYTES,
   readSessionFile,
   readSessionLines,
 } from '../src/fs-utils.js'
@@ -168,5 +169,27 @@ describe('readSessionLines', () => {
     }
     expect(lines).toEqual(['keep-me'])
     expect(tracker.lastCompleteLineOffset).toBe(Buffer.byteLength(content))
+  })
+
+  it('reads files at or under the stream cap', async () => {
+    const p = await tmpPath('a\nb\nc\n')
+    const lines: string[] = []
+    for await (const line of readSessionLines(p, undefined, { maxBytes: 1024 })) lines.push(line)
+    expect(lines).toEqual(['a', 'b', 'c'])
+  })
+
+  it('skips files over the stream cap and surfaces a notice without CODEBURN_VERBOSE', async () => {
+    const p = await tmpPath('a\nb\nc\n')
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const lines: string[] = []
+    for await (const line of readSessionLines(p, undefined, { maxBytes: 1 })) lines.push(line)
+    expect(lines).toEqual([])
+    expect(spy).toHaveBeenCalled()
+    expect(spy.mock.calls[0][0] as string).toContain('skipped oversize session')
+    spy.mockRestore()
+  })
+
+  it('stream cap is generous enough for multi-GB Codex sessions', () => {
+    expect(MAX_STREAM_SESSION_FILE_BYTES).toBe(4 * 1024 * 1024 * 1024)
   })
 })


### PR DESCRIPTION
## Problem

The streaming session reader (`readSessionLines`) had a 2GB hard cap (`MAX_STREAM_SESSION_FILE_BYTES`). Any file over it was dropped entirely, and the skip warning was gated behind `CODEBURN_VERBOSE`, so the drop was silent.

A live Codex session reached 2.4GB (image-heavy compacted turns: ~46 events re-embedding ~2,600 inline base64 images), which is ~308M tokens of real gpt-5.5 spend. It was excluded from every report, so the menubar showed Codex as $0 / no tab for the day with no signal that anything was missing.

## Fix

- Raise `MAX_STREAM_SESSION_FILE_BYTES` 2GB -> 4GB. The reader is line-by-line and bounded-memory, so multi-GB files are safe; the cap is only a guard against pathological inputs.
- Surface oversize skips via an always-on `notice()` instead of a verbose-gated `warn()`, so a dropped session is never silent.
- Add a `maxBytes` option to `readSessionLines` for testability.

## Tests

Three new tests: under-cap files read normally, over-cap files are skipped and emit the notice without `CODEBURN_VERBOSE`, and the cap constant is 4GB. Full fs-utils suite (17) and project typecheck pass.

## Follow-ups (not in this PR)

- Perf: `codex.ts` reads the whole file on each scan (no `startByteOffset`), so a live multi-GB session is re-read every refresh. Incremental reading is the recommended next step.
- Separate bug: the daily-cache folds unpriced `codex-auto-review` tokens into gpt-5.5 and prices them at gpt-5.5 rates, so MCP/menubar over-report Codex and disagree with `overview`/`export`.
