### PR TITLE
fix(bash): attribute wrapped commands to the real tool, not the wrapper

### DIFF
--- a/src/bash-utils.ts
+++ b/src/bash-utils.ts
@@ -5,6 +5,14 @@ function stripQuotedStrings(command: string): string {
   return command.replace(/"[^"]*"|'[^']*'/g, match => ' '.repeat(match.length))
 }
 
+const COMMAND_PREFIXES = new Set([
+  'sudo', 'doas',
+  'npx', 'bunx',
+  'time',
+  'nice', 'nohup', 'stdbuf',
+  'rtk',
+])
+
 export function extractBashCommands(rawCommand: string): string[] {
   if (!rawCommand || !rawCommand.trim()) return []
 
@@ -34,7 +42,17 @@ export function extractBashCommands(rawCommand: string): string[] {
 
     const tokens = segment.split(/\s+/)
     let i = 0
-    while (i < tokens.length && /^\w+=/.test(tokens[i]!)) i++
+    while (i < tokens.length) {
+      if (/^\w+=/.test(tokens[i]!)) { i++; continue }
+      const next = tokens[i + 1]
+      if (
+        next !== undefined &&
+        COMMAND_PREFIXES.has(basename(tokens[i]!)) &&
+        !next.startsWith('-') &&
+        !/["']/.test(next)
+      ) { i++; continue }
+      break
+    }
     const base = i < tokens.length ? basename(tokens[i]!) : ''
 
     if (base && base !== 'cd' && base !== 'true' && base !== 'false') {

--- a/tests/bash-commands.test.ts
+++ b/tests/bash-commands.test.ts
@@ -73,6 +73,43 @@ describe('extractBashCommands', () => {
   it('handles env vars combined with chained commands', () => {
     expect(extractBashCommands('NODE_ENV=test npm test && git push')).toEqual(['npm', 'git'])
   })
+
+  it('skips command wrapper prefixes', () => {
+    expect(extractBashCommands('rtk git status')).toEqual(['git'])
+    expect(extractBashCommands('sudo npm install')).toEqual(['npm'])
+    expect(extractBashCommands('npx vitest --run')).toEqual(['vitest'])
+  })
+
+  it('skips prefix combined with env var assignment', () => {
+    expect(extractBashCommands('DEBUG=1 rtk git status')).toEqual(['git'])
+  })
+
+  it('skips nested wrapper prefixes', () => {
+    expect(extractBashCommands('sudo npx vitest --run')).toEqual(['vitest'])
+  })
+
+  it('skips prefix across chained commands', () => {
+    expect(extractBashCommands('rtk git add . && rtk git commit -m "msg"')).toEqual(['git', 'git'])
+  })
+
+  it('keeps a standalone prefix with no following command', () => {
+    expect(extractBashCommands('rtk')).toEqual(['rtk'])
+    expect(extractBashCommands('sudo')).toEqual(['sudo'])
+  })
+
+  it('keeps prefix when the next token is a flag', () => {
+    expect(extractBashCommands('nice -n 10 git push')).toEqual(['nice'])
+  })
+
+  it('skips env assignment that follows a wrapper prefix', () => {
+    expect(extractBashCommands('sudo NODE_ENV=production node server.js')).toEqual(['node'])
+    expect(extractBashCommands('time FOO=1 make build')).toEqual(['make'])
+  })
+
+  it('keeps prefix when the next token is quoted', () => {
+    expect(extractBashCommands('npx "@angular/cli" new app')).toEqual(['npx'])
+    expect(extractBashCommands("npx 'ts-node' script.ts")).toEqual(['npx'])
+  })
 })
 
 describe('BASH_TOOLS', () => {


### PR DESCRIPTION
Closes #657.

## Problem

`extractBashCommands` in `src/bash-utils.ts` takes the first token of a shell command as the tool name. When an agent wraps its commands in a prefix, that first token is the wrapper, not the real tool:

| Agent ran | Recorded (before) | Real tool |
|---|---|---|
| `sudo apt update` | `sudo` | `apt` |
| `npx vitest --run` | `npx` | `vitest` |
| `rtk git push` | `rtk` | `git` |

Any agent that prefixes its shell calls collapses its whole bash breakdown into one bucket, and the optimize detectors lose the tool they key on. Reported on v0.9.15 by an agent config that prefixes with `rtk`.

## Change

Add a small set of known wrappers (`sudo`, `doas`, `npx`, `bunx`, `time`, `nice`, `nohup`, `stdbuf`, `rtk`) and skip past them to the delegated command. The skip is interleaved with the existing `VAR=value` env-assignment skip, so mixed forms like `sudo NODE_ENV=prod node server.js` resolve correctly.

Guards that keep it safe (no new garbage keys, no regressions):
- A wrapper with **no following command** is kept as-is (`sudo` alone stays `sudo`).
- A wrapper followed by a **flag** is kept (`nice -n 10 git` stays `nice`, since we can't know the flag's arity).
- A wrapper followed by a **quoted** token is kept (`npx "@angular/cli"` stays `npx`, never `cli"`).

One function, so every provider parser benefits.

## Tests

Added cases in `tests/bash-commands.test.ts` covering wrapper skip, nested wrappers, env+wrapper interleave, chained wrappers, standalone wrapper, flag guard, and quote guard. Full suite green (3086 tests).

Credit to @athoune (Mathieu Lecarme) for the report and the proposed approach.