### PR TITLE
fix(codex): support JetBrains ACP rollout sessions

### DIFF
--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -18,7 +18,7 @@ The discovery walk uses strict regex (`^\d{4}$`, `^\d{2}$`) on each path compone
 
 ## Storage format
 
-JSONL. The first line must be a `session_meta` entry with `payload.originator` starting with `codex` (case-insensitive). Files that fail this check are silently skipped.
+JSONL. The first line must be a `session_meta` entry with `payload.originator` starting with `codex` or `JetBrains.` (case-insensitive). JetBrains IntelliJ AI Assistant / ACP can create valid Codex rollouts under the Codex session directory. Files that fail this check are silently skipped.
 
 The first line read is capped at 1 MB (`FIRST_LINE_READ_CAP`). Codex CLI 0.128+ embeds the full system prompt in `session_meta`, which can run 20-27 KB; the cap leaves headroom while bounding memory if a corrupt file has no newline.
 
@@ -41,6 +41,7 @@ A session that yielded zero parseable lines does **not** write to the cache (`co
 - `prevCumulativeTotal` is initialized to `null`, not `0`. A session whose first event reports `total = 0` would otherwise be dropped as a "duplicate" of the initial state.
 - `prev*` token counters are advanced on **every** event, including ones that used `last_token_usage`. Earlier code only updated them on the fallback branch, which double-counted any session that mixed modes.
 - OpenAI counts cached tokens **inside** `input_tokens`. The parser subtracts them so the rest of the codebase can assume Anthropic semantics (cached are separate).
+- JetBrains IntelliJ ACP rollouts can contain multiple ACP tasks in one Codex rollout. When a turn advertises a JetBrains `aia/agents` workspace root, CodeBurn derives the session id as `<codex-session-id>:jetbrains:<turn-id>` so each ACP task is reported separately. Normal Codex turns in the same rollout stay grouped under the original session id.
 
 ## When fixing a bug here
 

--- a/src/codex-cache.ts
+++ b/src/codex-cache.ts
@@ -6,9 +6,9 @@ import { homedir } from 'os'
 
 import type { ParsedProviderCall } from './providers/types.js'
 
-// v4: attribute MCP calls emitted as event_msg/mcp_tool_call_end (issue #478).
-// Recent Codex sessions cached under v3 dropped these, so force a re-parse.
-const CODEX_CACHE_VERSION = 4
+// v5: split JetBrains IntelliJ ACP tasks in Codex rollouts by turn id (#626).
+// Older cache entries grouped those calls under the parent rollout session.
+const CODEX_CACHE_VERSION = 5
 const CACHE_FILE = 'codex-results.json'
 
 type FileFingerprint = { mtimeMs: number; sizeBytes: number }

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -43,6 +43,7 @@ const toolNameMap: Record<string, string> = {
 
 type CodexEntry = {
   type: string
+  turn_id?: string
   timestamp?: string
   payload?: {
     type?: string
@@ -72,6 +73,14 @@ type CodexTokenUsage = {
   total_tokens?: number
 }
 
+type CodexTokenState = {
+  prevCumulativeTotal: number | null
+  prevInput: number
+  prevCached: number
+  prevOutput: number
+  prevReasoning: number
+}
+
 const CHARS_PER_TOKEN = 4
 const RAW_HEAD_BYTES = 64 * 1024
 const LARGE_TEXT_CAP = 2000
@@ -82,6 +91,49 @@ function getCodexDir(override?: string): string {
 
 function sanitizeProject(cwd: string): string {
   return cwd.replace(/^\//, '').replace(/\//g, '-')
+}
+
+function isJetBrainsOriginator(originator: string): boolean {
+  return originator.toLowerCase().startsWith('jetbrains.')
+}
+
+function isCodexOriginator(originator: string): boolean {
+  const lower = originator.toLowerCase()
+  return lower.startsWith('codex') || isJetBrainsOriginator(originator)
+}
+
+function isJetBrainsAcpWorkspace(cwd: string | undefined): boolean {
+  if (!cwd) return false
+  const normalized = cwd.replace(/\\/g, '/').toLowerCase()
+  return normalized.includes('/aia/agents/') || normalized.endsWith('/aia/agents')
+}
+
+function rememberJetBrainsAcpTurn(entry: CodexEntry, turnIds: Set<string>): void {
+  if (typeof entry.turn_id !== 'string') return
+  if (!isJetBrainsAcpWorkspace(entry.payload?.cwd)) return
+  turnIds.add(entry.turn_id)
+}
+
+function resolveCodexSessionId(baseSessionId: string, entry: CodexEntry, jetBrainsAcpTurnIds: Set<string>): string {
+  const turnId = entry.turn_id
+  if (typeof turnId === 'string' && jetBrainsAcpTurnIds.has(turnId)) {
+    return `${baseSessionId}:jetbrains:${turnId}`
+  }
+  return baseSessionId
+}
+
+function getTokenState(states: Map<string, CodexTokenState>, sessionId: string): CodexTokenState {
+  const existing = states.get(sessionId)
+  if (existing) return existing
+  const created: CodexTokenState = {
+    prevCumulativeTotal: null,
+    prevInput: 0,
+    prevCached: 0,
+    prevOutput: 0,
+    prevReasoning: 0,
+  }
+  states.set(sessionId, created)
+  return created
 }
 
 // Cap how many bytes we'll read while looking for the first newline. Real
@@ -132,7 +184,7 @@ async function isValidCodexSession(filePath: string): Promise<{ valid: boolean; 
   if (!entry) return { valid: false }
   const valid = entry.type === 'session_meta' &&
     typeof entry.payload?.originator === 'string' &&
-    entry.payload.originator.toLowerCase().startsWith('codex')
+    isCodexOriginator(entry.payload.originator)
   return { valid, meta: valid ? entry : undefined }
 }
 
@@ -224,6 +276,7 @@ function parseCodexLine(line: string | Buffer): CodexEntry | null {
 
   const entry: CodexEntry = {
     type,
+    turn_id: getRawJsonStringField(head, 'turn_id'),
     timestamp: getRawJsonStringField(head, 'timestamp'),
     payload: {
       type: payloadType,
@@ -324,19 +377,11 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
       let sessionModel: string | undefined
       let sessionId = ''
+      let jetBrainsRollout = false
+      const jetBrainsAcpTurnIds = new Set<string>()
       let forkedFromId = ''
       let forkCutoff = ''
-      // Null sentinel rather than `0` so the FIRST event is never confused
-      // with a duplicate. A session that only emits last_token_usage (no
-      // total_token_usage) reports cumulativeTotal=0 on every event; with a
-      // 0-initialized prev, the first event would have matched and been
-      // dropped. Once we've observed any event, we record its cumulative
-      // total and dedup on equality regardless of whether it is zero.
-      let prevCumulativeTotal: number | null = null
-      let prevInput = 0
-      let prevCached = 0
-      let prevOutput = 0
-      let prevReasoning = 0
+      const tokenStates = new Map<string, CodexTokenState>()
       let pendingTools: string[] = []
       let pendingToolSequence: ToolCall[][] = []
       let pendingUserMessage = ''
@@ -359,6 +404,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
         if (entry.type === 'session_meta') {
           sessionId = entry.payload?.session_id ?? basename(source.path, '.jsonl')
+          currentTurnId = `${sessionId}:t0`
+          jetBrainsRollout = typeof entry.payload?.originator === 'string' && isJetBrainsOriginator(entry.payload.originator)
           forkedFromId = entry.payload?.forked_from_id ?? ''
           if (forkedFromId && entry.timestamp) {
             forkCutoff = new Date(new Date(entry.timestamp).getTime() + 5000).toISOString()
@@ -366,6 +413,9 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           sessionModel = entry.payload?.model ?? sessionModel
           continue
         }
+
+        if (jetBrainsRollout) rememberJetBrainsAcpTurn(entry, jetBrainsAcpTurnIds)
+        const entrySessionId = resolveCodexSessionId(sessionId, entry, jetBrainsAcpTurnIds)
 
         if (entry.type === 'turn_context' && entry.payload?.model) {
           sessionModel = entry.payload.model
@@ -429,7 +479,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             .filter(Boolean)
           if (texts.length > 0) {
             pendingUserMessage = texts.join(' ').slice(0, 500)
-            currentTurnId = `${sessionId}:t${++turnCounter}`
+            currentTurnId = `${entrySessionId}:t${++turnCounter}`
           }
           continue
         }
@@ -456,7 +506,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
             const model = sessionModel ?? 'gpt-5'
             const timestamp = entry.timestamp ?? ''
-            const dedupKey = `codex:${sessionId}:${timestamp}:est${estCounter++}`
+            const dedupKey = `codex:${entrySessionId}:${timestamp}:est${estCounter++}`
 
             if (seenKeys.has(dedupKey)) { pendingTools = []; pendingToolSequence = []; pendingUserMessage = ''; pendingOutputChars = 0; continue }
             seenKeys.add(dedupKey)
@@ -483,7 +533,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
               turnId: currentTurnId,
               toolSequence: pendingToolSequence.length > 0 ? pendingToolSequence : undefined,
               userMessage: pendingUserMessage,
-              sessionId,
+              sessionId: entrySessionId,
             })
 
             pendingTools = []
@@ -499,8 +549,9 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           // the previous `> 0` clause. The null sentinel ensures the FIRST
           // event always passes (so a session that never reports cumulative
           // doesn't lose its opening turn).
-          if (prevCumulativeTotal !== null && cumulativeTotal === prevCumulativeTotal) continue
-          prevCumulativeTotal = cumulativeTotal
+          const tokenState = getTokenState(tokenStates, entrySessionId)
+          if (tokenState.prevCumulativeTotal !== null && cumulativeTotal === tokenState.prevCumulativeTotal) continue
+          tokenState.prevCumulativeTotal = cumulativeTotal
 
           const last = info.last_token_usage
           let inputTokens = 0
@@ -516,10 +567,10 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           } else if (cumulativeTotal > 0) {
             const total = info.total_token_usage
             if (!total) continue
-            inputTokens = (total.input_tokens ?? 0) - prevInput
-            cachedInputTokens = (total.cached_input_tokens ?? 0) - prevCached
-            outputTokens = (total.output_tokens ?? 0) - prevOutput
-            reasoningTokens = (total.reasoning_output_tokens ?? 0) - prevReasoning
+            inputTokens = (total.input_tokens ?? 0) - tokenState.prevInput
+            cachedInputTokens = (total.cached_input_tokens ?? 0) - tokenState.prevCached
+            outputTokens = (total.output_tokens ?? 0) - tokenState.prevOutput
+            reasoningTokens = (total.reasoning_output_tokens ?? 0) - tokenState.prevReasoning
           }
 
           // Always advance the prev counters to track the cumulative state.
@@ -531,10 +582,10 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           // event used `last` or fell back to deltas.
           const total = info.total_token_usage
           if (total) {
-            prevInput = total.input_tokens ?? 0
-            prevCached = total.cached_input_tokens ?? 0
-            prevOutput = total.output_tokens ?? 0
-            prevReasoning = total.reasoning_output_tokens ?? 0
+            tokenState.prevInput = total.input_tokens ?? 0
+            tokenState.prevCached = total.cached_input_tokens ?? 0
+            tokenState.prevOutput = total.output_tokens ?? 0
+            tokenState.prevReasoning = total.reasoning_output_tokens ?? 0
           }
 
           const totalTokens = inputTokens + cachedInputTokens + outputTokens + reasoningTokens
@@ -560,7 +611,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           // are computed against a running `prev` that the fork advances
           // differently once the 5s cutoff skips some replays, so a delta-based
           // key would spuriously diverge on a replay and double-count it.
-          const dedupKey = `codex:${forkedFromId || sessionId}:${cumulativeTotal}:${total?.input_tokens ?? 0}:${total?.cached_input_tokens ?? 0}:${total?.output_tokens ?? 0}:${total?.reasoning_output_tokens ?? 0}`
+          const dedupKey = `codex:${forkedFromId || entrySessionId}:${cumulativeTotal}:${total?.input_tokens ?? 0}:${total?.cached_input_tokens ?? 0}:${total?.output_tokens ?? 0}:${total?.reasoning_output_tokens ?? 0}`
 
           if (seenKeys.has(dedupKey)) continue
           seenKeys.add(dedupKey)
@@ -593,7 +644,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             turnId: currentTurnId,
             toolSequence: pendingToolSequence.length > 0 ? pendingToolSequence : undefined,
             userMessage: pendingUserMessage,
-            sessionId,
+            sessionId: entrySessionId,
           })
 
           pendingTools = []

--- a/tests/providers/codex-jetbrains.test.ts
+++ b/tests/providers/codex-jetbrains.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { createCodexProvider } from '../../src/providers/codex.js'
+import type { ParsedProviderCall } from '../../src/providers/types.js'
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'codex-jetbrains-test-'))
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+function line(entry: object): string {
+  return JSON.stringify(entry)
+}
+
+function sessionMeta(): string {
+  return line({
+    type: 'session_meta',
+    timestamp: '2026-07-06T16:07:01Z',
+    payload: {
+      cwd: '/Users/test/Tech-Ascension-Workspace',
+      originator: 'JetBrains.IntelliJ IDEA',
+      session_id: '019f3941-7d76-74d0-95eb-f0f0d70acdb2',
+      model: 'gpt-5.5',
+    },
+  })
+}
+
+function turnContext(turnId: string, cwd: string): string {
+  return line({
+    type: 'turn_context',
+    turn_id: turnId,
+    timestamp: '2026-07-06T16:08:00Z',
+    payload: { cwd, model: 'gpt-5.5' },
+  })
+}
+
+function userMessage(turnId: string, text: string): string {
+  return line({
+    type: 'response_item',
+    turn_id: turnId,
+    timestamp: '2026-07-06T16:08:10Z',
+    payload: {
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_text', text }],
+    },
+  })
+}
+
+function tokenCount(turnId: string, input: number, output: number, total: number): string {
+  return line({
+    type: 'event_msg',
+    turn_id: turnId,
+    timestamp: '2026-07-06T16:08:30Z',
+    payload: {
+      type: 'token_count',
+      info: {
+        model: 'gpt-5.5',
+        last_token_usage: {
+          input_tokens: input,
+          output_tokens: output,
+          total_tokens: input + output,
+        },
+        total_token_usage: {
+          input_tokens: total,
+          output_tokens: output,
+          total_tokens: total + output,
+        },
+      },
+    },
+  })
+}
+
+async function writeSession(lines: string[]): Promise<string> {
+  const sessionDir = join(tmpDir, 'sessions', '2026', '07', '06')
+  await mkdir(sessionDir, { recursive: true })
+  const path = join(sessionDir, 'rollout-jetbrains.jsonl')
+  await writeFile(path, lines.join('\n') + '\n')
+  return path
+}
+
+async function parse(path: string): Promise<ParsedProviderCall[]> {
+  const provider = createCodexProvider(tmpDir)
+  const parser = provider.createSessionParser({ path, project: 'Tech-Ascension-Workspace', provider: 'codex' }, new Set())
+  const calls: ParsedProviderCall[] = []
+  for await (const call of parser.parse()) calls.push(call)
+  return calls
+}
+
+describe('codex provider - JetBrains IntelliJ ACP sessions', () => {
+  it('discovers Codex rollout files created by JetBrains IntelliJ ACP', async () => {
+    await writeSession([
+      sessionMeta(),
+      tokenCount('turn-a', 100, 50, 100),
+    ])
+
+    const sessions = await createCodexProvider(tmpDir).discoverSessions()
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.provider).toBe('codex')
+    expect(sessions[0]!.project).toBe('Users-test-Tech-Ascension-Workspace')
+  })
+
+  it('splits JetBrains ACP turns by turn id without splitting normal Codex turns', async () => {
+    const path = await writeSession([
+      sessionMeta(),
+      turnContext('019f3941-cabb-7281-b95b-14e2f422a72b', '/Users/test/.cache/JetBrains/IntelliJIdea2026.1/aia/agents/task-a'),
+      userMessage('019f3941-cabb-7281-b95b-14e2f422a72b', 'first JetBrains task'),
+      tokenCount('019f3941-cabb-7281-b95b-14e2f422a72b', 100, 50, 100),
+      turnContext('019f394d-29db-7930-b072-e0fdbcae54dd', '/Users/test/.cache/JetBrains/IntelliJIdea2026.1/aia/agents/task-b'),
+      userMessage('019f394d-29db-7930-b072-e0fdbcae54dd', 'second JetBrains task'),
+      tokenCount('019f394d-29db-7930-b072-e0fdbcae54dd', 100, 50, 100),
+      turnContext('normal-turn', '/Users/test/Tech-Ascension-Workspace'),
+      userMessage('normal-turn', 'normal Codex task'),
+      tokenCount('normal-turn', 300, 70, 600),
+    ])
+
+    const calls = await parse(path)
+
+    expect(calls.map(call => call.sessionId)).toEqual([
+      '019f3941-7d76-74d0-95eb-f0f0d70acdb2:jetbrains:019f3941-cabb-7281-b95b-14e2f422a72b',
+      '019f3941-7d76-74d0-95eb-f0f0d70acdb2:jetbrains:019f394d-29db-7930-b072-e0fdbcae54dd',
+      '019f3941-7d76-74d0-95eb-f0f0d70acdb2',
+    ])
+  })
+})


### PR DESCRIPTION
## What

Fixes #626.

CodeBurn now accepts Codex rollout files whose `session_meta.payload.originator` comes from JetBrains IntelliJ AI Assistant / ACP, and splits JetBrains ACP tasks inside one rollout by their `turn_id` when the turn advertises a JetBrains `aia/agents` workspace root.

Normal Codex turns in the same rollout stay grouped under the original rollout session id.

## Why

JetBrains ACP can write valid Codex rollouts under `~/.codex/sessions/...` with an originator such as `JetBrains.IntelliJ IDEA`. The previous discovery check only accepted originators beginning with `codex`, so those files were skipped entirely. Once accepted, multiple ACP tasks in the same rollout also need separate CodeBurn session ids:

```text
<codex-session-id>:jetbrains:<turn-id>
```

## Validation

- `npm test -- --run tests/providers/codex-jetbrains.test.ts` failed before the parser change for discovery and session splitting.
- `npm test -- --run tests/providers/codex-jetbrains.test.ts tests/providers/codex.test.ts`
- `npm test`
- `npx tsc --noEmit`
- `npm run build`
- `uvx semgrep --config .semgrep/rules/no-bracket-assign-hot-paths.yml --strict --json src/providers/ src/parser.ts`
- Manual CLI fixture with isolated `CODEX_HOME`: `codeburn report --provider codex --format json --day 2026-07-06` reported 3 sessions / 3 calls from one JetBrains-originated rollout.
