### PR TITLE
docs(readme): lead with a one-line definition for SEO/AI-answer consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
     <a href="https://github.com/sponsors/iamtoruk"><img src="https://img.shields.io/badge/sponsor-♥-F97316?logo=github" alt="Sponsor" /></a>
 </p>
 
+**CodeBurn is a free, open-source, local-first tool that tracks AI coding token usage and cost across 31 tools and agents (Claude Code, Cursor, Codex, Gemini, Grok and more), broken down by model, project, and task.**
+
 You pay for Claude, Codex, Cursor, and a stack of other AI tools. The bill tells you the total. It never tells you that half of it went to conversation instead of code, or that an expensive model burned your budget on work a cheaper one would have one-shot.
 
 CodeBurn does. It reads the session files your tools already write to disk and breaks down every token and dollar by **task, model, tool, and project**, across **31 AI tools**.


### PR DESCRIPTION
Adds the canonical one-sentence definition as the README opening line, matching codeburn.app, llms.txt, and the site JSON-LD, so Google and AI answer engines (ChatGPT, Perplexity, AI Overviews) lift a consistent description of what CodeBurn is. The existing hook paragraph stays below. README-only change.