### PR TITLE
feat: add `codeburn audit` token-source view

### DIFF
--- a/src/audit-report.ts
+++ b/src/audit-report.ts
@@ -1,0 +1,220 @@
+import { getModelCosts, type ModelCosts } from './models.js'
+import { getProvider } from './providers/index.js'
+import { formatCost, formatTokens } from './format.js'
+import { renderTable, type TableColumn } from './text-table.js'
+import type { ProjectSummary } from './types.js'
+
+// One (provider, model) bucket, exposing both the raw token fields as recorded
+// by the provider/transcript and the normalized totals codeburn actually
+// prices, so a mismatch between the two is visible in one place.
+export type AuditRow = {
+  provider: string
+  providerDisplayName: string
+  model: string
+  modelDisplayName: string
+  calls: number
+  // Summed straight from each call's usage, untouched.
+  raw: {
+    inputTokens: number
+    outputTokens: number
+    reasoningTokens: number
+    cacheCreationInputTokens: number
+    cacheReadInputTokens: number // Anthropic vocab
+    cachedInputTokens: number // OpenAI vocab
+    webSearchRequests: number
+  }
+  // What the reports display: reasoning folds into output, and the two
+  // cache-read vocabularies collapse to their max (providers fill one or both).
+  displayed: {
+    inputTokens: number
+    outputTokens: number
+    cacheWriteTokens: number
+    cacheReadTokens: number
+  }
+  // Per-token rates used for pricing; null when the model has no pricing entry.
+  rates: ModelCosts | null
+  // Cost split by component (displayed tokens x rate), plus the recomputed
+  // total. recomputedTotalUSD should track attributedCostUSD; a gap points at
+  // fast-mode multipliers or the 1-hour cache rate that calculateCost applies.
+  cost: {
+    input: number
+    output: number
+    cacheWrite: number
+    cacheRead: number
+    webSearch: number
+    recomputedTotalUSD: number
+  }
+  // The cost codeburn actually attributed to these calls (sum of call.costUSD).
+  attributedCostUSD: number
+}
+
+export async function aggregateAudit(projects: ProjectSummary[]): Promise<AuditRow[]> {
+  type Bucket = {
+    provider: string
+    model: string
+    calls: number
+    attributedCostUSD: number
+    cacheReadDisplayed: number
+    raw: AuditRow['raw']
+  }
+  const buckets = new Map<string, Bucket>()
+
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      for (const turn of session.turns) {
+        for (const call of turn.assistantCalls) {
+          const provider = call.provider || 'unknown'
+          const model = call.model || 'unknown'
+          const key = `${provider} ${model}`
+          let bucket = buckets.get(key)
+          if (!bucket) {
+            bucket = {
+              provider,
+              model,
+              calls: 0,
+              attributedCostUSD: 0,
+              cacheReadDisplayed: 0,
+              raw: {
+                inputTokens: 0,
+                outputTokens: 0,
+                reasoningTokens: 0,
+                cacheCreationInputTokens: 0,
+                cacheReadInputTokens: 0,
+                cachedInputTokens: 0,
+                webSearchRequests: 0,
+              },
+            }
+            buckets.set(key, bucket)
+          }
+          const u = call.usage
+          bucket.raw.inputTokens += u.inputTokens
+          bucket.raw.outputTokens += u.outputTokens
+          bucket.raw.reasoningTokens += u.reasoningTokens
+          bucket.raw.cacheCreationInputTokens += u.cacheCreationInputTokens
+          bucket.raw.cacheReadInputTokens += u.cacheReadInputTokens
+          bucket.raw.cachedInputTokens += u.cachedInputTokens
+          bucket.raw.webSearchRequests += u.webSearchRequests
+          // Per-call max (then summed) mirrors how the reports collapse the two
+          // cache-read vocabularies, so the audit's displayed total matches.
+          bucket.cacheReadDisplayed += Math.max(u.cacheReadInputTokens, u.cachedInputTokens)
+          bucket.attributedCostUSD += call.costUSD
+          bucket.calls += 1
+        }
+      }
+    }
+  }
+
+  const providerCache = new Map<string, { displayName: string; formatModel: (m: string) => string }>()
+  async function resolveProvider(name: string) {
+    const cached = providerCache.get(name)
+    if (cached) return cached
+    const p = await getProvider(name)
+    const entry = {
+      displayName: p?.displayName ?? name,
+      formatModel: p ? (m: string) => p.modelDisplayName(m) : (m: string) => m,
+    }
+    providerCache.set(name, entry)
+    return entry
+  }
+
+  const rows: AuditRow[] = []
+  for (const bucket of buckets.values()) {
+    const meta = await resolveProvider(bucket.provider)
+    const displayed = {
+      inputTokens: bucket.raw.inputTokens,
+      outputTokens: bucket.raw.outputTokens + bucket.raw.reasoningTokens,
+      cacheWriteTokens: bucket.raw.cacheCreationInputTokens,
+      cacheReadTokens: bucket.cacheReadDisplayed,
+    }
+    const rates = getModelCosts(bucket.model)
+    const cost = {
+      input: rates ? displayed.inputTokens * rates.inputCostPerToken : 0,
+      output: rates ? displayed.outputTokens * rates.outputCostPerToken : 0,
+      cacheWrite: rates ? displayed.cacheWriteTokens * rates.cacheWriteCostPerToken : 0,
+      cacheRead: rates ? displayed.cacheReadTokens * rates.cacheReadCostPerToken : 0,
+      webSearch: rates ? bucket.raw.webSearchRequests * rates.webSearchCostPerRequest : 0,
+      recomputedTotalUSD: 0,
+    }
+    cost.recomputedTotalUSD = cost.input + cost.output + cost.cacheWrite + cost.cacheRead + cost.webSearch
+    rows.push({
+      provider: bucket.provider,
+      providerDisplayName: meta.displayName,
+      model: bucket.model,
+      modelDisplayName: meta.formatModel(bucket.model),
+      calls: bucket.calls,
+      raw: bucket.raw,
+      displayed,
+      rates,
+      cost,
+      attributedCostUSD: bucket.attributedCostUSD,
+    })
+  }
+
+  rows.sort((a, b) => b.attributedCostUSD - a.attributedCostUSD)
+  return rows
+}
+
+export function renderAuditTable(rows: AuditRow[]): string {
+  const columns: TableColumn[] = [
+    { header: 'Provider' },
+    { header: 'Model' },
+    { header: 'Calls', right: true },
+    { header: 'Input', right: true },
+    { header: 'Output', right: true },
+    { header: 'Reason', right: true },
+    { header: 'Cache wr', right: true },
+    { header: 'Cache rd', right: true },
+    { header: 'Cost', right: true },
+  ]
+
+  const body = rows.map((r) => [
+    r.providerDisplayName,
+    r.modelDisplayName,
+    r.calls.toLocaleString(),
+    formatTokens(r.raw.inputTokens),
+    formatTokens(r.raw.outputTokens),
+    formatTokens(r.raw.reasoningTokens),
+    formatTokens(r.raw.cacheCreationInputTokens),
+    formatTokens(r.displayed.cacheReadTokens),
+    formatCost(r.attributedCostUSD),
+  ])
+
+  const totals = rows.reduce(
+    (a, r) => ({
+      calls: a.calls + r.calls,
+      input: a.input + r.raw.inputTokens,
+      output: a.output + r.raw.outputTokens,
+      reason: a.reason + r.raw.reasoningTokens,
+      cacheWrite: a.cacheWrite + r.raw.cacheCreationInputTokens,
+      cacheRead: a.cacheRead + r.displayed.cacheReadTokens,
+      cost: a.cost + r.attributedCostUSD,
+    }),
+    { calls: 0, input: 0, output: 0, reason: 0, cacheWrite: 0, cacheRead: 0, cost: 0 },
+  )
+  body.push([
+    'Total',
+    '',
+    totals.calls.toLocaleString(),
+    formatTokens(totals.input),
+    formatTokens(totals.output),
+    formatTokens(totals.reason),
+    formatTokens(totals.cacheWrite),
+    formatTokens(totals.cacheRead),
+    formatCost(totals.cost),
+  ])
+
+  const table = renderTable(columns, body, { boldRows: new Set([body.length - 1]) })
+  const legend = [
+    '',
+    'Columns are the raw token fields each provider records. codeburn then normalizes for pricing:',
+    '  - Reason folds into Output (priced output = output + reasoning)',
+    '  - Cache rd = max(Anthropic cacheReadInput, OpenAI cached), since providers fill one or both',
+    '  - Cache wr is priced at 1.25x the input rate, Cache rd at 0.1x, when a model omits explicit cache rates',
+    'Use --format json for per-component cost, the rates applied, and both raw cache-read fields.',
+  ].join('\n')
+  return table + '\n' + legend
+}
+
+export function renderAuditJson(rows: AuditRow[]): string {
+  return JSON.stringify(rows, null, 2)
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1348,6 +1348,46 @@ program
   })
 
 program
