### PR TITLE
Isolate a throwing provider so one bad file can't blank every scan

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -226,14 +226,40 @@ export async function getAllProviders(): Promise<Provider[]> {
 
 export const providers = coreProviders
 
-export async function discoverAllSessions(providerFilter?: string): Promise<SessionSource[]> {
-  const allProviders = await getAllProviders()
+// Isolate one provider's discovery. A provider that throws (a crafted/corrupt
+// file reaching a string op, an unexpected on-disk shape) must never take down
+// the whole scan and blank every other provider's usage. Warn once per
+// provider per run, then skip it. Mirrors the parse-failure isolation already
+// used per-file in parser.ts.
+const warnedDiscoveryFailures = new Set<string>()
+export async function safeDiscoverSessions(provider: Provider): Promise<SessionSource[]> {
+  try {
+    return await provider.discoverSessions()
+  } catch (err) {
+    if (!warnedDiscoveryFailures.has(provider.name)) {
+      warnedDiscoveryFailures.add(provider.name)
+      const msg = err instanceof Error ? err.message : String(err)
+      process.stderr.write(
+        `codeburn: skipped ${provider.name} discovery after an error: ${msg}\n`
+      )
+    }
+    return []
+  }
+}
+
+export async function discoverAllSessions(
+  providerFilter?: string,
+  // Injectable for tests so the isolation loop itself is exercised, not just
+  // the helper. Defaults to the real registry.
+  providerList?: Provider[],
+): Promise<SessionSource[]> {
+  const allProviders = providerList ?? await getAllProviders()
   const filtered = providerFilter && providerFilter !== 'all'
     ? allProviders.filter(p => p.name === providerFilter)
     : allProviders
   const all: SessionSource[] = []
   for (const provider of filtered) {
-    const sessions = await provider.discoverSessions()
+    const sessions = await safeDiscoverSessions(provider)
     all.push(...sessions)
   }
   return all

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -3,7 +3,7 @@ import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory, type DateRange
 import { type PeriodData, type ProviderCost, type BreakdownArrays, type MenubarPayload, buildMenubarPayload } from './menubar-json.js'
 import { parseAllSessions, filterProjectsByName, filterProjectsByDays } from './parser.js'
 import { findUnpricedModels, getLocalModelSavingsConfigHash, getPriceOverridesConfigHash, getShortModelName } from './models.js'
-import { getAllProviders } from './providers/index.js'
+import { getAllProviders, safeDiscoverSessions } from './providers/index.js'
 import { aggregateProjectsIntoDays, buildPeriodDataFromDays } from './day-aggregator.js'
 import { aggregateModelEfficiency } from './model-efficiency.js'
 import { aggregateModels } from './models-report.js'
@@ -200,7 +200,7 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
     }
     for (const p of allProviders) {
       if (providers.some(pc => pc.name === p.displayName)) continue
-      const sources = await p.discoverSessions()
+      const sources = await safeDiscoverSessions(p)
       if (sources.length > 0) providers.push({ name: p.displayName, cost: 0 })
     }
   } else {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from 'vitest'
-import { providers, getAllProviders, getProvider } from '../src/providers/index.js'
+import { describe, it, expect, vi } from 'vitest'
+import { providers, getAllProviders, getProvider, safeDiscoverSessions, discoverAllSessions } from '../src/providers/index.js'
+import type { Provider } from '../src/providers/types.js'
+
+function fakeProvider(name: string, discover: Provider['discoverSessions']): Provider {
+  return {
+    name,
+    displayName: name,
+    modelDisplayName: (m: string) => m,
+    toolDisplayName: (t: string) => t,
+    discoverSessions: discover,
+  } as unknown as Provider
+}
 
 describe('provider registry', () => {
   it('has core providers registered synchronously', () => {
@@ -116,5 +127,45 @@ describe('provider registry', () => {
     expect(cursor.modelDisplayName('claude-4.5-opus-high-thinking')).toBe('Opus 4.5 (Thinking)')
     expect(cursor.modelDisplayName('grok-code-fast-1')).toBe('Grok Code Fast')
     expect(cursor.modelDisplayName('unknown-model')).toBe('unknown-model')
+  })
+
+  describe('provider-discovery isolation', () => {
+    it('safeDiscoverSessions returns [] and warns once instead of propagating', async () => {
+      const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+      const boom = fakeProvider('boom-helper', async () => { throw new Error('crafted file blew up') })
+      try {
+        await expect(safeDiscoverSessions(boom)).resolves.toEqual([])
+        expect(warn.mock.calls.length).toBeGreaterThanOrEqual(1)
+        expect(String(warn.mock.calls[0]![0])).toContain('boom-helper')
+        // Deduped on repeat within the same run: no additional warning.
+        const afterFirst = warn.mock.calls.length
+        await safeDiscoverSessions(boom)
+        expect(warn.mock.calls.length).toBe(afterFirst)
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
+    it('discoverAllSessions drops a throwing provider but keeps the healthy ones', async () => {
+      const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+      const boom = fakeProvider('boom-loop', async () => { throw new Error('kaboom') })
+      const ok1 = fakeProvider('ok1', async () => [{ path: '/a.jsonl', project: 'p1', provider: 'ok1' }])
+      const ok2 = fakeProvider('ok2', async () => [{ path: '/b.jsonl', project: 'p2', provider: 'ok2' }])
+      try {
+        // A throwing provider in the middle must not abort the loop.
+        const sources = await discoverAllSessions('all', [ok1, boom, ok2])
+        expect(sources.map(s => s.path)).toEqual(['/a.jsonl', '/b.jsonl'])
+        expect(warn.mock.calls.some(c => String(c[0]).includes('boom-loop'))).toBe(true)
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
+    it('discoverAllSessions honors the provider filter', async () => {
+      const ok1 = fakeProvider('keep', async () => [{ path: '/keep.jsonl', project: 'k', provider: 'keep' }])
+      const ok2 = fakeProvider('drop', async () => [{ path: '/drop.jsonl', project: 'd', provider: 'drop' }])
+      const sources = await discoverAllSessions('keep', [ok1, ok2])
+      expect(sources.map(s => s.path)).toEqual(['/keep.jsonl'])
+    })
   })
 })


### PR DESCRIPTION
## Problem
Both provider-discovery loops — `discoverAllSessions` (src/providers/index.ts, used by the parser and optimize) and the menubar provider enumeration (src/usage-aggregator.ts) — called `discoverSessions()` with no try/catch. So any provider that threw (a crafted or corrupt file reaching a string op, an unexpected on-disk shape) took down usage discovery for all 32 providers at once, blanking the whole dashboard, CLI, and menubar. This is the same failure class as #441; it surfaced concretely during the review of the LingTai provider (#649), where a wrong-typed config file crashed the entire scan.

## Fix
`safeDiscoverSessions(provider)` wraps discovery in try/catch, warns once per provider per run to stderr (matching the per-file parse-failure isolation already in parser.ts and the whole-data-loss notices in fs-utils.ts), and returns `[]` instead of aborting. Both loop sites use it. A dropped provider's healthy siblings are unaffected.

## Testing
- `discoverAllSessions` now takes an injectable provider list so the isolation loop itself is exercised, not just the helper.
- **Mutation-verified**: reverting either call site to the unguarded call fails the new loop-level test; restoring passes.
- Full suite: 3,063 tests pass. tsc clean. Real discovery confirmed intact on live data.

## Reviewed by Codex 5.6
Adversarial pass confirmed the isolation is complete (no remaining unguarded call), no partial-data/double-count risk (discoverSessions is atomic per provider), no concurrency or circular-import issues. It also raised two enhancements I deliberately scoped OUT to keep this a tight isolation fix — documented as a follow-up below.

## Follow-up (separate, not in this PR)
1. Surface a structured "incomplete discovery" flag in the JSON/MCP payload so resident consumers (MCP server, web dashboard) can distinguish a genuine \$0 from a dropped provider, rather than showing "No usage recorded" as authoritative.
2. Scope the warn-dedup per top-level request rather than per process lifetime (matters only for the resident MCP server; the menubar spawns fresh each time). This matches the existing warn-cache convention in the codebase, so changing it is a cross-cutting cleanup.