### PR TITLE
fix(dash): use period-scoped cache tokens instead of summing entire history

### DIFF
--- a/dash/src/App.tsx
+++ b/dash/src/App.tsx
@@ -75,8 +75,8 @@ function Stat({ label: lbl, value }: { label: string; value: string }) {
 function DeviceView({ payload, isRemote, unit }: { payload?: Payload; isRemote: boolean; unit: Unit }) {
   const c = payload?.current
   const daily = payload?.history.daily ?? []
-  const cacheWrite = daily.reduce((s, d) => s + d.cacheWriteTokens, 0)
-  const cacheRead = daily.reduce((s, d) => s + d.cacheReadTokens, 0)
+  const cacheWrite = c?.cacheWriteTokens ?? 0
+  const cacheRead = c?.cacheReadTokens ?? 0
   const toolBars: BarItem[] = c
     ? Object.entries(c.providers).filter(([, v]) => v > 0).sort((a, b) => b[1] - a[1]).map(([k, v]) => ({ name: k, value: v, display: usd(v) }))
     : []
@@ -256,10 +256,8 @@ function CombinedView({ devices, unit }: { devices: DeviceUsage[]; unit: Unit })
     if (!c) continue
     inTok += c.inputTokens
     outTok += c.outputTokens
-    for (const e of d.payload?.history.daily ?? []) {
-      cacheWrite += e.cacheWriteTokens
-      cacheRead += e.cacheReadTokens
-    }
+    cacheWrite += c.cacheWriteTokens ?? 0
+    cacheRead += c.cacheReadTokens ?? 0
     for (const [k, v] of Object.entries(c.providers)) providers.set(k, (providers.get(k) ?? 0) + v)
     for (const m of c.topModels) models.set(m.name, (models.get(m.name) ?? 0) + m.cost)
     for (const a of c.topActivities) activities.set(a.name, (activities.get(a.name) ?? 0) + a.cost)

--- a/dash/src/lib/api.ts
+++ b/dash/src/lib/api.ts
@@ -28,6 +28,8 @@ export type Current = {
   inputTokens: number
   outputTokens: number
   cacheHitPercent: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
   codexCredits: number
   topActivities: Array<{ name: string; cost: number; turns: number; oneShotRate: number | null }>
   topModels: Array<{ name: string; cost: number; calls: number; savingsUSD: number }>
@@ -87,6 +89,8 @@ function normalizePayload(p?: Payload): Payload | undefined {
       inputTokens: c.inputTokens ?? 0,
       outputTokens: c.outputTokens ?? 0,
       cacheHitPercent: c.cacheHitPercent ?? 0,
+      cacheReadTokens: c.cacheReadTokens ?? 0,
+      cacheWriteTokens: c.cacheWriteTokens ?? 0,
       codexCredits: c.codexCredits ?? 0,
       topActivities: c.topActivities ?? [],
       topModels: c.topModels ?? [],

--- a/src/menubar-json.ts
+++ b/src/menubar-json.ts
@@ -198,6 +198,8 @@ export type MenubarPayload = {
     skills: Array<{ name: string; turns: number; cost: number }>
     subagents: Array<{ name: string; calls: number; cost: number }>
     mcpServers: Array<{ name: string; calls: number }>
+    cacheReadTokens: number
+    cacheWriteTokens: number
   }
   optimize: {
     findingCount: number
@@ -372,6 +374,8 @@ export function buildMenubarPayload(
       skills: breakdowns?.skills ?? [],
       subagents: breakdowns?.subagents ?? [],
       mcpServers: breakdowns?.mcpServers ?? [],
+      cacheReadTokens: current.cacheReadTokens,
+      cacheWriteTokens: current.cacheWriteTokens,
     },
     optimize: buildOptimize(optimize),
     history: buildHistory(dailyHistory),

--- a/tests/menubar-json.test.ts
+++ b/tests/menubar-json.test.ts
@@ -232,6 +232,22 @@ describe('buildMenubarPayload', () => {
     expect(payload.current.providers).toEqual({ claude: 76.45 })
   })
 
+  it('includes cacheReadTokens and cacheWriteTokens in current so the web dashboard can display period-scoped cache metrics', () => {
+    const period: PeriodData = {
+      label: '30 Days',
+      cost: 100, calls: 500, sessions: 20,
+      inputTokens: 120_800_000,
+      outputTokens: 5_600_000,
+      cacheReadTokens: 1_391_100_000,
+      cacheWriteTokens: 2_300_000,
+      categories: [],
+      models: [],
+    }
+    const payload = buildMenubarPayload(period, [], null)
+    expect(payload.current.cacheReadTokens).toBe(1_391_100_000)
+    expect(payload.current.cacheWriteTokens).toBe(2_300_000)
+  })
+
   it('omits combined usage by default and accepts the documented combined shape when attached', () => {
     const payload = buildMenubarPayload(emptyPeriod('Today'), [], null)
     expect(payload).not.toHaveProperty('combined')


### PR DESCRIPTION
## Summary

The web dashboard's **Cache read** and **Cache write** metric cards were summing the entire `history.daily` array (up to 365 days of backfill data intended for the trend chart) instead of using the current period's values. This caused them to show inflated numbers compared to `codeburn report`.

For example, with `codeburn web -p 30days` vs `codeburn report -p 30days`:
- Terminal shows: `1391.1M cached`
- Web showed: `Cache read: 2.07B` (summing ~365 days)

## Changes

1. **`src/menubar-json.ts`**: Added `cacheReadTokens` and `cacheWriteTokens` to the `MenubarPayload.current` type and populated them from `PeriodData` (which is already correctly scoped to the selected period).

2. **`dash/src/lib/api.ts`**: Added the new fields to the `Current` type and initialized them in `normalizePayload` (backward-compatible — defaults to 0 for older payloads).

3. **`dash/src/App.tsx`**: Changed both `DeviceView` and `CombinedView` to read cache tokens from `current` instead of reducing over `history.daily`.

4. **`tests/menubar-json.test.ts`**: Added a test asserting that `cacheReadTokens` and `cacheWriteTokens` are correctly passed through to the payload.

## Testing

All 1359 existing tests pass. The new test verifies the fix explicitly.

Fixes #583