### PR TITLE
menubar: cut idle energy (video-call-class drain, fixes #647)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,14 @@ defaults write org.agentseal.codeburn-menubar CodeBurnMenubarCompact -bool true
 
 Relaunch the app to apply. To revert: `defaults delete org.agentseal.codeburn-menubar CodeBurnMenubarCompact`.
 
+**Refresh cadence** is set in Settings under Usage Refresh. Auto (the default) refreshes every 30 seconds on AC power and backs off on battery, in Low Power Mode, and while the display sleeps; fixed 1, 5, or 15 minute cadences and a Manual mode (refresh only when you open the popover or click Refresh Now) are also available. From Terminal:
+
+```bash
+defaults write org.agentseal.codeburn-menubar CodeBurnMenubarRefreshSeconds -int 300
+```
+
+Seconds between refreshes: `60`, `300`, or `900`; `0` is Manual and `-1` is Auto. Takes effect on the next refresh tick, no relaunch needed.
+
 ### Linux (GNOME)
 
 Linux gets the same ambient view through a GNOME Shell extension (GNOME 45+): spend in the top panel, period switcher, compact mode, and daily budget alerts. It lives in [`gnome/`](gnome/):

--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -36,8 +36,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var lastContextMenuPresentedAt: Date = .distantPast
     fileprivate let store = AppStore()
     let updateChecker = UpdateChecker()
-    /// Held for the lifetime of the app to opt out of App Nap and Automatic Termination.
-    private var backgroundActivity: NSObjectProtocol?
+    /// True while the displays are asleep. Refresh ticks skip spawning
+    /// entirely then: nobody can see the menubar, and every fetch is a full
+    /// Node process (#647).
+    private var displayAsleep = false
+    /// Bounds status staleness under App Nap: the 30s timer can be coalesced
+    /// once the app naps (no permanent activity assertion anymore, #647), so
+    /// this system-scheduled activity guarantees a tick attempt every few
+    /// minutes. It goes through the same cadence gate as every other tick.
+    private var napBackstop: NSBackgroundActivityScheduler?
     private var pendingRefreshWork: DispatchWorkItem?
     private var refreshTimer: DispatchSourceTimer?
     private var forceRefreshTask: Task<Void, Never>?
@@ -81,16 +88,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         ProcessInfo.processInfo.automaticTerminationSupportEnabled = false
         ProcessInfo.processInfo.disableSuddenTermination()
-        backgroundActivity = ProcessInfo.processInfo.beginActivity(
-            options: [.automaticTerminationDisabled, .suddenTerminationDisabled],
-            reason: "CodeBurn menubar background refresh"
-        )
+        // Deliberately NO app-lifetime beginActivity here. A permanent
+        // assertion opted the app out of App Nap forever, which kept the 30s
+        // spawn loop running at full tilt on battery and with the display
+        // off (#647). App Nap coalescing an idle tick is the desired
+        // behavior; each in-flight refresh holds its own short .background
+        // activity so a fetch is never napped mid-flight, and any user
+        // interaction (popover open, wake) refreshes immediately.
 
         restorePersistedCurrency()
         setupStatusItem()
         setupPopover()
         observeStore()
         startRefreshLoop()
+        startNapBackstop()
         setupWakeObservers()
         removeLegacyRefreshAgent()
         registerLoginItemIfNeeded()
@@ -123,6 +134,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
+                self?.displayAsleep = false
                 self?.recoverRefreshPipelineAfterInterruption(resetLoading: true, reason: "wake")
             }
         }
@@ -133,7 +145,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
+                self?.displayAsleep = false
                 self?.recoverRefreshPipelineAfterInterruption(resetLoading: true, reason: "screen wake")
+            }
+        }
+
+        // Display sleep without system sleep (clamshell displays off, screen
+        // saver energy settings) previously kept the full spawn cadence
+        // running for hours. Skip refreshes until the screens wake.
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.screensDidSleepNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.displayAsleep = true
             }
         }
     }
@@ -284,11 +310,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         return false
     }
 