+  .command('audit')
+  .description("Token audit: raw provider token fields vs codeburn's displayed totals and cost derivation")
+  .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all', '30days')
+  .option('--from <date>', 'Custom range start (YYYY-MM-DD)')
+  .option('--to <date>', 'Custom range end (YYYY-MM-DD)')
+  .option('--provider <provider>', 'Filter by provider (e.g. claude, codex, cursor)', 'all')
+  .option('--format <format>', 'Output format: table, json', 'table')
+  .action(async (opts) => {
+    assertProvider(opts.provider, 'audit')
+    const { aggregateAudit, renderAuditTable, renderAuditJson } = await import('./audit-report.js')
+    await loadPricing()
+
+    let range
+    if (opts.from || opts.to) {
+      const customRange = parseDateRangeFlags(opts.from, opts.to)
+      if (!customRange) {
+        process.stderr.write('codeburn: --from and --to must be valid YYYY-MM-DD dates\n')
+        process.exit(1)
+      }
+      range = customRange
+    } else {
+      range = getDateRange(opts.period).range
+    }
+
+    const projects = await parseAllSessions(range, opts.provider)
+    const rows = await aggregateAudit(projects)
+
+    const fmt = (opts.format ?? 'table').toLowerCase()
+    if (fmt === 'json') {
+      process.stdout.write(renderAuditJson(rows) + '\n')
+    } else {
+      if (rows.length === 0) {
+        process.stdout.write('No model usage found for the selected period.\n')
+        return
+      }
+      process.stdout.write(renderAuditTable(rows) + '\n')
+    }
+  })
+
+program
   .command('models')
   .description('Per-model token + cost table, optionally exploded by task type')
   .option('-p, --period <period>', 'Analysis period: today, week, 30days, month, all', '30days')

