### PR TITLE
Fix cursor project parsing

### DIFF
--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -193,22 +193,31 @@ function loadWorkspaceMap(workspaceStorageDir: string): WorkspaceMapping {
       continue
     }
     try {
+      // Cursor renamed the per-workspace composer list from
+      // 'composer.composerData' to 'composer.composerHeaders' in newer builds
+      // (identical { allComposers: [{ composerId }] } shape). Read both keys
+      // and merge so the composer -> workspace mapping keeps working across
+      // Cursor versions. Without this, on builds that only write
+      // 'composer.composerHeaders' every composer falls through to the
+      // 'cursor' orphan bucket and per-project attribution is lost.
       const rows = db.query<{ value: string }>(
-        "SELECT value FROM ItemTable WHERE key='composer.composerData'",
+        "SELECT value FROM ItemTable WHERE key IN ('composer.composerData', 'composer.composerHeaders')",
       )
       if (rows.length === 0) continue
-      let parsed: { allComposers?: Array<{ composerId?: string }> }
-      try {
-        parsed = JSON.parse(rows[0]!.value)
-      } catch {
-        continue
-      }
       const project = sanitizeWorkspaceUri(folder)
       let added = 0
-      for (const c of parsed.allComposers ?? []) {
-        if (typeof c.composerId === 'string') {
-          result.composerToWorkspace.set(c.composerId, folder)
-          added += 1
+      for (const row of rows) {
+        let parsed: { allComposers?: Array<{ composerId?: string }> }
+        try {
+          parsed = JSON.parse(row.value)
+        } catch {
+          continue
+        }
+        for (const c of parsed.allComposers ?? []) {
+          if (typeof c.composerId === 'string') {
+            result.composerToWorkspace.set(c.composerId, folder)
+            added += 1
+          }
         }
       }
       if (added > 0) {

--- a/tests/providers/cursor.test.ts
+++ b/tests/providers/cursor.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createRequire } from 'node:module'
 import { getAllProviders } from '../../src/providers/index.js'
-import { getCursorTimeFloor } from '../../src/providers/cursor.js'
+import { getCursorTimeFloor, createCursorProvider, clearCursorWorkspaceMapCache } from '../../src/providers/cursor.js'
+import { isSqliteAvailable } from '../../src/sqlite.js'
 import type { Provider } from '../../src/providers/types.js'
 
 describe('cursor provider', () => {
@@ -82,4 +87,81 @@ describe('cursor cache', () => {
     const result = await readCachedResults('/nonexistent/path.db', new Date(0).toISOString())
     expect(result).toBeNull()
   })
+})
+
+// Regression: Cursor renamed the per-workspace composer list key from
+// 'composer.composerData' to 'composer.composerHeaders'. loadWorkspaceMap must
+// read both, otherwise every composer orphans into the 'cursor' catch-all and
+// per-project attribution is lost.
+describe('cursor workspace mapping (composer.composerHeaders regression)', () => {
+  const requireForTest = createRequire(import.meta.url)
+  type TestDb = {
+    exec(sql: string): void
+    prepare(sql: string): { run(...params: unknown[]): void }
+    close(): void
+  }
+  let root: string
+
+  function writeItemTableDb(dbPath: string, key: string, composerIds: string[]): void {
+    const { DatabaseSync } = requireForTest('node:sqlite') as { DatabaseSync: new (p: string) => TestDb }
+    const db = new DatabaseSync(dbPath)
+    db.exec('CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)')
+    if (key) {
+      const value = JSON.stringify({ allComposers: composerIds.map(composerId => ({ composerId })) })
+      db.prepare('INSERT INTO ItemTable (key, value) VALUES (?, ?)').run(key, value)
+    }
+    db.close()
+  }
+
+  async function makeWorkspace(hash: string, folderUri: string, key: string, composerIds: string[]): Promise<void> {
+    const wsDir = join(root, 'User', 'workspaceStorage', hash)
+    await mkdir(wsDir, { recursive: true })
+    await writeFile(join(wsDir, 'workspace.json'), JSON.stringify({ folder: folderUri }))
+    writeItemTableDb(join(wsDir, 'state.vscdb'), key, composerIds)
+  }
+
+  async function makeGlobalDb(): Promise<string> {
+    const gsDir = join(root, 'User', 'globalStorage')
+    await mkdir(gsDir, { recursive: true })
+    const dbPath = join(gsDir, 'state.vscdb')
+    // discoverSessions only needs the global DB to exist; the workspace map is
+    // built from the sibling workspaceStorage dir.
+    writeItemTableDb(dbPath, '', [])
+    return dbPath
+  }
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'cursor-ws-test-'))
+    clearCursorWorkspaceMapCache()
+  })
+
+  afterEach(async () => {
+    clearCursorWorkspaceMapCache()
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it.skipIf(!isSqliteAvailable())(
+    'maps composers to their workspace via composer.composerHeaders (new Cursor key)',
+    async () => {
+      await makeWorkspace('ws-headers', 'file:///home/user/myapp', 'composer.composerHeaders', ['comp-1', 'comp-2'])
+      const dbPath = await makeGlobalDb()
+
+      const sources = await createCursorProvider(dbPath).discoverSessions()
+      const projects = sources.map(s => s.project)
+
+      // Before the fix these composers orphaned to the 'cursor' catch-all.
+      expect(projects).toContain('-home-user-myapp')
+    },
+  )
+
+  it.skipIf(!isSqliteAvailable())(
+    'still maps composers via the legacy composer.composerData key',
+    async () => {
+      await makeWorkspace('ws-legacy', 'file:///home/user/legacy', 'composer.composerData', ['old-1'])
+      const dbPath = await makeGlobalDb()
+
+      const sources = await createCursorProvider(dbPath).discoverSessions()
+      expect(sources.map(s => s.project)).toContain('-home-user-legacy')
+    },
+  )
 })


### PR DESCRIPTION
## Summary

- Fixes Cursor usage being lumped under a single `cursor` project instead of the real workspace. Recent Cursor builds renamed the per-workspace composer list key from `composer.composerData` to `composer.composerHeaders` (identical `{ allComposers: [{ composerId }] }` shape); `loadWorkspaceMap` only read the old key, so every composer orphaned into the `cursor` catch-all.
- `loadWorkspaceMap` now reads **both** keys and merges their `allComposers` lists — restoring per-project attribution on current Cursor while staying backward-compatible with older installs.
- Adds a regression test covering the new `composer.composerHeaders` key and the legacy `composer.composerData` key.

## Testing

- [x] I have tested this locally against real data (not just unit tests)
- [x] `npm test` passes *(cursor suite 13/13; build clean.
- [x] `npm run build` succeeds

### For new providers only:

- [ ] N/A — this fixes the existing Cursor provider, not a new one

<!-- Real-data verification against an affected workspace state.vscdb -->

**Before (old `composer.composerData`-only query):** all usage orphaned 

projects: [ 'cursor' ] [cursor] calls=22 cost=$0.2506

**After (this PR):** usage attributed to the real workspace

discovered projects: [ '-Users-me-projects-superzoom', 'cursor' ] [-Users-me-projects-superzoom] calls=21 in=67472 out=7284 cost=$0.1653 [cursor] calls=1 in=545 out=5572 cost=$0.0852