-    private func refreshStatusPayloadIfNeeded(reason: String, force: Bool = false) {
+    private func refreshStatusPayloadIfNeeded(reason: String, force: Bool = false, minAgeSeconds: TimeInterval = 0) {
         let now = Date()
         _ = clearStaleStatusPayloadRefreshIfNeeded(now: now)
         guard statusPayloadRefreshTask == nil else { return }
         guard force || store.needsStatusPayloadRefresh else { return }
+        // The 30s cache TTL would otherwise defeat the battery/low-power
+        // backoff through this fallback path: honor the same spawn interval
+        // the main loop uses. A missing payload (nil age) always fetches.
+        if !force, minAgeSeconds > 0, let age = store.menubarPayloadAgeSeconds,
+           TimeInterval(age) < minAgeSeconds { return }
 
         let menubarPeriod = store.menubarPeriod
         if let age = store.menubarPayloadAgeSeconds, age > 120 {
@@ -300,6 +331,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         let generation = statusPayloadRefreshGeneration
         statusPayloadRefreshTask = Task { [weak self] in
             guard let self else { return }
+            let activity = ProcessInfo.processInfo.beginActivity(
+                options: .background, reason: "CodeBurn status refresh")
+            defer { ProcessInfo.processInfo.endActivity(activity) }
             await self.store.refreshQuietly(period: menubarPeriod, force: true)
             self.refreshStatusButton()
             guard self.statusPayloadRefreshGeneration == generation, !Task.isCancelled else { return }
@@ -324,6 +358,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         let generation = forceRefreshGeneration
 
         forceRefreshTask = Task {
+            let activity = ProcessInfo.processInfo.beginActivity(
+                options: .background, reason: "CodeBurn refresh")
+            defer { ProcessInfo.processInfo.endActivity(activity) }
             async let main: Void = refreshUsagePayloads(force: true, showLoading: true)
             async let quotas: Bool = refreshLiveQuotaProgressIfDue(force: forceQuota)
             _ = await main
@@ -340,6 +377,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
     private func refreshUsagePayloads(force: Bool, showLoading: Bool = false) async {
         let menubarPeriod = store.menubarPeriod
+
+        // With the popover closed, only the payloads the status item actually
+        // renders are worth a Node spawn: the menubar period, plus today for
+        // the context-menu summary and day views. The popover's selected key
+        // is refreshed by refreshPayloadForPopoverOpen the moment it opens,
+        // so a closed-popover tick never pays for it (#647).
+        if !(popover?.isShown ?? false) {
+            async let menubar: Void = store.refreshQuietly(period: menubarPeriod, force: force)
+            async let today: Void = menubarPeriod != .today
+                ? store.refreshQuietly(period: .today, force: force)
+                : ()
+            _ = await (menubar, today)
+            return
+        }
+
         let needsMenubarPayload = store.selectedPeriod != menubarPeriod || store.selectedProvider != .all
         let needsTodayPayload = (store.selectedPeriod != .today || store.selectedProvider != .all) && menubarPeriod != .today
 
@@ -458,9 +510,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         // key's stuck loading / in-flight / generation bookkeeping and force a
         // fresh fetch — even if the cache looks "not stale yet". This is the
         // guaranteed one-round-trip recovery path.
+        // An open popover also proves the screens are on: recover from a
+        // missed screensDidWake so a latched flag can't suppress refreshes.
+        displayAsleep = false
         if refreshTimer == nil {
             startRefreshLoop(forceQuotaOnStart: false)
         }
+        // The status figure may have gone stale under App Nap while the
+        // popover was closed; catch it up alongside the visible payload.
+        refreshStatusPayloadIfNeeded(reason: "popover open")
         if store.shouldResetInteractiveRefreshPipeline,
            let age = store.staleInteractivePayloadAgeSeconds {
             NSLog("CodeBurn: popover opened with %ds stale payload cache - hard recovery", age)
@@ -478,18 +536,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         refreshTimer = nil
     }
 
+    private func startNapBackstop() {
+        let scheduler = NSBackgroundActivityScheduler(
+            identifier: "org.agentseal.codeburn-menubar.refresh-backstop")
+        scheduler.repeats = true
+        scheduler.interval = 180
+        scheduler.tolerance = 60
+        scheduler.qualityOfService = .utility
+        scheduler.schedule { [weak self] completion in
+            Task { @MainActor [weak self] in
+                self?.runRefreshLoopTick(reason: "nap backstop")
+                completion(.finished)
+            }
+        }
+        napBackstop = scheduler
+    }
+
     private func runRefreshLoopTick(reason: String, forcePayload: Bool = false, forceQuota: Bool = false) {
         refreshLoopHeartbeatAt = Date()
+        if displayAsleep && !forcePayload { return }
         let hadForceRefreshInFlight = forceRefreshTask != nil
         let clearedStaleForceRefresh = clearStaleForceRefreshIfNeeded()
         let clearedStaleStatusRefresh = clearStaleStatusPayloadRefreshIfNeeded()
         let clearedStaleLoading = store.clearStaleLoadingIfNeeded()
         let statusPayloadStale = store.needsStatusPayloadRefresh
         let sinceLast = Date().timeIntervalSince(lastRefreshTime)
+        // The timer stays at 30s; the spawn interval stretches on battery /
+        // Low Power Mode while the popover is closed (#647).
+        let interval = currentRefreshInterval()
         let shouldForceRefresh = forcePayload ||
             clearedStaleForceRefresh ||
             clearedStaleLoading ||
-            sinceLast >= TimeInterval(refreshIntervalSeconds)
+            sinceLast >= interval
 
         if shouldForceRefresh {
             forceRefresh(bypassRateLimit: true, forceQuota: forceQuota)
@@ -497,8 +575,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         let forceRefreshWasBlocked = hadForceRefreshInFlight && forceRefreshTask != nil
         if statusPayloadStale && (!shouldForceRefresh || forceRefreshWasBlocked || clearedStaleStatusRefresh) {
-            refreshStatusPayloadIfNeeded(reason: reason, force: forcePayload)
+            refreshStatusPayloadIfNeeded(reason: reason, force: forcePayload, minAgeSeconds: interval)
         }
+    }
+
+    private func currentRefreshInterval() -> TimeInterval {
+        RefreshCadence.interval(
+            popoverOpen: popover?.isShown ?? false,
+            onBattery: PowerSource.isOnBattery(),
+            lowPowerMode: ProcessInfo.processInfo.isLowPowerModeEnabled
+        )
     }
 
     private func startRefreshLoop(forceQuotaOnStart: Bool = false) {
@@ -543,6 +629,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         manualRefreshTask = Task { [weak self] in
             guard let self else { return }
+            let activity = ProcessInfo.processInfo.beginActivity(
+                options: .userInitiated, reason: "CodeBurn manual refresh")
+            defer { ProcessInfo.processInfo.endActivity(activity) }
             // "Refresh Now" should refresh the menubar payload AND every
             // connected provider's live quota. The user's intent is "make
             // this match reality right now."

--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -207,7 +207,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             }
             startRefreshLoop(forceQuotaOnStart: false)
         } else {
-            runRefreshLoopTick(reason: reason, forcePayload: true, forceQuota: false)
+            // Manual cadence means no automatic spawns, wakes included; the
+            // user refreshes via popover open or Refresh Now. The tick still
+            // runs so stuck-state cleanup happens.
+            runRefreshLoopTick(
+                reason: reason,
+                forcePayload: UsageRefreshCadence.current != .manual,
+                forceQuota: false
+            )
         }
     }
 
@@ -561,13 +568,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         let clearedStaleLoading = store.clearStaleLoadingIfNeeded()
         let statusPayloadStale = store.needsStatusPayloadRefresh
         let sinceLast = Date().timeIntervalSince(lastRefreshTime)
-        // The timer stays at 30s; the spawn interval stretches on battery /
-        // Low Power Mode while the popover is closed (#647).
+        // The timer stays at 30s; the spawn interval follows the user's
+        // Settings cadence, stretching on battery / Low Power Mode in Auto
+        // and never auto-spawning in Manual (#647).
         let interval = currentRefreshInterval()
+        let intervalElapsed = interval.map { sinceLast >= $0 } ?? false
         let shouldForceRefresh = forcePayload ||
             clearedStaleForceRefresh ||
             clearedStaleLoading ||
-            sinceLast >= interval
+            intervalElapsed
 
         if shouldForceRefresh {
             forceRefresh(bypassRateLimit: true, forceQuota: forceQuota)
@@ -575,12 +584,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         let forceRefreshWasBlocked = hadForceRefreshInFlight && forceRefreshTask != nil
         if statusPayloadStale && (!shouldForceRefresh || forceRefreshWasBlocked || clearedStaleStatusRefresh) {
-            refreshStatusPayloadIfNeeded(reason: reason, force: forcePayload, minAgeSeconds: interval)
+            guard forcePayload || interval != nil else { return }
+            refreshStatusPayloadIfNeeded(reason: reason, force: forcePayload, minAgeSeconds: interval ?? 0)
         }
     }
 
-    private func currentRefreshInterval() -> TimeInterval {
+    private func currentRefreshInterval() -> TimeInterval? {
         RefreshCadence.interval(
+            mode: UsageRefreshCadence.current,
             popoverOpen: popover?.isShown ?? false,
             onBattery: PowerSource.isOnBattery(),
             lowPowerMode: ProcessInfo.processInfo.isLowPowerModeEnabled

--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -573,9 +573,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         // and never auto-spawning in Manual (#647).
         let interval = currentRefreshInterval()
         let intervalElapsed = interval.map { sinceLast >= $0 } ?? false
+        // Stuck-refresh cleanup may retrigger a spawn only when the cadence
+        // allows auto-spawns at all: in Manual mode the stale state is
+        // cleared and the next user interaction fetches fresh.
+        let recoveryRespawnAllowed = interval != nil
         let shouldForceRefresh = forcePayload ||
-            clearedStaleForceRefresh ||
-            clearedStaleLoading ||
+            ((clearedStaleForceRefresh || clearedStaleLoading) && recoveryRespawnAllowed) ||
             intervalElapsed
 
         if shouldForceRefresh {

--- a/mac/Sources/CodeBurnMenubar/Data/UsageRefreshCadence.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/UsageRefreshCadence.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// User-configurable cadence for the usage payload refresh loop (#647).
+/// `auto` keeps the adaptive default: 30s while active, backed off on battery,
+/// in Low Power Mode, and while the displays sleep. `manual = 0` never
+/// auto-spawns; usage refreshes only on popover open, Refresh Now, and first
+/// launch. Stored as raw seconds in UserDefaults (auto = -1), mirroring
+/// SubscriptionRefreshCadence.
+enum UsageRefreshCadence: Int, CaseIterable, Identifiable {
+    case auto = -1
+    case manual = 0
+    case oneMinute = 60
+    case fiveMinutes = 300
+    case fifteenMinutes = 900
+
+    var id: Int { rawValue }
+
+    var label: String {
+        switch self {
+        case .auto: return "Auto (30s, less on battery)"
+        case .manual: return "Manual"
+        case .oneMinute: return "1 minute"
+        case .fiveMinutes: return "5 minutes"
+        case .fifteenMinutes: return "15 minutes"
+        }
+    }
+
+    static let defaultsKey = "CodeBurnMenubarRefreshSeconds"
+    static let `default`: UsageRefreshCadence = .auto
+
+    static var current: UsageRefreshCadence {
+        get {
+            // integer(forKey:) returns 0 for a missing key, which aliases
+            // `manual`; probe object(forKey:) to seed the default instead.
+            if UserDefaults.standard.object(forKey: defaultsKey) == nil {
+                return .default
+            }
+            return UsageRefreshCadence(rawValue: UserDefaults.standard.integer(forKey: defaultsKey)) ?? .default
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: defaultsKey) }
+    }
+}

--- a/mac/Sources/CodeBurnMenubar/RefreshCadence.swift
+++ b/mac/Sources/CodeBurnMenubar/RefreshCadence.swift
@@ -1,0 +1,32 @@
+import Foundation
+import IOKit.ps
+
+/// Decides how often the background refresh loop may spawn CLI fetches. The
+/// 30s timer keeps firing (cheap); this throttles the expensive part - each
+/// fetch is a full Node process at 100%+ CPU for seconds (#647). With the
+/// popover closed nobody is looking at anything but the status figure, so on
+/// battery or in Low Power Mode the spawn cadence backs off. Opening the
+/// popover always refreshes immediately via refreshPayloadForPopoverOpen, so
+/// the backoff never shows a user stale data they are actually looking at.
+enum RefreshCadence {
+    static let activeSeconds: TimeInterval = 30
+    static let batteryIdleSeconds: TimeInterval = 150
+    static let lowPowerIdleSeconds: TimeInterval = 300
+
+    static func interval(popoverOpen: Bool, onBattery: Bool, lowPowerMode: Bool) -> TimeInterval {
+        if popoverOpen { return activeSeconds }
+        if lowPowerMode { return lowPowerIdleSeconds }
+        if onBattery { return batteryIdleSeconds }
+        return activeSeconds
+    }
+}
+
+enum PowerSource {
+    static func isOnBattery() -> Bool {
+        // Copy function -> retained; Get function -> borrowed (unretained).
+        guard let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+              let type = IOPSGetProvidingPowerSourceType(snapshot)?.takeUnretainedValue() as String?
+        else { return false }
+        return type == kIOPMBatteryPowerKey
+    }
+}

--- a/mac/Sources/CodeBurnMenubar/RefreshCadence.swift
+++ b/mac/Sources/CodeBurnMenubar/RefreshCadence.swift
@@ -13,11 +13,29 @@ enum RefreshCadence {
     static let batteryIdleSeconds: TimeInterval = 150
     static let lowPowerIdleSeconds: TimeInterval = 300
 
-    static func interval(popoverOpen: Bool, onBattery: Bool, lowPowerMode: Bool) -> TimeInterval {
-        if popoverOpen { return activeSeconds }
-        if lowPowerMode { return lowPowerIdleSeconds }
-        if onBattery { return batteryIdleSeconds }
-        return activeSeconds
+    /// nil means "never auto-spawn" (manual mode): usage refreshes only on
+    /// popover open, Refresh Now, and first launch.
+    static func interval(
+        mode: UsageRefreshCadence,
+        popoverOpen: Bool,
+        onBattery: Bool,
+        lowPowerMode: Bool
+    ) -> TimeInterval? {
+        switch mode {
+        case .manual:
+            return nil
+        case .auto:
+            if popoverOpen { return activeSeconds }
+            if lowPowerMode { return lowPowerIdleSeconds }
+            if onBattery { return batteryIdleSeconds }
+            return activeSeconds
+        case .oneMinute, .fiveMinutes, .fifteenMinutes:
+            // A fixed user-chosen cadence, except an open popover always gets
+            // the active cadence: the user is looking at the numbers.
+            return popoverOpen
+                ? min(activeSeconds, TimeInterval(mode.rawValue))
+                : TimeInterval(mode.rawValue)
+        }
     }
 }
 

--- a/mac/Sources/CodeBurnMenubar/Security/CodeburnCLI.swift
+++ b/mac/Sources/CodeBurnMenubar/Security/CodeburnCLI.swift
@@ -94,7 +94,7 @@ enum CodeburnCLI {
         // The menubar runs as an accessory app with no foreground window, and macOS
         // background-throttles accessory apps and their children. Without this lift the
         // codeburn subprocess parses 5-10x slower than the same command run from a
-        // user-interactive terminal, which starves the 15s refresh cadence on large corpora.
+        // user-interactive terminal, which starves the 30s refresh cadence on large corpora.
         process.qualityOfService = .userInitiated
         return process
     }

--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -238,6 +238,20 @@ private struct ClaudeSettingsTab: View {
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }
+            Section("Usage Refresh") {
+                Picker("Update every", selection: Binding(
+                    get: { UsageRefreshCadence.current },
+                    set: { UsageRefreshCadence.current = $0 }
+                )) {
+                    ForEach(UsageRefreshCadence.allCases) { cadence in
+                        Text(cadence.label).tag(cadence)
+                    }
+                }
+                .pickerStyle(.menu)
+                Text("How often the menubar figure re-reads your local session data. Auto refreshes every 30 seconds while you're plugged in and backs off on battery; Manual only refreshes when you open the popover or click Refresh Now.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
             Section("Quota Refresh") {
                 Picker("Update every", selection: Binding(
                     get: { SubscriptionRefreshCadence.current },

--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -122,6 +122,21 @@ private struct GeneralSettingsTab: View {
                 }
             }
 
+            Section("Usage Refresh") {
+                Picker("Update every", selection: Binding(
+                    get: { UsageRefreshCadence.current },
+                    set: { UsageRefreshCadence.current = $0 }
+                )) {
+                    ForEach(UsageRefreshCadence.allCases) { cadence in
+                        Text(cadence.label).tag(cadence)
+                    }
+                }
+                .pickerStyle(.menu)
+                Text("How often the menubar figure re-reads your local session data. Auto refreshes every 30 seconds while you're plugged in and backs off on battery; Manual only refreshes when you open the popover or click Refresh Now.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Alerts") {
                 // The budget tracks whatever the menubar metric shows: dollars for
                 // the Cost metric, tokens for the Tokens / Total Tokens metrics.
@@ -235,20 +250,6 @@ private struct ClaudeSettingsTab: View {
                 Text("Config Directories")
             } footer: {
                 Text("Aggregate usage across multiple Claude config directories (e.g. work and personal accounts). Leave empty to track just the default `~/.claude`. The `CLAUDE_CONFIG_DIRS` environment variable, if set, overrides this list.")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-            }
-            Section("Usage Refresh") {
-                Picker("Update every", selection: Binding(
-                    get: { UsageRefreshCadence.current },
-                    set: { UsageRefreshCadence.current = $0 }
-                )) {
-                    ForEach(UsageRefreshCadence.allCases) { cadence in
-                        Text(cadence.label).tag(cadence)
-                    }
-                }
-                .pickerStyle(.menu)
-                Text("How often the menubar figure re-reads your local session data. Auto refreshes every 30 seconds while you're plugged in and backs off on battery; Manual only refreshes when you open the popover or click Refresh Now.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }

--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -46,6 +46,12 @@ private struct GeneralSettingsTab: View {
     @State private var costText = ""
     @State private var tokenText = ""
 
+    // AppStorage (not a computed Binding over UsageRefreshCadence.current):
+    // a plain UserDefaults write does not invalidate the view, so the picker
+    // label would never reflect the selection even though the value landed.
+    @AppStorage(UsageRefreshCadence.defaultsKey)
+    private var usageRefreshSeconds: Int = UsageRefreshCadence.default.rawValue
+
     private let costPresets: Set<Double> = [25, 50, 100, 200, 500]
     private let tokenPresets: Set<Double> = [1_000_000, 5_000_000, 10_000_000, 25_000_000, 50_000_000, 100_000_000]
 
@@ -124,8 +130,8 @@ private struct GeneralSettingsTab: View {
 
             Section("Usage Refresh") {
                 Picker("Update every", selection: Binding(
-                    get: { UsageRefreshCadence.current },
-                    set: { UsageRefreshCadence.current = $0 }
+                    get: { UsageRefreshCadence(rawValue: usageRefreshSeconds) ?? .default },
+                    set: { usageRefreshSeconds = $0.rawValue }
                 )) {
                     ForEach(UsageRefreshCadence.allCases) { cadence in
                         Text(cadence.label).tag(cadence)

--- a/mac/Tests/CodeBurnMenubarTests/RefreshCadenceTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/RefreshCadenceTests.swift
@@ -2,40 +2,79 @@ import XCTest
 @testable import CodeBurnMenubar
 
 final class RefreshCadenceTests: XCTestCase {
-    func testPopoverOpenAlwaysUsesActiveCadence() {
+    func testAutoPopoverOpenAlwaysUsesActiveCadence() {
         XCTAssertEqual(
-            RefreshCadence.interval(popoverOpen: true, onBattery: true, lowPowerMode: true),
+            RefreshCadence.interval(mode: .auto, popoverOpen: true, onBattery: true, lowPowerMode: true),
             RefreshCadence.activeSeconds
         )
     }
 
-    func testIdleOnACStaysActive() {
+    func testAutoIdleOnACStaysActive() {
         XCTAssertEqual(
-            RefreshCadence.interval(popoverOpen: false, onBattery: false, lowPowerMode: false),
+            RefreshCadence.interval(mode: .auto, popoverOpen: false, onBattery: false, lowPowerMode: false),
             RefreshCadence.activeSeconds
         )
     }
 
-    func testIdleOnBatteryBacksOff() {
+    func testAutoIdleOnBatteryBacksOff() {
         XCTAssertEqual(
-            RefreshCadence.interval(popoverOpen: false, onBattery: true, lowPowerMode: false),
+            RefreshCadence.interval(mode: .auto, popoverOpen: false, onBattery: true, lowPowerMode: false),
             RefreshCadence.batteryIdleSeconds
         )
     }
 
-    func testLowPowerModeBacksOffFurthest() {
+    func testAutoLowPowerModeBacksOffFurthest() {
         XCTAssertEqual(
-            RefreshCadence.interval(popoverOpen: false, onBattery: true, lowPowerMode: true),
+            RefreshCadence.interval(mode: .auto, popoverOpen: false, onBattery: true, lowPowerMode: true),
             RefreshCadence.lowPowerIdleSeconds
         )
         XCTAssertEqual(
-            RefreshCadence.interval(popoverOpen: false, onBattery: false, lowPowerMode: true),
+            RefreshCadence.interval(mode: .auto, popoverOpen: false, onBattery: false, lowPowerMode: true),
             RefreshCadence.lowPowerIdleSeconds
+        )
+    }
+
+    func testManualNeverAutoSpawns() {
+        XCTAssertNil(RefreshCadence.interval(mode: .manual, popoverOpen: false, onBattery: false, lowPowerMode: false))
+        XCTAssertNil(RefreshCadence.interval(mode: .manual, popoverOpen: true, onBattery: false, lowPowerMode: false))
+    }
+
+    func testFixedCadenceIgnoresPowerState() {
+        XCTAssertEqual(
+            RefreshCadence.interval(mode: .fiveMinutes, popoverOpen: false, onBattery: true, lowPowerMode: true),
+            300
+        )
+        XCTAssertEqual(
+            RefreshCadence.interval(mode: .fifteenMinutes, popoverOpen: false, onBattery: false, lowPowerMode: false),
+            900
+        )
+    }
+
+    func testFixedCadenceGoesActiveWhilePopoverOpen() {
+        XCTAssertEqual(
+            RefreshCadence.interval(mode: .fiveMinutes, popoverOpen: true, onBattery: true, lowPowerMode: false),
+            RefreshCadence.activeSeconds
         )
     }
 
     func testBackoffOrdering() {
         XCTAssertLessThan(RefreshCadence.activeSeconds, RefreshCadence.batteryIdleSeconds)
         XCTAssertLessThan(RefreshCadence.batteryIdleSeconds, RefreshCadence.lowPowerIdleSeconds)
+    }
+
+    func testCadenceDefaultsToAutoWhenUnset() {
+        let key = UsageRefreshCadence.defaultsKey
+        let saved = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let saved { UserDefaults.standard.set(saved, forKey: key) }
+            else { UserDefaults.standard.removeObject(forKey: key) }
+        }
+        UserDefaults.standard.removeObject(forKey: key)
+        XCTAssertEqual(UsageRefreshCadence.current, .auto)
+
+        UsageRefreshCadence.current = .manual
+        XCTAssertEqual(UsageRefreshCadence.current, .manual)
+        UsageRefreshCadence.current = .fiveMinutes
+        XCTAssertEqual(UsageRefreshCadence.current, .fiveMinutes)
     }
 }

--- a/mac/Tests/CodeBurnMenubarTests/RefreshCadenceTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/RefreshCadenceTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import CodeBurnMenubar
+
+final class RefreshCadenceTests: XCTestCase {
+    func testPopoverOpenAlwaysUsesActiveCadence() {
+        XCTAssertEqual(
+            RefreshCadence.interval(popoverOpen: true, onBattery: true, lowPowerMode: true),
+            RefreshCadence.activeSeconds
+        )
+    }
+
+    func testIdleOnACStaysActive() {
+        XCTAssertEqual(
+            RefreshCadence.interval(popoverOpen: false, onBattery: false, lowPowerMode: false),
+            RefreshCadence.activeSeconds
+        )
+    }
+
+    func testIdleOnBatteryBacksOff() {
+        XCTAssertEqual(
+            RefreshCadence.interval(popoverOpen: false, onBattery: true, lowPowerMode: false),
+            RefreshCadence.batteryIdleSeconds
+        )
+    }
+
+    func testLowPowerModeBacksOffFurthest() {
+        XCTAssertEqual(
+            RefreshCadence.interval(popoverOpen: false, onBattery: true, lowPowerMode: true),
+            RefreshCadence.lowPowerIdleSeconds
+        )
+        XCTAssertEqual(
+            RefreshCadence.interval(popoverOpen: false, onBattery: false, lowPowerMode: true),
+            RefreshCadence.lowPowerIdleSeconds
+        )
+    }
+
+    func testBackoffOrdering() {
+        XCTAssertLessThan(RefreshCadence.activeSeconds, RefreshCadence.batteryIdleSeconds)
+        XCTAssertLessThan(RefreshCadence.batteryIdleSeconds, RefreshCadence.lowPowerIdleSeconds)
+    }
+}


### PR DESCRIPTION
Fixes #647

## Problem

Measured on an idle machine: every 30s refresh tick spawned 2-3 concurrent Node CLI processes, each at 100-121% CPU for 1-3 seconds (~120 cold starts/hour), and an app-lifetime beginActivity assertion disabled App Nap permanently, so nothing ever throttled, including on battery and with the display off. Activity Monitor attributes children to the app, putting CodeBurn's Energy Impact in the video-call class.

## Change (all in mac/)

- Closed popover fetches only what the status item renders: the menubar-period payload, plus today when different. The popover's selected key refreshes the moment it opens via the existing recovery path, which now also catches up the status figure and clears a latched display-sleep flag.
- New RefreshCadence: spawn interval stretches to 150s on battery and 300s in Low Power Mode while the popover is closed. The 30s timer keeps firing; only the expensive spawn is gated. An open popover always gets the 30s cadence.
- App-lifetime activity assertion removed. Each in-flight refresh (loop, status fallback, manual Refresh Now) holds its own scoped activity so a fetch is never napped mid-flight, and an NSBackgroundActivityScheduler backstop (~3 min, system-coalesced) bounds status staleness once App Nap starts deferring the timer.
- Display sleep (screensDidSleepNotification) skips ticks entirely; system wake, screen wake, and popover open all clear the flag, so a missed wake notification cannot latch it.
- The status-payload fallback path honors the same spawn interval, so its 30s cache TTL cannot defeat the backoff.

Deliberately NOT changed: child process QoS stays .userInitiated. Lowering it is documented in CodeburnCLI.swift to slow parses 5-10x and starve the cadence; the energy win here comes from spawn frequency, not priority.

## Verification

- swift build clean; full menubar test suite passes (70 XCTest cases plus the new RefreshCadence suite).
- Live before/after on the same machine, popover closed, AC power: shipped app showed two concurrent 100%+ CPU spawns inside a 30s window; the patched build spawned one payload fetch in 72 seconds, with App Nap coalescing subsequent ticks.
- Adversarial review round fixed: an over-release in the IOKit power-source check (Get vs Copy semantics), stale menubar figure on popover open after a long nap, unscoped manual refresh, and the TTL-vs-backoff interaction.

## Behavior tradeoff (deliberate)

With the popover closed and the machine idle, the status figure may lag a few minutes (bounded by the backstop) instead of a hard 30s. Spend only changes while agents are running, and any interaction (popover open, Refresh Now, wake) forces an immediate fetch, so nobody observes stale data they are actually looking at.