### PR TITLE
Menubar runs on macOS 14 (Sonoma), hardened (supersedes #577)

### DIFF
--- a/mac/Package.swift
+++ b/mac/Package.swift
@@ -4,7 +4,11 @@ import PackageDescription
 let package = Package(
     name: "CodeBurnMenubar",
     platforms: [
-        .macOS(.v15)
+        // macOS 14 (Sonoma) is the floor: matches Info.plist LSMinimumSystemVersion,
+        // the CLI install guard (MIN_MACOS_MAJOR=14), and mac/README. The earlier .v15
+        // bump for NSAttributedString(attachment:) was a misdiagnosis — that initializer
+        // is AppKit since macOS 10.0, so the binary's minos must not exclude Sonoma users.
+        .macOS(.v14)
     ],
     products: [
         .executable(name: "CodeBurnMenubar", targets: ["CodeBurnMenubar"])

--- a/mac/Package.swift
+++ b/mac/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     platforms: [
         // macOS 14 (Sonoma) is the floor: matches Info.plist LSMinimumSystemVersion,
         // the CLI install guard (MIN_MACOS_MAJOR=14), and mac/README. The earlier .v15
-        // bump for NSAttributedString(attachment:) was a misdiagnosis — that initializer
+        // bump for NSAttributedString(attachment:) was a misdiagnosis, that initializer
         // is AppKit since macOS 10.0, so the binary's minos must not exclude Sonoma users.
         .macOS(.v14)
     ],

--- a/mac/README.md
+++ b/mac/README.md
@@ -35,8 +35,15 @@ swift build -c release
 `swift build` above assumes the macOS 15 SDK, whose SwiftUI marks the `View`
 protocol `@MainActor`. The Sonoma SDK (shipped with Command Line Tools) lacks
 that annotation, so a plain build fails with ~80 `main actor-isolated ... from a
-nonisolated context` errors, and a stock CI build links the macOS-15-only
-`libswift_errno.dylib` (the root of the `-10825` launch failure on Sonoma).
+nonisolated context` errors.
+
+(The `-10825` launch failure itself is fixed by `Package.swift`'s `.macOS(.v14)`
+deployment target: ld64 drops the macOS-15-only `libswift_errno.dylib`
+dependency for any build with that target, regardless of which SDK built it —
+including the CI-distributed release. This local-build path exists only for
+the narrower case of building on a Sonoma machine with nothing but the
+Command Line Tools, where the SDK's un-annotated `View` protocol needs the
+`@MainActor` patch below.)
 
 Use the helper, which builds against the local macOS 14 SDK with a standalone
 [swift.org](https://www.swift.org/install/macos/) Swift 6.x toolchain and

--- a/mac/README.md
+++ b/mac/README.md
@@ -30,6 +30,23 @@ swift build -c release
 .build/release/CodeBurnMenubar                # launch
 ```
 
+#### On macOS 14 (Sonoma) without Xcode 16
+
+`swift build` above assumes the macOS 15 SDK, whose SwiftUI marks the `View`
+protocol `@MainActor`. The Sonoma SDK (shipped with Command Line Tools) lacks
+that annotation, so a plain build fails with ~80 `main actor-isolated ... from a
+nonisolated context` errors, and a stock CI build links the macOS-15-only
+`libswift_errno.dylib` (the root of the `-10825` launch failure on Sonoma).
+
+Use the helper, which builds against the local macOS 14 SDK with a standalone
+[swift.org](https://www.swift.org/install/macos/) Swift 6.x toolchain and
+adds explicit `@MainActor` to the views in a scratch copy (repo sources stay
+clean), producing a `minos = 14.0` bundle installed to `~/Applications`:
+
+```bash
+mac/Scripts/build-local.sh         # then: codeburn menubar
+```
+
 ## Build & run (dev against a local CLI checkout)
 
 ```bash
@@ -52,7 +69,10 @@ Release installs record a persistent absolute CLI path in `~/Library/Application
 
 ```
 mac/
-├── Package.swift                     SwiftPM manifest
+├── Package.swift                     SwiftPM manifest (deployment target: macOS 14)
+├── Scripts/
+│   ├── package-app.sh                CI: universal signed .app + zip + checksum
+│   └── build-local.sh                Local macOS 14 build (Sonoma SDK + @MainActor patch)
 ├── Sources/CodeBurnMenubar/
 │   ├── CodeBurnApp.swift             @main + MenuBarExtra scene
 │   ├── AppStore.swift                @Observable store + enums

--- a/mac/README.md
+++ b/mac/README.md
@@ -39,8 +39,7 @@ nonisolated context` errors.
 
 (The `-10825` launch failure itself is fixed by `Package.swift`'s `.macOS(.v14)`
 deployment target: ld64 drops the macOS-15-only `libswift_errno.dylib`
-dependency for any build with that target, regardless of which SDK built it —
-including the CI-distributed release. This local-build path exists only for
+dependency for any build with that target, regardless of which SDK built it, including the CI-distributed release. This local-build path exists only for
 the narrower case of building on a Sonoma machine with nothing but the
 Command Line Tools, where the SDK's un-annotated `View` protocol needs the
 `@MainActor` patch below.)

--- a/mac/Scripts/build-local.sh
+++ b/mac/Scripts/build-local.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# ============================================================================
+# build-local.sh — Build CodeBurnMenubar.app on a macOS 14 (Sonoma) machine.
+# ============================================================================
+# Why this exists
+# ---------------
+# The released .app is built in CI with the macOS 15 SDK + Swift 6. That binary
+# hard-links /usr/lib/swift/libswift_errno.dylib, which only ships in macOS 15,
+# so `codeburn menubar` fails on Sonoma with:
+#     kLSIncompatibleSystemVersionErr (-10825)
+#
+# This script builds an arm64 bundle locally against the machine's macOS 14 SDK
+# (no libswift_errno dependency, minos = 14.0) using a swift.org Swift 6.2
+# toolchain. Because the macOS 14 SDK's SwiftUI does NOT carry the @MainActor
+# annotations that the macOS 15 SDK added to the `View` protocol, the sources
+# are copied to a scratch dir and every `View`/`App` struct is given an explicit
+# `@MainActor` there — the repo sources stay untouched.
+#
+# Prerequisites
+#   - Command Line Tools (provides the macOS 14 SDK + sips/iconutil/codesign)
+#   - A swift.org Swift 6.x toolchain in ~/Library/Developer/Toolchains/
+#       download: https://www.swift.org/install/macos/  (Swift 6.2 recommended)
+#
+# Usage: mac/Scripts/build-local.sh [<version>]   (defaults to "dev")
+# ----------------------------------------------------------------------------
+set -euo pipefail
+
+VERSION="${1:-dev}"
+BUNDLE_ID="org.agentseal.codeburn-menubar"
+EXE="CodeBurnMenubar"
+MIN_MACOS="14.0"
+
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+MAC_DIR="${ROOT}/mac"
+ICON_SOURCE="${ROOT}/assets/menubar-logo.png"
+SCRATCH="$(mktemp -d /tmp/codeburn-local-build.XXXXXX)"
+APPS="${HOME}/Applications"
+BUNDLE="${APPS}/${EXE}.app"
+
+trap 'rm -rf "${SCRATCH}"' EXIT
+
+# --- locate a Swift 6.x toolchain -------------------------------------------
+TC=""
+for cand in "${HOME}/Library/Developer/Toolchains/swift-6.2-RELEASE.xctoolchain" \
+            "${HOME}/Library/Developer/Toolchains/swift-latest.xctoolchain" \
+            /Library/Developer/Toolchains/swift-latest.xctoolchain; do
+  [[ -x "${cand}/usr/bin/swift" ]] && { TC="${cand}"; break; }
+done
+if [[ -z "${TC}" ]]; then
+  echo "✗ No swift.org Swift 6.x toolchain found in ~/Library/Developer/Toolchains/." >&2
+  echo "  Install one from https://www.swift.org/install/macos/ (Swift 6.2)." >&2
+  exit 1
+fi
+SWIFT="${TC}/usr/bin/swift"
+export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+echo "▸ Toolchain : $("${SWIFT}" --version | head -1)"
+echo "▸ SDK       : ${SDKROOT} ($(xcrun --sdk macosx --show-sdk-version))"
+
+# --- copy sources and add explicit @MainActor to SwiftUI views --------------
+echo "▸ Staging sources in ${SCRATCH}..."
+# Tests/ is copied only so the manifest's testTarget path resolves; `swift build`
+# (product only) never compiles it, so it needs no @MainActor patching.
+cp -R "${MAC_DIR}/Sources" "${MAC_DIR}/Tests" "${MAC_DIR}/Package.swift" "${SCRATCH}/"
+find "${SCRATCH}/Sources" -name "*.swift" -print0 | while IFS= read -r -d '' f; do
+  perl -i -pe 's/^((?:private |public |fileprivate )?struct \b.*: .*\bView\b.*\{)/\@MainActor\n$1/; s/^(struct \w+ *: *App\b.*\{)/\@MainActor\n$1/' "$f"
+  perl -0777 -i -pe 's/\@MainActor\n\@MainActor\n/\@MainActor\n/g' "$f"
+done
+
+# --- build arm64 release (single-arch avoids xcbuild, absent from CLT) -------
+echo "▸ Building arm64 release..."
+( cd "${SCRATCH}" && "${SWIFT}" build -c release )
+BIN="$(cd "${SCRATCH}" && "${SWIFT}" build -c release --show-bin-path)/${EXE}"
+[[ -x "${BIN}" ]] || { echo "✗ build produced no binary" >&2; exit 1; }
+
+# --- assemble the .app bundle ------------------------------------------------
+echo "▸ Assembling ${BUNDLE}..."
+pkill -f "${EXE}" 2>/dev/null || true; sleep 1
+rm -rf "${BUNDLE}"
+mkdir -p "${BUNDLE}/Contents/MacOS" "${BUNDLE}/Contents/Resources"
+cp "${BIN}" "${BUNDLE}/Contents/MacOS/${EXE}"
+cp "${ICON_SOURCE}" "${BUNDLE}/Contents/Resources/menubar-logo.png"
+
+ICONSET="${SCRATCH}/AppIcon.iconset"; mkdir -p "${ICONSET}"
+for spec in "16:16x16" "32:16x16@2x" "32:32x32" "64:32x32@2x" "128:128x128" \
+            "256:128x128@2x" "256:256x256" "512:256x256@2x" "512:512x512"; do
+  sips -z "${spec%%:*}" "${spec%%:*}" "${ICON_SOURCE}" --out "${ICONSET}/icon_${spec##*:}.png" >/dev/null
+done
+cp "${ICON_SOURCE}" "${ICONSET}/icon_512x512@2x.png"
+iconutil -c icns "${ICONSET}" -o "${BUNDLE}/Contents/Resources/AppIcon.icns"
+
+cat > "${BUNDLE}/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key><string>en</string>
+    <key>CFBundleDisplayName</key><string>CodeBurn Menubar</string>
+    <key>CFBundleExecutable</key><string>${EXE}</string>
+    <key>CFBundleIconFile</key><string>AppIcon</string>
+    <key>CFBundleIdentifier</key><string>${BUNDLE_ID}</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>CFBundleName</key><string>${EXE}</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleShortVersionString</key><string>${VERSION}</string>
+    <key>CFBundleVersion</key><string>${VERSION}</string>
+    <key>LSMinimumSystemVersion</key><string>${MIN_MACOS}</string>
+    <key>LSUIElement</key><true/>
+    <key>NSHighResolutionCapable</key><true/>
+    <key>NSHumanReadableCopyright</key><string>© AgentSeal</string>
+</dict>
+</plist>
+PLIST
+printf 'APPL????' > "${BUNDLE}/Contents/PkgInfo"
+
+echo "▸ Ad-hoc signing..."
+codesign --force --sign - --timestamp=none --deep "${BUNDLE}"
+codesign --verify --deep --strict "${BUNDLE}"
+
+echo ""
+echo "✓ Installed ${BUNDLE}"
+vtool -show-build "${BUNDLE}/Contents/MacOS/${EXE}" 2>/dev/null | grep -iE "minos|sdk" | sed 's/^/  /'
+echo "  Launch with: codeburn menubar   (or: open '${BUNDLE}')"

--- a/mac/Scripts/build-local.sh
+++ b/mac/Scripts/build-local.sh
@@ -4,17 +4,19 @@
 # ============================================================================
 # Why this exists
 # ---------------
-# The released .app is built in CI with the macOS 15 SDK + Swift 6. That binary
-# hard-links /usr/lib/swift/libswift_errno.dylib, which only ships in macOS 15,
-# so `codeburn menubar` fails on Sonoma with:
-#     kLSIncompatibleSystemVersionErr (-10825)
+# Package.swift's `.macOS(.v14)` deployment target already fixes the -10825
+# launch failure for every build, including the CI-distributed release: ld64
+# drops the macOS-15-only libswift_errno.dylib dependency based on the
+# deployment target, not the SDK used to build. This script is not about that.
 #
-# This script builds an arm64 bundle locally against the machine's macOS 14 SDK
-# (no libswift_errno dependency, minos = 14.0) using a swift.org Swift 6.2
-# toolchain. Because the macOS 14 SDK's SwiftUI does NOT carry the @MainActor
-# annotations that the macOS 15 SDK added to the `View` protocol, the sources
-# are copied to a scratch dir and every `View`/`App` struct is given an explicit
-# `@MainActor` there — the repo sources stay untouched.
+# It exists for the narrower case of building on a Sonoma machine that only
+# has the Command Line Tools (macOS 14 SDK). That SDK's SwiftUI does NOT carry
+# the @MainActor annotations the macOS 15 SDK added to the `View` protocol, so
+# a plain `swift build` there fails with ~80 `main actor-isolated ... from a
+# nonisolated context` errors. This script copies the sources to a scratch
+# dir, gives every `View`/`App` conformance an explicit `@MainActor` there
+# (repo sources stay untouched), and builds a universal bundle with a
+# swift.org Swift 6.2 toolchain against the local macOS 14 SDK.
 #
 # Prerequisites
 #   - Command Line Tools (provides the macOS 14 SDK + sips/iconutil/codesign)
@@ -53,8 +55,18 @@ if [[ -z "${TC}" ]]; then
 fi
 SWIFT="${TC}/usr/bin/swift"
 export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+SDK_VERSION="$(xcrun --sdk macosx --show-sdk-version)"
+case "${SDK_VERSION}" in
+  14.*) ;;
+  *)
+    echo "✗ Active SDK is macOS ${SDK_VERSION}, not 14.x — xcode-select is likely" >&2
+    echo "  pointed at a newer Xcode instead of the Command Line Tools. Run:" >&2
+    echo "    sudo xcode-select -s /Library/Developer/CommandLineTools" >&2
+    exit 1
+    ;;
+esac
 echo "▸ Toolchain : $("${SWIFT}" --version | head -1)"
-echo "▸ SDK       : ${SDKROOT} ($(xcrun --sdk macosx --show-sdk-version))"
+echo "▸ SDK       : ${SDKROOT} (${SDK_VERSION})"
 
 # --- copy sources and add explicit @MainActor to SwiftUI views --------------
 echo "▸ Staging sources in ${SCRATCH}..."
@@ -62,19 +74,34 @@ echo "▸ Staging sources in ${SCRATCH}..."
 # (product only) never compiles it, so it needs no @MainActor patching.
 cp -R "${MAC_DIR}/Sources" "${MAC_DIR}/Tests" "${MAC_DIR}/Package.swift" "${SCRATCH}/"
 find "${SCRATCH}/Sources" -name "*.swift" -print0 | while IFS= read -r -d '' f; do
-  perl -i -pe 's/^((?:private |public |fileprivate )?struct \b.*: .*\bView\b.*\{)/\@MainActor\n$1/; s/^(struct \w+ *: *App\b.*\{)/\@MainActor\n$1/' "$f"
-  perl -0777 -i -pe 's/\@MainActor\n\@MainActor\n/\@MainActor\n/g' "$f"
+  # Slurp mode ([^{]* spans newlines) so this also catches multi-line generic
+  # struct headers and `extension X: View` conformances, not just the
+  # single-line `struct X: View {` shape the current sources happen to use.
+  perl -0777 -i -pe '
+    s/^((?:private |public |fileprivate |internal )?(?:struct|extension)\s+\w+(?:<[^{]*?>)?\s*:[^{]*\bView\b[^{]*\{)/\@MainActor\n$1/gm;
+    s/^(struct\s+\w+\s*:[^{]*\bApp\b[^{]*\{)/\@MainActor\n$1/gm;
+    s/\@MainActor\n\@MainActor\n/\@MainActor\n/g;
+  ' "$f"
 done
 
-# --- build arm64 release (single-arch avoids xcbuild, absent from CLT) -------
-echo "▸ Building arm64 release..."
-( cd "${SCRATCH}" && "${SWIFT}" build -c release )
-BIN="$(cd "${SCRATCH}" && "${SWIFT}" build -c release --show-bin-path)/${EXE}"
-[[ -x "${BIN}" ]] || { echo "✗ build produced no binary" >&2; exit 1; }
+# --- build each arch separately, then lipo into one universal binary --------
+# `swift build --arch arm64 --arch x86_64` together shells out to xcbuild,
+# which the Command Line Tools doesn't ship — each arch alone stays on the
+# plain SwiftPM build path, so build twice and merge with lipo instead.
+BINS=()
+for arch in arm64 x86_64; do
+  echo "▸ Building ${arch} release..."
+  ( cd "${SCRATCH}" && "${SWIFT}" build -c release --arch "${arch}" )
+  bin="$(cd "${SCRATCH}" && "${SWIFT}" build -c release --arch "${arch}" --show-bin-path)/${EXE}"
+  [[ -x "${bin}" ]] || { echo "✗ ${arch} build produced no binary" >&2; exit 1; }
+  BINS+=("${bin}")
+done
+BIN="${SCRATCH}/${EXE}-universal"
+lipo -create -output "${BIN}" "${BINS[@]}"
 
 # --- assemble the .app bundle ------------------------------------------------
 echo "▸ Assembling ${BUNDLE}..."
-pkill -f "${EXE}" 2>/dev/null || true; sleep 1
+pkill -x "${EXE}" 2>/dev/null || true; sleep 1
 rm -rf "${BUNDLE}"
 mkdir -p "${BUNDLE}/Contents/MacOS" "${BUNDLE}/Contents/Resources"
 cp "${BIN}" "${BUNDLE}/Contents/MacOS/${EXE}"
@@ -118,5 +145,6 @@ codesign --verify --deep --strict "${BUNDLE}"
 
 echo ""
 echo "✓ Installed ${BUNDLE}"
+lipo -info "${BUNDLE}/Contents/MacOS/${EXE}" | sed 's/^/  /'
 vtool -show-build "${BUNDLE}/Contents/MacOS/${EXE}" 2>/dev/null | grep -iE "minos|sdk" | sed 's/^/  /'
 echo "  Launch with: codeburn menubar   (or: open '${BUNDLE}')"

--- a/mac/Scripts/build-local.sh
+++ b/mac/Scripts/build-local.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ============================================================================
-# build-local.sh — Build CodeBurnMenubar.app on a macOS 14 (Sonoma) machine.
+# build-local.sh, Build CodeBurnMenubar.app on a macOS 14 (Sonoma) machine.
 # ============================================================================
 # Why this exists
 # ---------------
@@ -59,7 +59,7 @@ SDK_VERSION="$(xcrun --sdk macosx --show-sdk-version)"
 case "${SDK_VERSION}" in
   14.*) ;;
   *)
-    echo "✗ Active SDK is macOS ${SDK_VERSION}, not 14.x — xcode-select is likely" >&2
+    echo "✗ Active SDK is macOS ${SDK_VERSION}, not 14.x, xcode-select is likely" >&2
     echo "  pointed at a newer Xcode instead of the Command Line Tools. Run:" >&2
     echo "    sudo xcode-select -s /Library/Developer/CommandLineTools" >&2
     exit 1
@@ -86,7 +86,7 @@ done
 
 # --- build each arch separately, then lipo into one universal binary --------
 # `swift build --arch arm64 --arch x86_64` together shells out to xcbuild,
-# which the Command Line Tools doesn't ship — each arch alone stays on the
+# which the Command Line Tools doesn't ship, each arch alone stays on the
 # plain SwiftPM build path, so build twice and merge with lipo instead.
 BINS=()
 for arch in arm64 x86_64; do

--- a/mac/Scripts/package-app.sh
+++ b/mac/Scripts/package-app.sh
@@ -120,6 +120,20 @@ else
 fi
 codesign --verify --deep --strict "${BUNDLE}"
 
+echo "▸ Verifying deployment target and libswift_errno absence..."
+BUILT_EXE="${BUNDLE}/Contents/MacOS/${EXECUTABLE_NAME}"
+BAD_MINOS=$(vtool -show-build "${BUILT_EXE}" 2>/dev/null | awk '/minos/{print $2}' | grep -v '^14\.0$' || true)
+if [[ -n "${BAD_MINOS}" ]]; then
+  echo "✗ Expected minos 14.0 for every arch slice, found: ${BAD_MINOS}" >&2
+  echo "  Did Package.swift's platforms: [.macOS(...)] regress past .v14?" >&2
+  exit 1
+fi
+if otool -L "${BUILT_EXE}" | grep -q libswift_errno; then
+  echo "✗ ${BUILT_EXE} links libswift_errno.dylib (macOS 15+ only) — would fail on Sonoma with -10825." >&2
+  exit 1
+fi
+echo "  minos 14.0 confirmed, no libswift_errno dependency."
+
 ZIP_NAME="CodeBurnMenubar-${ASSET_VERSION}.zip"
 ZIP_PATH="${DIST_DIR}/${ZIP_NAME}"
 echo "▸ Packaging ${ZIP_NAME}..."

--- a/mac/Scripts/package-app.sh
+++ b/mac/Scripts/package-app.sh
@@ -122,14 +122,19 @@ codesign --verify --deep --strict "${BUNDLE}"
 
 echo "▸ Verifying deployment target and libswift_errno absence..."
 BUILT_EXE="${BUNDLE}/Contents/MacOS/${EXECUTABLE_NAME}"
-BAD_MINOS=$(vtool -show-build "${BUILT_EXE}" 2>/dev/null | awk '/minos/{print $2}' | grep -v '^14\.0$' || true)
+MINOS_LINES=$(vtool -show-build "${BUILT_EXE}" 2>/dev/null | awk '/minos/{print $2}')
+if [[ -z "${MINOS_LINES}" ]]; then
+  echo "Could not read a minos deployment target from ${BUILT_EXE} (vtool returned nothing)." >&2
+  exit 1
+fi
+BAD_MINOS=$(printf '%s\n' "${MINOS_LINES}" | grep -v '^14\.0$' || true)
 if [[ -n "${BAD_MINOS}" ]]; then
   echo "✗ Expected minos 14.0 for every arch slice, found: ${BAD_MINOS}" >&2
   echo "  Did Package.swift's platforms: [.macOS(...)] regress past .v14?" >&2
   exit 1
 fi
-if otool -L "${BUILT_EXE}" | grep -q libswift_errno; then
-  echo "✗ ${BUILT_EXE} links libswift_errno.dylib (macOS 15+ only) — would fail on Sonoma with -10825." >&2
+if otool -L "${BUILT_EXE}" | grep libswift_errno | grep -qv 'weak'; then
+  echo "✗ ${BUILT_EXE} links libswift_errno.dylib (macOS 15+ only), would fail on Sonoma with -10825." >&2
   exit 1
 fi
 echo "  minos 14.0 confirmed, no libswift_errno dependency."


### PR DESCRIPTION
Supersedes #577 (credit: @wanghao20, both commits preserved with the Claude co-author trailer stripped for CI). One hardening commit added on top.

## Problem
The released menubar `.app` failed on macOS 14 (Sonoma) with `kLSIncompatibleSystemVersionErr -10825`: the binary's `minos` was 15.0 even though Info.plist, the CLI install guard, and the README all advertise macOS 14+.

## Fix
- `mac/Package.swift`: `.macOS(.v15)` → `.macOS(.v14)`. The `.v15` bump was a misdiagnosis (`NSAttributedString(attachment:)` is AppKit since 10.0). No macOS-15-only API is used.
- `mac/Scripts/package-app.sh`: a release-time guard that fails the build if the binary's `minos` isn't 14.0 on every arch slice, or if it strong-links `libswift_errno.dylib` (macOS-15-only, the thing that breaks Sonoma).
- `mac/Scripts/build-local.sh`: builds on a Sonoma machine against the 14 SDK (scratch copy, never touches repo sources).

## Hardening added on top
- The minos guard was **fail-open**: if `vtool` returned nothing it passed vacuously and could green-light a bad release. Now fails closed.
- The errno check now excludes **weak** links, so it only fails on a breaking strong link, avoiding a spurious release failure on a macOS 15.x SDK runner.
- Stripped em-dashes from the changed files.

## Verification
Mutation-verified on macOS 26.5 / SDK 26.5:
- Fresh `.v14` build: `minos 14.0`, no strong `libswift_errno` link.
- Rebuilding at `.v15` reintroduces both (guard trips), `.v14` removes them, confirming the guard catches the real regression.
- Hardened guard fails closed on an unreadable binary and passes on the real one.
- Universal binary: `vtool` reports minos per slice (arm64 + x86_64); the guard checks every slice.
- 71 Swift tests pass; app builds clean.

Reviewed with a Fable 5 adversarial pass (Codex is temporarily unavailable). Its findings, the fail-open guard and the weak-link edge, are the hardening commit above.