### PR TITLE
Add progress indicator + event-loop yielding for large cold-cache Claude scans

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1530,6 +1530,8 @@ async function scanProjectDirs(
   const unchangedFiles: Array<{ filePath: string; dirName: string; cached: CachedFile }> = []
   const changedFiles: Array<{ filePath: string; info: FileInfo }> = []
 
+  const discoverProgress = createScanProgress('scanning claude project dirs', dirs.length)
+  let dirsDone = 0
   for (const { path: dirPath, name: dirName } of dirs) {
     const jsonlFiles = await collectJsonlFiles(dirPath)
     for (const filePath of jsonlFiles) {
@@ -1544,7 +1546,10 @@ async function scanProjectDirs(
         changedFiles.push({ filePath, info: { dirName, fp } })
       }
     }
+    dirsDone++
+    await discoverProgress.tick(dirsDone)
   }
+  discoverProgress.finish()
 
   // Pre-seed dedup set from cached (unchanged) files
   for (const { cached } of unchangedFiles) {
@@ -1555,13 +1560,15 @@ async function scanProjectDirs(
     }
   }
 
+  const parseProgress = createScanProgress('parsing changed claude sessions', changedFiles.length)
+  let filesDone = 0
   for (const { filePath, info } of changedFiles) {
     delete section.files[filePath]
 
     try {
       const tracker = { lastCompleteLineOffset: 0 }
       const entries = await parseClaudeEntries(filePath, tracker)
-      if (!entries) continue
+      if (!entries) { filesDone++; await parseProgress.tick(filesDone); continue }
 
       const turns = groupIntoTurns(dedupeStreamingMessageIds(entries), seenMsgIds)
       const cwd = extractCanonicalCwd(entries)
@@ -1586,7 +1593,10 @@ async function scanProjectDirs(
       ;(diskCache as { _dirty?: boolean })._dirty = true
       warnProviderParseFailure('claude', filePath, err)
     }
+    filesDone++
+    await parseProgress.tick(filesDone)
   }
+  parseProgress.finish()
 
   if (dirs.length > 0) {
     for (const cachedPath of Object.keys(section.files)) {
@@ -1955,6 +1965,44 @@ function warnProviderParseFailure(providerName: string, sourcePath: string, err:
   process.stderr.write(
     `codeburn: skipped ${providerName} session that failed to parse: ${sourcePath} (${msg})${tail}\n`
   )
+}
+
+// A cold-cache scan over a large ~/.claude/projects tree (hundreds of project
+// dirs, e.g. a git-worktree-per-task workflow) can run long enough that it
+// looks hung, and is CPU-heavy enough on a single thread to visibly compete
+// with anything else running interactively on the same machine. Two cheap
+// mitigations, neither of which reduces total CPU work: (1) a `\r`-updated
+// progress line so a long cold run reads as "working" instead of "stuck",
+// gated on isTTY so it never corrupts piped/captured output (export.ts, the
+// --no-color path, or a subprocess capturing stderr); (2) yielding to the
+// event loop every YIELD_EVERY items so the OS scheduler gets regular break
+// points instead of one long uninterrupted synchronous block. This does NOT
+// fix CPU contention with a separate process (that's the OS scheduler's job
+// regardless), it only keeps this process itself responsive and honest about
+// progress during the scan.
+const YIELD_EVERY = 25
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise(resolve => setImmediate(resolve))
+}
+
+function createScanProgress(label: string, total: number) {
+  const show = total > 20 && process.stderr.isTTY === true
+  let lastWrite = 0
+  return {
+    async tick(done: number): Promise<void> {
+      if (done % YIELD_EVERY === 0) await yieldToEventLoop()
+      if (!show) return
+      const now = Date.now()
+      if (done !== total && now - lastWrite < 100) return
+      lastWrite = now
+      process.stderr.write(`\rcodeburn: ${label} ${done}/${total}…`)
+    },
+    finish(): void {
+      if (!show) return
+      process.stderr.write('\r\x1b[K')
+    },
+  }
 }
 
 async function parseProviderSources(


### PR DESCRIPTION
## Summary
- On a large `~/.claude/projects` tree (hundreds of project dirs, e.g. a git-worktree-per-task workflow, plus months of session history), the CLI report-style commands (`overview`, `export`, `status`, etc.) go through `parseAllSessions` → `scanProjectDirs` with no progress indicator of any kind. A cold-cache run can take tens of seconds with zero output, which reads as a hang rather than as working. (The interactive `dashboard.tsx` TUI already has its own `loading` state for this — this gap is specific to the non-interactive CLI paths.)
- Adds a lightweight, TTY-gated `\r`-updated progress line during both the directory-discovery and file-parsing passes in `scanProjectDirs`, and yields to the event loop every 25 items in each pass so a long scan gives the OS scheduler more regular break points instead of running as one long block.
- Gated on `process.stderr.isTTY === true` so piped/captured output (`--no-color`, `export`, tests, any subprocess capturing stderr) is completely unaffected — verified by the full existing suite passing untouched.

## Verification
- Ran a true cold-cache scan against a real `~/.claude` tree with 934 project dirs / 18,182 session files (`rm ~/.cache/codeburn/session-cache.json` then `overview -p all` under a pty): 51s wall, 60% CPU (not pegged), progress visible throughout instead of silence. Warm-cache totals matched exactly before/after.
- `npx tsc --noEmit` clean.
- `npx vitest run`: all 121 test files / 1549 tests pass, unchanged.

## Test plan
- [x] Cold-cache run on a large real tree (934 dirs / 18k files) — progress renders, totals unchanged, CPU not pegged
- [x] Warm-cache run — no behavior change, no stray output
- [x] Piped/non-TTY output (`--no-color`, redirected to file) — no progress bytes leak into stdout/stderr
- [x] Full existing test suite passes unchanged
- [x] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)