### PR TITLE
fix: packaged desktop app cannot find node to run the CLI

### DIFF
--- a/app/electron/cli.test.ts
+++ b/app/electron/cli.test.ts
@@ -2,9 +2,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
-import { spawnCli, spawnCliAction, killAll, CliError, nodeManagerDirs, resolveCodeburnPath } from './cli'
+import { spawnCli, spawnCliAction, spawnEnvFor, killAll, CliError, nodeManagerDirs, resolveCodeburnPath } from './cli'
 
 let dir: string
 const originalBin = process.env.CODEBURN_BIN
@@ -112,6 +112,24 @@ describe('spawnCli', () => {
   it('rejects with kind "too-large" and kills a binary that floods stdout', async () => {
     fakeBin('flood.js', "const s='x'.repeat(1024*1024); for(let i=0;i<20;i++) process.stdout.write(s); setInterval(()=>{},1000)")
     await expect(spawnCli(['status'])).rejects.toMatchObject({ kind: 'too-large' } satisfies Partial<CliError>)
+  })
+})
+
+describe('spawn PATH augmentation (GUI-launched apps have a minimal PATH)', () => {
+  it("prepends the resolved binary's own directory so its env-shebang finds node", async () => {
+    const bin = fakeBin('path-echo.js', 'process.stdout.write(JSON.stringify({ path: process.env.PATH }))')
+    const result = await spawnCli(['status']) as { path: string }
+    expect(result.path.split(':')[0]).toBe(dirname(bin))
+  })
+
+  it('spawnEnvFor dedupes and keeps the original PATH entries', () => {
+    const env = spawnEnvFor('/some/tool/bin/codeburn')
+    const parts = (env.PATH ?? '').split(':')
+    expect(parts[0]).toBe('/some/tool/bin')
+    expect(new Set(parts).size).toBe(parts.length)
+    for (const original of (process.env.PATH ?? '').split(':').filter(Boolean)) {
+      expect(parts).toContain(original)
+    }
   })
 })
 

--- a/app/electron/cli.ts
+++ b/app/electron/cli.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { accessSync, constants, existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { homedir, platform } from 'node:os'
-import { delimiter, join } from 'node:path'
+import { delimiter, dirname, join } from 'node:path'
 
 // Runs entirely in the Electron main process. This module must NOT import
 // `electron` so it stays unit-testable in a plain node environment.
@@ -75,6 +75,21 @@ function searchDirs(): string[] {
   if (override !== undefined) return override.split(delimiter).filter(Boolean)
   const pathDirs = (process.env.PATH || '').split(delimiter).filter(Boolean)
   return [...pathDirs, ...nodeManagerDirs()]
+}
+
+/**
+ * Spawn env for the resolved CLI. A GUI-launched app inherits a minimal PATH
+ * (/usr/bin:/bin:...) that lacks the user's node install, and the `codeburn`
+ * npm shim starts with `#!/usr/bin/env node` — so spawning it fails with
+ * "env: node: No such file or directory" even though the shim itself was
+ * found. Prepend the shim's own directory (node sits beside it in nvm,
+ * Homebrew, and npm-prefix layouts) plus the same dirs the resolver searches.
+ */
+export function spawnEnvFor(bin: string): NodeJS.ProcessEnv {
+  const parts = [dirname(bin), ...searchDirs(), ...(process.env.PATH || '').split(delimiter)]
+  const seen = new Set<string>()
+  const path = parts.filter(p => p && !seen.has(p) && (seen.add(p), true)).join(delimiter)
+  return { ...process.env, PATH: path }
 }
 
 function isExecutableFile(p: string): boolean {
@@ -151,7 +166,7 @@ export function resolveCodeburnPath(): string | null {
 
 function runCli(bin: string, args: string[], timeoutMs: number): Promise<unknown> {
   return new Promise<unknown>((resolve, reject) => {
-    const child = spawn(bin, args, { shell: false, stdio: ['ignore', 'pipe', 'pipe'] })
+    const child = spawn(bin, args, { shell: false, stdio: ['ignore', 'pipe', 'pipe'], env: spawnEnvFor(bin) })
     activeChildren.add(child)
     let stdout = ''
     let stderr = ''
@@ -245,7 +260,7 @@ export function spawnCliAction(args: string[], opts: { timeoutMs?: number } = {}
       return
     }
 
-    const child = spawn(bin, args, { shell: false, stdio: ['ignore', 'pipe', 'pipe'] })
+    const child = spawn(bin, args, { shell: false, stdio: ['ignore', 'pipe', 'pipe'], env: spawnEnvFor(bin) })
     activeChildren.add(child)
     let stdout = ''
     let stderr = ''


### PR DESCRIPTION
Packaged (GUI-launched) builds got 'env: node: No such file or directory' on every screen: minimal GUI PATH lacks the user's node, and the codeburn shim needs it. Spawn env now prepends the resolved binary's directory + resolver search dirs. Two new tests; suite 275/275.