### PR TITLE
Cold-scan progress indicator (hardened) — supersedes #637

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeburn",
-  "version": "0.9.12",
+  "version": "0.9.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeburn",
-      "version": "0.9.12",
+      "version": "0.9.15",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/compare.tsx
+++ b/src/compare.tsx
@@ -4,7 +4,7 @@ import { render, Box, Text, useInput, useApp, useStdout } from 'ink'
 import type { ModelStats, ComparisonRow, CategoryComparison, WorkingStyleRow } from './compare-stats.js'
 import { aggregateModelStats, computeComparison, computeCategoryComparison, computeWorkingStyle, scanSelfCorrections } from './compare-stats.js'
 import { formatCost } from './format.js'
-import { parseAllSessions } from './parser.js'
+import { parseAllSessions, setInteractiveScanUI } from './parser.js'
 import { getAllProviders } from './providers/index.js'
 import type { ProjectSummary, DateRange } from './types.js'
 import { patchStdoutForWindows } from './ink-win.js'
@@ -467,6 +467,10 @@ export function CompareView({ projects, onBack }: CompareViewProps) {
 }
 
 export async function renderCompare(range: DateRange, provider: string): Promise<void> {
+  // Interactive Ink UI: suppress the CLI scan-progress line for the whole
+  // lifetime so it can't print over the rendered comparison. Plain CLI
+  // commands still show progress.
+  setInteractiveScanUI()
   const isTTY = process.stdin.isTTY && process.stdout.isTTY
   if (!isTTY) {
     process.stdout.write('Model comparison requires an interactive terminal.\n')

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -5,7 +5,7 @@ import { render, Box, Text, useInput, useApp, useWindowSize } from 'ink'
 import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory } from './types.js'
 import { formatCost, formatTokens } from './format.js'
 import { aggregateModelEfficiency } from './model-efficiency.js'
-import { parseAllSessions, filterProjectsByName } from './parser.js'
+import { parseAllSessions, filterProjectsByName, setInteractiveScanUI } from './parser.js'
 import { findUnpricedModels, loadPricing } from './models.js'
 import { getAllProviders } from './providers/index.js'
 import { scanAndDetect, type WasteFinding, type WasteAction, type OptimizeResult } from './optimize.js'
@@ -1086,6 +1086,11 @@ function StaticDashboard({ projects, period, activeProvider, planUsages, label, 
 }
 
 export async function renderDashboard(period: Period = 'week', provider: string = 'all', refreshSeconds?: number, projectFilter?: string[], excludeFilter?: string[], customRange?: DateRange | null, customRangeLabel?: string, initialDay?: string): Promise<void> {
+  // Interactive Ink UI: it renders to the same terminal and has its own in-frame
+  // loading state, so the CLI scan-progress line must stay silent for its whole
+  // lifetime (initial scan and every 30s auto-refresh, including the
+  // getPlanUsages → parseAllSessions path). Plain CLI commands are unaffected.
+  setInteractiveScanUI()
   await loadPricing()
   const dayRange = initialDay ? getDayRange(initialDay) : null
   const range = dayRange ?? customRange ?? getPeriodRange(period)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1986,8 +1986,22 @@ function yieldToEventLoop(): Promise<void> {
   return new Promise(resolve => setImmediate(resolve))
 }
 
-function createScanProgress(label: string, total: number) {
-  const show = total > 20 && process.stderr.isTTY === true
+// Suppress the scan-progress line while an interactive Ink UI is live. The
+// dashboard and compare render to stdout on the same terminal, and their scans
+// run (dashboard) or re-run every 30s (dashboard auto-refresh, including the
+// getPlanUsages → parseAllSessions path) AFTER render() has painted a frame, so
+// a `\r` progress line on stderr prints over it and garbles the screen. isTTY
+// alone can't tell them apart from a plain CLI command. The interactive
+// entrypoints call setInteractiveScanUI() right before render(); a pre-render
+// scan (e.g. compare's cold start) still shows progress and finish() clears the
+// line before Ink paints.
+let interactiveScanUI = false
+export function setInteractiveScanUI(active = true): void {
+  interactiveScanUI = active
+}
+
+export function createScanProgress(label: string, total: number) {
+  const show = !interactiveScanUI && total > 20 && process.stderr.isTTY === true
   let lastWrite = 0
   return {
     async tick(done: number): Promise<void> {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1530,6 +1530,8 @@ async function scanProjectDirs(
   const unchangedFiles: Array<{ filePath: string; dirName: string; cached: CachedFile }> = []
   const changedFiles: Array<{ filePath: string; info: FileInfo }> = []
 
+  const discoverProgress = createScanProgress('scanning claude project dirs', dirs.length)
+  let dirsDone = 0
   for (const { path: dirPath, name: dirName } of dirs) {
     const jsonlFiles = await collectJsonlFiles(dirPath)
     for (const filePath of jsonlFiles) {
@@ -1544,7 +1546,10 @@ async function scanProjectDirs(
         changedFiles.push({ filePath, info: { dirName, fp } })
       }
     }
+    dirsDone++
+    await discoverProgress.tick(dirsDone)
   }
+  discoverProgress.finish()
 
   // Pre-seed dedup set from cached (unchanged) files
   for (const { cached } of unchangedFiles) {
@@ -1555,13 +1560,15 @@ async function scanProjectDirs(
     }
   }
 
+  const parseProgress = createScanProgress('parsing changed claude sessions', changedFiles.length)
+  let filesDone = 0
   for (const { filePath, info } of changedFiles) {
     delete section.files[filePath]
 
     try {
       const tracker = { lastCompleteLineOffset: 0 }
       const entries = await parseClaudeEntries(filePath, tracker)
-      if (!entries) continue
+      if (!entries) { filesDone++; await parseProgress.tick(filesDone); continue }
 
       const turns = groupIntoTurns(dedupeStreamingMessageIds(entries), seenMsgIds)
       const cwd = extractCanonicalCwd(entries)
@@ -1586,7 +1593,10 @@ async function scanProjectDirs(
       ;(diskCache as { _dirty?: boolean })._dirty = true
       warnProviderParseFailure('claude', filePath, err)
     }
+    filesDone++
+    await parseProgress.tick(filesDone)
   }
+  parseProgress.finish()
 
   if (dirs.length > 0) {
     for (const cachedPath of Object.keys(section.files)) {
@@ -1955,6 +1965,44 @@ function warnProviderParseFailure(providerName: string, sourcePath: string, err:
   process.stderr.write(
     `codeburn: skipped ${providerName} session that failed to parse: ${sourcePath} (${msg})${tail}\n`
   )
+}
+
+// A cold-cache scan over a large ~/.claude/projects tree (hundreds of project
+// dirs, e.g. a git-worktree-per-task workflow) can run long enough that it
+// looks hung, and is CPU-heavy enough on a single thread to visibly compete
+// with anything else running interactively on the same machine. Two cheap
+// mitigations, neither of which reduces total CPU work: (1) a `\r`-updated
+// progress line so a long cold run reads as "working" instead of "stuck",
+// gated on isTTY so it never corrupts piped/captured output (export.ts, the
+// --no-color path, or a subprocess capturing stderr); (2) yielding to the
+// event loop every YIELD_EVERY items so the OS scheduler gets regular break
+// points instead of one long uninterrupted synchronous block. This does NOT
+// fix CPU contention with a separate process (that's the OS scheduler's job
+// regardless), it only keeps this process itself responsive and honest about
+// progress during the scan.
+const YIELD_EVERY = 25
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise(resolve => setImmediate(resolve))
+}
+
+function createScanProgress(label: string, total: number) {
+  const show = total > 20 && process.stderr.isTTY === true
+  let lastWrite = 0
+  return {
+    async tick(done: number): Promise<void> {
+      if (done % YIELD_EVERY === 0) await yieldToEventLoop()
+      if (!show) return
+      const now = Date.now()
+      if (done !== total && now - lastWrite < 100) return
+      lastWrite = now
+      process.stderr.write(`\rcodeburn: ${label} ${done}/${total}…`)
+    },
+    finish(): void {
+      if (!show) return
+      process.stderr.write('\r\x1b[K')
+    },
+  }
 }
 
 async function parseProviderSources(

--- a/tests/scan-progress.test.ts
+++ b/tests/scan-progress.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createScanProgress, setInteractiveScanUI } from '../src/parser.js'
+
+// The scan-progress line must be silent while an interactive Ink UI (dashboard,
+// compare) is live, because it renders to the same terminal. The end-to-end
+// proof (cold dashboard WITH a plan stays silent; cold overview shows progress)
+// is documented in the PR and was run under a PTY.
+describe('createScanProgress gate', () => {
+  const origTTY = process.stderr.isTTY
+
+  afterEach(() => {
+    setInteractiveScanUI(false)
+    Object.defineProperty(process.stderr, 'isTTY', { value: origTTY, configurable: true })
+    vi.restoreAllMocks()
+  })
+
+  function forceTTY(v: boolean) {
+    Object.defineProperty(process.stderr, 'isTTY', { value: v, configurable: true })
+  }
+
+  it('writes progress for a plain CLI command in a TTY over the threshold', async () => {
+    forceTTY(true)
+    const w = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    const p = createScanProgress('scanning', 100)
+    await p.tick(100) // final tick bypasses the 100ms throttle
+    expect(w).toHaveBeenCalled()
+    expect(String(w.mock.calls[0]![0])).toContain('scanning 100/100')
+  })
+
+  it('goes silent once an interactive Ink UI is active, even in a TTY', async () => {
+    forceTTY(true)
+    setInteractiveScanUI() // dashboard/compare call this right before render()
+    const w = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    const p = createScanProgress('scanning', 100)
+    for (let i = 1; i <= 100; i++) await p.tick(i)
+    p.finish()
+    expect(w).not.toHaveBeenCalled()
+  })
+
+  it('finish() clears the line when progress was shown', async () => {
+    forceTTY(true)
+    const w = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    const p = createScanProgress('scanning', 100)
+    await p.tick(100)
+    w.mockClear()
+    p.finish()
+    expect(String(w.mock.calls[0]![0])).toBe('\r\x1b[K')
+  })
+
+  it('writes nothing when stderr is not a TTY (piped/captured output)', async () => {
+    forceTTY(false)
+    const w = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    const p = createScanProgress('scanning', 100)
+    await p.tick(100)
+    p.finish()
+    expect(w).not.toHaveBeenCalled()
+  })
+
+  it('stays silent below the small-tree threshold', async () => {
+    forceTTY(true)
+    const w = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    const p = createScanProgress('scanning', 5)
+    await p.tick(5)
+    expect(w).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Supersedes #637 (credit: @41fred, commit preserved with the Claude co-author trailer stripped for CI). One hardening commit added on top.

## What #637 does
A cold-cache scan over a large `~/.claude/projects` tree runs 30-50s with no output, reading as a hang. #637 adds a `\r`-updated progress line during the scan plus event-loop yielding every 25 items.

## The bug it had
Gated only on `process.stderr.isTTY`, which is also true when the interactive dashboard and `codeburn compare` render Ink to the same terminal — so the progress line printed over their frame and garbled the TUI (reproduced under a PTY).

## The fix
Gate on an explicit "an interactive Ink UI is live" flag. `renderDashboard` and `renderCompare` call `setInteractiveScanUI()` before rendering, so every scan they trigger (including the dashboard's 30s auto-refresh and its `getPlanUsages → parseAllSessions` path) stays silent, while plain CLI commands keep the progress line. Event-loop yielding stays ungated.

## Verification
- Interactive dashboard (even `--refresh 3` forcing rescans): 0 progress bytes; renders correctly.
- `codeburn compare`: 0 progress bytes; renders correctly.
- `codeburn overview` and 13 other plain commands: work; overview shows progress.
- Full CLI smoke test: all 14 non-interactive data commands, 12 config/utility commands, 3 provider-filtered commands, and both interactive TUIs pass with no crash.
- Piped/non-TTY: silent. Full suite: 1,572 tests pass. tsc clean. Warm-cache totals unchanged.

## Reviewed by Fable 5 (adversarial)
Caught that my first approach missed a transitive scan path (`getPlanUsages`) and over-suppressed compare's progress, leading to this module-flag design. (The specific plan-usage corruption did not reproduce even when forced — caching absorbs it — but the flag defends against that whole class.)