### PR TITLE
fix(cursor): use Cursor's real context tokens for input (#574)

### DIFF
--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -17,7 +17,7 @@ const URL_PATTERN = /https?:\/\/\S+/i
 
 export const EDIT_TOOLS = new Set(['Edit', 'Write', 'FileEditTool', 'FileWriteTool', 'NotebookEdit', 'cursor:edit'])
 const READ_TOOLS = new Set(['Read', 'Grep', 'Glob', 'FileReadTool', 'GrepTool', 'GlobTool'])
-export const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool'])
+export const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool', 'Shell'])
 const TASK_TOOLS = new Set(['TaskCreate', 'TaskUpdate', 'TaskGet', 'TaskList', 'TaskOutput', 'TaskStop', 'TodoWrite'])
 const SEARCH_TOOLS = new Set(['WebSearch', 'WebFetch', 'ToolSearch'])
 

--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -17,7 +17,7 @@ const URL_PATTERN = /https?:\/\/\S+/i
 
 export const EDIT_TOOLS = new Set(['Edit', 'Write', 'FileEditTool', 'FileWriteTool', 'NotebookEdit', 'cursor:edit'])
 const READ_TOOLS = new Set(['Read', 'Grep', 'Glob', 'FileReadTool', 'GrepTool', 'GlobTool'])
-export const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool', 'Shell'])
+export const BASH_TOOLS = new Set(['Bash', 'BashTool', 'PowerShellTool'])
 const TASK_TOOLS = new Set(['TaskCreate', 'TaskUpdate', 'TaskGet', 'TaskList', 'TaskOutput', 'TaskStop', 'TodoWrite'])
 const SEARCH_TOOLS = new Set(['WebSearch', 'WebFetch', 'ToolSearch'])
 

--- a/src/cursor-cache.ts
+++ b/src/cursor-cache.ts
@@ -15,7 +15,11 @@ import type { ParsedProviderCall } from './providers/types.js'
 // real context tokens from composerData.promptTokenBreakdown now drive
 // input, and agentKv is used only for the tools/bash breakdown. Cached v4
 // results contain stale agentKv calls and lack the real token figures.