--- a/tests/audit-report.test.ts
+++ b/tests/audit-report.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+
+import { aggregateAudit } from '../src/audit-report.js'
+import type {
+  ProjectSummary,
+  SessionSummary,
+  ClassifiedTurn,
+  ParsedApiCall,
+  TokenUsage,
+  TaskCategory,
+} from '../src/types.js'
+
+function emptyTokens(): TokenUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    cachedInputTokens: 0,
+    reasoningTokens: 0,
+    webSearchRequests: 0,
+  }
+}
+
+function makeCall(usage: Partial<TokenUsage>, costUSD: number, model = 'unknown-model-xyz', provider = 'claude'): ParsedApiCall {
+  return {
+    provider,
+    model,
+    usage: { ...emptyTokens(), ...usage },
+    costUSD,
+    tools: [],
+    mcpTools: [],
+    skills: [],
+    hasAgentSpawn: false,
+    hasPlanMode: false,
+    speed: 'standard',
+    timestamp: '2026-05-09T00:00:00.000Z',
+    bashCommands: [],
+    deduplicationKey: `${provider}-${model}-${costUSD}-${usage.inputTokens ?? 0}-${usage.cachedInputTokens ?? 0}`,
+  }
+}
+
+function makeProject(calls: ParsedApiCall[]): ProjectSummary {
+  const turn: ClassifiedTurn = {
+    userMessage: 't',
+    assistantCalls: calls,
+    timestamp: '2026-05-09T00:00:00.000Z',
+    sessionId: 's1',
+    category: 'feature' as TaskCategory,
+    retries: 0,
+    hasEdits: false,
+  }
+  const session: SessionSummary = {
+    sessionId: 's1',
+    project: 'p',
+    firstTimestamp: '2026-05-09T00:00:00.000Z',
+    lastTimestamp: '2026-05-09T00:00:00.000Z',
+    totalCostUSD: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    apiCalls: 0,
+    turns: [turn],
+    modelBreakdown: {},
+    toolBreakdown: {},
+    mcpBreakdown: {},
+    bashBreakdown: {},
+    categoryBreakdown: {} as SessionSummary['categoryBreakdown'],
+    skillBreakdown: {},
+  }
+  return { project: 'p', projectPath: 'p', sessions: [session], totalCostUSD: 0, totalApiCalls: 0 }
+}
+
+describe('aggregateAudit', () => {
+  it('keeps raw fields and exposes codeburn normalizations', async () => {
+    const anthropicCall = makeCall({ inputTokens: 100, outputTokens: 50, reasoningTokens: 10, cacheReadInputTokens: 200 }, 0.5)
+    const openaiCall = makeCall({ inputTokens: 100, outputTokens: 50, cachedInputTokens: 300 }, 0.5)
+    const rows = await aggregateAudit([makeProject([anthropicCall, openaiCall])])
+
+    expect(rows).toHaveLength(1)
+    const r = rows[0]!
+    // raw fields are summed untouched
+    expect(r.raw.inputTokens).toBe(200)
+    expect(r.raw.outputTokens).toBe(100)
+    expect(r.raw.reasoningTokens).toBe(10)
+    expect(r.raw.cacheReadInputTokens).toBe(200)
+    expect(r.raw.cachedInputTokens).toBe(300)
+    // reasoning folds into output for pricing
+    expect(r.displayed.outputTokens).toBe(110)
+    // cache read is the SUM of per-call max(anthropic, openai), not max of sums
+    expect(r.displayed.cacheReadTokens).toBe(500)
+    // attributed cost is preserved exactly
+    expect(r.attributedCostUSD).toBeCloseTo(1.0)
+  })
+
+  it('returns null rates and zero component cost for an unpriced model', async () => {
+    const rows = await aggregateAudit([makeProject([makeCall({ inputTokens: 1000 }, 0, 'definitely-not-a-real-model-zzz')])])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.rates).toBeNull()
+    expect(rows[0]!.cost.recomputedTotalUSD).toBe(0)
+  })
+
+  it('splits buckets by (provider, model)', async () => {
+    const rows = await aggregateAudit([makeProject([
+      makeCall({ inputTokens: 10 }, 0.1, 'model-a', 'claude'),
+      makeCall({ inputTokens: 20 }, 0.2, 'model-b', 'claude'),
+      makeCall({ inputTokens: 30 }, 0.3, 'model-a', 'codex'),
+    ])])
+    expect(rows).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
## What

Adds `codeburn audit`, a token-source / conversion-transparency view to make token-amount mismatches (the #574 class of report) diagnosable in one command.

For each (provider, model) it shows the **raw token fields** the provider records next to the totals codeburn **displays and prices**, so any drift is visible:

```
codeburn audit              # table
codeburn audit --format json
```

| | what it surfaces |
|---|---|
| raw fields | input, output, reasoning, cache write, cache read, per provider/model |
| normalizations | reasoning folds into output; cache read = sum of per-call `max(Anthropic cacheReadInput, OpenAI cached)`; cache write/read priced at 1.25x / 0.1x input when a model omits explicit cache rates |
| `--format json` | per-component cost, the exact rates applied, both raw cache-read fields, and recomputed vs attributed cost |

It turns "your numbers look off" reports (cache pricing, reasoning tokens, unpriced models) into a one-command diff. On real data it immediately surfaces things like an unpriced model showing $0 and the reasoning-token split on GPT-5.5.

## Notes

- Same options as `codeburn models` (period / from / to / provider / format).
- New `tests/audit-report.test.ts` pins the normalizations (reasoning fold, per-call cache-read max, unpriced model -> null rates). Full suite green.
