### PR TITLE
fix(devin): report friendly GPT model names with effort tier

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/husamsoboh/codeburn/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/husamsoboh/codeburn/node_modules

--- a/src/model-efficiency.ts
+++ b/src/model-efficiency.ts
@@ -1,5 +1,5 @@
 import { getShortModelName } from './models.js'
-import type { ProjectSummary } from './types.js'
+import type { ParsedApiCall, ProjectSummary } from './types.js'
 
 export type ModelEfficiency = {
   model: string
@@ -19,6 +19,10 @@ function rate(num: number, den: number): number | null {
   return Math.round((num / den) * 1000) / 10
 }
 
+function modelKey(call: ParsedApiCall): string {
+  return call.provider === 'devin' ? call.model : getShortModelName(call.model)
+}
+
 export function aggregateModelEfficiency(projects: ProjectSummary[]): Map<string, ModelEfficiency> {
   const byModel = new Map<string, MutableModelEfficiency>()
 
@@ -36,16 +40,16 @@ export function aggregateModelEfficiency(projects: ProjectSummary[]): Map<string
       for (const turn of session.turns) {
         if (!turn.hasEdits || turn.assistantCalls.length === 0) continue
 
-        const primaryCall = turn.assistantCalls.find(c => getShortModelName(c.model) !== '<synthetic>')
+        const primaryCall = turn.assistantCalls.find(c => modelKey(c) !== '<synthetic>')
         if (!primaryCall) continue
-        const primaryModel = getShortModelName(primaryCall.model)
+        const primaryModel = modelKey(primaryCall)
 
         const stats = ensure(primaryModel)
         stats.editTurns++
         if (turn.retries === 0) stats.oneShotTurns++
         stats.retries += turn.retries
         stats.editCostUSD += turn.assistantCalls.reduce((sum, call) => {
-          return getShortModelName(call.model) === '<synthetic>' ? sum : sum + call.costUSD
+          return modelKey(call) === '<synthetic>' ? sum : sum + call.costUSD
         }, 0)
       }
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1335,7 +1335,7 @@ function buildSessionSummary(
       totalCacheWrite += call.usage.cacheCreationInputTokens
       apiCalls++
 
-      const modelKey = getShortModelName(call.model)
+      const modelKey = call.provider === 'devin' ? call.model : getShortModelName(call.model)
       if (!modelBreakdown[modelKey]) {
         modelBreakdown[modelKey] = {
           calls: 0,

--- a/src/providers/devin.ts
+++ b/src/providers/devin.ts
@@ -317,9 +317,14 @@ function getFriendlyGptName(model: string): string {
   const match = model.match(/^gpt-(\d+(?:\.\d+)*)(?:-(.+))?$/);
   if (!match) return shortName;
 
-  const suffix = match[2]
-    ?.split("-")
-    .filter(Boolean)
+  const suffixParts = match[2]?.split("-").filter(Boolean) ?? [];
+  // A purely numeric suffix token means this is a dated snapshot id such as
+  // gpt-4-1106-preview, not a clean version+word id. Fabricating a friendly
+  // name here would mislabel the date as text (e.g. "GPT-4 1106 Preview"), so
+  // defer to getShortModelName, which passes unknown snapshots through raw.
+  if (suffixParts.some((part) => /^\d+$/.test(part))) return shortName;
+
+  const suffix = suffixParts
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
 
@@ -340,7 +345,10 @@ function getDevinDisplayModelName(
   }
 
   if (generationModel.startsWith("gpt-")) {
-    const normalized = generationModel.replace(/^gpt-(\d+)-(\d+)/, "gpt-$1.$2");
+    // Devin minor versions are always a single digit (gpt-5-3-codex). Restrict
+    // the dash-to-dot rewrite to a single-digit minor at a token boundary so a
+    // dated snapshot like gpt-4-1106-preview is not misread as version 4.1106.
+    const normalized = generationModel.replace(/^gpt-(\d+)-(\d)(?=-|$)/, "gpt-$1.$2");
     const effortMatch = normalized.match(/-([^-]+)$/);
     const effort = effortMatch && DEVIN_EFFORT_TIERS.has(effortMatch[1]!)
       ? effortMatch[1]

--- a/src/providers/devin.ts
+++ b/src/providers/devin.ts
@@ -171,6 +171,7 @@ const DEVIN_PROVIDER_NAME = "devin";
 const DEVIN_PROVIDER_DISPLAY_NAME = "Devin";
 const DEVIN_TRANSCRIPTS_SUBDIR = "transcripts";
 const DEVIN_SESSIONS_DB = "sessions.db";
+const DEVIN_EFFORT_TIERS = new Set(["xhigh", "high", "medium", "low"]);
 
 function parseTranscript(raw: string): DevinAgentTrajectory | null {
   try {
@@ -303,21 +304,71 @@ function getTimestamp(
     .shift();
 }
 
+function firstPresentString(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+function getFriendlyGptName(model: string): string {
+  const shortName = getShortModelName(model);
+  const match = model.match(/^gpt-(\d+(?:\.\d+)*)(?:-(.+))?$/);
+  if (!match) return shortName;
+
+  const suffix = match[2]
+    ?.split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+
+  const reconstructed = `GPT-${match[1]}${suffix ? ` ${suffix}` : ""}`;
+  if (shortName !== model && (!suffix || shortName !== `GPT-${match[1]}`)) {
+    return shortName;
+  }
+
+  return reconstructed;
+}
+
+function getDevinDisplayModelName(
+  generationModel: string | undefined,
+  modelName: string,
+): string {
+  if (!generationModel || /^MODEL_/.test(generationModel)) {
+    return getShortModelName(modelName);
+  }
+
+  if (generationModel.startsWith("gpt-")) {
+    const normalized = generationModel.replace(/^gpt-(\d+)-(\d+)/, "gpt-$1.$2");
+    const effortMatch = normalized.match(/-([^-]+)$/);
+    const effort = effortMatch && DEVIN_EFFORT_TIERS.has(effortMatch[1]!)
+      ? effortMatch[1]
+      : undefined;
+    const base = effort ? normalized.slice(0, -(effort.length + 1)) : normalized;
+    const friendlyBase = getFriendlyGptName(base);
+    return effort ? `${friendlyBase} (${effort})` : friendlyBase;
+  }
+
+  return getShortModelName(generationModel);
+}
+
 function getModelName(
   transcript: DevinAgentTrajectory,
   step: DevinStep,
   session: DevinSessionMetadata | null,
 ): string {
-  return (
-    [
-      step.metadata?.generation_model,
-      step.model_name,
-      transcript.agent?.model_name,
-      session?.model,
-    ]
-      .filter(Boolean)
-      .shift() || DEFAULT_MODEL_NAME
+  const generationModel = firstPresentString(
+    step.metadata?.generation_model,
+    step.extra?.generation_model,
   );
+  const modelName = firstPresentString(
+    step.model_name,
+    transcript.agent?.model_name,
+    session?.model,
+  ) ?? DEFAULT_MODEL_NAME;
+
+  return getDevinDisplayModelName(generationModel, modelName);
 }
 
 function getToolNames(step: DevinStep): string[] {
@@ -479,7 +530,7 @@ export function createDevinProvider(cliDir: string): Provider {
     displayName: DEVIN_PROVIDER_DISPLAY_NAME,
 
     modelDisplayName(model: string): string {
-      return getShortModelName(model);
+      return model;
     },
 
     toolDisplayName(rawTool: string): string {

--- a/tests/cli-devin-model-variants.test.ts
+++ b/tests/cli-devin-model-variants.test.ts
@@ -1,0 +1,98 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+import { describe, expect, it } from 'vitest'
+
+function runCli(args: string[], home: string) {
+  return spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      HOMEPATH: home,
+      HOMEDRIVE: '',
+      CLAUDE_CONFIG_DIR: join(home, '.claude'),
+      CODEBURN_CACHE_DIR: join(home, '.cache', 'codeburn'),
+      TZ: 'UTC',
+    },
+    encoding: 'utf-8',
+    timeout: 30_000,
+  })
+}
+
+describe('codeburn report Devin model variants', () => {
+  it('keeps friendly Devin effort-tier names in JSON model rows and efficiency rows', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-cli-devin-models-'))
+    try {
+      await mkdir(join(home, '.config', 'codeburn'), { recursive: true })
+      await writeFile(join(home, '.config', 'codeburn', 'config.json'), JSON.stringify({
+        devin: { acuUsdRate: 1 },
+      }))
+
+      const transcriptsDir = join(home, '.local', 'share', 'devin', 'cli', 'transcripts')
+      await mkdir(transcriptsDir, { recursive: true })
+      await writeFile(join(transcriptsDir, 'session-487.json'), JSON.stringify({
+        schema_version: '1.4',
+        session_id: 'session-487',
+        agent: { model_name: 'GPT-5.4' },
+        steps: [
+          {
+            step_id: 1,
+            message: 'fix the model row',
+            metadata: { is_user_input: true, created_at: '2026-04-10T09:00:00.000Z' },
+          },
+          {
+            step_id: 2,
+            message: 'editing',
+            tool_calls: [{ function_name: 'Edit' }],
+            metadata: {
+              created_at: '2026-04-10T09:01:00.000Z',
+              committed_acu_cost: 0.25,
+              generation_model: 'gpt-5-3-codex-xhigh',
+              metrics: { input_tokens: 100, output_tokens: 25 },
+            },
+          },
+        ],
+      }))
+
+      const result = runCli([
+        'report',
+        '--format',
+        'json',
+        '--from',
+        '2026-04-10',
+        '--to',
+        '2026-04-10',
+        '--provider',
+        'devin',
+      ], home)
+
+      expect(result.status, result.stderr).toBe(0)
+      const report = JSON.parse(result.stdout) as {
+        models: Array<{
+          name: string
+          calls: number
+          cost: number
+          editTurns: number
+          oneShotTurns: number
+          costPerEdit: number | null
+        }>
+      }
+
+      expect(report.models).toHaveLength(1)
+      expect(report.models[0]).toMatchObject({
+        name: 'GPT-5.3 Codex (xhigh)',
+        calls: 1,
+        cost: 0.25,
+        editTurns: 1,
+        oneShotTurns: 1,
+        costPerEdit: 0.25,
+      })
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/providers/devin.test.ts
+++ b/tests/providers/devin.test.ts
@@ -235,6 +235,13 @@ describe('devin provider', () => {
         generationModel: 'gpt-5-codex',
         expected: 'GPT-5 Codex',
       },
+      {
+        schema: '1.4',
+        modelName: 'GPT-4',
+        location: 'metadata',
+        generationModel: 'gpt-4-1106-preview',
+        expected: 'gpt-4-1106-preview',
+      },
     ] as const
 
     for (let index = 0; index < cases.length; index++) {

--- a/tests/providers/devin.test.ts
+++ b/tests/providers/devin.test.ts
@@ -141,7 +141,7 @@ describe('devin provider', () => {
     expect(calls.reduce((sum, call) => sum + call.costUSD, 0)).toBeCloseTo(0.026182499248534442, 15)
     expect(calls[0]).toMatchObject({
       provider: 'devin',
-      model: 'claude-opus-4-6',
+      model: 'Opus 4.6',
       inputTokens: 100,
       outputTokens: 20,
       cacheCreationInputTokens: 10,
@@ -155,11 +155,127 @@ describe('devin provider', () => {
       sessionId: 'session-123',
     })
     expect(calls[1]).toMatchObject({
-      model: 'claude-sonnet-4-6',
+      model: 'Sonnet 4.6',
       timestamp: '2027-01-15T08:00:02.000Z',
       tools: ['str_replace'],
       deduplicationKey: 'devin:session-123:3',
     })
+  })
+
+  it('renders Devin generation_model variants as friendly display names with effort tiers', async () => {
+    await configureDevinRate()
+    const cases = [
+      {
+        schema: '1.4',
+        modelName: 'GPT-5.4',
+        location: 'metadata',
+        generationModel: 'gpt-5-3-codex-xhigh',
+        expected: 'GPT-5.3 Codex (xhigh)',
+      },
+      {
+        schema: '1.4',
+        modelName: 'GPT-5.5',
+        location: 'metadata',
+        generationModel: 'gpt-5-4-low',
+        expected: 'GPT-5.4 (low)',
+      },
+      {
+        schema: '1.4',
+        modelName: 'GPT-5.5',
+        location: 'metadata',
+        generationModel: 'gpt-5-5-medium',
+        expected: 'GPT-5.5 (medium)',
+      },
+      {
+        schema: '1.4',
+        modelName: 'Gemini 3 Flash',
+        location: 'metadata',
+        generationModel: 'MODEL_PRIVATE_11',
+        expected: 'Gemini 3 Flash',
+      },
+      {
+        schema: '1.4',
+        modelName: 'Gemini 3 Flash',
+        location: 'metadata',
+        generationModel: 'MODEL_GOOGLE_GEMINI_3_0_FLASH_MINIMAL',
+        expected: 'Gemini 3 Flash',
+      },
+      {
+        schema: '1.7',
+        modelName: 'GPT-5.3-Codex',
+        location: 'extra',
+        generationModel: 'gpt-5-3-codex-xhigh',
+        expected: 'GPT-5.3 Codex (xhigh)',
+      },
+      {
+        schema: '1.4',
+        modelName: 'GPT-5',
+        location: 'metadata',
+        generationModel: 'gpt-5',
+        expected: 'GPT-5',
+      },
+      {
+        schema: '1.4',
+        modelName: 'GPT-5.6',
+        location: 'metadata',
+        generationModel: 'gpt-5-6-medium',
+        expected: 'GPT-5.6 (medium)',
+      },
+      {
+        schema: '1.4',
+        modelName: 'GPT-5',
+        location: 'metadata',
+        generationModel: 'gpt-5-codex-xhigh',
+        expected: 'GPT-5 Codex (xhigh)',
+      },
+      {
+        schema: '1.4',
+        modelName: 'GPT-5',
+        location: 'metadata',
+        generationModel: 'gpt-5-codex',
+        expected: 'GPT-5 Codex',
+      },
+    ] as const
+
+    for (let index = 0; index < cases.length; index++) {
+      const row = cases[index]!
+      const metadata: Record<string, unknown> = {
+        created_at: '2027-01-15T08:00:01.000Z',
+        committed_acu_cost: 0.1,
+        metrics: { input_tokens: 1 },
+      }
+      const extra: Record<string, unknown> = {}
+      if (row.location === 'metadata') {
+        metadata['generation_model'] = row.generationModel
+      } else {
+        extra['generation_model'] = row.generationModel
+      }
+
+      const step: Record<string, unknown> = {
+        step_id: index + 1,
+        source: 'assistant',
+        message: 'working',
+        metadata,
+      }
+      if (row.location === 'extra') step['extra'] = extra
+
+      const filePath = await writeTranscript(`model-variant-${index}.json`, {
+        schema_version: row.schema,
+        session_id: `model-variant-${index}`,
+        agent: { model_name: row.modelName },
+        steps: [step],
+      })
+
+      const calls = await parseTranscript(filePath)
+      expect(calls).toHaveLength(1)
+      expect(calls[0]!.model).toBe(row.expected)
+    }
+  })
+
+  it('leaves already-friendly Devin model display names unchanged', () => {
+    const provider = createDevinProvider(tmpDir)
+
+    expect(provider.modelDisplayName('GPT-5.3 Codex (xhigh)')).toBe('GPT-5.3 Codex (xhigh)')
   })
 
   it('includes token-only steps and skips user-input or empty steps', async () => {
@@ -324,7 +440,7 @@ describe('devin provider', () => {
     expect(calls).toHaveLength(1)
     expect(calls[0]).toMatchObject({
       provider: 'devin',
-      model: 'claude-sonnet-4-6',
+      model: 'Sonnet 4.6',
       inputTokens: 200,
       outputTokens: 50,
       cacheCreationInputTokens: 20,
@@ -655,7 +771,7 @@ skipUnlessSqlite('devin provider sessions.db enrichment', () => {
 
     expect(calls).toHaveLength(1)
     expect(calls[0]).toMatchObject({
-      model: 'claude-sonnet-4-6',
+      model: 'Sonnet 4.6',
       project: 'codeburn',
       projectPath: '/Users/example/work/codeburn',
       timestamp: '2027-01-15T08:00:10.000Z',


### PR DESCRIPTION
## What

Devin transcripts label each step with a `generation_model` in dash form plus an
effort suffix (`gpt-5-3-codex-xhigh`). `getShortModelName` is keyed in dot form
(`gpt-5.3-codex`) and its version-boundary check matched the dash id against the
base `gpt-5` entry, collapsing every Devin GPT variant to `GPT-5`.

This normalizes the dash form to canonical dot form, maps it through the
short-name table, and surfaces the effort tier, e.g. `GPT-5.3 Codex (xhigh)`.
It falls back to the friendly `model_name` when `generation_model` is an opaque
`MODEL_*` id, and reads `extra.generation_model` so ATIF v1.7 transcripts behave
like v1.4. Devin rows in the JSON report and model-efficiency now key on the
friendly name.

## Robustness

The dash-to-dot rewrite is restricted to a single-digit minor at a token
boundary, and the friendly-name path defers to `getShortModelName` when a suffix
token is purely numeric. This keeps dated snapshot ids such as
`gpt-4-1106-preview` from being mislabeled as a fake version (`GPT-4.1106
Preview`); they now pass through raw.

## Test

Adds a Devin model-variant matrix covering the effort tiers, the `codex` suffix
with and without effort, the `MODEL_*` fallback, ATIF v1.7 via `extra`, and the
`gpt-4-1106-preview` snapshot regression. Full suite green.
