### PR TITLE
Extract shared token estimation helper, migrate all CHARS_PER_TOKEN sites

### DIFF
--- a/src/context-budget.ts
+++ b/src/context-budget.ts
@@ -4,8 +4,8 @@ import { join } from 'path'
 import { homedir } from 'os'
 
 import { readSessionFile } from './fs-utils.js'
+import { estimateTokensFromChars } from './token-estimate.js'
 
-const CHARS_PER_TOKEN = 4
 const SYSTEM_BASE_TOKENS = 10400
 const TOOL_TOKENS_OVERHEAD = 400
 const SKILL_FRONTMATTER_TOKENS = 80
@@ -20,7 +20,7 @@ export type ContextBudget = {
 }
 
 function estimateTokens(text: string): number {
-  return Math.ceil(text.length / CHARS_PER_TOKEN)
+  return estimateTokensFromChars(text.length)
 }
 
 async function readConfigFile(path: string): Promise<Record<string, unknown> | null> {

--- a/src/context-tree-codex.ts
+++ b/src/context-tree-codex.ts
@@ -4,6 +4,7 @@ import { basename, join } from 'path'
 import { homedir } from 'os'
 
 import { readSessionLines } from './fs-utils.js'
+import { estimateTokensFromChars } from './token-estimate.js'
 import {
   add,
   estimateTokens,
@@ -115,7 +116,7 @@ function addCodexItem(accs: Acc[], item: CodexItem): void {
     // so estimate from the decoded size.
     const encrypted = (item as { encrypted_content?: unknown }).encrypted_content
     const chars = typeof encrypted === 'string' ? encrypted.length * 0.75 : 0
-    for (const acc of accs) add(acc.userCompactSummary, Math.ceil(chars / 4))
+    for (const acc of accs) add(acc.userCompactSummary, estimateTokensFromChars(chars))
   } else if (item.type === 'reasoning') {
     // Tokens are patched from cumulative usage after the walk.
     for (const acc of accs) acc.assistantReasoning.count += 1

--- a/src/context-tree.ts
+++ b/src/context-tree.ts
@@ -6,13 +6,13 @@ import chalk from 'chalk'
 
 import { readSessionLines, type SessionLine } from './fs-utils.js'
 import { formatTokens } from './format.js'
+import { estimateTokensFromChars } from './token-estimate.js'
 
 // Block token counts are chars/4 estimates; the "context (exact)" line comes
 // from the last assistant message's API usage. Transcripts store thinking
 // blocks with their text stripped, so reasoning is derived per message as
 // output_tokens minus the estimated visible output.
 
-const CHARS_PER_TOKEN = 4
 export const IMAGE_TOKEN_FALLBACK = 1600
 
 export type BlockStat = { count: number; tokens: number }
@@ -146,7 +146,7 @@ export function newAcc(): Acc {
 }
 
 export function estimateTokens(text: string): number {
-  return Math.ceil(text.length / CHARS_PER_TOKEN)
+  return estimateTokensFromChars(text.length)
 }
 
 export function add(stat: BlockStat, tokens: number): void {

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -8,6 +8,7 @@ import { readSessionLines } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
 import { readCachedCodexResults, writeCachedCodexResults, getCachedCodexProject, fingerprintFile } from '../codex-cache.js'
 import { normalizeContentBlocks } from '../content-utils.js'
+import { estimateTokensFromChars } from '../token-estimate.js'
 import type { ToolCall } from '../types.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
@@ -106,7 +107,6 @@ type CodexTokenUsage = {
   total_tokens?: number
 }
 
-const CHARS_PER_TOKEN = 4
 const RAW_HEAD_BYTES = 64 * 1024
 const LARGE_TEXT_CAP = 2000
 
@@ -500,8 +500,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           const info = entry.payload.info
           if (!info) {
             if (pendingOutputChars === 0 && pendingUserMessage.length === 0) continue
-            const estInput = Math.ceil(pendingUserMessage.length / CHARS_PER_TOKEN)
-            const estOutput = Math.ceil(pendingOutputChars / CHARS_PER_TOKEN)
+            const estInput = estimateTokensFromChars(pendingUserMessage.length)
+            const estOutput = estimateTokensFromChars(pendingOutputChars)
             if (estInput === 0 && estOutput === 0) continue
 
             const model = sessionModel ?? 'gpt-5'

--- a/src/providers/cursor-agent.ts
+++ b/src/providers/cursor-agent.ts
@@ -7,6 +7,7 @@ import { homedir } from 'os'
 import { calculateCost } from '../models.js'
 import { openDatabase, type SqliteDatabase } from '../sqlite.js'
 import { normalizeContentBlocks } from '../content-utils.js'
+import { estimateTokensFromChars } from '../token-estimate.js'
 import type {
   Provider,
   SessionSource,
@@ -33,7 +34,6 @@ type ParsedTurn = {
 }
 
 const CURSOR_AGENT_COST_MODEL = 'claude-sonnet-4-5'
-const CHARS_PER_TOKEN = 4
 const MAX_USER_TEXT_LENGTH = 500
 const DIGITS_ONLY = /^\d+$/
 const UUID_LIKE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -82,7 +82,7 @@ function getAttributionDbPath(baseDir: string): string {
 
 function estimateTokens(charCount: number): number {
   if (charCount <= 0) return 0
-  return Math.ceil(charCount / CHARS_PER_TOKEN)
+  return estimateTokensFromChars(charCount)
 }
 
 function parseToolName(raw: string): string {

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -6,6 +6,7 @@ import { calculateCost } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
 import { readCachedResults, writeCachedResults } from '../cursor-cache.js'
 import { isSqliteAvailable, isSqliteBusyError, getSqliteLoadError, openDatabase, blobToText, type SqliteDatabase } from '../sqlite.js'
+import { estimateTokensFromChars } from '../token-estimate.js'
 import type { DateRange } from '../types.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
@@ -73,8 +74,6 @@ type AgentKvRow = {
 function rethrowBusy(err: unknown): void {
   if (isSqliteBusyError(err)) throw err
 }
-
-const CHARS_PER_TOKEN = 4
 
 function getCursorDbPath(): string {
   if (process.platform === 'darwin') {
@@ -801,10 +800,10 @@ function parseBubbles(
           // this loop; per-bubble text only counts when it is the
           // conversation's best available signal.
           if (inputSource(conversationId) === 'text' && textLen > 0) {
-            inputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
+            inputTokens = estimateTokensFromChars(textLen)
           }
         } else {
-          outputTokens = Math.ceil(textLen / CHARS_PER_TOKEN)
+          outputTokens = estimateTokensFromChars(textLen)
         }
         if (inputTokens === 0 && outputTokens === 0) continue
       }
@@ -875,10 +874,10 @@ function parseBubbles(
     const meta = composerMeta.get(cid)
     const inputTokens = source === 'meter'
       ? meta?.tokens ?? 0
-      : Math.ceil(((stream?.userChars ?? 0) + (stream?.contextChars ?? 0)) / CHARS_PER_TOKEN)
+      : estimateTokensFromChars((stream?.userChars ?? 0) + (stream?.contextChars ?? 0))
     // Reply text normally lives on assistant bubbles; count the stream's
     // reply deltas only when the bubbles carried none.
-    const outputTokens = scan.assistantTextChars > 0 ? 0 : Math.ceil((stream?.assistantChars ?? 0) / CHARS_PER_TOKEN)
+    const outputTokens = scan.assistantTextChars > 0 ? 0 : estimateTokensFromChars(stream?.assistantChars ?? 0)
     if (inputTokens === 0 && outputTokens === 0) continue
 
     const dedupKey = `cursor:composer-input:${cid}`
@@ -908,8 +907,8 @@ function parseBubbles(
   // requestId). agentKv stores no timestamps, so these reuse the DB file's
   // mtime as a bounded "last write" time, like the pre-composer parser did.
   for (const [requestId, stream] of unjoined) {
-    const inputTokens = Math.ceil((stream.userChars + stream.contextChars) / CHARS_PER_TOKEN)
-    const outputTokens = Math.ceil(stream.assistantChars / CHARS_PER_TOKEN)
+    const inputTokens = estimateTokensFromChars(stream.userChars + stream.contextChars)
+    const outputTokens = estimateTokensFromChars(stream.assistantChars)
     if (inputTokens === 0 && outputTokens === 0) continue
 
     const dedupKey = `cursor:agentKv:${requestId}`

--- a/src/providers/kiro.ts
+++ b/src/providers/kiro.ts
@@ -6,10 +6,10 @@ import { homedir } from 'os'
 
 import { readSessionFile } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
+import { estimateTokensFromChars } from '../token-estimate.js'
 import type { ToolCall } from '../types.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
-const CHARS_PER_TOKEN = 4
 // Kiro bills in credits: individual plans are $20/mo for 1,000 credits and
 // overage is billed at $0.04 per additional credit. We price credits at the
 // public overage rate (the marginal price), mirroring the Codebuff provider's
@@ -225,8 +225,8 @@ function parseChatFile(data: KiroChatFile, sessionId: string, project: string, s
   const dedupKey = `kiro:${sessionId}:${data.executionId}`
   if (seenKeys.has(dedupKey)) return results
 
-  const outputTokens = Math.ceil(totalOutputChars / CHARS_PER_TOKEN)
-  const inputTokens = Math.ceil(pendingUserMessage.length / CHARS_PER_TOKEN)
+  const outputTokens = estimateTokensFromChars(totalOutputChars)
+  const inputTokens = estimateTokensFromChars(pendingUserMessage.length)
   const costUSD = calculateCost(modelId, inputTokens, outputTokens, 0, 0, 0)
   const tsDate = parseKiroTimestamp(metadata.startTime)
   if (!tsDate) return results
@@ -372,8 +372,8 @@ function parseModernExecution(data: KiroModernExecution, sourcePath: string, see
   const tsDate = parseKiroTimestamp(rawStartTime)
   if (!tsDate) return results
 
-  const inputTokens = Math.ceil(inputChars / CHARS_PER_TOKEN)
-  const outputTokens = Math.ceil(outputChars / CHARS_PER_TOKEN)
+  const inputTokens = estimateTokensFromChars(inputChars)
+  const outputTokens = estimateTokensFromChars(outputChars)
   // Prefer real metered credits at the public overage rate; fall back to
   // token-estimated pricing when the execution has no usage data — same
   // contract as the CLI and v2 parsers.
@@ -462,8 +462,8 @@ function parseCliSession(meta: KiroCliSessionMeta, entries: KiroCliEntry[], seen
     const tsDate = parseKiroTimestamp(timestamp)
     if (!tsDate) { turnIndex++; return }
 
-    const inputTokens = Math.ceil(inputChars / CHARS_PER_TOKEN)
-    const outputTokens = Math.ceil(outputChars / CHARS_PER_TOKEN)
+    const inputTokens = estimateTokensFromChars(inputChars)
+    const outputTokens = estimateTokensFromChars(outputChars)
     // metering_usage values are credits (unit: "credit"), not dollars —
     // convert at the public overage rate. Gate on credits > 0, not array
     // presence: real sessions carry empty metering_usage arrays (turn still
@@ -631,8 +631,8 @@ async function parseWorkspaceSession(record: Record<string, unknown>, source: Se
   if (seenKeys.has(dedupKey)) return results
   seenKeys.add(dedupKey)
 
-  const inputTokens = Math.ceil(inputChars / CHARS_PER_TOKEN)
-  const outputTokens = Math.ceil(outputChars / CHARS_PER_TOKEN)
+  const inputTokens = estimateTokensFromChars(inputChars)
+  const outputTokens = estimateTokensFromChars(outputChars)
   const costUSD = calculateCost(modelId, inputTokens, outputTokens, 0, 0, 0)
 
   results.push({
@@ -732,12 +732,12 @@ async function parseV2Session(source: SessionSource, seenKeys: Set<string>): Pro
         seenKeys.add(dedupKey)
         // Tool results are fed back to the model as input context, so count them
         // toward input tokens — same treatment as the CLI parser's ToolResults.
-        const inputTokens = Math.ceil((turnUserChars + toolResultChars) / CHARS_PER_TOKEN)
+        const inputTokens = estimateTokensFromChars(turnUserChars + toolResultChars)
         // outputTokens and reasoningTokens are kept disjoint — downstream
         // aggregation (models-report, audit-report, parser) sums the two
         // fields, so folding reasoning into outputTokens would double-count.
-        const reasoningTokens = Math.ceil(reasoningChars / CHARS_PER_TOKEN)
-        const outputTokens = Math.ceil(outputChars / CHARS_PER_TOKEN)
+        const reasoningTokens = estimateTokensFromChars(reasoningChars)
+        const outputTokens = estimateTokensFromChars(outputChars)
         // Prefer real metered credits (converted at the public overage rate)
         // over token estimation; fall back to token pricing when the turn has
         // no usage_summary (e.g. still in progress or null usage). Reasoning

--- a/src/providers/warp.ts
+++ b/src/providers/warp.ts
@@ -4,6 +4,7 @@ import { homedir } from 'os'
 import { extractBashCommands } from '../bash-utils.js'
 import { calculateCost, getShortModelName } from '../models.js'
 import { blobToText, getSqliteLoadError, isSqliteAvailable, openDatabase, type SqliteDatabase } from '../sqlite.js'
+import { estimateTokensFromChars } from '../token-estimate.js'
 import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
 import { safeNumber } from '../parser.js'
 
@@ -11,8 +12,6 @@ const WARP_GROUP_CONTAINER = '2BBY89MBSN.dev.warp'
 const WARP_STABLE_BUNDLE_ID = 'dev.warp.Warp-Stable'
 const WARP_PREVIEW_BUNDLE_ID = 'dev.warp.Warp-Preview'
 const PRIMARY_AGENT_CATEGORY = 'primary_agent'
-const CHARS_PER_TOKEN = 4
-
 const modelAliases: Record<string, string> = {
   'Claude Sonnet 4.6': 'claude-sonnet-4-6',
   'Claude Sonnet 4.5': 'claude-sonnet-4-5',
@@ -199,7 +198,7 @@ function extractUserMessage(rawInput: string): string {
 function estimateWeight(rawInput: string): number {
   const userMessage = extractUserMessage(rawInput)
   const source = userMessage || rawInput
-  const tokens = Math.ceil(source.length / CHARS_PER_TOKEN)
+  const tokens = estimateTokensFromChars(source.length)
   return Math.max(1, tokens)
 }
 

--- a/src/token-estimate.ts
+++ b/src/token-estimate.ts
@@ -1,0 +1,5 @@
+export const CHARS_PER_TOKEN = 4
+
+export function estimateTokensFromChars(chars: number): number {
+  return Math.ceil(chars / CHARS_PER_TOKEN)
+}

--- a/tests/providers/cursor-agent.test.ts
+++ b/tests/providers/cursor-agent.test.ts
@@ -6,10 +6,10 @@ import { tmpdir } from 'os'
 
 import { getAllProviders } from '../../src/providers/index.js'
 import { createCursorAgentProvider } from '../../src/providers/cursor-agent.js'
+import { estimateTokensFromChars } from '../../src/token-estimate.js'
 import type { ParsedProviderCall, Provider, SessionSource } from '../../src/providers/types.js'
 import { isSqliteAvailable } from '../../src/sqlite.js'
 
-const CHARS_PER_TOKEN = 4
 const CURSOR_AGENT_DEFAULT_MODEL = 'cursor-agent-auto'
 const FIXED_UUID = '123e4567-e89b-12d3-a456-426614174000'
 
@@ -180,8 +180,8 @@ describe('cursor-agent provider', () => {
     expect(calls).toHaveLength(1)
     expect(calls[0]!.provider).toBe('cursor-agent')
     expect(calls[0]!.model).toBe(CURSOR_AGENT_DEFAULT_MODEL)
-    expect(calls[0]!.inputTokens).toBe(Math.ceil(userText.length / CHARS_PER_TOKEN))
-    expect(calls[0]!.outputTokens).toBe(Math.ceil(assistantText.length / CHARS_PER_TOKEN))
+    expect(calls[0]!.inputTokens).toBe(estimateTokensFromChars(userText.length))
+    expect(calls[0]!.outputTokens).toBe(estimateTokensFromChars(assistantText.length))
     expect(calls[0]!.reasoningTokens).toBe(0)
     expect(calls[0]!.deduplicationKey).toBe(`cursor-agent:${FIXED_UUID}:0`)
   })

--- a/tests/token-estimate.test.ts
+++ b/tests/token-estimate.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { CHARS_PER_TOKEN, estimateTokensFromChars } from '../src/token-estimate.js'
+
+describe('estimateTokensFromChars', () => {
+  it('uses four characters per token', () => {
+    expect(CHARS_PER_TOKEN).toBe(4)
+  })
+
+  it('rounds partial tokens up', () => {
+    expect(estimateTokensFromChars(5)).toBe(2)
+  })
+
+  it('handles zero and boundary character counts', () => {
+    expect(estimateTokensFromChars(0)).toBe(0)
+    expect(estimateTokensFromChars(1)).toBe(1)
+    expect(estimateTokensFromChars(4)).toBe(1)
+  })
+})


### PR DESCRIPTION
## Problem

`CHARS_PER_TOKEN` is defined independently in 7 files (`src/context-tree.ts`, `src/context-budget.ts`, and the kiro / cursor / warp / codex / cursor-agent providers), with `Math.ceil(len / CHARS_PER_TOKEN)` re-derived at each site. Any future refinement of the heuristic would silently apply to some providers and not others, skewing cross-provider comparisons. (#644)

## Fix

New leaf module `src/token-estimate.ts` exporting `CHARS_PER_TOKEN` and `estimateTokensFromChars(chars)`; all 7 local constants deleted and every call site migrated. One additional hardcoded `/ 4` site in `src/context-tree-codex.ts` (same heuristic, just never named) is migrated too.

Behavior-identical by construction: every site already used ratio 4 with `Math.ceil`, and the two sites with extra semantics keep them — `cursor-agent`'s non-positive guard is preserved, and `context-tree-codex`'s fractional decoded-size input goes through the same `ceil(chars / 4)`.

The module imports nothing from `src/`, so providers stay lazy-loadable.

## Tests

- New `tests/token-estimate.test.ts` pins the heuristic: ratio value, ceil rounding, zero/boundary inputs. The ratio can now only change in one place, guarded by one test.
- `npx tsc --noEmit` clean.
- Full suite: `npx vitest run` — 130 files passed, 1713 tests passed, 0 failed.

Closes #644