### PR TITLE
feat(kiro): add CLI tool-name mappings and MCP passthrough

### DIFF
--- a/src/providers/kiro.ts
+++ b/src/providers/kiro.ts
@@ -54,9 +54,12 @@ const toolNameMap: Record<string, string> = {
   fileSearch: 'Glob',
   webSearch: 'WebSearch',
   web_search: 'WebSearch',
+  web_fetch: 'WebFetch',
   fsWrite: 'Edit',
   strReplace: 'Edit',
   listDirectory: 'LS',
+  code: 'Read',
+  subagent: 'Agent',
 }
 
 type KiroChatMessage = {
@@ -853,6 +856,7 @@ export function createKiroProvider(agentDirOverride?: string, workspaceStorageDi
     },
 
     toolDisplayName(rawTool: string): string {
+      if (rawTool.startsWith('mcp__')) return rawTool
       return toolNameMap[rawTool] ?? rawTool
     },
 

--- a/tests/providers/kiro.test.ts
+++ b/tests/providers/kiro.test.ts
@@ -599,6 +599,17 @@ describe('kiro provider - metadata', () => {
     expect(kiro.toolDisplayName('unknown_tool')).toBe('unknown_tool')
   })
 
+  it('normalizes CLI-specific tool names', () => {
+    expect(kiro.toolDisplayName('code')).toBe('Read')
+    expect(kiro.toolDisplayName('subagent')).toBe('Agent')
+    expect(kiro.toolDisplayName('web_fetch')).toBe('WebFetch')
+  })
+
+  it('passes through MCP tool names unchanged', () => {
+    expect(kiro.toolDisplayName('mcp__server__searchJira')).toBe('mcp__server__searchJira')
+    expect(kiro.toolDisplayName('mcp__atlassian__getIssue')).toBe('mcp__atlassian__getIssue')
+  })
+
   it('longest-prefix match for versioned model IDs', () => {
     expect(kiro.modelDisplayName('claude-sonnet-4-5-20260101')).toBe('Sonnet 4.5')
     expect(kiro.modelDisplayName('claude-haiku-4-5-20260101')).toBe('Haiku 4.5')


### PR DESCRIPTION
## Summary

Small follow-up to #502. Adds missing tool-name mappings for Kiro CLI built-in tools and ensures MCP tool names pass through unchanged.

## Changes

**`src/providers/kiro.ts`**
- Added `code` → Read, `subagent` → Agent, `web_fetch` → WebFetch to `toolNameMap`
- `toolDisplayName` now returns `mcp__*` prefixed tools as-is instead of falling through to the raw name (preserves the server/tool structure for dashboard display)

**`tests/providers/kiro.test.ts`**
- Test for CLI-specific tool normalization (`code`, `subagent`, `web_fetch`)
- Test for MCP tool passthrough (`mcp__server__tool` stays unchanged)

## Testing

```bash
npx vitest run tests/providers/kiro.test.ts  # 44 tests pass
```
