### PR TITLE
feat(dashboard): add inline daily history paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Sync sends token counts, costs, models, and projects — never prompts or code. 
 | `codeburn models --task feature` | Filter to feature-development work |
 | `codeburn models --provider claude` | Filter to a single provider |
 
-Arrow keys switch between Today, 7 Days, 30 Days, Month, and 6 Months (use `--from` / `--to` for an exact historical window). Press `q` to quit, `1` `2` `3` `4` `5` as shortcuts, `c` to open model comparison, `o` to open optimize. The dashboard auto-refreshes every 30 seconds by default (`--refresh 0` to disable). It also shows average cost per session and the five most expensive sessions across all projects.
+Arrow keys switch between Today, 7 Days, 30 Days, Month, and 6 Months (use `--from` / `--to` for an exact historical window). Press `h` to toggle the main Daily Activity panel between the selected period and full history. In full-history mode, use Page Up/Page Down (or Shift+Space/Space) to page, `j`/`k` or the up/down arrows to move one row, and `g`/`G` to jump to either end. Press `q` to quit, `1` `2` `3` `4` `5` as period shortcuts, `c` to open model comparison, or `o` to open optimize. The dashboard auto-refreshes every 30 seconds by default (`--refresh 0` to disable). It also shows average cost per session and the five most expensive sessions across all projects.
 
 </details>
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -19,6 +19,17 @@ import { patchStdoutForWindows } from './ink-win.js'
 
 type View = 'dashboard' | 'optimize' | 'compare'
 
+export type DailyActivityRow = {
+  day: string
+  cost: number
+  calls: number
+}
+
+export function pageHistoryCursor(cursor: number, direction: -1 | 1, pageSize: number, rowCount: number): number {
+  const maxCursor = Math.max(0, rowCount - pageSize)
+  return Math.max(0, Math.min(cursor + direction * pageSize, maxCursor))
+}
+
 const MIN_WIDE = 90
 const ORANGE = '#FF8C42'
 const DIM = '#555555'
@@ -253,7 +264,7 @@ function Overview({ projects, label, width, planUsages }: { projects: ProjectSum
   )
 }
 
