### PR TITLE
Add menubar Claude config selector

### DIFF
--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -17,13 +17,20 @@ struct PayloadCacheKey: Hashable {
     let provider: ProviderFilter
     let day: String?
     let days: Set<String>
+    let claudeConfigSourceId: String?
 
-    init(scope: MenubarScope = .local, period: Period, provider: ProviderFilter, day: String? = nil, days: Set<String> = []) {
+    init(scope: MenubarScope = .local,
+         period: Period,
+         provider: ProviderFilter,
+         day: String? = nil,
+         days: Set<String> = [],
+         claudeConfigSourceId: String? = nil) {
         self.scope = scope
         self.period = period
         self.provider = provider
         self.day = days.count <= 1 ? (day ?? days.first) : nil
         self.days = days.count > 1 ? days : []
+        self.claudeConfigSourceId = claudeConfigSourceId
     }
 
     var label: String {
@@ -40,6 +47,7 @@ final class AppStore {
     var selectedProvider: ProviderFilter = .all
     var selectedPeriod: Period = .today
     var selectedScope: MenubarScope = MenubarScope.savedMenubarScope()
+    var selectedClaudeConfigSourceId: String?
     var selectedDays: Set<String> = []
     var activeScope: MenubarScope { effectiveSelectedScope }
 
@@ -175,15 +183,36 @@ final class AppStore {
     }
 
     private var currentKey: PayloadCacheKey {
-        PayloadCacheKey(scope: effectiveSelectedScope, period: selectedPeriod, provider: selectedProvider, day: selectedDay, days: selectedDays)
+        PayloadCacheKey(
+            scope: effectiveSelectedScope,
+            period: selectedPeriod,
+            provider: selectedProvider,
+            day: selectedDay,
+            days: selectedDays,
+            claudeConfigSourceId: selectedClaudeConfigSourceId
+        )
     }
 
     private var localCurrentKey: PayloadCacheKey {
-        PayloadCacheKey(scope: .local, period: selectedPeriod, provider: selectedProvider, day: selectedDay, days: selectedDays)
+        PayloadCacheKey(
+            scope: .local,
+            period: selectedPeriod,
+            provider: selectedProvider,
+            day: selectedDay,
+            days: selectedDays,
+            claudeConfigSourceId: selectedClaudeConfigSourceId
+        )
     }
 
     private var periodAllKey: PayloadCacheKey {
-        PayloadCacheKey(scope: .local, period: selectedPeriod, provider: .all, day: selectedDay, days: selectedDays)
+        PayloadCacheKey(
+            scope: .local,
+            period: selectedPeriod,
+            provider: .all,
+            day: selectedDay,
+            days: selectedDays,
+            claudeConfigSourceId: selectedClaudeConfigSourceId
+        )
     }
 
     var payload: MenubarPayload {
@@ -196,7 +225,8 @@ final class AppStore {
                         current: localPayload.current,
                         optimize: localPayload.optimize,
                         history: localPayload.history,
-                        combined: combined
+                        combined: combined,
+                        claudeConfigs: localPayload.claudeConfigs
                     )
                 }
                 return localPayload
@@ -235,6 +265,17 @@ final class AppStore {
     /// per-provider costs that match the active period, not just today.
     var periodAllPayload: MenubarPayload? {
         cache[periodAllKey]?.payload
+    }
+
+    var claudeConfigOptions: [ClaudeConfigOption] {
+        payload.claudeConfigs?.options
+            ?? periodAllPayload?.claudeConfigs?.options
+            ?? todayPayload?.claudeConfigs?.options
+            ?? []
+    }
+
+    var shouldShowClaudeConfigSelector: Bool {
+        claudeConfigOptions.count > 1
     }
 
     var isDayMode: Bool {
@@ -313,16 +354,18 @@ final class AppStore {
                                     provider: ProviderFilter,
                                     day: String? = nil,
                                     days: Set<String> = [],
+                                    claudeConfigSourceId: String? = nil,
                                     fetchedAt: Date) {
-        cache[PayloadCacheKey(scope: scope, period: period, provider: provider, day: day, days: days)] = CachedPayload(payload: payload, fetchedAt: fetchedAt)
+        cache[PayloadCacheKey(scope: scope, period: period, provider: provider, day: day, days: days, claudeConfigSourceId: claudeConfigSourceId)] = CachedPayload(payload: payload, fetchedAt: fetchedAt)
     }
 
     func cachedPayloadForTesting(scope: MenubarScope = .local,
                                  period: Period,
                                  provider: ProviderFilter,
                                  day: String? = nil,
-                                 days: Set<String> = []) -> MenubarPayload? {
-        cache[PayloadCacheKey(scope: scope, period: period, provider: provider, day: day, days: days)]?.payload
+                                 days: Set<String> = [],
+                                 claudeConfigSourceId: String? = nil) -> MenubarPayload? {
+        cache[PayloadCacheKey(scope: scope, period: period, provider: provider, day: day, days: days, claudeConfigSourceId: claudeConfigSourceId)]?.payload
     }
 
     func setLastErrorForTesting(_ error: String,
@@ -412,6 +455,9 @@ final class AppStore {
         if shouldResetProvider {
             selectedProvider = .all
         }
+        if scope == .combined {
+            selectedClaudeConfigSourceId = nil
+        }
 #if DEBUG
         if refreshSuppressedForTesting { return }
 #endif
@@ -429,12 +475,25 @@ final class AppStore {
         startInteractiveSelectionRefresh()
     }
 
+    func switchTo(claudeConfigSourceId: String?) {
+        guard selectedClaudeConfigSourceId != claudeConfigSourceId else { return }
+        selectedClaudeConfigSourceId = claudeConfigSourceId
+        if claudeConfigSourceId != nil {
+            selectedProvider = .all
+            selectedScope = .local
+        }
+        startInteractiveSelectionRefresh()
+    }
+
     func switchTo(scope: MenubarScope) {
         let shouldResetProvider = scope == .combined && selectedProvider != .all
         guard selectedScope != scope || shouldResetProvider else { return }
         selectedScope = scope
         if shouldResetProvider {
             selectedProvider = .all
+        }
+        if scope == .combined {
+            selectedClaudeConfigSourceId = nil
         }
         startInteractiveSelectionRefresh()
     }
@@ -450,9 +509,10 @@ final class AppStore {
         let scope = effectiveSelectedScope
         let day = selectedDay
         let days = selectedDays
-        let key = PayloadCacheKey(scope: scope, period: period, provider: provider, day: day, days: days)
-        let localKey = PayloadCacheKey(scope: .local, period: period, provider: provider, day: day, days: days)
-        let allKey = PayloadCacheKey(scope: .local, period: period, provider: .all, day: day, days: days)
+        let claudeConfigSourceId = selectedClaudeConfigSourceId
+        let key = PayloadCacheKey(scope: scope, period: period, provider: provider, day: day, days: days, claudeConfigSourceId: claudeConfigSourceId)
+        let localKey = PayloadCacheKey(scope: .local, period: period, provider: provider, day: day, days: days, claudeConfigSourceId: claudeConfigSourceId)
+        let allKey = PayloadCacheKey(scope: .local, period: period, provider: .all, day: day, days: days, claudeConfigSourceId: claudeConfigSourceId)
         lastErrorByKey[key] = nil
         switchTask = Task {
             if scope == .combined {
@@ -569,6 +629,15 @@ final class AppStore {
         cache.removeAll()
     }
 
+    private func reconcileClaudeConfigSelection(from payload: MenubarPayload, for key: PayloadCacheKey) {
+        guard let selected = key.claudeConfigSourceId else { return }
+        guard selectedClaudeConfigSourceId == selected else { return }
+        let valid = payload.claudeConfigs?.options.contains { $0.id == selected } ?? false
+        if !valid || payload.claudeConfigs?.selectedId != selected {
+            selectedClaudeConfigSourceId = nil
+        }
+    }
+
     func recoverFromStuckLoading() async {
         guard prepareStuckLoadingRecovery() else { return }
         await refresh(includeOptimize: false, force: true, showLoading: true)
@@ -612,7 +681,8 @@ final class AppStore {
             period: selectedPeriod,
             provider: selectedProvider,
             day: selectedDay,
-            days: selectedDays
+            days: selectedDays,
+            claudeConfigSourceId: selectedClaudeConfigSourceId
         )
         if scope == .combined {
             async let local: Void = refreshQuietly(key: localCurrentKey, includeOptimize: false, force: false)
@@ -659,7 +729,15 @@ final class AppStore {
             }
         }
         do {
-            let fresh = try await DataClient.fetch(period: key.period, day: key.day, days: key.days, provider: key.provider, includeOptimize: includeOptimize, scope: key.scope)
+            let fresh = try await DataClient.fetch(
+                period: key.period,
+                day: key.day,
+                days: key.days,
+                provider: key.provider,
+                includeOptimize: includeOptimize,
+                scope: key.scope,
+                claudeConfigSourceId: key.claudeConfigSourceId
+            )
             if generationAtStart != payloadRefreshGeneration {
                 NSLog("CodeBurn: dropping fetch result for \(key.label)/\(key.provider.rawValue) — refresh pipeline reset mid-fetch")
                 return
@@ -682,6 +760,7 @@ final class AppStore {
                 return
             }
             cache[key] = CachedPayload(payload: fresh, fetchedAt: Date())
+            reconcileClaudeConfigSelection(from: fresh, for: key)
             lastSuccessByKey[key] = Date()
             lastErrorByKey[key] = nil
         } catch {
@@ -689,7 +768,15 @@ final class AppStore {
             NSLog("CodeBurn: fetch failed for \(key.label)/\(key.provider.rawValue): \(error)")
             if includeOptimize, cache[key] == nil {
                 do {
-                    let fallback = try await DataClient.fetch(period: key.period, day: key.day, days: key.days, provider: key.provider, includeOptimize: false, scope: key.scope)
+                    let fallback = try await DataClient.fetch(
+                        period: key.period,
+                        day: key.day,
+                        days: key.days,
+                        provider: key.provider,
+                        includeOptimize: false,
+                        scope: key.scope,
+                        claudeConfigSourceId: key.claudeConfigSourceId
+                    )
                     guard !Task.isCancelled else { return }
                     if generationAtStart != payloadRefreshGeneration { return }
                     if cacheDate != cacheDateAtStart || cacheDate != currentCacheDate() {
@@ -697,6 +784,7 @@ final class AppStore {
                         return
                     }
                     cache[key] = CachedPayload(payload: fallback, fetchedAt: Date())
+                    reconcileClaudeConfigSelection(from: fallback, for: key)
                     lastSuccessByKey[key] = Date()
                     lastErrorByKey[key] = nil
                     return
@@ -708,7 +796,14 @@ final class AppStore {
             lastErrorByKey[key] = String(describing: error)
         }
 
-        let allKey = PayloadCacheKey(scope: .local, period: key.period, provider: .all, day: key.day, days: key.days)
+        let allKey = PayloadCacheKey(
+            scope: .local,
+            period: key.period,
+            provider: .all,
+            day: key.day,
+            days: key.days,
+            claudeConfigSourceId: key.claudeConfigSourceId
+        )
         if key != allKey, cache[allKey]?.isFresh != true {
             await refreshQuietly(key: allKey, includeOptimize: false, force: false)
         }
@@ -742,7 +837,8 @@ final class AppStore {
                 days: key.days,
                 provider: key.provider,
                 includeOptimize: includeOptimize,
-                scope: key.scope
+                scope: key.scope,
+                claudeConfigSourceId: key.claudeConfigSourceId
             )
             if generationAtStart != payloadRefreshGeneration {
                 NSLog("CodeBurn: dropping quiet fetch result for \(key.label) — refresh pipeline reset mid-fetch")
@@ -755,6 +851,7 @@ final class AppStore {
                 return
             }
             cache[key] = CachedPayload(payload: fresh, fetchedAt: Date())
+            reconcileClaudeConfigSelection(from: fresh, for: key)
             lastSuccessByKey[key] = Date()
             lastErrorByKey[key] = nil
         } catch {

--- a/mac/Sources/CodeBurnMenubar/Data/DataClient.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/DataClient.swift
@@ -45,14 +45,16 @@ struct DataClient {
                       days: Set<String> = [],
                       provider: ProviderFilter,
                       includeOptimize: Bool,
-                      scope: MenubarScope = .local) async throws -> MenubarPayload {
+                      scope: MenubarScope = .local,
+                      claudeConfigSourceId: String? = nil) async throws -> MenubarPayload {
         let subcommand = statusSubcommand(
             period: period,
             day: day,
             days: days,
             provider: provider,
             includeOptimize: includeOptimize,
-            scope: scope
+            scope: scope,
+            claudeConfigSourceId: claudeConfigSourceId
         )
         let result = try await runCLI(subcommand: subcommand)
         guard result.exitCode == 0 else {
@@ -76,7 +78,8 @@ struct DataClient {
                                  days: Set<String> = [],
                                  provider: ProviderFilter,
                                  includeOptimize: Bool,
-                                 scope: MenubarScope = .local) -> [String] {
+                                 scope: MenubarScope = .local,
+                                 claudeConfigSourceId: String? = nil) -> [String] {
         let effectiveScope: MenubarScope = days.count > 1 ? .local : scope
         let effectiveProvider: ProviderFilter = effectiveScope == .combined ? .all : provider
         var subcommand = [
@@ -86,6 +89,9 @@ struct DataClient {
         ]
         if effectiveScope == .combined {
             subcommand.append(contentsOf: ["--scope", effectiveScope.cliArg])
+        }
+        if effectiveScope == .local, let claudeConfigSourceId, !claudeConfigSourceId.isEmpty {
+            subcommand.append(contentsOf: ["--claude-config-source", claudeConfigSourceId])
         }
         if days.count > 1 {
             subcommand.append(contentsOf: ["--days", days.sorted().joined(separator: ",")])

--- a/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
@@ -8,6 +8,46 @@ struct MenubarPayload: Codable, Sendable {
     let optimize: OptimizeBlock
     let history: HistoryBlock
     let combined: CombinedUsage?
+    let claudeConfigs: ClaudeConfigSelector?
+
+    init(generated: String,
+         current: CurrentBlock,
+         optimize: OptimizeBlock,
+         history: HistoryBlock,
+         combined: CombinedUsage?,
+         claudeConfigs: ClaudeConfigSelector? = nil) {
+        self.generated = generated
+        self.current = current
+        self.optimize = optimize
+        self.history = history
+        self.combined = combined
+        self.claudeConfigs = claudeConfigs
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case generated, current, optimize, history, combined, claudeConfigs
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        generated = try c.decode(String.self, forKey: .generated)
+        current = try c.decode(CurrentBlock.self, forKey: .current)
+        optimize = try c.decode(OptimizeBlock.self, forKey: .optimize)
+        history = try c.decode(HistoryBlock.self, forKey: .history)
+        combined = try c.decodeIfPresent(CombinedUsage.self, forKey: .combined)
+        claudeConfigs = try c.decodeIfPresent(ClaudeConfigSelector.self, forKey: .claudeConfigs)
+    }
+}
+
+struct ClaudeConfigSelector: Codable, Sendable {
+    let selectedId: String?
+    let options: [ClaudeConfigOption]
+}
+
+struct ClaudeConfigOption: Codable, Identifiable, Hashable, Sendable {
+    let id: String
+    let label: String
+    let path: String
 }
 
 struct CombinedUsage: Codable, Sendable {
@@ -422,6 +462,7 @@ extension MenubarPayload {
         ),
         optimize: OptimizeBlock(findingCount: 0, savingsUSD: 0, topFindings: []),
         history: HistoryBlock(daily: []),
-        combined: nil
+        combined: nil,
+        claudeConfigs: nil
     )
 }

--- a/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
@@ -125,34 +125,107 @@ private struct ScopeSegmentedControl: View {
     @Environment(AppStore.self) private var store
 
     var body: some View {
-        HStack(spacing: 1) {
-            ForEach(MenubarScope.allCases) { scope in
-                let isActive = store.activeScope == scope
-                Button {
-                    store.switchTo(scope: scope)
-                } label: {
-                    Text(scope.rawValue)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(isActive ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 4)
-                        .contentShape(Rectangle())
+        HStack(spacing: 8) {
+            HStack(spacing: 1) {
+                ForEach(MenubarScope.allCases) { scope in
+                    let isActive = store.activeScope == scope
+                    Button {
+                        store.switchTo(scope: scope)
+                    } label: {
+                        Text(scope.rawValue)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(isActive ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 4)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .background(
+                        RoundedRectangle(cornerRadius: 5)
+                            .fill(isActive ? Color(NSColor.windowBackgroundColor).opacity(0.85) : .clear)
+                            .shadow(color: .black.opacity(isActive ? 0.06 : 0), radius: 1, y: 0.5)
+                    )
                 }
-                .buttonStyle(.plain)
-                .background(
-                    RoundedRectangle(cornerRadius: 5)
-                        .fill(isActive ? Color(NSColor.windowBackgroundColor).opacity(0.85) : .clear)
-                        .shadow(color: .black.opacity(isActive ? 0.06 : 0), radius: 1, y: 0.5)
-                )
+            }
+            .padding(2)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(Color.secondary.opacity(0.08))
+            )
+            .frame(maxWidth: .infinity)
+
+            if store.shouldShowClaudeConfigSelector {
+                ClaudeConfigPicker()
             }
         }
-        .padding(2)
-        .background(
-            RoundedRectangle(cornerRadius: 7)
-                .fill(Color.secondary.opacity(0.08))
-        )
         .padding(.horizontal, 12)
         .padding(.bottom, 10)
+    }
+}
+
+private struct ClaudeConfigPicker: View {
+    @Environment(AppStore.self) private var store
+
+    private var selectedLabel: String {
+        guard let selected = store.selectedClaudeConfigSourceId,
+              let option = store.claudeConfigOptions.first(where: { $0.id == selected }) else {
+            return "All"
+        }
+        return option.label
+    }
+
+    var body: some View {
+        Menu {
+            Button {
+                store.switchTo(claudeConfigSourceId: nil)
+            } label: {
+                HStack {
+                    if store.selectedClaudeConfigSourceId == nil {
+                        Image(systemName: "checkmark")
+                    }
+                    Text("All")
+                }
+            }
+
+            Divider()
+
+            ForEach(store.claudeConfigOptions) { option in
+                Button {
+                    store.switchTo(claudeConfigSourceId: option.id)
+                } label: {
+                    HStack {
+                        if store.selectedClaudeConfigSourceId == option.id {
+                            Image(systemName: "checkmark")
+                        }
+                        Text(option.label)
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "person.crop.circle")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text(selectedLabel)
+                    .font(.system(size: 11, weight: .medium))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(.secondary)
+            }
+            .foregroundStyle(.primary)
+            .frame(width: 118, height: 26)
+            .padding(.horizontal, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(Color.secondary.opacity(0.08))
+            )
+            .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize(horizontal: true, vertical: false)
+        .help("Claude config")
     }
 }
 

--- a/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
@@ -35,7 +35,19 @@ private func combinedUsage(cost: Double = 12.5) -> CombinedUsage {
     )
 }
 
-private func menubarPayload(cost: Double, combined: CombinedUsage? = nil) -> MenubarPayload {
+private func claudeConfigSelector(selectedId: String? = nil) -> ClaudeConfigSelector {
+    ClaudeConfigSelector(
+        selectedId: selectedId,
+        options: [
+            ClaudeConfigOption(id: "claude-config:work", label: "claude-work", path: "/tmp/claude-work"),
+            ClaudeConfigOption(id: "claude-config:personal", label: "claude-personal", path: "/tmp/claude-personal")
+        ]
+    )
+}
+
+private func menubarPayload(cost: Double,
+                            combined: CombinedUsage? = nil,
+                            claudeConfigs: ClaudeConfigSelector? = nil) -> MenubarPayload {
     MenubarPayload(
         generated: "test",
         current: CurrentBlock(
@@ -64,7 +76,8 @@ private func menubarPayload(cost: Double, combined: CombinedUsage? = nil) -> Men
         ),
         optimize: OptimizeBlock(findingCount: 0, savingsUSD: 0, topFindings: []),
         history: HistoryBlock(daily: []),
-        combined: combined
+        combined: combined,
+        claudeConfigs: claudeConfigs
     )
 }
 
@@ -199,6 +212,72 @@ struct AppStoreRefreshRecoveryTests {
         store.switchTo(scope: .combined)
 
         #expect(store.selectedScope == .combined)
+        #expect(store.selectedProvider == .all)
+    }
+
+    @Test("selected Claude config partitions payload cache")
+    func selectedClaudeConfigPartitionsPayloadCache() {
+        let store = AppStore()
+        store.setCachedPayloadForTesting(
+            menubarPayload(cost: 10, claudeConfigs: claudeConfigSelector()),
+            scope: .local,
+            period: .today,
+            provider: .all,
+            fetchedAt: Date()
+        )
+        store.setCachedPayloadForTesting(
+            menubarPayload(cost: 4, claudeConfigs: claudeConfigSelector(selectedId: "claude-config:work")),
+            scope: .local,
+            period: .today,
+            provider: .all,
+            claudeConfigSourceId: "claude-config:work",
+            fetchedAt: Date()
+        )
+
+        #expect(store.payload.current.cost == 10)
+
+        store.selectedClaudeConfigSourceId = "claude-config:work"
+
+        #expect(store.payload.current.cost == 4)
+        #expect(store.cachedPayloadForTesting(scope: .local, period: .today, provider: .all)?.current.cost == 10)
+        #expect(store.cachedPayloadForTesting(scope: .local, period: .today, provider: .all, claudeConfigSourceId: "claude-config:work")?.current.cost == 4)
+    }
+
+    @Test("Claude config selector is hidden until multiple configs are available")
+    func claudeConfigSelectorVisibilityRequiresMultipleConfigs() {
+        let store = AppStore()
+        store.setCachedPayloadForTesting(
+            menubarPayload(cost: 1),
+            scope: .local,
+            period: .today,
+            provider: .all,
+            fetchedAt: Date()
+        )
+        #expect(!store.shouldShowClaudeConfigSelector)
+
+        store.setCachedPayloadForTesting(
+            menubarPayload(cost: 2, claudeConfigs: claudeConfigSelector()),
+            scope: .local,
+            period: .today,
+            provider: .all,
+            fetchedAt: Date()
+        )
+
+        #expect(store.shouldShowClaudeConfigSelector)
+        #expect(store.claudeConfigOptions.map(\.label) == ["claude-work", "claude-personal"])
+    }
+
+    @Test("selecting Claude config resets provider and combined scope")
+    func selectingClaudeConfigResetsProviderAndCombinedScope() {
+        let store = AppStore()
+        store.suppressRefreshesForTesting()
+        store.selectedScope = .combined
+        store.selectedProvider = .codex
+
+        store.switchTo(claudeConfigSourceId: "claude-config:work")
+
+        #expect(store.selectedClaudeConfigSourceId == "claude-config:work")
+        #expect(store.selectedScope == .local)
         #expect(store.selectedProvider == .all)
     }
 

--- a/mac/Tests/CodeBurnMenubarTests/DataClientProcessTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/DataClientProcessTests.swift
@@ -47,6 +47,33 @@ struct DataClientProcessTests {
         #expect(value(after: "--days", in: args) == "2026-06-01,2026-06-02")
     }
 
+    @Test("status argv local includes Claude config source")
+    func statusSubcommandLocalIncludesClaudeConfigSource() {
+        let args = DataClient.statusSubcommand(
+            period: .today,
+            provider: .all,
+            includeOptimize: false,
+            scope: .local,
+            claudeConfigSourceId: "claude-config:work"
+        )
+
+        #expect(value(after: "--claude-config-source", in: args) == "claude-config:work")
+    }
+
+    @Test("status argv combined omits Claude config source")
+    func statusSubcommandCombinedOmitsClaudeConfigSource() {
+        let args = DataClient.statusSubcommand(
+            period: .today,
+            provider: .all,
+            includeOptimize: false,
+            scope: .combined,
+            claudeConfigSourceId: "claude-config:work"
+        )
+
+        #expect(value(after: "--scope", in: args) == "combined")
+        #expect(!args.contains("--claude-config-source"))
+    }
+
     /// Concurrency + timeout smoke test: launch more hung subprocesses than
     /// there are cooperative threads, all at once, with a short timeout, and
     /// assert every call returns once the timeout kills its sleep.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { isAbsolute } from 'path'
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 import { installMenubarApp } from './menubar-installer.js'
 import { exportCsv, exportJson, type PeriodExport } from './export.js'
 import { loadPricing, setModelAliases, setPriceOverrides, setLocalModelSavings, setProxyPaths, normalizeProxyPath } from './models.js'
@@ -653,6 +653,7 @@ program
   .option('--to <date>', 'End date (YYYY-MM-DD) for custom range')
   .option('--days <dates>', 'Comma-separated dates (YYYY-MM-DD) for multi-day selection')
   .option('--no-optimize', 'Skip optimize findings (menubar-json only, faster)')
+  .addOption(new Option('--claude-config-source <id>').hideHelp())
   .action(async (opts) => {
     assertFormat(opts.format, ['terminal', 'menubar-json', 'json'], 'status')
     assertScope(opts.scope, ['local', 'combined'], 'status')
@@ -667,6 +668,10 @@ program
     }
     if (opts.format === 'menubar-json' && opts.scope === 'combined' && opts.days) {
       process.stderr.write('error: --scope combined cannot be combined with --days\n')
+      process.exit(1)
+    }
+    if (opts.format === 'menubar-json' && opts.scope === 'combined' && opts.claudeConfigSource) {
+      process.stderr.write('error: --scope combined cannot be combined with --claude-config-source\n')
       process.exit(1)
     }
     if (opts.scope === 'combined' && (opts.provider !== 'all' || opts.project.length > 0 || opts.exclude.length > 0)) {
@@ -691,6 +696,7 @@ program
         exclude: opts.exclude,
         daysSelection,
         optimize: opts.optimize !== false,
+        claudeConfigSourceId: opts.claudeConfigSource,
       })
       if (opts.scope === 'combined') {
         // Combined multi-device usage is best-effort enrichment on the menubar's

--- a/src/menubar-json.ts
+++ b/src/menubar-json.ts
@@ -108,6 +108,17 @@ export type CombinedUsage = {
   }
 }
 
+export type ClaudeConfigOption = {
+  id: string
+  label: string
+  path: string
+}
+
+export type ClaudeConfigSelector = {
+  selectedId: string | null
+  options: ClaudeConfigOption[]
+}
+
 export type MenubarPayload = {
   generated: string
   current: {
@@ -217,6 +228,7 @@ export type MenubarPayload = {
     daily: DailyHistoryEntry[]
   }
   combined?: CombinedUsage
+  claudeConfigs?: ClaudeConfigSelector
 }
 
 function oneShotRateFor(editTurns: number, oneShotTurns: number): number | null {
@@ -351,8 +363,9 @@ export function buildMenubarPayload(
   retryTax?: MenubarPayload['current']['retryTax'],
   routingWaste?: MenubarPayload['current']['routingWaste'],
   breakdowns?: BreakdownArrays,
+  claudeConfigs?: ClaudeConfigSelector,
 ): MenubarPayload {
-  return {
+  const payload: MenubarPayload = {
     generated: new Date().toISOString(),
     current: {
       label: current.label,
@@ -383,4 +396,8 @@ export function buildMenubarPayload(
     optimize: buildOptimize(optimize),
     history: buildHistory(dailyHistory),
   }
+  if (claudeConfigs && claudeConfigs.options.length > 1) {
+    payload.claudeConfigs = claudeConfigs
+  }
+  return payload
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -33,6 +33,7 @@ import type {
   ParsedTurn,
   ProjectSummary,
   SessionSummary,
+  type SessionSourceMetadata,
   TokenUsage,
   ToolCall,
   ToolUseBlock,
@@ -1274,6 +1275,7 @@ function buildSessionSummary(
   project: string,
   turns: ClassifiedTurn[],
   mcpInventory?: string[],
+  source?: SessionSourceMetadata,
 ): SessionSummary {
   const modelBreakdown: SessionSummary['modelBreakdown'] = Object.create(null)
   const toolBreakdown: SessionSummary['toolBreakdown'] = Object.create(null)
@@ -1399,6 +1401,7 @@ function buildSessionSummary(
     categoryBreakdown,
     skillBreakdown,
     subagentBreakdown,
+    ...(source ? { source } : {}),
     ...(mcpInventory && mcpInventory.length > 0 ? { mcpInventory } : {}),
   }
 }
@@ -1518,7 +1521,7 @@ export async function readAgentType(filePath: string): Promise<string | undefine
 }
 
 async function scanProjectDirs(
-  dirs: Array<{ path: string; name: string }>,
+  dirs: Array<{ path: string; name: string; source?: SessionSourceMetadata }>,
   seenMsgIds: Set<string>,
   diskCache: SessionCache,
   dateRange?: DateRange,
@@ -1526,11 +1529,11 @@ async function scanProjectDirs(
   const section = getOrCreateProviderSection(diskCache, 'claude')
   const allDiscoveredFiles = new Set<string>()
 
-  type FileInfo = { dirName: string; fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>> }
-  const unchangedFiles: Array<{ filePath: string; dirName: string; cached: CachedFile }> = []
+  type FileInfo = { dirName: string; fp: NonNullable<Awaited<ReturnType<typeof fingerprintFile>>>; source?: SessionSourceMetadata }
+  const unchangedFiles: Array<{ filePath: string; dirName: string; source?: SessionSourceMetadata; cached: CachedFile }> = []
   const changedFiles: Array<{ filePath: string; info: FileInfo }> = []
 
-  for (const { path: dirPath, name: dirName } of dirs) {
+  for (const { path: dirPath, name: dirName, source } of dirs) {
     const jsonlFiles = await collectJsonlFiles(dirPath)
     for (const filePath of jsonlFiles) {
       allDiscoveredFiles.add(filePath)
@@ -1539,9 +1542,9 @@ async function scanProjectDirs(
 
       const action = reconcileFile(fp, section.files[filePath])
       if (action.action === 'unchanged') {
-        unchangedFiles.push({ filePath, dirName, cached: section.files[filePath]! })
+        unchangedFiles.push({ filePath, dirName, source, cached: section.files[filePath]! })
       } else {
-        changedFiles.push({ filePath, info: { dirName, fp } })
+        changedFiles.push({ filePath, info: { dirName, fp, source } })
       }
     }
   }
@@ -1600,11 +1603,11 @@ async function scanProjectDirs(
   const projectMap = new Map<string, { project: string; projectPath: string; sessions: SessionSummary[]; dirNames: Set<string> }>()
 
   const allFiles = [
-    ...unchangedFiles.map(f => ({ filePath: f.filePath, dirName: f.dirName })),
-    ...changedFiles.map(f => ({ filePath: f.filePath, dirName: f.info.dirName })),
+    ...unchangedFiles.map(f => ({ filePath: f.filePath, dirName: f.dirName, source: f.source })),
+    ...changedFiles.map(f => ({ filePath: f.filePath, dirName: f.info.dirName, source: f.info.source })),
   ]
 
-  for (const { filePath, dirName } of allFiles) {
+  for (const { filePath, dirName, source } of allFiles) {
     const cachedFile = section.files[filePath]
     if (!cachedFile || cachedFile.turns.length === 0) continue
 
@@ -1626,7 +1629,7 @@ async function scanProjectDirs(
     const projectPath = cachedFile.canonicalCwd ?? claudeSlugFallbackPath(dirName)
     const projectName = cachedFile.canonicalProjectName ?? dirName
     const mcpInv = cachedFile.mcpInventory.length > 0 ? cachedFile.mcpInventory : undefined
-    const session = buildSessionSummary(sessionId, projectName, classifiedTurns, mcpInv)
+    const session = buildSessionSummary(sessionId, projectName, classifiedTurns, mcpInv, source)
     session.agentType = cachedFile.agentType
 
     if (session.apiCalls > 0) {
@@ -2317,8 +2320,20 @@ export function filterProjectsByDays(projects: ProjectSummary[], days: Set<strin
         return ds !== null && days.has(ds)
       })
       if (turns.length === 0) continue
-      sessions.push(buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory))
+      sessions.push(buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory, session.source))
     }
+    if (sessions.length === 0) continue
+    filtered.push(summarizeProject(project.project, project.projectPath, sessions))
+  }
+  return filtered.sort((a, b) => b.totalCostUSD - a.totalCostUSD)
+}
+
+export function filterProjectsByClaudeConfigSource(projects: ProjectSummary[], sourceId: string): ProjectSummary[] {
+  const filtered: ProjectSummary[] = []
+  for (const project of projects) {
+    const sessions = project.sessions.filter(session =>
+      session.source?.kind === 'claude-config' && session.source.id === sourceId
+    )
     if (sessions.length === 0) continue
     filtered.push(summarizeProject(project.project, project.projectPath, sessions))
   }
@@ -2332,7 +2347,7 @@ export function filterProjectsByDateRange(projects: ProjectSummary[], dateRange:
     for (const session of project.sessions) {
       const turns = session.turns.filter(turn => turnIsInDateRange(turn, dateRange))
       if (turns.length === 0) continue
-      sessions.push(buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory))
+      sessions.push(buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory, session.source))
     }
     if (sessions.length === 0) continue
     filtered.push(summarizeProject(project.project, project.projectPath, sessions))
@@ -2355,7 +2370,13 @@ export async function parseAllSessions(dateRange?: DateRange, providerFilter?: s
   const claudeSources = allSources.filter(s => s.provider === 'claude')
   const nonClaudeSources = allSources.filter(s => s.provider !== 'claude')
 
-  const claudeDirs = claudeSources.map(s => ({ path: s.path, name: s.project }))
+  const claudeDirs = claudeSources.map(s => ({
+    path: s.path,
+    name: s.project,
+    source: s.sourceId && s.sourceLabel && s.sourcePath && s.sourceKind
+      ? { id: s.sourceId, label: s.sourceLabel, path: s.sourcePath, kind: s.sourceKind }
+      : undefined,
+  }))
   const claudeProjects = await scanProjectDirs(claudeDirs, seenMsgIds, diskCache, dateRange)
 
   const providerGroups = new Map<string, SessionSource[]>()

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -1,10 +1,17 @@
 import { readFile, readdir, stat } from 'fs/promises'
 import { basename, delimiter as pathDelimiter, join, resolve } from 'path'
 import { homedir } from 'os'
+import { createHash } from 'crypto'
 
 import type { Provider, SessionSource, SessionParser } from './types.js'
 import { getShortModelName } from '../models.js'
 import { readConfig } from '../config.js'
+
+export type ClaudeConfigSource = {
+  id: string
+  label: string
+  path: string
+}
 
 function expandHome(p: string): string {
   if (p === '~') return homedir()
@@ -22,6 +29,31 @@ function dedupeResolved(paths: string[]): string[] {
     }
   }
   return out
+}
+
+function claudeConfigSourceId(path: string): string {
+  return 'claude-config:' + createHash('sha256').update(path).digest('hex').slice(0, 16)
+}
+
+function baseClaudeConfigLabel(path: string): string {
+  const normalized = resolve(path)
+  if (normalized === resolve(join(homedir(), '.claude'))) return 'Default Claude'
+  const name = basename(normalized).replace(/^\./, '').trim()
+  return name || normalized
+}
+
+function makeUniqueLabels(sources: ClaudeConfigSource[]): ClaudeConfigSource[] {
+  const counts = new Map<string, number>()
+  for (const source of sources) counts.set(source.label, (counts.get(source.label) ?? 0) + 1)
+  if (![...counts.values()].some(count => count > 1)) return sources
+
+  const seen = new Map<string, number>()
+  return sources.map(source => {
+    if ((counts.get(source.label) ?? 0) <= 1) return source
+    const index = (seen.get(source.label) ?? 0) + 1
+    seen.set(source.label, index)
+    return { ...source, label: `${source.label} ${index}` }
+  })
 }
 
 /// Returns every Claude config dir to scan, in priority order with duplicates
@@ -58,6 +90,15 @@ async function getClaudeConfigDirs(): Promise<string[]> {
   }
 
   return [join(homedir(), '.claude')]
+}
+
+export async function discoverClaudeConfigSources(): Promise<ClaudeConfigSource[]> {
+  const dirs = await getClaudeConfigDirs()
+  return makeUniqueLabels(dirs.map(path => ({
+    id: claudeConfigSourceId(path),
+    label: baseClaudeConfigLabel(path),
+    path,
+  })))
 }
 
 export function getDesktopSessionsDir(): string {
@@ -174,10 +215,11 @@ export const claude: Provider = {
   async discoverSessions(): Promise<SessionSource[]> {
     const sources: SessionSource[] = []
     const seenProjectDirs = new Set<string>()
-    const configDirs = await getClaudeConfigDirs()
+    const configSources = await discoverClaudeConfigSources()
     let anyDirReadable = false
 
-    for (const claudeDir of configDirs) {
+    for (const configSource of configSources) {
+      const claudeDir = configSource.path
       const projectsDir = join(claudeDir, 'projects')
       let entries: string[]
       try {
@@ -201,7 +243,15 @@ export const claude: Provider = {
         // `project: dirName` is identical across config dirs for the same
         // sanitized slug, which is exactly what makes the parser merge
         // their sessions into a single ProjectSummary.
-        sources.push({ path: dirPath, project: dirName, provider: 'claude' })
+        sources.push({
+          path: dirPath,
+          project: dirName,
+          provider: 'claude',
+          sourceId: configSource.id,
+          sourceLabel: configSource.label,
+          sourcePath: configSource.path,
+          sourceKind: 'claude-config',
+        })
       }
     }
 
@@ -211,10 +261,10 @@ export const claude: Provider = {
     // the platform expects `;`, which produces a single bogus path that
     // silently resolves to nothing on disk.
     const explicitMulti = process.env['CLAUDE_CONFIG_DIRS']
-    if (!anyDirReadable && explicitMulti !== undefined && explicitMulti !== '' && configDirs.length > 0) {
+    if (!anyDirReadable && explicitMulti !== undefined && explicitMulti !== '' && configSources.length > 0) {
       process.stderr.write(
         `codeburn: CLAUDE_CONFIG_DIRS was set but no listed directory could be read. ` +
-        `Tried: ${configDirs.join(', ')}. ` +
+        `Tried: ${configSources.map(s => s.path).join(', ')}. ` +
         `Use "${pathDelimiter}" as the separator on this platform.\n`,
       )
     }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -4,6 +4,10 @@ export type SessionSource = {
   path: string
   project: string
   provider: string
+  sourceId?: string
+  sourceLabel?: string
+  sourcePath?: string
+  sourceKind?: 'claude-config' | 'claude-desktop'
 }
 
 export type SessionParser = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,9 +123,17 @@ export type ClassifiedTurn = ParsedTurn & {
   hasEdits: boolean
 }
 
+export type SessionSourceMetadata = {
+  id: string
+  label: string
+  path: string
+  kind: 'claude-config' | 'claude-desktop'
+}
+
 export type SessionSummary = {
   sessionId: string
   project: string
+  source?: SessionSourceMetadata
   // Claude Code only: agent type of a subagent transcript session
   // (`workflow-subagent`, `Explore`, `general-purpose`, …); undefined for
   // ordinary sessions. Drives the Claude-scoped agent-type breakdown.

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -1,9 +1,10 @@
 import { homedir } from 'node:os'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory, type DateRange } from './types.js'
-import { type PeriodData, type ProviderCost, type BreakdownArrays, type MenubarPayload, buildMenubarPayload } from './menubar-json.js'
-import { parseAllSessions, filterProjectsByName, filterProjectsByDays } from './parser.js'
+import { type PeriodData, type ProviderCost, type BreakdownArrays, type MenubarPayload, type ClaudeConfigSelector, buildMenubarPayload } from './menubar-json.js'
+import { parseAllSessions, filterProjectsByName, filterProjectsByDays, filterProjectsByClaudeConfigSource } from './parser.js'
 import { getLocalModelSavingsConfigHash, getPriceOverridesConfigHash, getShortModelName } from './models.js'
 import { getAllProviders } from './providers/index.js'
+import { claude } from './providers/claude.js'
 import { aggregateProjectsIntoDays, buildPeriodDataFromDays } from './day-aggregator.js'
 import { aggregateModelEfficiency } from './model-efficiency.js'
 import { aggregateModels } from './models-report.js'
@@ -87,6 +88,64 @@ export type AggregateOpts = {
   exclude?: string[]
   daysSelection?: { range: DateRange; label: string; days: Set<string> } | null
   optimize?: boolean
+  claudeConfigSourceId?: string | null
+}
+
+function claudeConfigSelectorFromProjects(projects: ProjectSummary[], selectedId?: string | null): ClaudeConfigSelector | undefined {
+  const byId = new Map<string, { id: string; label: string; path: string }>()
+  for (const session of projects.flatMap(project => project.sessions)) {
+    const source = session.source
+    if (source?.kind !== 'claude-config') continue
+    if (!byId.has(source.id)) byId.set(source.id, { id: source.id, label: source.label, path: source.path })
+  }
+
+  const options = [...byId.values()].sort((a, b) => a.label.localeCompare(b.label))
+  if (options.length <= 1) return undefined
+  const validSelectedId = selectedId && options.some(option => option.id === selectedId) ? selectedId : null
+  return { selectedId: validSelectedId, options }
+}
+
+async function claudeConfigSelectorFromDiscovery(selectedId?: string | null): Promise<ClaudeConfigSelector | undefined> {
+  const byId = new Map<string, { id: string; label: string; path: string }>()
+  for (const source of await claude.discoverSessions()) {
+    if (source.sourceKind !== 'claude-config' || !source.sourceId || !source.sourceLabel || !source.sourcePath) continue
+    if (!byId.has(source.sourceId)) {
+      byId.set(source.sourceId, { id: source.sourceId, label: source.sourceLabel, path: source.sourcePath })
+    }
+  }
+
+  const options = [...byId.values()].sort((a, b) => a.label.localeCompare(b.label))
+  if (options.length <= 1) return undefined
+  const validSelectedId = selectedId && options.some(option => option.id === selectedId) ? selectedId : null
+  return { selectedId: validSelectedId, options }
+}
+
+function dailyEntriesToHistory(days: ReturnType<typeof aggregateProjectsIntoDays>): MenubarPayload['history']['daily'] {
+  return days.map(d => {
+    const topModels = Object.entries(d.models)
+      .filter(([name]) => name !== '<synthetic>')
+      .sort(([, a], [, b]) => b.cost - a.cost)
+      .slice(0, 5)
+      .map(([name, m]) => ({
+        name,
+        cost: m.cost,
+        savingsUSD: m.savingsUSD,
+        calls: m.calls,
+        inputTokens: m.inputTokens,
+        outputTokens: m.outputTokens,
+      }))
+    return {
+      date: d.date,
+      cost: d.cost,
+      savingsUSD: d.savingsUSD,
+      calls: d.calls,
+      inputTokens: d.inputTokens,
+      outputTokens: d.outputTokens,
+      cacheReadTokens: d.cacheReadTokens,
+      cacheWriteTokens: d.cacheWriteTokens,
+      topModels,
+    }
+  })
 }
 
 /**
@@ -129,10 +188,28 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
   let currentData: PeriodData
   let scanProjects: ProjectSummary[]
   let scanRange: DateRange
-  let cache: DailyCache
+  let cache: DailyCache = emptyCache()
   let todayProviderData: PeriodData | null = null
+  let claudeConfigs: ClaudeConfigSelector | undefined
+  const requestedClaudeConfigSourceId = opts.claudeConfigSourceId?.trim() || null
+  const isClaudeConfigScoped = requestedClaudeConfigSourceId !== null
 
-  if (isAllProviders) {
+  if (isClaudeConfigScoped) {
+    const rawProjects = fp(await parseAllSessions(periodInfo.range, 'all'))
+    const fullProjects = daysSelection ? filterProjectsByDays(rawProjects, daysSelection.days) : rawProjects
+    claudeConfigs =
+      await claudeConfigSelectorFromDiscovery(requestedClaudeConfigSourceId) ??
+      claudeConfigSelectorFromProjects(fullProjects, requestedClaudeConfigSourceId)
+    const selectedSourceId = claudeConfigs?.selectedId ?? null
+    scanProjects = selectedSourceId
+      ? filterProjectsByClaudeConfigSource(fullProjects, selectedSourceId)
+      : fullProjects
+    scanRange = periodInfo.range
+    currentData = buildPeriodData(periodInfo.label, scanProjects)
+    if (!selectedSourceId && isAllProviders) {
+      cache = await hydrateCache()
+    }
+  } else if (isAllProviders) {
     cache = await hydrateCache()
     const todayProjects = await getTodayAllProjects()
     const todayDays = await getTodayAllDays()
@@ -164,6 +241,7 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
   if (isAllProviders) {
     currentData = buildPeriodData(periodInfo.label, scanProjects)
   }
+  claudeConfigs = claudeConfigs ?? await claudeConfigSelectorFromDiscovery(null) ?? claudeConfigSelectorFromProjects(scanProjects, null)
 
   // Codex credits for the period. Reuses the models aggregation (folds reasoning
   // into output, keeps non-cached input + cached-read separate) so the figure
@@ -180,7 +258,20 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
   const allProviders = await getAllProviders()
   const displayNameByName = new Map(allProviders.map(p => [p.name, p.displayName]))
   const providers: ProviderCost[] = []
-  if (isAllProviders) {
+  if (isClaudeConfigScoped) {
+    const providerTotals: Record<string, number> = {}
+    for (const d of aggregateProjectsIntoDays(scanProjects)) {
+      for (const [name, p] of Object.entries(d.providers)) {
+        providerTotals[name] = (providerTotals[name] ?? 0) + p.cost
+      }
+    }
+    for (const [name, cost] of Object.entries(providerTotals)) {
+      providers.push({ name: displayNameByName.get(name) ?? name, cost })
+    }
+    if (providers.length === 0 && claudeConfigs?.selectedId) {
+      providers.push({ name: displayNameByName.get('claude') ?? 'Claude', cost: 0 })
+    }
+  } else if (isAllProviders) {
     const unfilteredProviderDays = [
       ...(rangeStartStr <= historicalRangeEndStr ? getDaysInRange(cache, rangeStartStr, historicalRangeEndStr) : []),
       ...(await getTodayAllDays()).filter(d => d.date >= rangeStartStr && d.date <= rangeEndStr),
@@ -213,34 +304,20 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
   const allCacheDays = getDaysInRange(cache, historyStartStr, yesterdayStr)
 
   let dailyHistory
-  if (isAllProviders) {
+  if (isClaudeConfigScoped && claudeConfigs?.selectedId) {
+    const historyRange: DateRange = {
+      start: new Date(now.getFullYear(), now.getMonth(), now.getDate() - BACKFILL_DAYS),
+      end: now,
+    }
+    const historyProjects = filterProjectsByClaudeConfigSource(
+      fp(await parseAllSessions(historyRange, 'all')),
+      claudeConfigs.selectedId,
+    )
+    dailyHistory = dailyEntriesToHistory(aggregateProjectsIntoDays(historyProjects))
+  } else if (isAllProviders) {
     const todayDays = (await getTodayAllDays()).filter(d => d.date === todayStr)
     const fullHistory = [...allCacheDays, ...todayDays]
-    dailyHistory = fullHistory.map(d => {
-      const topModels = Object.entries(d.models)
-        .filter(([name]) => name !== '<synthetic>')
-        .sort(([, a], [, b]) => b.cost - a.cost)
-        .slice(0, 5)
-        .map(([name, m]) => ({
-          name,
-          cost: m.cost,
-          savingsUSD: m.savingsUSD,
-          calls: m.calls,
-          inputTokens: m.inputTokens,
-          outputTokens: m.outputTokens,
-        }))
-      return {
-        date: d.date,
-        cost: d.cost,
-        savingsUSD: d.savingsUSD,
-        calls: d.calls,
-        inputTokens: d.inputTokens,
-        outputTokens: d.outputTokens,
-        cacheReadTokens: d.cacheReadTokens,
-        cacheWriteTokens: d.cacheWriteTokens,
-        topModels,
-      }
-    })
+    dailyHistory = dailyEntriesToHistory(fullHistory)
   } else {
     const emptyModels = [] as { name: string; cost: number; savingsUSD: number; calls: number; inputTokens: number; outputTokens: number }[]
     const historyFromCache = allCacheDays.map(d => {
@@ -421,5 +498,5 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
   })()
 
   const optimize = opts.optimize === false ? null : await scanAndDetect(scanProjects, scanRange)
-  return buildMenubarPayload(currentData, providers, optimize, dailyHistory, retryTax, routingWaste, breakdowns)
+  return buildMenubarPayload(currentData, providers, optimize, dailyHistory, retryTax, routingWaste, breakdowns, claudeConfigs)
 }

--- a/tests/cli-status-menubar.test.ts
+++ b/tests/cli-status-menubar.test.ts
@@ -1,11 +1,11 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { delimiter as pathDelimiter, join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 
 import { describe, expect, it } from 'vitest'
 
-function runCli(args: string[], home: string) {
+function runCli(args: string[], home: string, extraEnv: Record<string, string | undefined> = {}) {
   return spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], {
     cwd: process.cwd(),
     env: {
@@ -13,6 +13,7 @@ function runCli(args: string[], home: string) {
       CLAUDE_CONFIG_DIR: join(home, '.claude'),
       HOME: home,
       TZ: 'UTC',
+      ...extraEnv,
     },
     encoding: 'utf-8',
     timeout: 30_000,
@@ -150,6 +151,158 @@ describe('codeburn status --format menubar-json', () => {
       expect(payload.current.topProjects).toHaveLength(1)
       expect(payload.current.topProjects[0]?.sessions).toBe(1)
       expect(payload.current.topProjects[0]?.sessionDetails.map(s => s.date)).toEqual(['2026-04-10'])
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('filters the whole menubar payload to a selected Claude config source', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-menubar-claude-config-'))
+
+    try {
+      const work = join(home, 'claude-work')
+      const personal = join(home, 'claude-personal')
+      const slug = 'shared-app'
+      await mkdir(join(work, 'projects', slug), { recursive: true })
+      await mkdir(join(personal, 'projects', slug), { recursive: true })
+
+      await writeFile(
+        join(work, 'projects', slug, 'work.jsonl'),
+        [
+          userLine('work', '2026-04-10T11:59:00Z'),
+          assistantLine('work', '2026-04-10T12:00:00Z', 'msg-work'),
+        ].join('\n'),
+      )
+      await writeFile(
+        join(personal, 'projects', slug, 'personal.jsonl'),
+        [
+          userLine('personal', '2026-04-10T12:59:00Z'),
+          assistantLine('personal', '2026-04-10T13:00:00Z', 'msg-personal'),
+        ].join('\n'),
+      )
+
+      const env = { CLAUDE_CONFIG_DIRS: [work, personal].join(pathDelimiter) }
+      const allResult = runCli([
+        'status',
+        '--format', 'menubar-json',
+        '--period', 'all',
+        '--provider', 'all',
+        '--no-optimize',
+      ], home, env)
+
+      expect(allResult.status, `stderr: ${allResult.stderr}`).toBe(0)
+      const allPayload = JSON.parse(allResult.stdout) as {
+        current: { calls: number; sessions: number }
+        claudeConfigs?: { selectedId: string | null; options: Array<{ id: string; label: string; path: string }> }
+      }
+      expect(allPayload.current.calls).toBe(2)
+      expect(allPayload.current.sessions).toBe(2)
+      expect(allPayload.claudeConfigs?.selectedId).toBeNull()
+      expect(allPayload.claudeConfigs?.options.map(o => o.label).sort()).toEqual(['claude-personal', 'claude-work'])
+
+      const workSourceId = allPayload.claudeConfigs!.options.find(o => o.label === 'claude-work')!.id
+      const workResult = runCli([
+        'status',
+        '--format', 'menubar-json',
+        '--period', 'all',
+        '--provider', 'all',
+        '--claude-config-source', workSourceId,
+        '--no-optimize',
+      ], home, env)
+
+      expect(workResult.status, `stderr: ${workResult.stderr}`).toBe(0)
+      const workPayload = JSON.parse(workResult.stdout) as {
+        current: { calls: number; sessions: number; providers: Record<string, number> }
+        history: { daily: Array<{ calls: number }> }
+        claudeConfigs?: { selectedId: string | null }
+      }
+      expect(workPayload.claudeConfigs?.selectedId).toBe(workSourceId)
+      expect(workPayload.current.calls).toBe(1)
+      expect(workPayload.current.sessions).toBe(1)
+      expect(Object.keys(workPayload.current.providers)).toEqual(['claude'])
+      expect(workPayload.history.daily.reduce((sum, d) => sum + d.calls, 0)).toBe(1)
+
+      const invalidResult = runCli([
+        'status',
+        '--format', 'menubar-json',
+        '--period', 'all',
+        '--provider', 'all',
+        '--claude-config-source', 'claude-config:missing',
+        '--no-optimize',
+      ], home, env)
+
+      expect(invalidResult.status, `stderr: ${invalidResult.stderr}`).toBe(0)
+      const invalidPayload = JSON.parse(invalidResult.stdout) as {
+        current: { calls: number }
+        claudeConfigs?: { selectedId: string | null }
+      }
+      expect(invalidPayload.current.calls).toBe(2)
+      expect(invalidPayload.claudeConfigs?.selectedId).toBeNull()
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps idle Claude config options visible for the selected period', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-menubar-claude-config-idle-'))
+
+    try {
+      const work = join(home, 'claude-work')
+      const personal = join(home, 'claude-personal')
+      await mkdir(join(work, 'projects', 'app'), { recursive: true })
+      await mkdir(join(personal, 'projects', 'app'), { recursive: true })
+
+      await writeFile(
+        join(work, 'projects', 'app', 'work.jsonl'),
+        [
+          userLine('work', '2026-04-10T11:59:00Z'),
+          assistantLine('work', '2026-04-10T12:00:00Z', 'msg-work'),
+        ].join('\n'),
+      )
+      await writeFile(
+        join(personal, 'projects', 'app', 'personal.jsonl'),
+        [
+          userLine('personal', '2026-04-09T11:59:00Z'),
+          assistantLine('personal', '2026-04-09T12:00:00Z', 'msg-personal'),
+        ].join('\n'),
+      )
+
+      const env = { CLAUDE_CONFIG_DIRS: [work, personal].join(pathDelimiter) }
+      const allResult = runCli([
+        'status',
+        '--format', 'menubar-json',
+        '--day', '2026-04-10',
+        '--provider', 'all',
+        '--no-optimize',
+      ], home, env)
+
+      expect(allResult.status, `stderr: ${allResult.stderr}`).toBe(0)
+      const allPayload = JSON.parse(allResult.stdout) as {
+        current: { calls: number }
+        claudeConfigs?: { options: Array<{ id: string; label: string }> }
+      }
+      expect(allPayload.current.calls).toBe(1)
+      expect(allPayload.claudeConfigs?.options.map(o => o.label).sort()).toEqual(['claude-personal', 'claude-work'])
+
+      const personalSourceId = allPayload.claudeConfigs!.options.find(o => o.label === 'claude-personal')!.id
+      const personalResult = runCli([
+        'status',
+        '--format', 'menubar-json',
+        '--day', '2026-04-10',
+        '--provider', 'all',
+        '--claude-config-source', personalSourceId,
+        '--no-optimize',
+      ], home, env)
+
+      expect(personalResult.status, `stderr: ${personalResult.stderr}`).toBe(0)
+      const personalPayload = JSON.parse(personalResult.stdout) as {
+        current: { calls: number; sessions: number; providers: Record<string, number> }
+        claudeConfigs?: { selectedId: string | null }
+      }
+      expect(personalPayload.claudeConfigs?.selectedId).toBe(personalSourceId)
+      expect(personalPayload.current.calls).toBe(0)
+      expect(personalPayload.current.sessions).toBe(0)
+      expect(personalPayload.current.providers).toEqual({ claude: 0 })
     } finally {
       await rm(home, { recursive: true, force: true })
     }

--- a/tests/menubar-json.test.ts
+++ b/tests/menubar-json.test.ts
@@ -298,4 +298,28 @@ describe('buildMenubarPayload', () => {
 
     expect(payload.combined).toEqual(combined)
   })
+
+  it('emits Claude config selector metadata only when multiple configs are available', () => {
+    const oneConfig = buildMenubarPayload(emptyPeriod('Today'), [], null, undefined, undefined, undefined, undefined, {
+      selectedId: null,
+      options: [{ id: 'claude-config:a', label: 'claude-work', path: '/tmp/claude-work' }],
+    })
+    expect(oneConfig).not.toHaveProperty('claudeConfigs')
+
+    const twoConfigs = buildMenubarPayload(emptyPeriod('Today'), [], null, undefined, undefined, undefined, undefined, {
+      selectedId: 'claude-config:b',
+      options: [
+        { id: 'claude-config:a', label: 'claude-work', path: '/tmp/claude-work' },
+        { id: 'claude-config:b', label: 'claude-personal', path: '/tmp/claude-personal' },
+      ],
+    })
+
+    expect(twoConfigs.claudeConfigs).toEqual({
+      selectedId: 'claude-config:b',
+      options: [
+        { id: 'claude-config:a', label: 'claude-work', path: '/tmp/claude-work' },
+        { id: 'claude-config:b', label: 'claude-personal', path: '/tmp/claude-personal' },
+      ],
+    })
+  })
 })

--- a/tests/providers/claude-config-dirs.test.ts
+++ b/tests/providers/claude-config-dirs.test.ts
@@ -5,7 +5,7 @@ import { tmpdir, homedir } from 'os'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 
 import { claude } from '../../src/providers/claude.js'
-import { parseAllSessions } from '../../src/parser.js'
+import { clearSessionCache, filterProjectsByClaudeConfigSource, parseAllSessions } from '../../src/parser.js'
 
 let tmpRoot: string
 const savedEnv = {
@@ -15,6 +15,7 @@ const savedEnv = {
 }
 
 beforeEach(async () => {
+  clearSessionCache()
   tmpRoot = await mkdtemp(join(tmpdir(), 'codeburn-claude-multi-'))
   // Point HOME at a scratch dir so the default `~/.claude` fallback resolves
   // somewhere we control. Without this, a stray `~/.claude` on the test
@@ -26,6 +27,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
+  clearSessionCache()
   for (const [k, v] of Object.entries(savedEnv)) {
     if (v === undefined) delete process.env[k]
     else process.env[k] = v
@@ -139,6 +141,9 @@ describe('claude provider — CLAUDE_CONFIG_DIRS discovery', () => {
     )
     expect(ourSources).toHaveLength(2)
     expect(new Set(ourSources.map(s => s.project))).toEqual(new Set(['-Users-you-app']))
+    expect(new Set(ourSources.map(s => s.sourceKind))).toEqual(new Set(['claude-config']))
+    expect(new Set(ourSources.map(s => s.sourceLabel))).toEqual(new Set(['claude-work', 'claude-personal']))
+    expect(ourSources.every(s => typeof s.sourceId === 'string' && s.sourceId.startsWith('claude-config:'))).toBe(true)
   })
 
   it('tolerates a non-existent dir in the list without dropping the real ones', async () => {
@@ -303,6 +308,41 @@ describe('claude parser — multi-dir aggregation (issue #208 option 1)', () => 
     // — option 1 explicitly avoids attribution.
     expect((matches[0]! as Record<string, unknown>)['account']).toBeUndefined()
     expect((matches[0]! as Record<string, unknown>)['accountPath']).toBeUndefined()
+  })
+
+  it('keeps source metadata on merged sessions so one Claude config can be selected', async () => {
+    const work = await makeConfigDir('claude-work', [])
+    const personal = await makeConfigDir('claude-personal', [])
+    process.env['CLAUDE_CONFIG_DIRS'] = [work, personal].join(pathDelimiter)
+
+    const slug = '-Users-you-shared-app'
+    const cwd = '/Users/you/shared-app'
+    await writeSession(work, slug, 'sess-work', [
+      summaryLine('sess-work', cwd),
+      userLine('u1', 'sess-work', cwd, 'hi from work'),
+      assistantLine('a1', 'u1', 'sess-work', cwd),
+    ])
+    await writeSession(personal, slug, 'sess-personal', [
+      summaryLine('sess-personal', cwd),
+      userLine('u2', 'sess-personal', cwd, 'hi from personal'),
+      assistantLine('a2', 'u2', 'sess-personal', cwd),
+    ])
+
+    const projects = await parseAllSessions(undefined, 'claude')
+    const merged = projects.find(p => p.project === slug)
+    expect(merged).toBeDefined()
+    expect(merged!.sessions).toHaveLength(2)
+
+    const sourceIds = new Map(merged!.sessions.map(s => [s.source?.label, s.source?.id]))
+    const workSourceId = sourceIds.get('claude-work')
+    expect(workSourceId).toBeDefined()
+
+    const workOnly = filterProjectsByClaudeConfigSource(projects, workSourceId!)
+    expect(workOnly).toHaveLength(1)
+    expect(workOnly[0]!.project).toBe(slug)
+    expect(workOnly[0]!.totalApiCalls).toBe(1)
+    expect(workOnly[0]!.sessions.map(s => s.sessionId)).toEqual(['sess-work'])
+    expect(workOnly[0]!.sessions[0]!.source?.label).toBe('claude-work')
   })
 
   // Documents the path-aware merge behavior: the mergedMap in parseAllSessions


### PR DESCRIPTION
## Summary
- Add a menubar-only Claude config selector for multi-config setups
- Keep All as the default merged view while allowing one config to scope the whole popover
- Include selector metadata in menubar JSON and cache selected config payloads separately

For #627.

## Tests
- npm test -- --run
- npm run build
- swift test