-const CURSOR_CACHE_VERSION = 5
+// Version 6: conversation input moved to composer-anchored records
+// (cursor:composer-input:<id>) with per-conversation source selection, the
+// agent stream regained tool/system context and stream-only sessions, and
+// tool names are canonicalized. v5 results mix crediting regimes.
+const CURSOR_CACHE_VERSION = 6
 
 type ResultCache = {
   version?: number

--- a/src/cursor-cache.ts
+++ b/src/cursor-cache.ts
@@ -11,7 +11,11 @@ import type { ParsedProviderCall } from './providers/types.js'
 // router relies on those composer ids to bucket calls per project.
 // Version 2 caches contain `sessionId: 'unknown'` for every call and would
 // route everything to the orphan project, so we invalidate them.
-const CURSOR_CACHE_VERSION = 4
+// Version 5: parseAgentKv was removed (it double-counted against bubbles);
+// real context tokens from composerData.promptTokenBreakdown now drive
+// input, and agentKv is used only for the tools/bash breakdown. Cached v4
+// results contain stale agentKv calls and lack the real token figures.
+const CURSOR_CACHE_VERSION = 5
 
 type ResultCache = {
   version?: number

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -5,18 +5,18 @@ import { homedir } from 'os'
 import { join } from 'path'
 import type { DateRange, ProjectSummary } from './types.js'
 
-// Bumped to 9: providers added since the v8 rollup (Grok, Hermes, ZCode) parse
-// usage that older binaries skipped, so days cached at v8 omit them and report
-// $0 for those providers across history. Raising MIN_SUPPORTED_VERSION to 9 too
-// forces a one-time full re-hydration so newly supported providers backfill
-// without a manual cache clear.
+// Bumped to 10: cursor accounting changed (real composer context tokens on
+// conversation-anchored records, Cursor-published composer pricing), so days
+// finalized at v9 carry the old double-counted agentKv estimates and
+// sonnet-proxy composer costs. Raising MIN_SUPPORTED_VERSION forces the
+// one-time full re-hydration that backfills history under the new accounting.
 //
-// v8 added local-model savings to the daily rollup (savingsUSD per day / model /
-// category / provider). The `savingsConfigHash` field is invalidated separately
-// when the user changes their `localModelSavings` mapping so historical "saved"
-// totals stay in sync with the active baseline.
-export const DAILY_CACHE_VERSION = 9
-const MIN_SUPPORTED_VERSION = 9
+// v9: providers added since the v8 rollup (Grok, Hermes, ZCode) parse usage
+// that older binaries skipped. v8 added local-model savings to the daily
+// rollup; the `savingsConfigHash` field is invalidated separately when the
+// user changes their `localModelSavings` mapping.
+export const DAILY_CACHE_VERSION = 10
+const MIN_SUPPORTED_VERSION = 10
 const DAILY_CACHE_FILENAME = 'daily-cache.json'
 
 export type DailyEntry = {

--- a/src/models.ts
+++ b/src/models.ts
@@ -40,10 +40,11 @@ const WEB_SEARCH_COST = 0.01
 const ONE_HOUR_CACHE_WRITE_MULTIPLIER_FROM_FIVE_MINUTE_RATE = 1.6
 
 // Explicit USD/token prices that must override LiteLLM/cache data. Cursor
-// publishes house-model rates under provider "Cursor" in USD per 1M tokens:
-// composer-2/2.5: $0.50 input, $2.50 output, $0.20 cache read; composer-1.5:
-// $3.50/$17.50/$0.35; composer-1: $1.25/$10/$0.125. Cursor publishes no
-// separate cache-write rate for these, so cache write uses the input rate.
+// publishes house-model rates in the models table at cursor.com/docs/models
+// (provider "Cursor", USD per 1M tokens): composer-2/2.5: $0.50 input, $2.50
+// output, $0.20 cache read; composer-1.5: $3.50/$17.50/$0.35; composer-1:
+// $1.25/$10/$0.125. Cursor publishes no separate cache-write rate for these,
+// so cache write uses the input rate.
 const BUILTIN_PRICE_OVERRIDES: Record<string, SnapshotEntry> = {
   'composer-2.5': [0.5e-6, 2.5e-6, 0.5e-6, 0.2e-6],
   'composer-2': [0.5e-6, 2.5e-6, 0.5e-6, 0.2e-6],
@@ -501,8 +502,11 @@ export function getLocalModelSavingsConfigHash(): string {
 }
 
 export function getPriceOverridesConfigHash(): string {
+  // The builtin overrides participate so editing BUILTIN_PRICE_OVERRIDES in a
+  // release invalidates cached daily costs the same way a user override does.
+  const builtin = `builtin:${JSON.stringify(BUILTIN_PRICE_OVERRIDES)}`
   const keys = Object.keys(userPriceOverridesConfig).sort()
-  if (keys.length === 0) return ''
+  if (keys.length === 0) return builtin
   const parts = keys.map(k => {
     const rates = userPriceOverridesConfig[k]
     return [
@@ -513,7 +517,7 @@ export function getPriceOverridesConfigHash(): string {
       rates.cacheCreation ?? '',
     ].join('\u0001')
   })
-  return parts.join('\u0002')
+  return [builtin, ...parts].join('\u0002')
 }
 
 // Absolute directory prefixes whose sessions are routed through a

--- a/src/models.ts
+++ b/src/models.ts
@@ -304,11 +304,12 @@ const BUILTIN_ALIASES: Record<string, string> = {
   'claude-4.5-haiku':               'claude-haiku-4-5',
   'claude-4.6-haiku':               'claude-haiku-4-5',
   // Cursor's house models have no LiteLLM pricing entry. composer-1 is
-  // sonnet-4.5-class per Cursor docs; composer-2 is built on Sonnet 4.6
-  // per cursor.com/blog/composer-2.
+  // sonnet-4.5-class per Cursor docs; composer-2 and composer-2.5 are built on
+  // Sonnet 4.6 per cursor.com/blog/composer-2.
   'composer-1':                     'claude-sonnet-4-5',
   'composer-1.5':                   'claude-sonnet-4-5',
   'composer-2':                     'claude-sonnet-4-6',
+  'composer-2.5':                   'claude-sonnet-4-6',
   // Cursor's "fast" routing variant of GPT-5 is the same model behind a
   // lower-latency endpoint; price as base GPT-5 until LiteLLM tracks it.
   'gpt-5-fast':                     'gpt-5',

--- a/src/models.ts
+++ b/src/models.ts
@@ -39,6 +39,18 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const WEB_SEARCH_COST = 0.01
 const ONE_HOUR_CACHE_WRITE_MULTIPLIER_FROM_FIVE_MINUTE_RATE = 1.6
 
+// Explicit USD/token prices that must override LiteLLM/cache data. Cursor
+// publishes house-model rates under provider "Cursor" in USD per 1M tokens:
+// composer-2/2.5: $0.50 input, $2.50 output, $0.20 cache read; composer-1.5:
+// $3.50/$17.50/$0.35; composer-1: $1.25/$10/$0.125. Cursor publishes no
+// separate cache-write rate for these, so cache write uses the input rate.
+const BUILTIN_PRICE_OVERRIDES: Record<string, SnapshotEntry> = {
+  'composer-2.5': [0.5e-6, 2.5e-6, 0.5e-6, 0.2e-6],
+  'composer-2': [0.5e-6, 2.5e-6, 0.5e-6, 0.2e-6],
+  'composer-1.5': [3.5e-6, 17.5e-6, 3.5e-6, 0.35e-6],
+  'composer-1': [1.25e-6, 10e-6, 1.25e-6, 0.125e-6],
+}
+
 // Assemble a ModelCosts, applying the cache-cost heuristics (write = 1.25x
 // input, read = 0.1x input) when a source omits them. Shared by the bundled
 // tuple path (tupleToCosts) and the live LiteLLM path (parseLiteLLMEntry) so the
@@ -65,6 +77,13 @@ function tupleToCosts(raw: SnapshotEntry): ModelCosts {
   return buildCosts(input, output, cacheWrite, cacheRead, fast)
 }
 
+function applyBuiltinPriceOverrides(pricing: Map<string, ModelCosts>): Map<string, ModelCosts> {
+  for (const [name, raw] of Object.entries(BUILTIN_PRICE_OVERRIDES)) {
+    pricing.set(name, tupleToCosts(raw))
+  }
+  return pricing
+}
+
 function loadSnapshot(): Map<string, ModelCosts> {
   const map = new Map<string, ModelCosts>()
   for (const [name, raw] of Object.entries(snapshotData as unknown as Record<string, SnapshotEntry>)) {
@@ -85,7 +104,7 @@ const fallbackCosts: Map<string, ModelCosts> = (() => {
   return map
 })()
 
-let pricingCache: Map<string, ModelCosts> = loadSnapshot()
+let pricingCache: Map<string, ModelCosts> = applyBuiltinPriceOverrides(loadSnapshot())
 let sortedPricingKeys: string[] | null = null
 let lowercasePricingIndex: Map<string, ModelCosts> | null = null
 
@@ -202,7 +221,7 @@ function mergeSnapshotFallbacks(pricing: Map<string, ModelCosts>): Map<string, M
   for (const [name, costs] of loadSnapshot()) {
     if (!pricing.has(name)) pricing.set(name, costs)
   }
-  return pricing
+  return applyBuiltinPriceOverrides(pricing)
 }
 
 export async function loadPricing(): Promise<void> {
@@ -303,13 +322,9 @@ const BUILTIN_ALIASES: Record<string, string> = {
   'claude-opus-4-7-thinking-high':  'claude-opus-4-7',
   'claude-4.5-haiku':               'claude-haiku-4-5',
   'claude-4.6-haiku':               'claude-haiku-4-5',
-  // Cursor's house models have no LiteLLM pricing entry. composer-1 is
-  // sonnet-4.5-class per Cursor docs; composer-2 and composer-2.5 are built on
-  // Sonnet 4.6 per cursor.com/blog/composer-2.
-  'composer-1':                     'claude-sonnet-4-5',
-  'composer-1.5':                   'claude-sonnet-4-5',
-  'composer-2':                     'claude-sonnet-4-6',
-  'composer-2.5':                   'claude-sonnet-4-6',
+  // Cursor house composer models use Cursor-published rates in
+  // BUILTIN_PRICE_OVERRIDES; keep them out of this alias map so they do not
+  // inherit Claude Sonnet proxy pricing.
   // Cursor's "fast" routing variant of GPT-5 is the same model behind a
   // lower-latency endpoint; price as base GPT-5 until LiteLLM tracks it.
   'gpt-5-fast':                     'gpt-5',

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -1,10 +1,11 @@
-import { existsSync, readdirSync, readFileSync } from 'fs'
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 
 import { calculateCost } from '../models.js'
+import { extractBashCommands } from '../bash-utils.js'
 import { readCachedResults, writeCachedResults } from '../cursor-cache.js'
-import { isSqliteAvailable, getSqliteLoadError, openDatabase, blobToText, type SqliteDatabase } from '../sqlite.js'
+import { isSqliteAvailable, isSqliteBusyError, getSqliteLoadError, openDatabase, blobToText, type SqliteDatabase } from '../sqlite.js'
 import type { DateRange } from '../types.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
@@ -48,7 +49,7 @@ type BubbleRow = {
   output_tokens: number | null
   model: string | null
   created_at: string | null
-  conversation_id: string | null
+  request_id: string | null
   user_text: Uint8Array | string | null
   text_length: number | null
   bubble_type: number | null
@@ -59,11 +60,18 @@ type BubbleRow = {
 }
 
 type AgentKvRow = {
-  key: string
   role: string | null
   content: Uint8Array | string | null
   request_id: string | null
-  content_length: number
+  model: string | null
+}
+
+// SQLITE_BUSY must reach parser.ts, whose busy path skips the source without
+// caching; swallowing it here would stamp a silently degraded parse into the
+// results cache under an unchanged DB fingerprint (Cursor writes via WAL, so
+// contention does not change the main file's stat).
+function rethrowBusy(err: unknown): void {
+  if (isSqliteBusyError(err)) throw err
 }
 
 const CHARS_PER_TOKEN = 4
@@ -298,7 +306,7 @@ const BUBBLE_QUERY_BASE = `
     json_extract(value, '$.tokenCount.outputTokens') as output_tokens,
     json_extract(value, '$.modelInfo.modelName') as model,
     json_extract(value, '$.createdAt') as created_at,
-    json_extract(value, '$.conversationId') as conversation_id,
+    json_extract(value, '$.requestId') as request_id,
     CAST(substr(json_extract(value, '$.text'), 1, 500) AS BLOB) as user_text,
     length(json_extract(value, '$.text')) as text_length,
     json_extract(value, '$.type') as bubble_type,
@@ -309,11 +317,10 @@ const BUBBLE_QUERY_BASE = `
 
 const AGENTKV_QUERY = `
   SELECT
-    key,
     json_extract(value, '$.role') as role,
     CAST(json_extract(value, '$.content') AS BLOB) as content,
     json_extract(value, '$.providerOptions.cursor.requestId') as request_id,
-    length(value) as content_length
+    json_extract(value, '$.providerOptions.cursor.modelName') as model
   FROM cursorDiskKV
   WHERE key LIKE 'agentKv:blob:%'
     AND hex(substr(value, 1, 1)) = '7B'
@@ -356,7 +363,7 @@ const BUBBLE_QUERY_PAGE = `
     json_extract(value, '$.tokenCount.outputTokens') as output_tokens,
     json_extract(value, '$.modelInfo.modelName') as model,
     json_extract(value, '$.createdAt') as created_at,
-    json_extract(value, '$.conversationId') as conversation_id,
+    json_extract(value, '$.requestId') as request_id,
     CAST(substr(json_extract(value, '$.text'), 1, 500) AS BLOB) as user_text,
     length(json_extract(value, '$.text')) as text_length,
     json_extract(value, '$.type') as bubble_type,
@@ -373,7 +380,8 @@ function validateSchema(db: SqliteDatabase): boolean {
       "SELECT COUNT(*) as cnt FROM cursorDiskKV WHERE key LIKE 'bubbleId:%' LIMIT 1"
     )
     return rows.length > 0
-  } catch {
+  } catch (err) {
+    rethrowBusy(err)
     return false
   }
 }
@@ -406,7 +414,9 @@ function buildUserMessageMap(db: SqliteDatabase, timeFloor: string): Map<string,
         map.set(composerId, { messages: [text], pos: 0 })
       }
     }
-  } catch {}
+  } catch (err) {
+    rethrowBusy(err)
+  }
   return map
 }
 
@@ -438,7 +448,8 @@ function scanBubblesPaged(
     let batch: BubbleRow[]
     try {
       batch = db.query<BubbleRow>(BUBBLE_QUERY_PAGE, [beforeRowId, BATCH])
-    } catch {
+    } catch (err) {
+      rethrowBusy(err)
       break
     }
     if (batch.length === 0) break
@@ -468,82 +479,146 @@ function scanBubblesPaged(
 // contextTokensUsed (the in-app context meter). This is not cumulative per-turn,
 // so local SQLite undercounts admin-console usage; parity requires the opt-in
 // Cursor Admin API: POST api.cursor.com/teams/filtered-usage-events.
-// Keyed by composerId so parseBubbles can credit it to the right conversation.
-const COMPOSER_TOKENS_QUERY = `
+// The key-range predicate seeks the primary key instead of scanning the table.
+const COMPOSER_META_QUERY = `
   SELECT
-    substr(key, 14) as composer_id,
+    substr(key, length('composerData:') + 1) as composer_id,
     json_extract(value, '$.promptTokenBreakdown.totalUsedTokens') as used,
-    json_extract(value, '$.contextTokensUsed') as ctx
+    json_extract(value, '$.contextTokensUsed') as ctx,
+    json_extract(value, '$.createdAt') as created_at
   FROM cursorDiskKV
-  WHERE key LIKE 'composerData:%'
+  WHERE key >= 'composerData:' AND key < 'composerData;'
 `
 
-function loadComposerInputTokens(db: SqliteDatabase): Map<string, number> {
-  const map = new Map<string, number>()
+type ComposerMeta = { tokens: number; createdAt: number | null }
+
+function loadComposerMeta(db: SqliteDatabase): Map<string, ComposerMeta> {
+  const map = new Map<string, ComposerMeta>()
   try {
-    const rows = db.query<{ composer_id: string; used: number | null; ctx: number | null }>(COMPOSER_TOKENS_QUERY)
+    const rows = db.query<{ composer_id: string; used: number | null; ctx: number | null; created_at: number | null }>(COMPOSER_META_QUERY)
     for (const r of rows) {
-      const tokens = r.used ?? r.ctx ?? 0
-      if (r.composer_id && tokens > 0) map.set(r.composer_id, tokens)
+      // `||` rather than `??`: a recorded-but-zero breakdown must fall through
+      // to the context meter instead of shadowing it.
+      const tokens = (r.used || r.ctx) ?? 0
+      if (r.composer_id && tokens > 0) map.set(r.composer_id, { tokens, createdAt: r.created_at ?? null })
     }
-  } catch {
+  } catch (err) {
+    rethrowBusy(err)
     /* best-effort: callers fall back to the per-bubble text estimate */
   }
   return map
 }
 
-type AgentTools = { tools: string[]; bash: string[]; userChars: number }
+type AgentStream = {
+  tools: string[]
+  bash: string[]
+  userChars: number
+  contextChars: number
+  assistantChars: number
+  model: string | null
+}
 
-// Cursor logs the agent's tool calls (Read, Grep, Shell, ...) in agentKv blobs
-// keyed by requestId. Bubbles carry the same requestId plus the composerId, so
-// joining the two attributes each conversation's tools and Shell commands.
-const BUBBLE_REQUESTID_QUERY = `
-  SELECT key as bubble_key, json_extract(value, '$.requestId') as request_id
-  FROM cursorDiskKV
-  WHERE key LIKE 'bubbleId:%' AND json_extract(value, '$.requestId') IS NOT NULL
-`
+function newAgentStream(): AgentStream {
+  return { tools: [], bash: [], userChars: 0, contextChars: 0, assistantChars: 0, model: null }
+}
 
-function loadAgentToolsByComposer(db: SqliteDatabase): Map<string, AgentTools> {
-  const byComposer = new Map<string, AgentTools>()
-
-  const requestToComposer = new Map<string, string>()
-  try {
-    const rows = db.query<{ bubble_key: string; request_id: string | null }>(BUBBLE_REQUESTID_QUERY)
-    for (const r of rows) {
-      const composer = parseComposerIdFromKey(r.bubble_key)
-      if (composer && r.request_id) requestToComposer.set(r.request_id, composer)
+// agentKv rows store content as a plain string or a block array; count only
+// the text inside blocks so the JSON envelope and non-text parts are not
+// billed as prompt characters.
+function contentTextLength(raw: string): number {
+  const trimmed = raw.trimStart()
+  if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown
+      const blocks = Array.isArray(parsed) ? parsed : [parsed]
+      let len = 0
+      for (const block of blocks) {
+        if (block == null || typeof block !== 'object') continue
+        const b = block as { text?: unknown; content?: unknown }
+        if (typeof b.text === 'string') len += b.text.length
+        else if (typeof b.content === 'string') len += b.content.length
+      }
+      return len
+    } catch {
+      return raw.length
     }
-  } catch {
-    return byComposer
   }
+  return raw.length
+}
+
+// Cursor logs the agent's stream (prompt, injected context, tool calls, reply
+// deltas) in agentKv blobs keyed by requestId. Bubbles carry the same
+// requestId, so the map built from the scanned bubbles joins each request to
+// its conversation. Requests with no matching bubble are kept separately:
+// they are real sessions (background runs, older builds) that would otherwise
+// vanish from totals.
+function loadAgentStreams(
+  db: SqliteDatabase,
+  requestToComposer: Map<string, string>,
+): { byComposer: Map<string, AgentStream>; unjoined: Map<string, AgentStream> } {
+  const byComposer = new Map<string, AgentStream>()
+  const unjoined = new Map<string, AgentStream>()
 
   let rows: AgentKvRow[]
   try {
     rows = db.query<AgentKvRow>(AGENTKV_QUERY)
-  } catch {
-    return byComposer
+  } catch (err) {
+    rethrowBusy(err)
+    return { byComposer, unjoined }
   }
 
-  // Only the turn-opening (user) agentKv row carries the requestId; the
-  // assistant rows that follow inherit it, so track it positionally.
-  let currentRequestId: string | null = null
-  for (const row of rows) {
-    if (row.request_id) currentRequestId = row.request_id
-    if (!row.content || !currentRequestId) continue
-    const composer = requestToComposer.get(currentRequestId)
-    if (!composer) continue
+  const bucketFor = (requestId: string): AgentStream => {
+    const composer = requestToComposer.get(requestId)
+    const map = composer ? byComposer : unjoined
+    const key = composer ?? requestId
+    const existing = map.get(key)
+    if (existing) return existing
+    const fresh = newAgentStream()
+    map.set(key, fresh)
+    return fresh
+  }
 
-    // A user turn stores its prompt (plus injected context) as a plain string.
-    // Track its length so a turn whose bubble text is empty — non-Composer
-    // sessions such as GPT keep it in the agent stream — can still be
-    // estimated instead of dropped.
-    if (row.role === 'user') {
-      const bucket = byComposer.get(composer) ?? { tools: [], bash: [], userChars: 0 }
-      bucket.userChars += blobToText(row.content).length
-      byComposer.set(composer, bucket)
+  // Only the turn-opening (user) agentKv row carries the requestId; rows that
+  // follow inherit it. Rows written BEFORE their request's id appears (the
+  // system prompt and opening user prompt at a conversation start) buffer
+  // until the next id, and a system row closes the previous request so
+  // interleaved sessions cannot inherit across a conversation boundary.
+  let currentRequestId: string | null = null
+  let pendingUserChars = 0
+  let pendingContextChars = 0
+  for (const row of rows) {
+    if (row.request_id) {
+      currentRequestId = row.request_id
+      if (pendingUserChars > 0 || pendingContextChars > 0) {
+        const bucket = bucketFor(currentRequestId)
+        bucket.userChars += pendingUserChars
+        bucket.contextChars += pendingContextChars
+        pendingUserChars = 0
+        pendingContextChars = 0
+      }
+    }
+    if (row.model && currentRequestId) {
+      const bucket = bucketFor(currentRequestId)
+      if (!bucket.model) bucket.model = row.model
+    }
+    if (!row.content) continue
+
+    if (row.role === 'system') {
+      pendingContextChars += contentTextLength(blobToText(row.content))
+      currentRequestId = null
       continue
     }
-    if (row.role !== 'assistant') continue
+    if (row.role === 'user') {
+      const len = contentTextLength(blobToText(row.content))
+      if (currentRequestId) bucketFor(currentRequestId).userChars += len
+      else pendingUserChars += len
+      continue
+    }
+    if (row.role === 'tool') {
+      if (currentRequestId) bucketFor(currentRequestId).contextChars += contentTextLength(blobToText(row.content))
+      continue
+    }
+    if (row.role !== 'assistant' || !currentRequestId) continue
 
     let content: unknown
     try {
@@ -552,48 +627,50 @@ function loadAgentToolsByComposer(db: SqliteDatabase): Map<string, AgentTools> {
       continue
     }
     if (!Array.isArray(content)) continue
-    const bucket = byComposer.get(composer) ?? { tools: [], bash: [], userChars: 0 }
-    for (const block of content as Array<{ type?: string; toolName?: string; args?: { command?: string } }>) {
-      if (!block || block.type !== 'tool-call' || !block.toolName) continue
-      bucket.tools.push(block.toolName)
-      if (block.toolName === 'Shell') {
-        const command = block.args?.command?.trim()
-        if (command) bucket.bash.push(command)
+    const bucket = bucketFor(currentRequestId)
+    for (const block of content as Array<{ type?: string; text?: unknown; toolName?: unknown; args?: { command?: unknown } }>) {
+      if (block == null || typeof block !== 'object') continue
+      if (typeof block.text === 'string') bucket.assistantChars += block.text.length
+      if (block.type !== 'tool-call' || typeof block.toolName !== 'string' || !block.toolName) continue
+      // Cursor's terminal tool is 'Shell'; emit the canonical 'Bash' so the
+      // cross-provider tool and command breakdowns merge.
+      bucket.tools.push(block.toolName === 'Shell' ? 'Bash' : block.toolName)
+      if (block.toolName === 'Shell' && typeof block.args?.command === 'string') {
+        bucket.bash.push(...extractBashCommands(block.args.command))
       }
     }
-    byComposer.set(composer, bucket)
   }
-  return byComposer
+  return { byComposer, unjoined }
+}
+
+// What drives a conversation's input figure, decided once per conversation so
+// the sources can never stack on each other:
+//   bubbleTokens - some bubble carries a real tokenCount (older builds), so
+//                  per-turn counts are authoritative and nothing is estimated.
+//   meter        - the composerData context meter exists; one conversation
+//                  record carries it.
+//   stream       - no meter, but the agent stream holds the prompt/context; one
+//                  conversation record carries the estimate.
+//   text         - only visible bubble text exists; estimated per bubble.
+type InputSource = 'bubbleTokens' | 'meter' | 'stream' | 'text'
+
+type ComposerScan = {
+  hasRealTokens: boolean
+  firstBubbleTs: string | null
+  assistantTextChars: number
+  model: string | null
 }
 
 function parseBubbles(
   db: SqliteDatabase,
   seenKeys: Set<string>,
   timeFloor: string,
-  composerInput: Map<string, number>,
-  agentTools: Map<string, AgentTools>,
+  agentKvTimestamp: string,
 ): { calls: ParsedProviderCall[] } {
   const results: ParsedProviderCall[] = []
   let skipped = 0
-  // Each conversation's real context is credited once (on its first turn) so a
-  // multi-turn chat does not multiply the snapshot across every bubble.
-  const creditedComposers = new Set<string>()
 
-  // Build a composerId -> model map from assistant bubbles. User bubbles
-  // (type=1) carry no modelInfo, so when we credit real input tokens onto a
-  // user bubble we need the conversation's actual model for pricing.
-  const composerModel = new Map<string, string>()
-  try {
-    const modelRows = db.query<{ bubble_key: string; model: string | null }>(`
-      SELECT key as bubble_key, json_extract(value, '$.modelInfo.modelName') as model
-      FROM cursorDiskKV
-      WHERE key LIKE 'bubbleId:%' AND json_extract(value, '$.modelInfo.modelName') IS NOT NULL
-    `)
-    for (const r of modelRows) {
-      const cid = parseComposerIdFromKey(r.bubble_key)
-      if (cid && r.model && !composerModel.has(cid)) composerModel.set(cid, r.model)
-    }
-  } catch { /* best-effort */ }
+  const composerMeta = loadComposerMeta(db)
 
   // The bubble timestamp lives inside the JSON value (no index), so the date
   // filter forces a full JSON decode per row. Multi-GB Cursor DBs (500k+
@@ -612,9 +689,9 @@ function parseBubbles(
       "SELECT COUNT(*) as cnt FROM cursorDiskKV WHERE key LIKE 'bubbleId:%'"
     )
     total = countRows[0]?.cnt ?? 0
-  } catch { /* best-effort */ }
-
-  const userMessages = buildUserMessageMap(db, timeFloor)
+  } catch (err) {
+    rethrowBusy(err)
+  }
 
   let rows: BubbleRow[]
   try {
@@ -631,121 +708,141 @@ function parseBubbles(
     } else {
       rows = db.query<BubbleRow>(BUBBLE_QUERY_SINCE, [timeFloor])
     }
-  } catch {
+  } catch (err) {
+    rethrowBusy(err)
     return { calls: results }
   }
 
+  // Pre-pass: per-conversation facts the crediting decisions need, plus the
+  // requestId join for the agent stream — all from the rows already fetched,
+  // so no extra unbudgeted table scans.
+  const scans = new Map<string, ComposerScan>()
+  const requestToComposer = new Map<string, string>()
+  for (const row of rows) {
+    const cid = parseComposerIdFromKey(row.bubble_key)
+    if (!cid) continue
+    if (row.request_id) requestToComposer.set(row.request_id, cid)
+    let scan = scans.get(cid)
+    if (!scan) {
+      scan = { hasRealTokens: false, firstBubbleTs: null, assistantTextChars: 0, model: null }
+      scans.set(cid, scan)
+    }
+    if ((row.input_tokens ?? 0) > 0 || (row.output_tokens ?? 0) > 0) scan.hasRealTokens = true
+    if (!scan.firstBubbleTs && row.created_at) scan.firstBubbleTs = row.created_at
+    if (row.bubble_type !== 1) scan.assistantTextChars += row.text_length ?? 0
+    if (!scan.model && row.model) scan.model = row.model
+  }
+
+  const { byComposer: agentStreams, unjoined } = loadAgentStreams(db, requestToComposer)
+  const userMessages = buildUserMessageMap(db, timeFloor)
+  const lastUserMsg = new Map<string, string>()
+
+  const inputSource = (cid: string): InputSource => {
+    if (scans.get(cid)?.hasRealTokens) return 'bubbleTokens'
+    if (composerMeta.has(cid)) return 'meter'
+    const stream = agentStreams.get(cid)
+    if ((stream?.userChars ?? 0) + (stream?.contextChars ?? 0) > 0) return 'stream'
+    return 'text'
+  }
+
+  const emit = (call: Omit<ParsedProviderCall, 'provider' | 'speed' | 'cacheCreationInputTokens' | 'cacheReadInputTokens' | 'cachedInputTokens' | 'reasoningTokens' | 'webSearchRequests' | 'costIsEstimated'>): void => {
+    results.push({
+      provider: 'cursor',
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      cachedInputTokens: 0,
+      reasoningTokens: 0,
+      webSearchRequests: 0,
+      speed: 'standard',
+      // Output is a reply-text estimate and the input meter is the latest
+      // context snapshot, not a per-turn sum, so no cursor figure is exact.
+      costIsEstimated: true,
+      ...call,
+    })
+  }
+
+  const toolsAttached = new Set<string>()
   for (const row of rows) {
     try {
-      // The JSON `conversationId` field on bubbles is empty in current Cursor
-      // builds. The real composerId lives in the row key
-      // `bubbleId:<composerId>:<bubbleUuid>`. parseComposerIdFromKey returns
-      // null for non-UUID composer segments (Cursor stores tool-call output
-      // under `bubbleId:task-call_xxx\nfc_yyy:<bubbleUuid>` and similar shapes),
-      // which are NOT standalone sessions.
-      const parsedComposerId = parseComposerIdFromKey(row.bubble_key)
-      if (!parsedComposerId) {
+      // The real composerId lives in the row key `bubbleId:<composerId>:<uuid>`
+      // (the JSON conversationId field is empty in current builds).
+      // parseComposerIdFromKey returns null for non-UUID composer segments
+      // (tool-call output rows and similar shapes), which are NOT sessions.
+      const conversationId = parseComposerIdFromKey(row.bubble_key)
+      if (!conversationId) {
         skipped++
         continue
       }
-      const conversationId = parsedComposerId
-
-      const createdAt = row.created_at ?? ''
+      const createdAt = row.created_at
       if (!createdAt) continue
+
+      // Pair each user turn with its own prompt (even when the turn itself
+      // emits nothing) so the assistant reply that follows classifies against
+      // the right question.
+      if (row.bubble_type === 1) {
+        lastUserMsg.set(conversationId, takeUserMessage(userMessages, conversationId))
+      }
 
       let inputTokens = row.input_tokens ?? 0
       let outputTokens = row.output_tokens ?? 0
-      // The conversation's tools/bash attach to the single call that carries its
-      // real input (its first turn), so they are counted exactly once.
-      let creditedHere = false
-
-      // Current Cursor leaves tokenCount at {0,0}. Use the latest local
-      // context-window snapshot for input, credited once per conversation; it is
-      // not cumulative per-turn, so it undercounts Cursor Admin console totals.
-      // Output is a reply-text estimate, and cache tokens are server-side only
-      // (0 on disk). Admin-console parity requires POST
-      // api.cursor.com/teams/filtered-usage-events.
-      // Fall back to the visible-text estimate only when no breakdown was
-      // recorded (older builds).
       if (inputTokens === 0 && outputTokens === 0) {
         const textLen = row.text_length ?? 0
         if (row.bubble_type === 1) {
-          const real = composerInput.get(conversationId)
-          if (real != null) {
-            if (creditedComposers.has(conversationId)) {
-              inputTokens = 0
-            } else {
-              inputTokens = real
-              creditedComposers.add(conversationId)
-              creditedHere = true
-            }
-          } else if (textLen > 0) {
+          // Conversation-level input (meter or stream) is emitted once after
+          // this loop; per-bubble text only counts when it is the
+          // conversation's best available signal.
+          if (inputSource(conversationId) === 'text' && textLen > 0) {
             inputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
-          } else if (!creditedComposers.has(conversationId)) {
-            // Non-Composer sessions (e.g. GPT) record no context meter and keep
-            // the prompt in the agent stream, leaving the bubble text empty.
-            // Estimate from the stream text, credited once per conversation.
-            const agentChars = agentTools.get(conversationId)?.userChars ?? 0
-            if (agentChars > 0) {
-              inputTokens = Math.ceil(agentChars / CHARS_PER_TOKEN)
-              creditedComposers.add(conversationId)
-              creditedHere = true
-            }
           }
         } else {
           outputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
         }
         if (inputTokens === 0 && outputTokens === 0) continue
       }
+
       // Use the SQLite row key (bubbleId:<unique>) as the dedup key.
       // Cursor mutates token counts on the row in place when streaming
       // completes — including tokens in the dedup key (the previous
       // implementation) caused the same bubble to be counted twice once
       // its tokens stabilized.
       const dedupKey = `cursor:bubble:${row.bubble_key}`
-
       if (seenKeys.has(dedupKey)) continue
       seenKeys.add(dedupKey)
 
-      // User bubbles (type=1) carry no modelInfo, so when real input tokens
-      // are credited onto them, fall back to the conversation's model (found
-      // on the assistant bubble) for pricing and display.
-      const effectiveModel = row.model ?? composerModel.get(conversationId) ?? null
+      // User bubbles (type=1) carry no modelInfo, so fall back to the
+      // conversation's model seen on its assistant bubbles or agent stream.
+      const effectiveModel = row.model ?? scans.get(conversationId)?.model ?? agentStreams.get(conversationId)?.model ?? null
       const pricingModel = resolveModel(effectiveModel)
-      const displayModel = modelForDisplay(effectiveModel)
-
       const costUSD = calculateCost(pricingModel, inputTokens, outputTokens, 0, 0, 0)
 
-      const timestamp = createdAt
-      const userQuestion = takeUserMessage(userMessages, conversationId)
+      const userQuestion = lastUserMsg.get(conversationId) ?? ''
       const assistantText = blobToText(row.user_text)
       const userText = (userQuestion + ' ' + assistantText).trim()
 
       const languages = extractLanguages(blobToText(row.code_blocks))
       const hasCode = languages.length > 0
 
-      const agentTurn = creditedHere ? agentTools.get(conversationId) : undefined
-      const cursorTools: string[] = [
-        ...(hasCode ? ['cursor:edit', ...languages.map(l => `lang:${l}`)] : []),
-        ...(agentTurn?.tools ?? []),
-      ]
-      const bashCommands = agentTurn?.bash ?? []
+      // Meter/stream conversations carry their agent tools on the synthetic
+      // conversation record below; the rest attach them to their first
+      // emitted call so they are counted exactly once.
+      let agentTurn: AgentStream | undefined
+      const source = inputSource(conversationId)
+      if ((source === 'text' || source === 'bubbleTokens') && !toolsAttached.has(conversationId)) {
+        agentTurn = agentStreams.get(conversationId)
+        if (agentTurn) toolsAttached.add(conversationId)
+      }
 
-      results.push({
-        provider: 'cursor',
-        model: displayModel,
+      emit({
+        model: modelForDisplay(effectiveModel),
         inputTokens,
         outputTokens,
-        cacheCreationInputTokens: 0,
-        cacheReadInputTokens: 0,
-        cachedInputTokens: 0,
-        reasoningTokens: 0,
-        webSearchRequests: 0,
         costUSD,
-        tools: cursorTools,
-        bashCommands,
-        timestamp,
-        speed: 'standard',
+        tools: [
+          ...(hasCode ? ['cursor:edit', ...languages.map(l => `lang:${l}`)] : []),
+          ...(agentTurn?.tools ?? []),
+        ],
+        bashCommands: agentTurn?.bash ?? [],
+        timestamp: createdAt,
         deduplicationKey: dedupKey,
         userMessage: userText,
         sessionId: conversationId,
@@ -753,6 +850,75 @@ function parseBubbles(
     } catch {
       skipped++
     }
+  }
+
+  // One conversation-level input record per metered/stream conversation,
+  // anchored to the conversation's own start (composerData.createdAt) so the
+  // credited day never depends on the parse window or cache state, and keyed
+  // by composerId so re-parses and daily-cache gap fills dedupe instead of
+  // multiplying. The meter is the LATEST context size, not a per-turn sum;
+  // growth after the anchor day is finalized stays uncounted, which keeps the
+  // documented undercount-vs-admin-console tradeoff but never double counts.
+  for (const [cid, scan] of scans) {
+    const source = inputSource(cid)
+    if (source !== 'meter' && source !== 'stream') continue
+    const stream = agentStreams.get(cid)
+    const meta = composerMeta.get(cid)
+    const inputTokens = source === 'meter'
+      ? meta?.tokens ?? 0
+      : Math.ceil(((stream?.userChars ?? 0) + (stream?.contextChars ?? 0)) / CHARS_PER_TOKEN)
+    // Reply text normally lives on assistant bubbles; count the stream's
+    // reply deltas only when the bubbles carried none.
+    const outputTokens = scan.assistantTextChars > 0 ? 0 : Math.ceil((stream?.assistantChars ?? 0) / CHARS_PER_TOKEN)
+    if (inputTokens === 0 && outputTokens === 0) continue
+
+    const dedupKey = `cursor:composer-input:${cid}`
+    if (seenKeys.has(dedupKey)) continue
+    seenKeys.add(dedupKey)
+
+    const createdAtMs = meta?.createdAt
+    const timestamp = typeof createdAtMs === 'number' && createdAtMs > 0 ? new Date(createdAtMs).toISOString() : scan.firstBubbleTs
+    if (!timestamp) continue
+
+    const effectiveModel = scan.model ?? stream?.model ?? null
+    emit({
+      model: modelForDisplay(effectiveModel),
+      inputTokens,
+      outputTokens,
+      costUSD: calculateCost(resolveModel(effectiveModel), inputTokens, outputTokens, 0, 0, 0),
+      tools: stream?.tools ?? [],
+      bashCommands: stream?.bash ?? [],
+      timestamp,
+      deduplicationKey: dedupKey,
+      userMessage: '',
+      sessionId: cid,
+    })
+  }
+
+  // Sessions recorded only in the agent stream (no bubble carries their
+  // requestId). agentKv stores no timestamps, so these reuse the DB file's
+  // mtime as a bounded "last write" time, like the pre-composer parser did.
+  for (const [requestId, stream] of unjoined) {
+    const inputTokens = Math.ceil((stream.userChars + stream.contextChars) / CHARS_PER_TOKEN)
+    const outputTokens = Math.ceil(stream.assistantChars / CHARS_PER_TOKEN)
+    if (inputTokens === 0 && outputTokens === 0) continue
+
+    const dedupKey = `cursor:agentKv:${requestId}`
+    if (seenKeys.has(dedupKey)) continue
+    seenKeys.add(dedupKey)
+
+    emit({
+      model: modelForDisplay(stream.model),
+      inputTokens,
+      outputTokens,
+      costUSD: calculateCost(resolveModel(stream.model), inputTokens, outputTokens, 0, 0, 0),
+      tools: stream.tools,
+      bashCommands: stream.bash,
+      timestamp: agentKvTimestamp,
+      deduplicationKey: dedupKey,
+      userMessage: '',
+      sessionId: requestId,
+    })
   }
 
   if (skipped > 0) {
@@ -815,6 +981,7 @@ function createParser(
         try {
           db = openDatabase(dbPath)
         } catch (err) {
+          rethrowBusy(err)
           process.stderr.write(`codeburn: cannot open Cursor database: ${err instanceof Error ? err.message : err}\n`)
           return
         }
@@ -827,14 +994,15 @@ function createParser(
           // seenKeys is not mutated by calls that the workspace filter is
           // about to drop. Cross-source dedup happens at yield time.
           const localSeen = new Set<string>()
-          // Real per-conversation input tokens from
-          // composerData.promptTokenBreakdown supersedes the old agentKv
-          // content-char estimate, which double-counted against the bubble
-          // stream. agentKv is now used only for the tools/bash breakdown
-          // via loadAgentToolsByComposer().
-          const composerInput = loadComposerInputTokens(db)
-          const agentTools = loadAgentToolsByComposer(db)
-          const { calls: bubbleCalls } = parseBubbles(db, localSeen, timeFloor, composerInput, agentTools)
+          // agentKv rows carry no timestamps; sessions found only there get
+          // the DB's last-write time.
+          let agentKvTimestamp: string
+          try {
+            agentKvTimestamp = new Date(statSync(dbPath).mtimeMs).toISOString()
+          } catch {
+            agentKvTimestamp = new Date().toISOString()
+          }
+          const { calls: bubbleCalls } = parseBubbles(db, localSeen, timeFloor, agentKvTimestamp)
           allCalls = bubbleCalls
           await writeCachedResults(dbPath, allCalls, timeFloor)
         } finally {

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -322,7 +322,7 @@ const AGENTKV_QUERY = `
 
 const USER_MESSAGES_QUERY = `
   SELECT
-    json_extract(value, '$.conversationId') as conversation_id,
+    key as bubble_key,
     json_extract(value, '$.createdAt') as created_at,
     CAST(substr(json_extract(value, '$.text'), 1, 500) AS BLOB) as text
   FROM cursorDiskKV
@@ -378,7 +378,7 @@ function validateSchema(db: SqliteDatabase): boolean {
   }
 }
 
-type UserMsgRow = { conversation_id: string; created_at: string; text: Uint8Array | string }
+type UserMsgRow = { bubble_key: string; created_at: string; text: Uint8Array | string }
 
 /// Per-conversation user-message buffer. We pop messages in arrival order via
 /// the `pos` cursor — a previous implementation called Array.shift() which is
@@ -394,13 +394,16 @@ function buildUserMessageMap(db: SqliteDatabase, timeFloor: string): Map<string,
   try {
     const rows = db.query<UserMsgRow>(USER_MESSAGES_QUERY, [timeFloor])
     for (const row of rows) {
-      if (!row.conversation_id || !row.text) continue
+      // Extract the composerId from the bubble key, matching parseBubbles().
+      // The JSON `conversationId` field is empty in current Cursor builds.
+      const composerId = parseComposerIdFromKey(row.bubble_key)
+      if (!composerId || !row.text) continue
       const text = blobToText(row.text)
-      const existing = map.get(row.conversation_id)
+      const existing = map.get(composerId)
       if (existing) {
         existing.messages.push(text)
       } else {
-        map.set(row.conversation_id, { messages: [text], pos: 0 })
+        map.set(composerId, { messages: [text], pos: 0 })
       }
     }
   } catch {}
@@ -477,7 +480,9 @@ function loadComposerInputTokens(db: SqliteDatabase): Map<string, number> {
   try {
     const rows = db.query<{ composer_id: string; used: number | null; ctx: number | null }>(COMPOSER_TOKENS_QUERY)
     for (const r of rows) {
-      const tokens = r.used ?? r.ctx ?? 0
+      // Distinguish null (field absent) from 0 (valid token count).
+      // `used ?? ctx` would fall through on 0, suppressing a real zero.
+      const tokens = r.used !== null ? r.used : (r.ctx ?? 0)
       if (r.composer_id && tokens > 0) map.set(r.composer_id, tokens)
     }
   } catch {
@@ -560,6 +565,22 @@ function parseBubbles(
   // multi-turn chat does not multiply the snapshot across every bubble.
   const creditedComposers = new Set<string>()
 
+  // Build a composerId -> model map from assistant bubbles. User bubbles
+  // (type=1) carry no modelInfo, so when we credit real input tokens onto a
+  // user bubble we need the conversation's actual model for pricing.
+  const composerModel = new Map<string, string>()
+  try {
+    const modelRows = db.query<{ bubble_key: string; model: string | null }>(`
+      SELECT key as bubble_key, json_extract(value, '$.modelInfo.modelName') as model
+      FROM cursorDiskKV
+      WHERE key LIKE 'bubbleId:%' AND json_extract(value, '$.modelInfo.modelName') IS NOT NULL
+    `)
+    for (const r of modelRows) {
+      const cid = parseComposerIdFromKey(r.bubble_key)
+      if (cid && r.model && !composerModel.has(cid)) composerModel.set(cid, r.model)
+    }
+  } catch { /* best-effort */ }
+
   // The bubble timestamp lives inside the JSON value (no index), so the date
   // filter forces a full JSON decode per row. Multi-GB Cursor DBs (500k+
   // bubbles) were producing 30s+ parse stalls, so the scan is bounded. The old
@@ -620,9 +641,6 @@ function parseBubbles(
 
       let inputTokens = row.input_tokens ?? 0
       let outputTokens = row.output_tokens ?? 0
-      // The conversation's tools/bash attach to the single call that carries its
-      // real input (its first turn), so they are counted exactly once.
-      let creditedHere = false
 
       // Current Cursor leaves tokenCount at {0,0}. Use the conversation's real
       // context size (promptTokenBreakdown) for input, credited once per
@@ -638,7 +656,6 @@ function parseBubbles(
             } else {
               inputTokens = real
               creditedComposers.add(conversationId)
-              creditedHere = true
             }
           } else {
             inputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
@@ -658,8 +675,12 @@ function parseBubbles(
       if (seenKeys.has(dedupKey)) continue
       seenKeys.add(dedupKey)
 
-      const pricingModel = resolveModel(row.model)
-      const displayModel = modelForDisplay(row.model)
+      // User bubbles (type=1) carry no modelInfo, so when real input tokens
+      // are credited onto them, fall back to the conversation's model (found
+      // on the assistant bubble) for pricing and display.
+      const effectiveModel = row.model ?? composerModel.get(conversationId) ?? null
+      const pricingModel = resolveModel(effectiveModel)
+      const displayModel = modelForDisplay(effectiveModel)
 
       const costUSD = calculateCost(pricingModel, inputTokens, outputTokens, 0, 0, 0)
 
@@ -671,7 +692,7 @@ function parseBubbles(
       const languages = extractLanguages(blobToText(row.code_blocks))
       const hasCode = languages.length > 0
 
-      const agentTurn = creditedHere ? agentTools.get(conversationId) : undefined
+      const agentTurn = agentTools.get(conversationId)
       const cursorTools: string[] = [
         ...(hasCode ? ['cursor:edit', ...languages.map(l => `lang:${l}`)] : []),
         ...(agentTurn?.tools ?? []),
@@ -774,10 +795,11 @@ function createParser(
           // seenKeys is not mutated by calls that the workspace filter is
           // about to drop. Cross-source dedup happens at yield time.
           const localSeen = new Set<string>()
-          // promptTokenBreakdown carries Cursor's real per-conversation input
-          // count, so it supersedes the old agentKv content-char estimate,
-          // which double-counted against the bubble stream. parseAgentKv is
-          // kept for the tools/bash breakdown in a follow-up.
+          // Real per-conversation input tokens from
+          // composerData.promptTokenBreakdown supersedes the old agentKv
+          // content-char estimate, which double-counted against the bubble
+          // stream. agentKv is now used only for the tools/bash breakdown
+          // via loadAgentToolsByComposer().
           const composerInput = loadComposerInputTokens(db)
           const agentTools = loadAgentToolsByComposer(db)
           const { calls: bubbleCalls } = parseBubbles(db, localSeen, timeFloor, composerInput, agentTools)

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -480,9 +480,7 @@ function loadComposerInputTokens(db: SqliteDatabase): Map<string, number> {
   try {
     const rows = db.query<{ composer_id: string; used: number | null; ctx: number | null }>(COMPOSER_TOKENS_QUERY)
     for (const r of rows) {
-      // Distinguish null (field absent) from 0 (valid token count).
-      // `used ?? ctx` would fall through on 0, suppressing a real zero.
-      const tokens = r.used !== null ? r.used : (r.ctx ?? 0)
+      const tokens = r.used ?? r.ctx ?? 0
       if (r.composer_id && tokens > 0) map.set(r.composer_id, tokens)
     }
   } catch {
@@ -641,6 +639,9 @@ function parseBubbles(
 
       let inputTokens = row.input_tokens ?? 0
       let outputTokens = row.output_tokens ?? 0
+      // The conversation's tools/bash attach to the single call that carries its
+      // real input (its first turn), so they are counted exactly once.
+      let creditedHere = false
 
       // Current Cursor leaves tokenCount at {0,0}. Use the conversation's real
       // context size (promptTokenBreakdown) for input, credited once per
@@ -656,6 +657,7 @@ function parseBubbles(
             } else {
               inputTokens = real
               creditedComposers.add(conversationId)
+              creditedHere = true
             }
           } else {
             inputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
@@ -692,7 +694,7 @@ function parseBubbles(
       const languages = extractLanguages(blobToText(row.code_blocks))
       const hasCode = languages.length > 0
 
-      const agentTurn = agentTools.get(conversationId)
+      const agentTurn = creditedHere ? agentTools.get(conversationId) : undefined
       const cursorTools: string[] = [
         ...(hasCode ? ['cursor:edit', ...languages.map(l => `lang:${l}`)] : []),
         ...(agentTurn?.tools ?? []),

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -462,9 +462,12 @@ function scanBubblesPaged(
   return { rows: collected, truncated }
 }
 
-// Cursor leaves the per-bubble tokenCount at {0,0} on current builds; the only
-// real input figure on disk is the conversation's context size, which Cursor
-// records in composerData.promptTokenBreakdown (the in-app context meter).
+// Cursor leaves the per-bubble tokenCount at {0,0} on current builds. The only
+// real input figure on disk is the latest context-window snapshot, which Cursor
+// records in composerData.promptTokenBreakdown.totalUsedTokens or
+// contextTokensUsed (the in-app context meter). This is not cumulative per-turn,
+// so local SQLite undercounts admin-console usage; parity requires the opt-in
+// Cursor Admin API: POST api.cursor.com/teams/filtered-usage-events.
 // Keyed by composerId so parseBubbles can credit it to the right conversation.
 const COMPOSER_TOKENS_QUERY = `
   SELECT
@@ -643,10 +646,14 @@ function parseBubbles(
       // real input (its first turn), so they are counted exactly once.
       let creditedHere = false
 
-      // Current Cursor leaves tokenCount at {0,0}. Use the conversation's real
-      // context size (promptTokenBreakdown) for input, credited once per
-      // conversation, and the reply text for output. Fall back to the
-      // visible-text estimate only when no breakdown was recorded (older builds).
+      // Current Cursor leaves tokenCount at {0,0}. Use the latest local
+      // context-window snapshot for input, credited once per conversation; it is
+      // not cumulative per-turn, so it undercounts Cursor Admin console totals.
+      // Output is a reply-text estimate, and cache tokens are server-side only
+      // (0 on disk). Admin-console parity requires POST
+      // api.cursor.com/teams/filtered-usage-events.
+      // Fall back to the visible-text estimate only when no breakdown was
+      // recorded (older builds).
       if (inputTokens === 0 && outputTokens === 0) {
         const textLen = row.text_length ?? 0
         if (row.bubble_type === 1) {

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync, readdirSync, readFileSync } from 'fs'
+import { existsSync, readdirSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 
@@ -64,17 +64,6 @@ type AgentKvRow = {
   content: Uint8Array | string | null
   request_id: string | null
   content_length: number
-}
-
-type AgentKvContent = {
-  type?: string
-  text?: string
-  providerOptions?: {
-    cursor?: {
-      modelName?: string
-      requestId?: string
-    }
-  }
 }
 
 const CHARS_PER_TOKEN = 4
@@ -497,11 +486,73 @@ function loadComposerInputTokens(db: SqliteDatabase): Map<string, number> {
   return map
 }
 
+type AgentTools = { tools: string[]; bash: string[] }
+
+// Cursor logs the agent's tool calls (Read, Grep, Shell, ...) in agentKv blobs
+// keyed by requestId. Bubbles carry the same requestId plus the composerId, so
+// joining the two attributes each conversation's tools and Shell commands.
+const BUBBLE_REQUESTID_QUERY = `
+  SELECT key as bubble_key, json_extract(value, '$.requestId') as request_id
+  FROM cursorDiskKV
+  WHERE key LIKE 'bubbleId:%' AND json_extract(value, '$.requestId') IS NOT NULL
+`
+
+function loadAgentToolsByComposer(db: SqliteDatabase): Map<string, AgentTools> {
+  const byComposer = new Map<string, AgentTools>()
+
+  const requestToComposer = new Map<string, string>()
+  try {
+    const rows = db.query<{ bubble_key: string; request_id: string | null }>(BUBBLE_REQUESTID_QUERY)
+    for (const r of rows) {
+      const composer = parseComposerIdFromKey(r.bubble_key)
+      if (composer && r.request_id) requestToComposer.set(r.request_id, composer)
+    }
+  } catch {
+    return byComposer
+  }
+
+  let rows: AgentKvRow[]
+  try {
+    rows = db.query<AgentKvRow>(AGENTKV_QUERY)
+  } catch {
+    return byComposer
+  }
+
+  // Only the turn-opening (user) agentKv row carries the requestId; the
+  // assistant rows that follow inherit it, so track it positionally.
+  let currentRequestId: string | null = null
+  for (const row of rows) {
+    if (row.request_id) currentRequestId = row.request_id
+    if (row.role !== 'assistant' || !row.content || !currentRequestId) continue
+    const composer = requestToComposer.get(currentRequestId)
+    if (!composer) continue
+    let content: unknown
+    try {
+      content = JSON.parse(blobToText(row.content))
+    } catch {
+      continue
+    }
+    if (!Array.isArray(content)) continue
+    const bucket = byComposer.get(composer) ?? { tools: [], bash: [] }
+    for (const block of content as Array<{ type?: string; toolName?: string; args?: { command?: string } }>) {
+      if (!block || block.type !== 'tool-call' || !block.toolName) continue
+      bucket.tools.push(block.toolName)
+      if (block.toolName === 'Shell') {
+        const command = block.args?.command?.trim()
+        if (command) bucket.bash.push(command)
+      }
+    }
+    byComposer.set(composer, bucket)
+  }
+  return byComposer
+}
+
 function parseBubbles(
   db: SqliteDatabase,
   seenKeys: Set<string>,
   timeFloor: string,
   composerInput: Map<string, number>,
+  agentTools: Map<string, AgentTools>,
 ): { calls: ParsedProviderCall[] } {
   const results: ParsedProviderCall[] = []
   let skipped = 0
@@ -569,6 +620,9 @@ function parseBubbles(
 
       let inputTokens = row.input_tokens ?? 0
       let outputTokens = row.output_tokens ?? 0
+      // The conversation's tools/bash attach to the single call that carries its
+      // real input (its first turn), so they are counted exactly once.
+      let creditedHere = false
 
       // Current Cursor leaves tokenCount at {0,0}. Use the conversation's real
       // context size (promptTokenBreakdown) for input, credited once per
@@ -579,8 +633,13 @@ function parseBubbles(
         if (row.bubble_type === 1) {
           const real = composerInput.get(conversationId)
           if (real != null) {
-            inputTokens = creditedComposers.has(conversationId) ? 0 : real
-            creditedComposers.add(conversationId)
+            if (creditedComposers.has(conversationId)) {
+              inputTokens = 0
+            } else {
+              inputTokens = real
+              creditedComposers.add(conversationId)
+              creditedHere = true
+            }
           } else {
             inputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
           }
@@ -612,7 +671,12 @@ function parseBubbles(
       const languages = extractLanguages(blobToText(row.code_blocks))
       const hasCode = languages.length > 0
 
-      const cursorTools: string[] = hasCode ? ['cursor:edit', ...languages.map(l => `lang:${l}`)] : []
+      const agentTurn = creditedHere ? agentTools.get(conversationId) : undefined
+      const cursorTools: string[] = [
+        ...(hasCode ? ['cursor:edit', ...languages.map(l => `lang:${l}`)] : []),
+        ...(agentTurn?.tools ?? []),
+      ]
+      const bashCommands = agentTurn?.bash ?? []
 
       results.push({
         provider: 'cursor',
@@ -626,7 +690,7 @@ function parseBubbles(
         webSearchRequests: 0,
         costUSD,
         tools: cursorTools,
-        bashCommands: [],
+        bashCommands,
         timestamp,
         speed: 'standard',
         deduplicationKey: dedupKey,
@@ -640,136 +704,6 @@ function parseBubbles(
 
   if (skipped > 0) {
     process.stderr.write(`codeburn: skipped ${skipped} unreadable Cursor entries\n`)
-  }
-
-  return { calls: results }
-}
-
-function extractModelFromContent(content: AgentKvContent[]): string | null {
-  for (const c of content) {
-    if (c.providerOptions?.cursor?.modelName) {
-      return c.providerOptions.cursor.modelName
-    }
-  }
-  return null
-}
-
-function extractTextLength(content: AgentKvContent[]): number {
-  let total = 0
-  for (const c of content) {
-    if (c.text) total += c.text.length
-  }
-  return total
-}
-
-function parseAgentKv(db: SqliteDatabase, seenKeys: Set<string>, dbPath: string): { calls: ParsedProviderCall[] } {
-  const results: ParsedProviderCall[] = []
-
-  // Cursor's agentKv schema does not record per-message timestamps. Use the
-  // SQLite file's mtime as a bounded "last write" timestamp for all calls;
-  // it's at least honest (no future time, no always-now). Users running
-  // codeburn against an idle Cursor install will see agentKv calls land at
-  // the actual last activity time rather than today's date.
-  let agentKvTimestamp: string
-  try {
-    agentKvTimestamp = new Date(statSync(dbPath).mtimeMs).toISOString()
-  } catch {
-    agentKvTimestamp = new Date().toISOString()
-  }
-
-  let rows: AgentKvRow[]
-  try {
-    rows = db.query<AgentKvRow>(AGENTKV_QUERY)
-  } catch {
-    return { calls: results }
-  }
-
-  const sessions: Map<string, { inputChars: number; outputChars: number; model: string | null; userText: string }> = new Map()
-  let currentRequestId = 'unknown'
-  let turnIndex = 0
-
-  for (const row of rows) {
-    if (!row.role || !row.content) continue
-    const contentText = blobToText(row.content)
-
-    let content: AgentKvContent[]
-    let plainTextLength = 0
-    try {
-      const parsed = JSON.parse(contentText)
-      if (Array.isArray(parsed)) {
-        content = parsed
-      } else {
-        content = []
-        plainTextLength = contentText.length
-      }
-    } catch {
-      content = []
-      plainTextLength = contentText.length
-    }
-
-    const requestId = row.request_id ?? currentRequestId
-    if (requestId !== currentRequestId) {
-      currentRequestId = requestId
-      turnIndex = 0
-    }
-
-    const textLength = plainTextLength || extractTextLength(content)
-    const model = extractModelFromContent(content)
-
-    if (row.role === 'user') {
-      const existing = sessions.get(requestId) ?? { inputChars: 0, outputChars: 0, model: null, userText: '' }
-      existing.inputChars += textLength
-      if (!existing.userText) {
-        const text = content[0]?.text ?? contentText
-        const queryMatch = text.match(/<user_query>([\s\S]*?)<\/user_query>/)
-        existing.userText = queryMatch ? queryMatch[1].trim().slice(0, 500) : text.slice(0, 500)
-      }
-      sessions.set(requestId, existing)
-    } else if (row.role === 'assistant') {
-      const existing = sessions.get(requestId) ?? { inputChars: 0, outputChars: 0, model: null, userText: '' }
-      existing.outputChars += textLength
-      if (model) existing.model = model
-      sessions.set(requestId, existing)
-    } else if (row.role === 'tool' || row.role === 'system') {
-      const existing = sessions.get(requestId) ?? { inputChars: 0, outputChars: 0, model: null, userText: '' }
-      existing.inputChars += textLength
-      sessions.set(requestId, existing)
-    }
-  }
-
-  for (const [requestId, session] of sessions) {
-    if (session.inputChars === 0 && session.outputChars === 0) continue
-
-    const inputTokens = Math.ceil(session.inputChars / CHARS_PER_TOKEN)
-    const outputTokens = Math.ceil(session.outputChars / CHARS_PER_TOKEN)
-    const dedupKey = `cursor:agentKv:${requestId}`
-
-    if (seenKeys.has(dedupKey)) continue
-    seenKeys.add(dedupKey)
-
-    const pricingModel = resolveModel(session.model)
-    const displayModel = modelForDisplay(session.model)
-    const costUSD = calculateCost(pricingModel, inputTokens, outputTokens, 0, 0, 0)
-
-    results.push({
-      provider: 'cursor',
-      model: displayModel,
-      inputTokens,
-      outputTokens,
-      cacheCreationInputTokens: 0,
-      cacheReadInputTokens: 0,
-      cachedInputTokens: 0,
-      reasoningTokens: 0,
-      webSearchRequests: 0,
-      costUSD,
-      tools: [],
-      bashCommands: [],
-      timestamp: agentKvTimestamp,
-      speed: 'standard',
-      deduplicationKey: dedupKey,
-      userMessage: session.userText,
-      sessionId: requestId,
-    })
   }
 
   return { calls: results }
@@ -845,7 +779,8 @@ function createParser(
           // which double-counted against the bubble stream. parseAgentKv is
           // kept for the tools/bash breakdown in a follow-up.
           const composerInput = loadComposerInputTokens(db)
-          const { calls: bubbleCalls } = parseBubbles(db, localSeen, timeFloor, composerInput)
+          const agentTools = loadAgentToolsByComposer(db)
+          const { calls: bubbleCalls } = parseBubbles(db, localSeen, timeFloor, composerInput, agentTools)
           allCalls = bubbleCalls
           await writeCachedResults(dbPath, allCalls, timeFloor)
         } finally {

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -492,7 +492,7 @@ function loadComposerInputTokens(db: SqliteDatabase): Map<string, number> {
   return map
 }
 
-type AgentTools = { tools: string[]; bash: string[] }
+type AgentTools = { tools: string[]; bash: string[]; userChars: number }
 
 // Cursor logs the agent's tool calls (Read, Grep, Shell, ...) in agentKv blobs
 // keyed by requestId. Bubbles carry the same requestId plus the composerId, so
@@ -529,9 +529,22 @@ function loadAgentToolsByComposer(db: SqliteDatabase): Map<string, AgentTools> {
   let currentRequestId: string | null = null
   for (const row of rows) {
     if (row.request_id) currentRequestId = row.request_id
-    if (row.role !== 'assistant' || !row.content || !currentRequestId) continue
+    if (!row.content || !currentRequestId) continue
     const composer = requestToComposer.get(currentRequestId)
     if (!composer) continue
+
+    // A user turn stores its prompt (plus injected context) as a plain string.
+    // Track its length so a turn whose bubble text is empty — non-Composer
+    // sessions such as GPT keep it in the agent stream — can still be
+    // estimated instead of dropped.
+    if (row.role === 'user') {
+      const bucket = byComposer.get(composer) ?? { tools: [], bash: [], userChars: 0 }
+      bucket.userChars += blobToText(row.content).length
+      byComposer.set(composer, bucket)
+      continue
+    }
+    if (row.role !== 'assistant') continue
+
     let content: unknown
     try {
       content = JSON.parse(blobToText(row.content))
@@ -539,7 +552,7 @@ function loadAgentToolsByComposer(db: SqliteDatabase): Map<string, AgentTools> {
       continue
     }
     if (!Array.isArray(content)) continue
-    const bucket = byComposer.get(composer) ?? { tools: [], bash: [] }
+    const bucket = byComposer.get(composer) ?? { tools: [], bash: [], userChars: 0 }
     for (const block of content as Array<{ type?: string; toolName?: string; args?: { command?: string } }>) {
       if (!block || block.type !== 'tool-call' || !block.toolName) continue
       bucket.tools.push(block.toolName)
@@ -666,8 +679,18 @@ function parseBubbles(
               creditedComposers.add(conversationId)
               creditedHere = true
             }
-          } else {
+          } else if (textLen > 0) {
             inputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
+          } else if (!creditedComposers.has(conversationId)) {
+            // Non-Composer sessions (e.g. GPT) record no context meter and keep
+            // the prompt in the agent stream, leaving the bubble text empty.
+            // Estimate from the stream text, credited once per conversation.
+            const agentChars = agentTools.get(conversationId)?.userChars ?? 0
+            if (agentChars > 0) {
+              inputTokens = Math.ceil(agentChars / CHARS_PER_TOKEN)
+              creditedComposers.add(conversationId)
+              creditedHere = true
+            }
           }
         } else {
           outputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -470,13 +470,44 @@ function scanBubblesPaged(
   return { rows: collected, truncated }
 }
 
+// Cursor leaves the per-bubble tokenCount at {0,0} on current builds; the only
+// real input figure on disk is the conversation's context size, which Cursor
+// records in composerData.promptTokenBreakdown (the in-app context meter).
+// Keyed by composerId so parseBubbles can credit it to the right conversation.
+const COMPOSER_TOKENS_QUERY = `
+  SELECT
+    substr(key, 14) as composer_id,
+    json_extract(value, '$.promptTokenBreakdown.totalUsedTokens') as used,
+    json_extract(value, '$.contextTokensUsed') as ctx
+  FROM cursorDiskKV
+  WHERE key LIKE 'composerData:%'
+`
+
+function loadComposerInputTokens(db: SqliteDatabase): Map<string, number> {
+  const map = new Map<string, number>()
+  try {
+    const rows = db.query<{ composer_id: string; used: number | null; ctx: number | null }>(COMPOSER_TOKENS_QUERY)
+    for (const r of rows) {
+      const tokens = r.used ?? r.ctx ?? 0
+      if (r.composer_id && tokens > 0) map.set(r.composer_id, tokens)
+    }
+  } catch {
+    /* best-effort: callers fall back to the per-bubble text estimate */
+  }
+  return map
+}
+
 function parseBubbles(
   db: SqliteDatabase,
   seenKeys: Set<string>,
   timeFloor: string,
+  composerInput: Map<string, number>,
 ): { calls: ParsedProviderCall[] } {
   const results: ParsedProviderCall[] = []
   let skipped = 0
+  // Each conversation's real context is credited once (on its first turn) so a
+  // multi-turn chat does not multiply the snapshot across every bubble.
+  const creditedComposers = new Set<string>()
 
   // The bubble timestamp lives inside the JSON value (no index), so the date
   // filter forces a full JSON decode per row. Multi-GB Cursor DBs (500k+
@@ -520,36 +551,44 @@ function parseBubbles(
 
   for (const row of rows) {
     try {
-      let inputTokens = row.input_tokens ?? 0
-      let outputTokens = row.output_tokens ?? 0
-
-      // Cursor v3 stores zero token counts — estimate from text length
-      if (inputTokens === 0 && outputTokens === 0) {
-        const textLen = row.text_length ?? 0
-        if (textLen === 0) continue
-        if (row.bubble_type === 1) {
-          inputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
-        } else {
-          outputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
-        }
-      }
-
-      const createdAt = row.created_at ?? ''
-      if (!createdAt) continue
-      // The JSON `conversationId` field on bubbles is empty in current
-      // Cursor builds. The real composerId lives in the row key
-      // `bubbleId:<composerId>:<bubbleUuid>`. Extract from the key so the
-      // workspace map join works. parseComposerIdFromKey returns null for
-      // non-UUID composer segments (Cursor stores tool-call output under
-      // `bubbleId:task-call_xxx\nfc_yyy:<bubbleUuid>` and similar shapes —
-      // those bubbles are NOT standalone sessions; their tokens are
-      // already accounted for inside the parent composer's stream).
+      // The JSON `conversationId` field on bubbles is empty in current Cursor
+      // builds. The real composerId lives in the row key
+      // `bubbleId:<composerId>:<bubbleUuid>`. parseComposerIdFromKey returns
+      // null for non-UUID composer segments (Cursor stores tool-call output
+      // under `bubbleId:task-call_xxx\nfc_yyy:<bubbleUuid>` and similar shapes),
+      // which are NOT standalone sessions.
       const parsedComposerId = parseComposerIdFromKey(row.bubble_key)
       if (!parsedComposerId) {
         skipped++
         continue
       }
       const conversationId = parsedComposerId
+
+      const createdAt = row.created_at ?? ''
+      if (!createdAt) continue
+
+      let inputTokens = row.input_tokens ?? 0
+      let outputTokens = row.output_tokens ?? 0
+
+      // Current Cursor leaves tokenCount at {0,0}. Use the conversation's real
+      // context size (promptTokenBreakdown) for input, credited once per
+      // conversation, and the reply text for output. Fall back to the
+      // visible-text estimate only when no breakdown was recorded (older builds).
+      if (inputTokens === 0 && outputTokens === 0) {
+        const textLen = row.text_length ?? 0
+        if (row.bubble_type === 1) {
+          const real = composerInput.get(conversationId)
+          if (real != null) {
+            inputTokens = creditedComposers.has(conversationId) ? 0 : real
+            creditedComposers.add(conversationId)
+          } else {
+            inputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
+          }
+        } else {
+          outputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
+        }
+        if (inputTokens === 0 && outputTokens === 0) continue
+      }
       // Use the SQLite row key (bubbleId:<unique>) as the dedup key.
       // Cursor mutates token counts on the row in place when streaming
       // completes — including tokens in the dedup key (the previous
@@ -801,9 +840,13 @@ function createParser(
           // seenKeys is not mutated by calls that the workspace filter is
           // about to drop. Cross-source dedup happens at yield time.
           const localSeen = new Set<string>()
-          const { calls: bubbleCalls } = parseBubbles(db, localSeen, timeFloor)
-          const { calls: agentKvCalls } = parseAgentKv(db, localSeen, dbPath)
-          allCalls = [...bubbleCalls, ...agentKvCalls]
+          // promptTokenBreakdown carries Cursor's real per-conversation input
+          // count, so it supersedes the old agentKv content-char estimate,
+          // which double-counted against the bubble stream. parseAgentKv is
+          // kept for the tools/bash breakdown in a follow-up.
+          const composerInput = loadComposerInputTokens(db)
+          const { calls: bubbleCalls } = parseBubbles(db, localSeen, timeFloor, composerInput)
+          allCalls = bubbleCalls
           await writeCachedResults(dbPath, allCalls, timeFloor)
         } finally {
           db.close()

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -110,6 +110,7 @@ export const DURABLE_PROVIDER_NAMES: ReadonlySet<string> = new Set(['copilot'])
 const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   claude: 'cowork-space-grouping-v1',
   cline: 'worktree-project-grouping-v1',
+  cursor: 'composer-anchored-crediting-v1',
   'cursor-agent': 'workspaceless-transcript-v1',
   copilot: 'otel-durable-v1',
   hermes: 'reasoning-output-accounting-v1',

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -316,13 +316,16 @@ describe('user price overrides', () => {
     expect(mini!.outputCostPerToken).toBe(miniSnapshot!.outputCostPerToken)
   })
 
-  it('includes price overrides in the daily cache config hash without changing the empty-override hash', () => {
+  it('includes builtin and user price overrides in the daily cache config hash', () => {
     setLocalModelSavings({ local: 'gpt-4o' })
     setPriceOverrides({})
 
-    const savingsOnly = getLocalModelSavingsConfigHash()
-    expect(getPriceOverridesConfigHash()).toBe('')
-    expect(getDailyCacheConfigHash()).toBe(savingsOnly)
+    // The builtin overrides always participate, so a release that edits them
+    // invalidates cached daily costs even with no user overrides configured.
+    const builtinOnly = getPriceOverridesConfigHash()
+    expect(builtinOnly).toContain('builtin:')
+    expect(getPriceOverridesConfigHash()).toBe(builtinOnly)
+    const baseline = getDailyCacheConfigHash()
 
     setPriceOverrides({ 'price-hash-model': { input: 1, output: 2 } })
     const firstCombined = getDailyCacheConfigHash()
@@ -330,8 +333,8 @@ describe('user price overrides', () => {
     setPriceOverrides({ 'price-hash-model': { input: 3, output: 2 } })
     const secondCombined = getDailyCacheConfigHash()
 
-    expect(firstCombined).not.toBe(savingsOnly)
-    expect(secondCombined).not.toBe(savingsOnly)
+    expect(firstCombined).not.toBe(baseline)
+    expect(secondCombined).not.toBe(baseline)
     expect(secondCombined).not.toBe(firstCombined)
   })
 })

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -455,10 +455,7 @@ describe('Cursor model variants resolve to pricing', () => {
     // Haiku family
     ['claude-4.5-haiku', 'claude-haiku-4-5'],
     ['claude-4.6-haiku', 'claude-haiku-4-5'],
-    // Cursor house models
-    ['composer-1', 'claude-sonnet-4-5'],
-    ['composer-1.5', 'claude-sonnet-4-5'],
-    ['composer-2', 'claude-sonnet-4-6'],
+    // Cursor auto proxy
     ['cursor-auto', 'claude-sonnet-4-5'],
     // OpenAI variants Cursor emits
     ['gpt-5', 'gpt-5'],
@@ -483,6 +480,26 @@ describe('Cursor model variants resolve to pricing', () => {
       // where a future edit re-points an alias at a wrong-but-positive entry.
       expect(costs!.inputCostPerToken).toBe(expected!.inputCostPerToken)
       expect(costs!.outputCostPerToken).toBe(expected!.outputCostPerToken)
+    })
+  }
+})
+
+describe('Cursor house model pricing', () => {
+  const cases: Array<[string, { input: number; output: number; cacheWrite: number; cacheRead: number }]> = [
+    ['composer-2.5', { input: 0.5, output: 2.5, cacheWrite: 0.5, cacheRead: 0.2 }],
+    ['composer-2', { input: 0.5, output: 2.5, cacheWrite: 0.5, cacheRead: 0.2 }],
+    ['composer-1.5', { input: 3.5, output: 17.5, cacheWrite: 3.5, cacheRead: 0.35 }],
+    ['composer-1', { input: 1.25, output: 10, cacheWrite: 1.25, cacheRead: 0.125 }],
+  ]
+
+  for (const [model, rates] of cases) {
+    it(`${model} uses Cursor-published rates instead of Claude Sonnet proxy pricing`, () => {
+      const costs = getModelCosts(model)
+      expect(costs).not.toBeNull()
+      expect(costs!.inputCostPerToken).toBeCloseTo(rates.input * 1e-6, 12)
+      expect(costs!.outputCostPerToken).toBeCloseTo(rates.output * 1e-6, 12)
+      expect(costs!.cacheWriteCostPerToken).toBeCloseTo(rates.cacheWrite * 1e-6, 12)
+      expect(costs!.cacheReadCostPerToken).toBeCloseTo(rates.cacheRead * 1e-6, 12)
     })
   }
 })

--- a/tests/providers/cursor-real-tokens.test.ts
+++ b/tests/providers/cursor-real-tokens.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { createRequire } from 'node:module'
+
+import {
+  createCursorProvider,
+  clearCursorWorkspaceMapCache,
+} from '../../src/providers/cursor.js'
+import { isSqliteAvailable } from '../../src/sqlite.js'
+import type { ParsedProviderCall } from '../../src/providers/types.js'
+
+const requireForTest = createRequire(import.meta.url)
+
+const skipReason = isSqliteAvailable()
+  ? null
+  : 'node:sqlite not available — needs Node 22+; skipping'
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'cursor-tokens-test-'))
+  clearCursorWorkspaceMapCache()
+})
+
+afterEach(async () => {
+  clearCursorWorkspaceMapCache()
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+function buildDb(fn: (db: {
+  exec(sql: string): void
+  prepare(sql: string): { run(...params: unknown[]): void }
+  close(): void
+}) => void): string {
+  const dbPath = join(tmpDir, 'state.vscdb')
+  writeFile(dbPath, '')
+  const { DatabaseSync: Database } = requireForTest('node:sqlite')
+  const db = new Database(dbPath)
+  db.exec('CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value BLOB)')
+  db.exec('CREATE TABLE ItemTable (key TEXT UNIQUE, value BLOB)')
+  fn(db)
+  db.close()
+  return dbPath
+}
+
+function insertBubble(db: {
+  prepare(sql: string): { run(...params: unknown[]): void }
+}, opts: {
+  composerId: string
+  bubbleUuid: string
+  type: 1 | 2
+  text: string
+  model?: string
+  inputTokens?: number
+  outputTokens?: number
+  createdAt?: string
+  requestId?: string
+  codeBlocks?: string
+}): void {
+  const key = `bubbleId:${opts.composerId}:${opts.bubbleUuid}`
+  const value = JSON.stringify({
+    type: opts.type,
+    conversationId: '',
+    createdAt: opts.createdAt ?? new Date().toISOString(),
+    tokenCount: {
+      inputTokens: opts.inputTokens ?? 0,
+      outputTokens: opts.outputTokens ?? 0,
+    },
+    modelInfo: opts.model ? { modelName: opts.model } : undefined,
+    text: opts.text,
+    codeBlocks: opts.codeBlocks ?? '[]',
+    requestId: opts.requestId,
+  })
+  db.prepare('INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)').run(key, value)
+}
+
+function insertComposerData(db: {
+  prepare(sql: string): { run(...params: unknown[]): void }
+}, opts: {
+  composerId: string
+  totalUsedTokens?: number | null
+  contextTokensUsed?: number | null
+}): void {
+  const key = `composerData:${opts.composerId}`
+  const breakdown = opts.totalUsedTokens !== undefined
+    ? { totalUsedTokens: opts.totalUsedTokens }
+    : {}
+  const value = JSON.stringify({
+    promptTokenBreakdown: breakdown,
+    contextTokensUsed: opts.contextTokensUsed ?? undefined,
+  })
+  db.prepare('INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)').run(key, value)
+}
+
+function insertAgentKv(db: {
+  prepare(sql: string): { run(...params: unknown[]): void }
+}, opts: {
+  blobId: string
+  role: string
+  content: unknown
+  requestId?: string
+}): void {
+  const key = `agentKv:blob:${opts.blobId}`
+  const value = JSON.stringify({
+    role: opts.role,
+    content: opts.content,
+    providerOptions: opts.requestId
+      ? { cursor: { requestId: opts.requestId } }
+      : undefined,
+  })
+  db.prepare('INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)').run(key, value)
+}
+
+async function collectCalls(provider: ReturnType<typeof createCursorProvider>, dbPath: string): Promise<ParsedProviderCall[]> {
+  const source = { path: dbPath, project: 'test', provider: 'cursor' as const }
+  const calls: ParsedProviderCall[] = []
+  for await (const call of provider.createSessionParser(source, new Set()).parse()) {
+    calls.push(call)
+  }
+  return calls
+}
+
+describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => {
+  it('credits composerData.promptTokenBreakdown.totalUsedTokens as input', async () => {
+    const composerId = 'aaaa1111-2222-3333-4444-555566667777'
+    const dbPath = buildDb((db) => {
+      insertComposerData(db, { composerId, totalUsedTokens: 50000 })
+      insertBubble(db, {
+        composerId, bubbleUuid: 'b1', type: 1, text: 'user prompt',
+        inputTokens: 0, outputTokens: 0,
+      })
+      insertBubble(db, {
+        composerId, bubbleUuid: 'b2', type: 2, text: 'assistant reply',
+        model: 'claude-4.6-sonnet', inputTokens: 0, outputTokens: 0,
+      })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    // User bubble gets the real context; assistant gets text estimate.
+    const userCall = calls.find(c => c.inputTokens === 50000)
+    expect(userCall).toBeDefined()
+    expect(userCall!.inputTokens).toBe(50000)
+  })
+
+  it('credits real input tokens once per conversation, not per bubble', async () => {
+    const composerId = 'bbbb1111-2222-3333-4444-555566667777'
+    const dbPath = buildDb((db) => {
+      insertComposerData(db, { composerId, totalUsedTokens: 30000 })
+      // Multiple user bubbles in the same conversation
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: 'turn 1' })
+      insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'reply 1', model: 'gpt-5' })
+      insertBubble(db, { composerId, bubbleUuid: 'b3', type: 1, text: 'turn 2' })
+      insertBubble(db, { composerId, bubbleUuid: 'b4', type: 2, text: 'reply 2', model: 'gpt-5' })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    // Exactly one call should have 30000 input tokens
+    const credited = calls.filter(c => c.inputTokens === 30000)
+    expect(credited.length).toBe(1)
+  })
+
+  it('falls back to text estimation when no composerData exists', async () => {
+    const composerId = 'cccc1111-2222-3333-4444-555566667777'
+    const dbPath = buildDb((db) => {
+      // No composerData row
+      insertBubble(db, {
+        composerId, bubbleUuid: 'b1', type: 1, text: 'hello world this is a test',
+      })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    const userCall = calls.find(c => c.inputTokens > 0)
+    expect(userCall).toBeDefined()
+    // text length 25 / 4 = 7 tokens
+    expect(userCall!.inputTokens).toBe(Math.ceil('hello world this is a test'.length / 4))
+  })
+
+  it('uses contextTokensUsed when totalUsedTokens is null', async () => {
+    const composerId = 'dddd1111-2222-3333-4444-555566667777'
+    const dbPath = buildDb((db) => {
+      insertComposerData(db, { composerId, totalUsedTokens: null, contextTokensUsed: 42000 })
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: 'prompt' })
+      insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'reply', model: 'gpt-5' })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    const credited = calls.find(c => c.inputTokens === 42000)
+    expect(credited).toBeDefined()
+  })
+
+  it('attributes tools and bash commands from agentKv to the correct conversation', async () => {
+    const composerId = 'eeee1111-2222-3333-4444-555566667777'
+    const requestId = 'req-001'
+    const dbPath = buildDb((db) => {
+      insertComposerData(db, { composerId, totalUsedTokens: 10000 })
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: 'do stuff', requestId })
+      insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'doing stuff', model: 'gpt-5' })
+      // agentKv with tool calls
+      insertAgentKv(db, {
+        blobId: 'akv-1', role: 'user',
+        content: [{ type: 'text', text: 'do stuff' }],
+        requestId,
+      })
+      insertAgentKv(db, {
+        blobId: 'akv-2', role: 'assistant',
+        content: [
+          { type: 'tool-call', toolName: 'Read', args: {} },
+          { type: 'tool-call', toolName: 'Shell', args: { command: 'npm test' } },
+        ],
+      })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    const callWithTools = calls.find(c => c.tools.length > 0)
+    expect(callWithTools).toBeDefined()
+    expect(callWithTools!.tools).toContain('Read')
+    expect(callWithTools!.tools).toContain('Shell')
+    expect(callWithTools!.bashCommands).toContain('npm test')
+  })
+
+  it('uses conversation model for pricing when input is on a user bubble', async () => {
+    const composerId = 'ffff1111-2222-3333-4444-555566667777'
+    const dbPath = buildDb((db) => {
+      insertComposerData(db, { composerId, totalUsedTokens: 100000 })
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: 'prompt' })
+      insertBubble(db, {
+        composerId, bubbleUuid: 'b2', type: 2, text: 'reply',
+        model: 'claude-4.5-opus-high-thinking',
+      })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    const creditedCall = calls.find(c => c.inputTokens === 100000)
+    expect(creditedCall).toBeDefined()
+    // Should NOT be cursor-auto (the fallback for user bubbles without model)
+    expect(creditedCall!.model).not.toBe('cursor-auto')
+    // Should be the conversation's actual model
+    expect(creditedCall!.model).toBe('claude-4.5-opus-high-thinking')
+  })
+})

--- a/tests/providers/cursor-real-tokens.test.ts
+++ b/tests/providers/cursor-real-tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { mkdtemp, rm } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { createRequire } from 'node:module'
@@ -35,7 +35,6 @@ function buildDb(fn: (db: {
   close(): void
 }) => void): string {
   const dbPath = join(tmpDir, 'state.vscdb')
-  writeFile(dbPath, '')
   const { DatabaseSync: Database } = requireForTest('node:sqlite')
   const db = new Database(dbPath)
   db.exec('CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value BLOB)')
@@ -82,6 +81,7 @@ function insertComposerData(db: {
   composerId: string
   totalUsedTokens?: number | null
   contextTokensUsed?: number | null
+  createdAt?: number
 }): void {
   const key = `composerData:${opts.composerId}`
   const breakdown = opts.totalUsedTokens !== undefined
@@ -90,6 +90,7 @@ function insertComposerData(db: {
   const value = JSON.stringify({
     promptTokenBreakdown: breakdown,
     contextTokensUsed: opts.contextTokensUsed ?? undefined,
+    createdAt: opts.createdAt ?? undefined,
   })
   db.prepare('INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)').run(key, value)
 }
@@ -140,17 +141,16 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
     const provider = createCursorProvider(dbPath)
     const calls = await collectCalls(provider, dbPath)
 
-    // User bubble gets the real context; assistant gets text estimate.
-    const userCall = calls.find(c => c.inputTokens === 50000)
-    expect(userCall).toBeDefined()
-    expect(userCall!.inputTokens).toBe(50000)
+    const credited = calls.find(c => c.inputTokens === 50000)
+    expect(credited).toBeDefined()
+    expect(credited!.deduplicationKey).toBe(`cursor:composer-input:${composerId}`)
+    expect(credited!.costIsEstimated).toBe(true)
   })
 
   it('credits real input tokens once per conversation, not per bubble', async () => {
     const composerId = 'bbbb1111-2222-3333-4444-555566667777'
     const dbPath = buildDb((db) => {
       insertComposerData(db, { composerId, totalUsedTokens: 30000 })
-      // Multiple user bubbles in the same conversation
       insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: 'turn 1' })
       insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'reply 1', model: 'gpt-5' })
       insertBubble(db, { composerId, bubbleUuid: 'b3', type: 1, text: 'turn 2' })
@@ -160,15 +160,32 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
     const provider = createCursorProvider(dbPath)
     const calls = await collectCalls(provider, dbPath)
 
-    // Exactly one call should have 30000 input tokens
     const credited = calls.filter(c => c.inputTokens === 30000)
     expect(credited.length).toBe(1)
+    // The metered conversation's user-bubble text must not be counted on top.
+    const inputTotal = calls.reduce((s, c) => s + c.inputTokens, 0)
+    expect(inputTotal).toBe(30000)
+  })
+
+  it('anchors the conversation record to composerData.createdAt, independent of the parse window', async () => {
+    const composerId = 'ab121111-2222-3333-4444-555566667777'
+    const startMs = Date.parse('2026-06-01T10:00:00.000Z')
+    const dbPath = buildDb((db) => {
+      insertComposerData(db, { composerId, totalUsedTokens: 20000, createdAt: startMs })
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: 'later turn' })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    const credited = calls.find(c => c.inputTokens === 20000)
+    expect(credited).toBeDefined()
+    expect(credited!.timestamp).toBe(new Date(startMs).toISOString())
   })
 
   it('falls back to text estimation when no composerData exists', async () => {
     const composerId = 'cccc1111-2222-3333-4444-555566667777'
     const dbPath = buildDb((db) => {
-      // No composerData row
       insertBubble(db, {
         composerId, bubbleUuid: 'b1', type: 1, text: 'hello world this is a test',
       })
@@ -179,7 +196,6 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
 
     const userCall = calls.find(c => c.inputTokens > 0)
     expect(userCall).toBeDefined()
-    // text length 25 / 4 = 7 tokens
     expect(userCall!.inputTokens).toBe(Math.ceil('hello world this is a test'.length / 4))
   })
 
@@ -198,7 +214,38 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
     expect(credited).toBeDefined()
   })
 
-  it('attributes aggregated agentKv tools once in a multi-bubble conversation', async () => {
+  it('uses contextTokensUsed when totalUsedTokens is present but zero', async () => {
+    const composerId = 'de001111-2222-3333-4444-555566667777'
+    const dbPath = buildDb((db) => {
+      insertComposerData(db, { composerId, totalUsedTokens: 0, contextTokensUsed: 42000 })
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: 'prompt' })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    const credited = calls.find(c => c.inputTokens === 42000)
+    expect(credited).toBeDefined()
+  })
+
+  it('skips the meter when any bubble carries real tokenCounts', async () => {
+    const composerId = 'ef001111-2222-3333-4444-555566667777'
+    const dbPath = buildDb((db) => {
+      insertComposerData(db, { composerId, totalUsedTokens: 80000 })
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: 'prompt', inputTokens: 6000 })
+      insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'reply', model: 'gpt-5', outputTokens: 900 })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    // Real per-bubble counts are authoritative; the snapshot must not stack.
+    expect(calls.find(c => c.inputTokens === 80000)).toBeUndefined()
+    const inputTotal = calls.reduce((s, c) => s + c.inputTokens, 0)
+    expect(inputTotal).toBe(6000)
+  })
+
+  it('attributes aggregated agentKv tools once, with canonical Bash names', async () => {
     const composerId = 'eeee1111-2222-3333-4444-555566667777'
     const requestId = 'req-001'
     const dbPath = buildDb((db) => {
@@ -207,7 +254,6 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
       insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'doing stuff', model: 'gpt-5' })
       insertBubble(db, { composerId, bubbleUuid: 'b3', type: 1, text: 'do more stuff', requestId: 'req-002' })
       insertBubble(db, { composerId, bubbleUuid: 'b4', type: 2, text: 'doing more stuff', model: 'gpt-5' })
-      // agentKv with tool calls
       insertAgentKv(db, {
         blobId: 'akv-1', role: 'user',
         content: [{ type: 'text', text: 'do stuff' }],
@@ -228,17 +274,17 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
     const callWithTools = calls.find(c => c.tools.length > 0)
     expect(callWithTools).toBeDefined()
     expect(callWithTools!.tools).toContain('Read')
-    expect(callWithTools!.tools).toContain('Shell')
-    expect(callWithTools!.bashCommands).toContain('npm test')
+    expect(callWithTools!.tools).toContain('Bash')
+    expect(callWithTools!.bashCommands).toContain('npm')
 
     const allTools = calls.flatMap(c => c.tools)
     const allBashCommands = calls.flatMap(c => c.bashCommands)
     expect(allTools.filter(t => t === 'Read').length).toBe(1)
-    expect(allTools.filter(t => t === 'Shell').length).toBe(1)
-    expect(allBashCommands.filter(cmd => cmd === 'npm test').length).toBe(1)
+    expect(allTools.filter(t => t === 'Bash').length).toBe(1)
+    expect(allBashCommands.filter(cmd => cmd === 'npm').length).toBe(1)
   })
 
-  it('uses conversation model for pricing when input is on a user bubble', async () => {
+  it('uses conversation model for pricing the conversation record', async () => {
     const composerId = 'ffff1111-2222-3333-4444-555566667777'
     const dbPath = buildDb((db) => {
       insertComposerData(db, { composerId, totalUsedTokens: 100000 })
@@ -254,9 +300,6 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
 
     const creditedCall = calls.find(c => c.inputTokens === 100000)
     expect(creditedCall).toBeDefined()
-    // Should NOT be cursor-auto (the fallback for user bubbles without model)
-    expect(creditedCall!.model).not.toBe('cursor-auto')
-    // Should be the conversation's actual model
     expect(creditedCall!.model).toBe('claude-4.5-opus-high-thinking')
   })
 
@@ -265,8 +308,6 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
     const requestId = 'req-gpt-1'
     const prompt = '<user_info>OS: darwin</user_info> refactor the auth module and add tests'
     const dbPath = buildDb((db) => {
-      // No composerData meter (non-Composer session, e.g. GPT), and the user
-      // turn's text lives in the agent stream, so the bubble text is empty.
       insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: '', requestId })
       insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'done', model: 'gpt-5' })
       insertAgentKv(db, { blobId: 'akv-1', role: 'user', content: prompt, requestId })
@@ -278,6 +319,82 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
     const credited = calls.find(c => c.inputTokens > 0)
     expect(credited).toBeDefined()
     expect(credited!.inputTokens).toBe(Math.ceil(prompt.length / 4))
+  })
+
+  it('counts tool and system stream rows as context for meterless sessions', async () => {
+    const composerId = '77770000-1111-2222-3333-444455556666'
+    const requestId = 'req-gpt-2'
+    const prompt = 'summarize the repo'
+    const toolResult = 'x'.repeat(4000)
+    const dbPath = buildDb((db) => {
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: '', requestId })
+      insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'done', model: 'gpt-5' })
+      insertAgentKv(db, { blobId: 'akv-1', role: 'user', content: prompt, requestId })
+      insertAgentKv(db, { blobId: 'akv-2', role: 'tool', content: [{ type: 'text', text: toolResult }] })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    const credited = calls.find(c => c.inputTokens > 0)
+    expect(credited).toBeDefined()
+    expect(credited!.inputTokens).toBe(Math.ceil((prompt.length + toolResult.length) / 4))
+  })
+
+  it('does not double count turns that also have bubble text in stream-estimated conversations', async () => {
+    const composerId = '66660000-1111-2222-3333-444455556666'
+    const requestId = 'req-gpt-3'
+    const streamPrompt = 'the full prompt with injected context'
+    const dbPath = buildDb((db) => {
+      // Turn 1 has visible bubble text; turn 2's lives only in the stream.
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: 'visible text', requestId })
+      insertBubble(db, { composerId, bubbleUuid: 'b2', type: 1, text: '' })
+      insertAgentKv(db, { blobId: 'akv-1', role: 'user', content: streamPrompt, requestId })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    const inputTotal = calls.reduce((s, c) => s + c.inputTokens, 0)
+    expect(inputTotal).toBe(Math.ceil(streamPrompt.length / 4))
+  })
+
+  it('emits sessions recorded only in the agent stream', async () => {
+    const requestId = 'req-headless-1'
+    const prompt = 'run the nightly data export'
+    const reply = 'export completed with 3 warnings'
+    const dbPath = buildDb((db) => {
+      insertAgentKv(db, { blobId: 'akv-1', role: 'user', content: prompt, requestId })
+      insertAgentKv(db, { blobId: 'akv-2', role: 'assistant', content: [{ type: 'text', text: reply }] })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    const session = calls.find(c => c.deduplicationKey === `cursor:agentKv:${requestId}`)
+    expect(session).toBeDefined()
+    expect(session!.inputTokens).toBe(Math.ceil(prompt.length / 4))
+    expect(session!.outputTokens).toBe(Math.ceil(reply.length / 4))
+  })
+
+  it('pairs each assistant reply with its own turn\'s user question', async () => {
+    const composerId = '55550000-1111-2222-3333-444455556666'
+    const dbPath = buildDb((db) => {
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: 'first question' })
+      insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'first reply', model: 'gpt-5' })
+      insertBubble(db, { composerId, bubbleUuid: 'b3', type: 1, text: 'second question' })
+      insertBubble(db, { composerId, bubbleUuid: 'b4', type: 2, text: 'second reply', model: 'gpt-5' })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    const firstReply = calls.find(c => c.userMessage.includes('first reply'))
+    const secondReply = calls.find(c => c.userMessage.includes('second reply'))
+    expect(firstReply).toBeDefined()
+    expect(secondReply).toBeDefined()
+    expect(firstReply!.userMessage).toContain('first question')
+    expect(secondReply!.userMessage).toContain('second question')
   })
 
   it('does not fabricate input when an empty-text turn has no agent stream', async () => {

--- a/tests/providers/cursor-real-tokens.test.ts
+++ b/tests/providers/cursor-real-tokens.test.ts
@@ -198,13 +198,15 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
     expect(credited).toBeDefined()
   })
 
-  it('attributes tools and bash commands from agentKv to the correct conversation', async () => {
+  it('attributes aggregated agentKv tools once in a multi-bubble conversation', async () => {
     const composerId = 'eeee1111-2222-3333-4444-555566667777'
     const requestId = 'req-001'
     const dbPath = buildDb((db) => {
       insertComposerData(db, { composerId, totalUsedTokens: 10000 })
       insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: 'do stuff', requestId })
       insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'doing stuff', model: 'gpt-5' })
+      insertBubble(db, { composerId, bubbleUuid: 'b3', type: 1, text: 'do more stuff', requestId: 'req-002' })
+      insertBubble(db, { composerId, bubbleUuid: 'b4', type: 2, text: 'doing more stuff', model: 'gpt-5' })
       // agentKv with tool calls
       insertAgentKv(db, {
         blobId: 'akv-1', role: 'user',
@@ -228,6 +230,12 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
     expect(callWithTools!.tools).toContain('Read')
     expect(callWithTools!.tools).toContain('Shell')
     expect(callWithTools!.bashCommands).toContain('npm test')
+
+    const allTools = calls.flatMap(c => c.tools)
+    const allBashCommands = calls.flatMap(c => c.bashCommands)
+    expect(allTools.filter(t => t === 'Read').length).toBe(1)
+    expect(allTools.filter(t => t === 'Shell').length).toBe(1)
+    expect(allBashCommands.filter(cmd => cmd === 'npm test').length).toBe(1)
   })
 
   it('uses conversation model for pricing when input is on a user bubble', async () => {

--- a/tests/providers/cursor-real-tokens.test.ts
+++ b/tests/providers/cursor-real-tokens.test.ts
@@ -259,4 +259,37 @@ describe.skipIf(skipReason !== null)('cursor real context tokens (#575)', () => 
     // Should be the conversation's actual model
     expect(creditedCall!.model).toBe('claude-4.5-opus-high-thinking')
   })
+
+  it('estimates input from the agent stream when a non-Composer turn has empty bubble text', async () => {
+    const composerId = '99990000-1111-2222-3333-444455556666'
+    const requestId = 'req-gpt-1'
+    const prompt = '<user_info>OS: darwin</user_info> refactor the auth module and add tests'
+    const dbPath = buildDb((db) => {
+      // No composerData meter (non-Composer session, e.g. GPT), and the user
+      // turn's text lives in the agent stream, so the bubble text is empty.
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: '', requestId })
+      insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'done', model: 'gpt-5' })
+      insertAgentKv(db, { blobId: 'akv-1', role: 'user', content: prompt, requestId })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    const credited = calls.find(c => c.inputTokens > 0)
+    expect(credited).toBeDefined()
+    expect(credited!.inputTokens).toBe(Math.ceil(prompt.length / 4))
+  })
+
+  it('does not fabricate input when an empty-text turn has no agent stream', async () => {
+    const composerId = '88880000-1111-2222-3333-444455556666'
+    const dbPath = buildDb((db) => {
+      insertBubble(db, { composerId, bubbleUuid: 'b1', type: 1, text: '' })
+      insertBubble(db, { composerId, bubbleUuid: 'b2', type: 2, text: 'done', model: 'gpt-5' })
+    })
+
+    const provider = createCursorProvider(dbPath)
+    const calls = await collectCalls(provider, dbPath)
+
+    expect(calls.find(c => c.inputTokens > 0)).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## What

Targets #574 (Cursor token amounts way under the admin portal).

Current Cursor builds store the per-bubble `tokenCount` as `{0,0}`, so codeburn could only estimate Cursor input from visible text (plus an `agentKv` content-char pass that double-counted the same conversation). Cursor actually records its own tokenizer-accurate context size per conversation in `composerData.promptTokenBreakdown.totalUsedTokens`, the number behind the in-app context-window bar. This reads that and credits it once per conversation for input.

## Result (measured on a real local DB)

| | input tokens | output tokens |
|---|---|---|
| before | 44,873 | 18,087 |
| after | **168,486** | 8,716 |

The new input matches the sum of the real per-conversation context.

## Known limits (this is why it's a draft, please validate)

We searched the entire local Cursor footprint (global + workspace `state.vscdb`, `ai-code-tracking.db`, logs, LevelDB, `~/.cursor`). The exact figures are **not stored locally**, only Cursor's client-side input/context count is. So:

- It's the **latest context snapshot** per conversation, not cumulative-per-turn, so a long multi-turn chat still undercounts versus the admin portal.
- **Output** is a reply-text estimate (no output count exists on disk).
- **Cache** tokens are server-side only.
- `composer-2.5` and other Cursor model names need price mappings (cost shows 0 for those).
- Exact parity with the admin portal needs an opt-in Cursor API key (planned follow-up).

`agentKv` parsing is retained for a tools + bash-command breakdown in a follow-up.

## For testers

Compare codeburn's Cursor numbers on this branch against your Cursor admin portal. This read-only query reports the real on-disk context total (aggregate only, no chat content) so you can see local vs codeburn vs admin:

```bash
DB="$HOME/Library/Application Support/Cursor/User/globalStorage/state.vscdb"
sqlite3 "$DB" "SELECT COALESCE(SUM(CAST(json_extract(value,'\$.promptTokenBreakdown.totalUsedTokens') AS INT)),0) AS real_context_tokens FROM cursorDiskKV WHERE key LIKE 'composerData:%';"
```
(If it says "database is locked," quit Cursor and rerun.)