-function DailyActivity({ projects, days = 14, pw, bw }: { projects: ProjectSummary[]; days?: number; pw: number; bw: number }) {
+export function getDailyActivityRows(projects: ProjectSummary[]): DailyActivityRow[] {
   const dailyCosts: Record<string, number> = {}
   const dailyCalls: Record<string, number> = {}
   for (const project of projects) {
@@ -266,20 +277,37 @@ function DailyActivity({ projects, days = 14, pw, bw }: { projects: ProjectSumma
       }
     }
   }
-  const sortedDays = days !== undefined ? Object.keys(dailyCosts).sort().slice(-days) : Object.keys(dailyCosts).sort()
-  const maxCost = Math.max(...sortedDays.map(d => dailyCosts[d] ?? 0))
+  return Object.keys(dailyCosts).sort().map(day => ({
+    day,
+    cost: dailyCosts[day] ?? 0,
+    calls: dailyCalls[day] ?? 0,
+  }))
+}
+
+function DailyActivity({ projects, days = 14, pw, bw, fullHistory = false, cursor = 0, loading = false }: { projects: ProjectSummary[]; days?: number; pw: number; bw: number; fullHistory?: boolean; cursor?: number; loading?: boolean }) {
+  const allRows = getDailyActivityRows(projects)
+  const orderedRows = fullHistory ? [...allRows].reverse() : allRows
+  const rows = fullHistory ? orderedRows.slice(cursor, cursor + days) : orderedRows.slice(-days)
+  const maxCost = Math.max(0, ...(fullHistory ? orderedRows : rows).map(row => row.cost))
 
   return (
     <Panel title="Daily Activity" color={PANEL_COLORS.daily} width={pw}>
-      <Text dimColor wrap="truncate-end">{''.padEnd(6 + bw)}{'cost'.padStart(8)}{'calls'.padStart(6)}</Text>
-      {sortedDays.map(day => (
-        <Text key={day} wrap="truncate-end">
-          <Text dimColor>{day.slice(5)} </Text>
-          <HBar value={dailyCosts[day] ?? 0} max={maxCost} width={bw} />
-          <Text color={GOLD}>{formatCost(dailyCosts[day] ?? 0).padStart(8)}</Text>
-          <Text>{String(dailyCalls[day] ?? 0).padStart(6)}</Text>
-        </Text>
-      ))}
+      {loading
+        ? <Text dimColor>Loading full history...</Text>
+        : <>
+            <Text dimColor wrap="truncate-end">{''.padEnd((fullHistory ? 11 : 6) + bw)}{'cost'.padStart(8)}{'calls'.padStart(6)}</Text>
+            {rows.map(row => (
+              <Text key={row.day} wrap="truncate-end">
+                <Text dimColor>{fullHistory ? row.day : row.day.slice(5)} </Text>
+                <HBar value={row.cost} max={maxCost} width={bw} />
+                <Text color={GOLD}>{formatCost(row.cost).padStart(8)}</Text>
+                <Text>{String(row.calls).padStart(6)}</Text>
+              </Text>
+            ))}
+            {fullHistory && orderedRows.length > 0 && (
+              <Text dimColor wrap="truncate-end">Full history · Showing {cursor + 1}–{Math.min(cursor + days, orderedRows.length)} of {orderedRows.length} · newest first</Text>
+            )}
+          </>}
     </Panel>
   )
 }
@@ -694,7 +722,7 @@ function OptimizeView({ findings, costRate, projects, label, width, healthScore,
   )
 }
 
-function StatusBar({ width, showProvider, view, findingCount, optimizeAvailable, compareAvailable, customRange, dayMode }: { width: number; showProvider?: boolean; view?: View; findingCount?: number; optimizeAvailable?: boolean; compareAvailable?: boolean; customRange?: boolean; dayMode?: boolean }) {
+function StatusBar({ width, showProvider, view, findingCount, optimizeAvailable, compareAvailable, customRange, dayMode, dailyHistory }: { width: number; showProvider?: boolean; view?: View; findingCount?: number; optimizeAvailable?: boolean; compareAvailable?: boolean; customRange?: boolean; dayMode?: boolean; dailyHistory?: boolean }) {
   const isOptimize = view === 'optimize'
   return (
     <Box borderStyle="round" borderColor={DIM} width={width} justifyContent="center" paddingX={1}>
@@ -727,6 +755,12 @@ function StatusBar({ width, showProvider, view, findingCount, optimizeAvailable,
         {!isOptimize && compareAvailable && (
           <><Text dimColor>   </Text><Text color={ORANGE} bold>c</Text><Text dimColor> compare</Text></>
         )}
+        {!isOptimize && !customRange && !dayMode && view === 'dashboard' && (
+          <>
+            <Text dimColor>   </Text><Text color={PANEL_COLORS.daily} bold>h</Text><Text dimColor>{dailyHistory ? ' hide daily history' : ' daily history'}</Text>
+            {dailyHistory && <><Text dimColor>   </Text><Text color={PANEL_COLORS.daily} bold>PgUp</Text><Text dimColor>/</Text><Text color={PANEL_COLORS.daily} bold>PgDn</Text><Text dimColor> daily</Text></>}
+          </>
+        )}
         {showProvider && (<><Text dimColor>   </Text><Text color={ORANGE} bold>p</Text><Text dimColor> provider</Text></>)}
       </Text>
     </Box>
@@ -738,13 +772,13 @@ function Row({ wide, width, children }: { wide: boolean; width: number; children
   return <>{children}</>
 }
 
-function DashboardContent({ projects, period, columns, activeProvider, budgets, planUsages, label, dayMode }: { projects: ProjectSummary[]; period: Period; columns?: number; activeProvider?: string; budgets?: Map<string, ContextBudget>; planUsages?: PlanUsage[]; label?: string; dayMode?: boolean }) {
+function DashboardContent({ projects, period, columns, activeProvider, budgets, planUsages, label, dayMode, dailyHistoryProjects, dailyHistory, dailyHistoryCursor = 0, dailyHistoryLoading = false }: { projects: ProjectSummary[]; period: Period; columns?: number; activeProvider?: string; budgets?: Map<string, ContextBudget>; planUsages?: PlanUsage[]; label?: string; dayMode?: boolean; dailyHistoryProjects?: ProjectSummary[]; dailyHistory?: boolean; dailyHistoryCursor?: number; dailyHistoryLoading?: boolean }) {
   const { dashWidth, wide, halfWidth, barWidth } = getLayout(columns)
   const isCursor = activeProvider === 'cursor'
   const activeLabel = label ?? PERIOD_LABELS[period]
-  if (projects.length === 0) return <Panel title="CodeBurn" color={ORANGE} width={dashWidth}><Text dimColor>No usage data found for {activeLabel}.</Text></Panel>
+  if (projects.length === 0 && !dailyHistory) return <Panel title="CodeBurn" color={ORANGE} width={dashWidth}><Text dimColor>No usage data found for {activeLabel}.</Text></Panel>
   const pw = wide ? halfWidth : dashWidth
-  const days = dayMode ? 1 : period === 'all' ? undefined : (period === 'month' || period === '30days' ? 31 : 14)
+  const days = dayMode ? 1 : (period === 'month' || period === '30days' ? 31 : 14)
   // A provider-scoped plan (e.g. SuperGrok) only makes sense on its own
   // provider tab, where the shown cost matches the plan's spend. Hide it on
   // every other tab, including All, so its budget isn't compared to spend it
@@ -753,7 +787,7 @@ function DashboardContent({ projects, period, columns, activeProvider, budgets, 
   return (
     <Box flexDirection="column" width={dashWidth}>
       <Overview projects={projects} label={activeLabel} width={dashWidth} planUsages={visiblePlanUsages} />
-      <Row wide={wide} width={dashWidth}><DailyActivity projects={projects} days={days} pw={pw} bw={barWidth} /><ProjectBreakdown projects={projects} pw={pw} bw={barWidth} budgets={budgets} rows={dayMode ? 8 : period === 'all' ? 14 : period === 'month' || period === '30days' ? 14 : 8} /></Row>
+      <Row wide={wide} width={dashWidth}><DailyActivity projects={dailyHistory ? (dailyHistoryProjects ?? []) : projects} days={days} pw={pw} bw={barWidth} fullHistory={dailyHistory} cursor={dailyHistoryCursor} loading={dailyHistoryLoading} /><ProjectBreakdown projects={projects} pw={pw} bw={barWidth} budgets={budgets} rows={dayMode ? 8 : period === 'all' ? 14 : period === 'month' || period === '30days' ? 14 : 8} /></Row>
       <Row wide={wide} width={dashWidth}><ActivityBreakdown projects={projects} pw={pw} bw={barWidth} /><ModelBreakdown projects={projects} pw={pw} bw={barWidth} /></Row>
       {isCursor ? (
         <ToolBreakdown projects={projects} pw={dashWidth} bw={barWidth} title="Languages" filterPrefix="lang:" />
@@ -788,6 +822,10 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
   const [projectBudgets, setProjectBudgets] = useState<Map<string, ContextBudget>>(new Map())
   const [planUsages, setPlanUsages] = useState<PlanUsage[]>(initialPlanUsages ?? [])
   const [dayDate, setDayDate] = useState<string | null>(initialDay ?? null)
+  const [dailyHistory, setDailyHistory] = useState(false)
+  const [dailyHistoryProjects, setDailyHistoryProjects] = useState<ProjectSummary[]>([])
+  const [dailyHistoryLoading, setDailyHistoryLoading] = useState(false)
+  const [dailyHistoryCursor, setDailyHistoryCursor] = useState(0)
   // Cursor for the OptimizeView's findings window. Reset whenever the user
   // leaves the optimize view OR the underlying findings change so a long
   // findings list never strands the user past the new array length.
@@ -796,6 +834,9 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
   const isCustomRange = customRange != null && !isDayMode
   const { columns } = useWindowSize()
   const { dashWidth } = getLayout(columns)
+  const dailyHistoryPageSize = isDayMode ? 1 : (period === 'month' || period === '30days' ? 31 : 14)
+  const dailyHistoryRowCount = getDailyActivityRows(dailyHistoryProjects).length
+  const dailyHistoryMaxCursor = Math.max(0, dailyHistoryRowCount - dailyHistoryPageSize)
   const multipleProviders = detectedProviders.length > 1
   const optimizeAvailable = !isCustomRange && (activeProvider === 'all' || activeProvider === 'claude')
   const modelCount = new Set(
@@ -807,6 +848,7 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
   const reloadInFlightRef = useRef(false)
   const currentReloadRef = useRef<{ period: Period; provider: string; day: string | null } | null>(null)
   const pendingReloadRef = useRef<{ period: Period; provider: string; day: string | null } | null>(null)
+  const dailyHistoryGenerationRef = useRef(0)
   const findingCount = optimizeResult?.findings.length ?? 0
 
   useEffect(() => {
@@ -908,6 +950,32 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
     }
   }, [optimizeAvailable, projects, currentRange, optimizeLoading, optimizeResult])
 
+  const loadDailyHistory = useCallback(async (provider: string) => {
+    const generation = ++dailyHistoryGenerationRef.current
+    setDailyHistoryLoading(true)
+    try {
+      const data = await parseAllSessions(undefined, provider)
+      if (dailyHistoryGenerationRef.current !== generation) return
+      setDailyHistoryProjects(filterProjectsByName(data, projectFilter, excludeFilter))
+    } catch (error) {
+      if (dailyHistoryGenerationRef.current !== generation) return
+      console.error(error)
+      setDailyHistoryProjects([])
+    } finally {
+      if (dailyHistoryGenerationRef.current === generation) setDailyHistoryLoading(false)
+    }
+  }, [projectFilter, excludeFilter])
+
+  const toggleDailyHistory = useCallback(() => {
+    setDailyHistoryCursor(0)
+    if (dailyHistory) {
+      setDailyHistory(false)
+      return
+    }
+    setDailyHistory(true)
+    void loadDailyHistory(activeProvider)
+  }, [activeProvider, dailyHistory, loadDailyHistory])
+
   useEffect(() => {
     if (!refreshSeconds || refreshSeconds <= 0) return
     if (!dayDate && isHeavyPeriod(period)) return
@@ -923,6 +991,7 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
     // there's a frame-to-hundreds-of-ms window where users saw wrong
     // figures captioned with the new period.
     setPeriod(np)
+    setDailyHistoryCursor(0)
     setDayDate(null)
     setProjects([])
     setLoading(true)
@@ -933,6 +1002,7 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
   const switchPeriodImmediate = useCallback(async (np: Period) => {
     if (np === period && !dayDate) return
     setPeriod(np)
+    setDailyHistoryCursor(0)
     setDayDate(null)
     setProjects([])
     setLoading(true)
@@ -945,6 +1015,8 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
     const clampedDay = nextDay > today ? today : nextDay
     if (clampedDay === dayDate) return
     setDayDate(clampedDay)
+    setDailyHistory(false)
+    setDailyHistoryCursor(0)
     setProjects([])
     setLoading(true)
     setView('dashboard')
@@ -970,9 +1042,19 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
     }
     if (input === 'c' && compareAvailable && view === 'dashboard') { setView('compare'); return }
     if ((input === 'b' || key.escape) && view === 'compare') { setView('dashboard'); return }
+    if (input === 'h' && view === 'dashboard' && !isCustomRange && !isDayMode) { toggleDailyHistory(); return }
+    if (view === 'dashboard' && dailyHistory) {
+      if (key.pageDown || (input === ' ' && !key.shift)) { setDailyHistoryCursor(c => pageHistoryCursor(c, 1, dailyHistoryPageSize, dailyHistoryRowCount)); return }
+      if (key.pageUp || (input === ' ' && key.shift)) { setDailyHistoryCursor(c => pageHistoryCursor(c, -1, dailyHistoryPageSize, dailyHistoryRowCount)); return }
+      if (input === 'j' || key.downArrow) { setDailyHistoryCursor(c => Math.min(c + 1, dailyHistoryMaxCursor)); return }
+      if (input === 'k' || key.upArrow) { setDailyHistoryCursor(c => Math.max(c - 1, 0)); return }
+      if (input === 'g') { setDailyHistoryCursor(0); return }
+      if (input === 'G') { setDailyHistoryCursor(dailyHistoryMaxCursor); return }
+    }
     if (input === 'p' && multipleProviders && view !== 'compare') {
       const opts = ['all', ...detectedProviders]; const next = opts[(opts.indexOf(activeProvider) + 1) % opts.length]
       setActiveProvider(next); setView('dashboard')
+      setDailyHistory(false); setDailyHistoryCursor(0)
       if (debounceRef.current) clearTimeout(debounceRef.current)
       reloadData(period, next, dayDate); return
     }
@@ -984,6 +1066,8 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
     if (!customRange && input === 'd') {
       if (dayDate) {
         setDayDate(null)
+        setDailyHistory(false)
+        setDailyHistoryCursor(0)
         setProjects([])
         setLoading(true)
         void reloadData(period, activeProvider, null)
@@ -1037,7 +1121,7 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
           : view === 'optimize'
             ? <Panel title="CodeBurn Optimize" color={ORANGE} width={dashWidth}><Text dimColor>Scanning {headerLabel}...</Text></Panel>
             : <Panel title="CodeBurn" color={ORANGE} width={dashWidth}><Text dimColor>Loading {headerLabel}...</Text></Panel>}
-        {view !== 'compare' && <StatusBar width={dashWidth} showProvider={multipleProviders} view={view} findingCount={0} optimizeAvailable={false} compareAvailable={false} customRange={isCustomRange} dayMode={isDayMode} />}
+        {view !== 'compare' && <StatusBar width={dashWidth} showProvider={multipleProviders} view={view} findingCount={0} optimizeAvailable={false} compareAvailable={false} customRange={isCustomRange} dayMode={isDayMode} dailyHistory={dailyHistory} />}
       </Box>
     )
   }
@@ -1051,8 +1135,8 @@ function InteractiveDashboard({ initialProjects, initialPeriod, initialProvider,
         ? <CompareView projects={projects} onBack={() => setView('dashboard')} />
         : view === 'optimize' && optimizeResult
           ? <OptimizeView findings={optimizeResult.findings} costRate={optimizeResult.costRate} projects={projects} label={headerLabel} width={dashWidth} healthScore={optimizeResult.healthScore} healthGrade={optimizeResult.healthGrade} cursor={findingsCursor} />
-          : <DashboardContent projects={projects} period={period} columns={columns} activeProvider={activeProvider} budgets={projectBudgets} planUsages={planUsages} label={headerLabel} dayMode={isDayMode} />}
-      {view !== 'compare' && <StatusBar width={dashWidth} showProvider={multipleProviders} view={view} findingCount={findingCount} optimizeAvailable={optimizeAvailable} compareAvailable={compareAvailable} customRange={isCustomRange} dayMode={isDayMode} />}
+          : <DashboardContent projects={projects} period={period} columns={columns} activeProvider={activeProvider} budgets={projectBudgets} planUsages={planUsages} label={headerLabel} dayMode={isDayMode} dailyHistoryProjects={dailyHistoryProjects} dailyHistory={dailyHistory} dailyHistoryCursor={Math.min(dailyHistoryCursor, dailyHistoryMaxCursor)} dailyHistoryLoading={dailyHistoryLoading} />}
+      {view !== 'compare' && <StatusBar width={dashWidth} showProvider={multipleProviders} view={view} findingCount={findingCount} optimizeAvailable={optimizeAvailable} compareAvailable={compareAvailable} customRange={isCustomRange} dayMode={isDayMode} dailyHistory={dailyHistory} />}
     </Box>
   )
 }

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -2,7 +2,7 @@ import { homedir } from 'os'
 
 import { describe, it, expect } from 'vitest'
 
-import { shortProject } from '../src/dashboard.js'
+import { getDailyActivityRows, pageHistoryCursor, shortProject } from '../src/dashboard.js'
 import { formatCost } from '../src/format.js'
 import type { ProjectSummary, SessionSummary } from '../src/types.js'
 
@@ -51,6 +51,33 @@ function makeProject(name: string, sessions: SessionSummary[]): ProjectSummary {
     sessions,
     totalCostUSD: sessions.reduce((s, x) => s + x.totalCostUSD, 0),
     totalApiCalls: sessions.reduce((s, x) => s + x.apiCalls, 0),
+  }
+}
+
+function makeTurn(timestamp: string, costs: number[]): SessionSummary['turns'][number] {
+  return {
+    userMessage: 'fixture turn',
+    sessionId: 'fixture-session',
+    timestamp,
+    category: 'coding',
+    retries: 0,
+    hasEdits: false,
+    assistantCalls: costs.map((costUSD, index) => ({
+      provider: 'codex',
+      model: 'test-model',
+      usage: { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0, webSearchRequests: 0 },
+      costUSD,
+      tools: [],
+      mcpTools: [],
+      skills: [],
+      subagentTypes: [],
+      hasAgentSpawn: false,
+      hasPlanMode: false,
+      speed: 'standard',
+      timestamp,
+      bashCommands: [],
+      deduplicationKey: `fixture-${timestamp}-${index}`,
+    })),
   }
 }
 
@@ -142,5 +169,26 @@ describe('avg/s in ProjectBreakdown', () => {
     const sessions = [makeSession('s1', 2.0), makeSession('s2', 4.0)]
     const project = makeProject('proj', sessions)
     expect(avgCostLabel(project)).toBe(formatCost(3.0))
+  })
+})
+
+describe('Daily Activity history', () => {
+  it('aggregates every active day in chronological order', () => {
+    const session = makeSession('s1', 0)
+    session.turns = [
+      makeTurn('2025-01-02T12:00:00Z', [1.25, 0.75]),
+      makeTurn('2024-12-31T12:00:00Z', [3]),
+    ]
+
+    expect(getDailyActivityRows([makeProject('proj', [session])])).toEqual([
+      { day: '2024-12-31', cost: 3, calls: 1 },
+      { day: '2025-01-02', cost: 2, calls: 2 },
+    ])
+  })
+
+  it('pages one viewport and keeps the final page full', () => {
+    expect(pageHistoryCursor(0, 1, 35, 69)).toBe(34)
+    expect(pageHistoryCursor(34, -1, 35, 69)).toBe(0)
+    expect(pageHistoryCursor(0, -1, 35, 69)).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

- Keep full daily history inside the existing Daily Activity panel instead of opening a separate view.
- Add `h` to show or hide full history while leaving the selected-period overview and the rest of the dashboard in place.
- Add Page Up/Page Down and Space/Shift+Space paging, `j`/`k` row movement, and `g`/`G` end jumps.

## Why

The separate Daily Activity Full History screen duplicated navigation and removed the surrounding project, activity, and model context. An inline mode makes historical inspection a small extension of the main dashboard.

The separate-screen design was considered and rejected because the same fixed-height, pageable panel handles long histories without adding another view or back-navigation path.

## Validation

`npm test -- --run --maxWorkers=1 --testTimeout=20000` passed 1,676 tests across 128 files; 5 opt-in infrastructure/browser tests remained intentionally skipped. `npm run build` and `npx tsc --noEmit` succeeded.

The Homebrew-installed CodeBurn 0.9.15 runtime was updated from this build and exercised in a live terminal with `h` and the physical Page Down escape sequence.

The terminal evidence uses 21 isolated, genuine-format Codex rollout JSONL files (42 calls, $2.5676 parsed cost; source SHA-256 `29364829f265a006cd2cbca965eec1714aea1fea94039b609453c7eeadd32f1c`). An automated verifier matched every displayed date, cost, and call count on both pages to CodeBurn's JSON report and the underlying rollout records.

## Live terminal evidence

<!-- daily-history-page-1 -->

<!-- daily-history-page-2 -->
