### PR TITLE
feat(doctor): per-provider detection diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ Sync sends token counts, costs, models, and projects — never prompts or code. 
 
 | Command | What it does |
 |---------|--------------|
+| `codeburn doctor` | Per-provider detection status: paths probed, sessions found, parse health (`--json`, `--provider`) |
 | `codeburn audit` | Per provider-model token source table: where every number comes from |
 | `codeburn context` | What fills a session's context window: interactive browser (Claude Code and Codex) |
 | `codeburn context <id> --json` | The same context tree, scriptable |
@@ -559,6 +560,18 @@ codeburn report --to 2026-04-10                      # earliest data through thi
 ```
 
 Either flag alone is valid. Inverted or malformed dates exit with a clear error. In the TUI, the custom range sets the initial load only; pressing `1` through `5` switches back to predefined periods.
+
+### Diagnosing detection
+
+When a tool shows zero (or a number that looks wrong), `codeburn doctor` explains why. It runs fully offline and read-only, and never writes to caches or config.
+
+```bash
+codeburn doctor                     # every provider, human-readable table
+codeburn doctor --provider opencode # diagnose one provider
+codeburn doctor --json              # machine-readable, pipe to jq
+```
+
+For each provider it shows the exact directories or databases probed (with any env override such as `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, or `OPENCODE_DATA_DIR` and whether the path exists), how many session files were found, how many of a bounded sample parsed cleanly, the cached file count, and a one-line verdict: `OK (n sessions)`, `NOTHING FOUND` with the likely cause (directory missing, override points at an empty dir, or the tool is not installed), or `ERRORS (n parse failures)`. A provider that throws is caught and reported as its own error row, never crashing the rest of the report.
 
 ### JSON Output
 

--- a/src/cursor-cache.ts
+++ b/src/cursor-cache.ts
@@ -79,6 +79,10 @@ export async function writeCachedResults(
   calls: ParsedProviderCall[],
   lookbackFloor: string,
 ): Promise<void> {
+  // Diagnostic contexts (codeburn doctor) sample-parse providers under a
+  // strictly read-only promise; this is the one parse path that writes to
+  // disk before its first yield, so it honors the suppression flag.
+  if (process.env['CODEBURN_SUPPRESS_CACHE_WRITES']) return
   const fp = await getDbFingerprint(dbPath)
   if (!fp) return
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,346 @@
+import { existsSync } from 'fs'
+import { dirname } from 'path'
+
+import { Chalk } from 'chalk'
+
+import { getAllProviders } from './providers/index.js'
+import type { Provider } from './providers/types.js'
+import {
+  PROVIDER_ENV_VARS,
+  PROVIDER_PARSE_VERSIONS,
+  loadCache,
+  type SessionCache,
+} from './session-cache.js'
+import { renderTable } from './text-table.js'
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export type DoctorProbePath = {
+  path: string
+  label: string
+  exists: boolean
+}
+
+export type DoctorEnvOverride = {
+  name: string
+  value: string
+}
+
+export type DoctorStatus = 'ok' | 'empty' | 'errors' | 'error' | 'network'
+
+export type DoctorProviderReport = {
+  provider: string
+  displayName: string
+  status: DoctorStatus
+  /** Directories/dbs the provider scans, with existence checked (may be empty
+   *  for providers that do not expose probeRoots). */
+  probePaths: DoctorProbePath[]
+  /** Env overrides that are actually set for this provider. */
+  envOverrides: DoctorEnvOverride[]
+  parseVersion?: string
+  /** Session sources discovered (candidate files/dbs). */
+  candidatesFound: number
+  /** How many discovered sources we attempted to parse (bounded sample). */
+  sampled: number
+  parsedOk: number
+  parseFailed: number
+  /** True when we sampled fewer sources than were discovered. */
+  bounded: boolean
+  /** Files cached for this provider in session-cache.json. */
+  cachedFiles: number
+  /** Cached entries flagged as parse failures. */
+  cachedFailed: number
+  /** One-line human verdict. */
+  verdict: string
+  /** Message when the provider itself threw (status 'error'). */
+  error?: string
+}
+
+export type DoctorReport = {
+  generatedAt: string
+  providers: DoctorProviderReport[]
+}
+
+export type CollectDoctorOptions = {
+  /** Injectable provider list (defaults to the real registry). */
+  providers?: Provider[]
+  /** Injectable cache snapshot (defaults to reading session-cache.json). */
+  cache?: SessionCache
+  /** Max discovered sources to parse-sample per provider. */
+  sampleLimit?: number
+}
+
+// Bound the parse sample so doctor never does a full expensive parse of a huge
+// history: sample at most this many discovered sources per provider, and read
+// at most this many calls out of each before moving on.
+const DEFAULT_SAMPLE_LIMIT = 8
+const PARSE_CALL_CAP = 500
+
+// ── Collect (pure, testable) ─────────────────────────────────────────────
+
+function collectEnvOverrides(providerName: string): DoctorEnvOverride[] {
+  const vars = PROVIDER_ENV_VARS[providerName] ?? []
+  const out: DoctorEnvOverride[] = []
+  for (const name of vars) {
+    const value = process.env[name]
+    if (value !== undefined && value !== '') out.push({ name, value })
+  }
+  return out
+}
+
+async function collectProbePaths(provider: Provider): Promise<DoctorProbePath[]> {
+  if (!provider.probeRoots) return []
+  const roots = await provider.probeRoots()
+  return roots.map(r => ({ path: r.path, label: r.label, exists: existsSync(r.path) }))
+}
+
+// A discovered source path can carry a virtual suffix (`<db>#cursor-ws=...`,
+// `<db>:<sessionId>`); strip it to the real on-disk path, then to its parent
+// dir so many per-session sources collapse to a handful of probed directories.
+function realPathOf(sourcePath: string): string {
+  const hashIdx = sourcePath.indexOf('#')
+  let p = hashIdx > 0 ? sourcePath.slice(0, hashIdx) : sourcePath
+  const colonIdx = p.lastIndexOf(':')
+  // Keep Windows drive letters (`C:\...`): only strip a colon that is not the
+  // drive separator (index > 1).
+  if (colonIdx > 1) p = p.slice(0, colonIdx)
+  return p
+}
+
+function derivePathsFromSources(sourcePaths: string[]): DoctorProbePath[] {
+  const dirs = new Set<string>()
+  for (const sp of sourcePaths) {
+    const real = realPathOf(sp)
+    dirs.add(existsSync(real) ? dirname(real) : real)
+  }
+  return [...dirs].sort().map(path => ({ path, label: 'discovered', exists: existsSync(path) }))
+}
+
+function pluralSessions(n: number): string {
+  return `${n} session${n === 1 ? '' : 's'}`
+}
+
+function emptyVerdict(
+  probePaths: DoctorProbePath[],
+  envOverrides: DoctorEnvOverride[],
+): string {
+  const overrideNames = envOverrides.map(o => o.name).join(', ')
+  const hasOverride = envOverrides.length > 0
+  const known = probePaths.filter(p => p.label !== 'discovered')
+  const missing = known.filter(p => !p.exists)
+  const present = known.filter(p => p.exists)
+
+  // No known probe roots to check: honest, override-aware fallback.
+  if (known.length === 0) {
+    return hasOverride
+      ? `NOTHING FOUND (override ${overrideNames} set, but nothing was discovered)`
+      : 'NOTHING FOUND (tool likely not installed or no history yet)'
+  }
+  // With an override set, a missing probed path is the likely culprit; name it
+  // so the row itself points at the misconfiguration (Details lists them all).
+  if (hasOverride) {
+    return missing.length > 0
+      ? `NOTHING FOUND (override ${overrideNames} set; ${missing[0]!.path} does not exist)`
+      : `NOTHING FOUND (override ${overrideNames} set; ${present[0]!.path} holds no sessions)`
+  }
+  // No override. If every probed path is missing, the tool is likely not
+  // installed; if some exist, the data dir is there but empty (no history).
+  return present.length === 0
+    ? `NOTHING FOUND (${missing[0]!.path} does not exist; tool likely not installed)`
+    : `NOTHING FOUND (${present[0]!.path} exists but holds no sessions; no history yet)`
+}
+
+async function collectOneProvider(
+  provider: Provider,
+  cache: SessionCache,
+  sampleLimit: number,
+): Promise<DoctorProviderReport> {
+  const base: DoctorProviderReport = {
+    provider: provider.name,
+    displayName: provider.displayName,
+    status: 'ok',
+    probePaths: [],
+    envOverrides: collectEnvOverrides(provider.name),
+    parseVersion: PROVIDER_PARSE_VERSIONS[provider.name],
+    candidatesFound: 0,
+    sampled: 0,
+    parsedOk: 0,
+    parseFailed: 0,
+    bounded: false,
+    cachedFiles: 0,
+    cachedFailed: 0,
+    verdict: '',
+  }
+
+  const section = cache.providers[provider.name]
+  if (section) {
+    const files = Object.values(section.files)
+    base.cachedFiles = files.length
+    base.cachedFailed = files.filter(f => f.failed).length
+  }
+
+  // Any single provider throwing (probe, discovery, or a parser) must never
+  // crash doctor or blank the other rows: catch and report it as an ERROR row.
+  try {
+    base.probePaths = await collectProbePaths(provider)
+
+    const sources = await provider.discoverSessions()
+    base.candidatesFound = sources.length
+    if (base.probePaths.length === 0) {
+      base.probePaths = derivePathsFromSources(sources.map(s => s.path))
+    }
+
+    // Network providers fetch on parse; doctor runs offline, so we never parse
+    // them. Discovery for the one network provider is offline (it only checks
+    // for a configured API key), so the count above still means something.
+    if (provider.network) {
+      base.status = 'network'
+      base.verdict = base.candidatesFound > 0
+        ? `NETWORK (${base.candidatesFound} source configured; parse skipped offline)`
+        : 'NETWORK (not configured; no API key)'
+      return base
+    }
+
+    if (sources.length > 0) {
+      const sample = sources.slice(0, sampleLimit)
+      base.bounded = sample.length < sources.length
+      const seenKeys = new Set<string>()
+      for (const source of sample) {
+        base.sampled++
+        try {
+          const parser = provider.createSessionParser(source, seenKeys)
+          let n = 0
+          for await (const _call of parser.parse()) {
+            if (++n >= PARSE_CALL_CAP) break
+          }
+          base.parsedOk++
+        } catch {
+          base.parseFailed++
+        }
+      }
+    }
+
+    if (base.parseFailed > 0) {
+      base.status = 'errors'
+      base.verdict = `ERRORS (${base.parseFailed}/${base.sampled} sampled file${base.sampled === 1 ? '' : 's'} failed to parse)`
+    } else if (base.candidatesFound === 0) {
+      base.status = 'empty'
+      base.verdict = emptyVerdict(base.probePaths, base.envOverrides)
+    } else {
+      base.status = 'ok'
+      base.verdict = `OK (${pluralSessions(base.candidatesFound)})`
+    }
+  } catch (err) {
+    base.status = 'error'
+    base.error = err instanceof Error ? err.message : String(err)
+    base.verdict = `ERROR (${base.error})`
+  }
+
+  return base
+}
+
+export async function collectDoctorReport(
+  providerFilter?: string,
+  opts: CollectDoctorOptions = {},
+): Promise<DoctorReport> {
+  const all = opts.providers ?? await getAllProviders()
+  const filtered = providerFilter && providerFilter !== 'all'
+    ? all.filter(p => p.name === providerFilter)
+    : all
+  const cache = opts.cache ?? await loadCache()
+  const sampleLimit = opts.sampleLimit ?? DEFAULT_SAMPLE_LIMIT
+
+  const providers: DoctorProviderReport[] = []
+  for (const provider of filtered) {
+    providers.push(await collectOneProvider(provider, cache, sampleLimit))
+  }
+  providers.sort((a, b) => (a.displayName < b.displayName ? -1 : a.displayName > b.displayName ? 1 : 0))
+
+  return { generatedAt: new Date().toISOString(), providers }
+}
+
+// ── Render ────────────────────────────────────────────────────────────────
+
+export function renderDoctorJson(report: DoctorReport): string {
+  return JSON.stringify(report, null, 2)
+}
+
+export function renderDoctorTable(
+  report: DoctorReport,
+  opts: { color?: boolean } = {},
+): string {
+  const c = new Chalk(opts.color === false ? { level: 0 } : {})
+  const out: string[] = []
+
+  const n = report.providers.length
+  out.push(c.bold('CodeBurn doctor') + c.dim(`   ${n} provider${n === 1 ? '' : 's'}   ${report.generatedAt.slice(0, 19).replace('T', ' ')} UTC`))
+  out.push('')
+
+  const colorVerdict = (r: DoctorProviderReport): string => {
+    if (r.status === 'ok') return c.green(r.verdict)
+    if (r.status === 'network') return c.cyan(r.verdict)
+    if (r.status === 'empty') return c.yellow(r.verdict)
+    return c.red(r.verdict)
+  }
+
+  const rows = report.providers.map(r => [
+    r.displayName,
+    r.status === 'network' ? '-' : String(r.candidatesFound),
+    r.status === 'network' || r.sampled === 0 ? '-' : `${r.parsedOk}/${r.sampled}${r.bounded ? '+' : ''}`,
+    String(r.cachedFiles),
+    colorVerdict(r),
+  ])
+
+  out.push(renderTable(
+    [
+      { header: 'Provider' },
+      { header: 'Sessions', right: true },
+      { header: 'Parsed', right: true },
+      { header: 'Cached', right: true },
+      { header: 'Verdict' },
+    ],
+    rows,
+    { color: opts.color },
+  ))
+
+  // Detail: show the exact probed paths + overrides only where there is
+  // something diagnostic to show (known probe roots, an override, a hard
+  // error, or cached parse failures), so a wrong path is spotted at a glance
+  // without a wall of empty blocks for tools that are simply not installed.
+  const detail = report.providers.filter(
+    r =>
+      r.status === 'error' ||
+      r.status === 'errors' ||
+      r.envOverrides.length > 0 ||
+      r.cachedFailed > 0 ||
+      r.probePaths.some(p => p.label !== 'discovered'),
+  )
+  if (detail.length > 0) {
+    out.push('')
+    out.push(c.bold('Details'))
+    for (const r of detail) {
+      out.push('  ' + c.bold(r.displayName))
+      for (const o of r.envOverrides) {
+        out.push('    ' + c.dim('override ') + `${o.name}=${o.value}`)
+      }
+      for (const p of r.probePaths) {
+        const mark = p.exists ? c.green('exists') : c.red('missing')
+        out.push('    ' + c.dim(`${p.label}: `) + p.path + ' ' + c.dim('(') + mark + c.dim(')'))
+      }
+      if (r.parseVersion) out.push('    ' + c.dim('parser: ') + r.parseVersion)
+      if (r.cachedFailed > 0) out.push('    ' + c.dim('cached parse failures: ') + String(r.cachedFailed))
+      if (r.error) out.push('    ' + c.red('error: ') + r.error)
+    }
+  }
+
+  out.push('')
+  const broken = report.providers.filter(r => r.status === 'error' || r.status === 'errors')
+  const empty = report.providers.filter(r => r.status === 'empty')
+  const ok = report.providers.filter(r => r.status === 'ok')
+  out.push(
+    c.dim('Bottom line: ') +
+    `${ok.length} OK, ${empty.length} with nothing found, ${broken.length} with errors.`,
+  )
+
+  return out.join('\n') + '\n'
+}

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -70,11 +70,23 @@ export type CollectDoctorOptions = {
   sampleLimit?: number
 }
 
-// Bound the parse sample so doctor never does a full expensive parse of a huge
-// history: sample at most this many discovered sources per provider, and read
-// at most this many calls out of each before moving on.
+// Bound the parse sample: at most this many discovered sources per provider,
+// truncating each source's yields at PARSE_CALL_CAP. Note the cap bounds the
+// yield loop only; eager parsers (codex, cursor) do their full per-file work
+// before the first yield, so a very large single source is still parsed whole.
 const DEFAULT_SAMPLE_LIMIT = 8
 const PARSE_CALL_CAP = 500
+
+// Providers whose parse() has side effects beyond reading: antigravity probes
+// for a live language server (spawns ps/lsof and RPCs it when found). A
+// diagnostic that promises to be inert must not sample-parse those; discovery
+// (readdir/stat only) still runs, so session counts stay meaningful.
+const PARSE_SPAWNS = new Set(['antigravity'])
+
+// CodeBurn's own cache location: listed in PROVIDER_ENV_VARS for cache
+// fingerprinting, but it is not a discovery path, so it must never be blamed
+// in a NOTHING FOUND hint.
+const NON_DISCOVERY_ENV_VARS = new Set(['CODEBURN_CACHE_DIR'])
 
 // ── Collect (pure, testable) ─────────────────────────────────────────────
 
@@ -124,8 +136,9 @@ function emptyVerdict(
   probePaths: DoctorProbePath[],
   envOverrides: DoctorEnvOverride[],
 ): string {
-  const overrideNames = envOverrides.map(o => o.name).join(', ')
-  const hasOverride = envOverrides.length > 0
+  const discoveryOverrides = envOverrides.filter(o => !NON_DISCOVERY_ENV_VARS.has(o.name))
+  const overrideNames = discoveryOverrides.map(o => o.name).join(', ')
+  const hasOverride = discoveryOverrides.length > 0
   const known = probePaths.filter(p => p.label !== 'discovered')
   const missing = known.filter(p => !p.exists)
   const present = known.filter(p => p.exists)
@@ -201,6 +214,12 @@ async function collectOneProvider(
       return base
     }
 
+    if (sources.length > 0 && PARSE_SPAWNS.has(provider.name)) {
+      base.status = 'ok'
+      base.verdict = `OK (${pluralSessions(sources.length)}; parse sample skipped, provider probes live processes)`
+      return base
+    }
+
     if (sources.length > 0) {
       const sample = sources.slice(0, sampleLimit)
       base.bounded = sample.length < sources.length
@@ -250,13 +269,25 @@ export async function collectDoctorReport(
   const cache = opts.cache ?? await loadCache()
   const sampleLimit = opts.sampleLimit ?? DEFAULT_SAMPLE_LIMIT
 
-  const providers: DoctorProviderReport[] = []
-  for (const provider of filtered) {
-    providers.push(await collectOneProvider(provider, cache, sampleLimit))
-  }
-  providers.sort((a, b) => (a.displayName < b.displayName ? -1 : a.displayName > b.displayName ? 1 : 0))
+  // Doctor promises to be strictly read-only, but sample-parsing drives real
+  // provider parsers, and cursor's writes its results cache to disk before its
+  // first yield. The flag tells cache writers to stand down for this process
+  // while doctor collects; restored afterwards so long-lived embedders (tests,
+  // MCP) keep normal behavior.
+  const prevSuppress = process.env['CODEBURN_SUPPRESS_CACHE_WRITES']
+  process.env['CODEBURN_SUPPRESS_CACHE_WRITES'] = '1'
+  try {
+    const providers: DoctorProviderReport[] = []
+    for (const provider of filtered) {
+      providers.push(await collectOneProvider(provider, cache, sampleLimit))
+    }
+    providers.sort((a, b) => (a.displayName < b.displayName ? -1 : a.displayName > b.displayName ? 1 : 0))
 
-  return { generatedAt: new Date().toISOString(), providers }
+    return { generatedAt: new Date().toISOString(), providers }
+  } finally {
+    if (prevSuppress === undefined) delete process.env['CODEBURN_SUPPRESS_CACHE_WRITES']
+    else process.env['CODEBURN_SUPPRESS_CACHE_WRITES'] = prevSuppress
+  }
 }
 
 // ── Render ────────────────────────────────────────────────────────────────

--- a/src/main.ts
+++ b/src/main.ts
@@ -1843,6 +1843,23 @@ program
     await startStdioServer(version)
   })
 
+program
+  .command('doctor')
+  .description('Per-provider detection status: paths probed, sessions found, parse health (diagnose empty or wrong numbers)')
+  .option('--provider <provider>', 'Diagnose a single provider (e.g. claude, codex, opencode)', 'all')
+  .option('--json', 'Output machine-readable JSON')
+  .option('--no-color', 'Disable ANSI colors')
+  .action(async (opts) => {
+    assertProvider(opts.provider, 'doctor')
+    const { collectDoctorReport, renderDoctorTable, renderDoctorJson } = await import('./doctor.js')
+    const report = await collectDoctorReport(opts.provider)
+    if (opts.json) {
+      process.stdout.write(renderDoctorJson(report) + '\n')
+      return
+    }
+    process.stdout.write(renderDoctorTable(report, { color: opts.color }))
+  })
+
 registerActCommands(program)
 registerGuardCommands(program)
 registerSyncCommands(program)

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -3,7 +3,7 @@ import { basename, delimiter as pathDelimiter, join, resolve } from 'path'
 import { homedir } from 'os'
 import { createHash } from 'crypto'
 
-import type { Provider, SessionSource, SessionParser } from './types.js'
+import type { Provider, ProbeRoot, SessionSource, SessionParser } from './types.js'
 import { getShortModelName } from '../models.js'
 import { readConfig } from '../config.js'
 
@@ -213,6 +213,16 @@ export const claude: Provider = {
 
   toolDisplayName(rawTool: string): string {
     return rawTool
+  },
+
+  // Each config dir's `projects/` subdir is what discoverSessions readdir's,
+  // plus the Claude Desktop sessions base. Resolved via the same helpers so a
+  // CLAUDE_CONFIG_DIR(S) override is reflected exactly.
+  async probeRoots(): Promise<ProbeRoot[]> {
+    const dirs = await getClaudeConfigDirs()
+    const roots: ProbeRoot[] = dirs.map(dir => ({ path: join(dir, 'projects'), label: 'projects' }))
+    roots.push({ path: getDesktopSessionsDir(), label: 'desktop' })
+    return roots
   },
 
   async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -9,7 +9,7 @@ import { calculateCost } from '../models.js'
 import { readCachedCodexResults, writeCachedCodexResults, getCachedCodexProject, fingerprintFile } from '../codex-cache.js'
 import { normalizeContentBlocks } from '../content-utils.js'
 import type { ToolCall } from '../types.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { Provider, ProbeRoot, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
 const modelDisplayNames: Record<string, string> = {
   'codex-auto-review': 'Codex Auto Review',
@@ -683,6 +683,15 @@ export function createCodexProvider(codexDir?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return toolNameMap[rawTool] ?? rawTool
+    },
+
+    // Same `dir` discoverSessionsInDir walks: <codexDir>/sessions (dated
+    // rollout files) and <codexDir>/archived_sessions. Honors CODEX_HOME.
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [
+        { path: join(dir, 'sessions'), label: 'sessions' },
+        { path: join(dir, 'archived_sessions'), label: 'archived' },
+      ]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/opencode.ts
+++ b/src/providers/opencode.ts
@@ -4,7 +4,7 @@ import { homedir } from 'os'
 import { getShortModelName } from '../models.js'
 import { discoverSqliteSessions, createSqliteSessionParser, type SqliteProviderConfig } from './sqlite-session-parser.js'
 import { discoverOpenCodeFileSessions, createOpenCodeFileSessionParser } from './opencode-file-parser.js'
-import type { Provider, SessionSource, SessionParser } from './types.js'
+import type { Provider, ProbeRoot, SessionSource, SessionParser } from './types.js'
 
 const toolNameMap: Record<string, string> = {
   bash: 'Bash',
@@ -78,6 +78,13 @@ export function createOpenCodeProvider(dataDir?: string): Provider {
     // sources so migrated installs keep reporting legacy sessions AND pick up
     // current SQLite data. Dedup is handled per-message in createSessionParser
     // via seenKeys (keyed by `${provider}:${sessionId}:${messageId}`).
+    // Both the legacy JSON store (storage/session/*.json) and the SQLite DB
+    // (opencode*.db) live under this one data dir, resolved via OPENCODE_DATA_DIR
+    // or XDG_DATA_HOME the same way discoverSessions does.
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: resolvedDataDir, label: 'data' }]
+    },
+
     async discoverSessions(): Promise<SessionSource[]> {
       const fileSessions = await discoverOpenCodeFileSessions(resolvedDataDir, 'opencode')
       const sqliteSessions = await discoverSqliteSessions(sqliteConfig)

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -45,6 +45,15 @@ export type ParsedProviderCall = {
   projectPath?: string
 }
 
+// A directory or database file that a provider's discoverSessions() scans.
+// Reported by `codeburn doctor` so an empty or wrong result is self-diagnosable:
+// the path is resolved exactly as discovery resolves it (honoring env overrides
+// and configured dirs), and the doctor checks existence separately.
+export type ProbeRoot = {
+  path: string
+  label: string
+}
+
 export type Provider = {
   name: string
   displayName: string
@@ -60,4 +69,10 @@ export type Provider = {
   toolDisplayName(rawTool: string): string
   discoverSessions(): Promise<SessionSource[]>
   createSessionParser(source: SessionSource, seenKeys: Set<string>, dateRange?: DateRange): SessionParser
+  // The exact directories/dbs discoverSessions() scans, resolved the same way.
+  // Optional: providers that implement it let `codeburn doctor` show and
+  // existence-check the probed paths even when zero sessions are found (so
+  // "tool not installed" vs "wrong override" is distinguishable). Providers
+  // without it fall back to the paths of whatever sessions were discovered.
+  probeRoots?(): Promise<ProbeRoot[]>
 }

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -91,7 +91,7 @@ export const CACHE_VERSION = 5
 const CACHE_FILE = 'session-cache.json'
 const TEMP_FILE_MAX_AGE_MS = 5 * 60 * 1000
 
-const PROVIDER_ENV_VARS: Record<string, string[]> = {
+export const PROVIDER_ENV_VARS: Record<string, string[]> = {
   claude: ['CLAUDE_CONFIG_DIRS', 'CLAUDE_CONFIG_DIR'],
   codewhale: ['CODEWHALE_HOME'],
   codex: ['CODEX_HOME'],
@@ -113,7 +113,7 @@ const PROVIDER_ENV_VARS: Record<string, string[]> = {
 // disappear — they are preserved so month-to-date totals never drop.
 export const DURABLE_PROVIDER_NAMES: ReadonlySet<string> = new Set(['copilot'])
 
-const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
+export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   claude: 'advisor-usage-v1',
   cline: 'worktree-project-grouping-v1',
   codewhale: 'aggregate-session-v1',

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { collectDoctorReport, renderDoctorTable, renderDoctorJson } from '../src/doctor.js'
+import { createCodexProvider } from '../src/providers/codex.js'
+import { emptyCache, type SessionCache } from '../src/session-cache.js'
+import type { Provider, ProbeRoot, SessionSource } from '../src/providers/types.js'
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+// A valid single-line Codex rollout so real discovery + probeRoots + parse run
+// end to end against a fixture directory.
+function sessionMeta(): string {
+  return JSON.stringify({
+    type: 'session_meta',
+    timestamp: '2026-04-14T10:00:00Z',
+    payload: {
+      cwd: '/Users/test/proj',
+      originator: 'codex-cli',
+      session_id: 'sess-001',
+      model: 'gpt-5.3-codex',
+    },
+  })
+}
+
+function tokenCount(): string {
+  return JSON.stringify({
+    type: 'event_msg',
+    timestamp: '2026-04-14T10:01:00Z',
+    payload: {
+      type: 'token_count',
+      info: {
+        total_token_usage: {
+          input_tokens: 100,
+          cached_input_tokens: 0,
+          output_tokens: 50,
+          reasoning_output_tokens: 0,
+          total_tokens: 150,
+        },
+      },
+    },
+  })
+}
+
+async function writeCodexSession(codexDir: string): Promise<void> {
+  const dayDir = join(codexDir, 'sessions', '2026', '04', '14')
+  await mkdir(dayDir, { recursive: true })
+  await writeFile(join(dayDir, 'rollout-sess-001.jsonl'), `${sessionMeta()}\n${tokenCount()}\n`)
+}
+
+// Fully controllable synthetic provider for the edge cases (network, throwing,
+// parse failure) that on-disk fixtures cannot force deterministically.
+function fakeProvider(over: Partial<Provider> & { name: string }): Provider {
+  return {
+    displayName: over.name,
+    modelDisplayName: (m: string) => m,
+    toolDisplayName: (t: string) => t,
+    discoverSessions: async () => [],
+    createSessionParser: () => ({ async *parse() {} }),
+    ...over,
+  }
+}
+
+function only(report: Awaited<ReturnType<typeof collectDoctorReport>>, name: string) {
+  const r = report.providers.find(p => p.provider === name)
+  if (!r) throw new Error(`no report row for ${name}`)
+  return r
+}
+
+let tmpDir: string
+beforeEach(async () => { tmpDir = await mkdtemp(join(tmpdir(), 'doctor-test-')) })
+afterEach(async () => { await rm(tmpDir, { recursive: true, force: true }) })
+
+// ── Real-provider fixture-dir cases: found / empty / missing ───────────────
+
+describe('collectDoctorReport - codex fixture dirs', () => {
+  it('found: a real session file yields an OK verdict and a parsed sample', async () => {
+    await writeCodexSession(tmpDir)
+    const provider = createCodexProvider(tmpDir)
+    const report = await collectDoctorReport('all', { providers: [provider], cache: emptyCache() })
+    const r = only(report, 'codex')
+
+    expect(r.status).toBe('ok')
+    expect(r.candidatesFound).toBeGreaterThanOrEqual(1)
+    expect(r.parsedOk).toBeGreaterThanOrEqual(1)
+    expect(r.parseFailed).toBe(0)
+    expect(r.verdict).toMatch(/^OK \(/)
+    const sessions = r.probePaths.find(p => p.label === 'sessions')
+    expect(sessions?.exists).toBe(true)
+  })
+
+  it('empty: sessions dir exists but holds nothing -> NOTHING FOUND (no sessions)', async () => {
+    await mkdir(join(tmpDir, 'sessions'), { recursive: true })
+    const provider = createCodexProvider(tmpDir)
+    const report = await collectDoctorReport('all', { providers: [provider], cache: emptyCache() })
+    const r = only(report, 'codex')
+
+    expect(r.status).toBe('empty')
+    expect(r.candidatesFound).toBe(0)
+    expect(r.verdict).toContain('holds no sessions')
+    expect(r.probePaths.find(p => p.label === 'sessions')?.exists).toBe(true)
+  })
+
+  it('missing: no sessions dir -> NOTHING FOUND names the missing path', async () => {
+    // tmpDir has no `sessions` subdir at all.
+    const provider = createCodexProvider(tmpDir)
+    const report = await collectDoctorReport('all', { providers: [provider], cache: emptyCache() })
+    const r = only(report, 'codex')
+
+    expect(r.status).toBe('empty')
+    expect(r.candidatesFound).toBe(0)
+    // Mutation guard: if the exists-check is broken to always return true, this
+    // flips to false and the verdict drops "does not exist".
+    expect(r.probePaths.find(p => p.label === 'sessions')?.exists).toBe(false)
+    expect(r.verdict).toContain('does not exist')
+    expect(r.verdict).toContain(join(tmpDir, 'sessions'))
+  })
+})
+
+// ── Override case ──────────────────────────────────────────────────────────
+
+describe('collectDoctorReport - env override', () => {
+  it('names a set override pointing at a missing dir', async () => {
+    const prev = process.env['CODEX_HOME']
+    const bogus = join(tmpDir, 'does-not-exist')
+    process.env['CODEX_HOME'] = bogus
+    try {
+      // Construct after setting env so the provider resolves CODEX_HOME.
+      const provider = createCodexProvider()
+      const report = await collectDoctorReport('all', { providers: [provider], cache: emptyCache() })
+      const r = only(report, 'codex')
+
+      expect(r.envOverrides).toEqual([{ name: 'CODEX_HOME', value: bogus }])
+      expect(r.status).toBe('empty')
+      expect(r.verdict).toContain('override CODEX_HOME set')
+      expect(r.verdict).toContain('does not exist')
+    } finally {
+      if (prev === undefined) delete process.env['CODEX_HOME']
+      else process.env['CODEX_HOME'] = prev
+    }
+  })
+})
+
+// ── Synthetic edge cases ───────────────────────────────────────────────────
+
+describe('collectDoctorReport - isolation and edge cases', () => {
+  it('a provider that throws in discovery becomes an ERROR row, others survive', async () => {
+    const boom = fakeProvider({
+      name: 'boom',
+      discoverSessions: async () => { throw new Error('disk on fire') },
+    })
+    const good = fakeProvider({
+      name: 'good',
+      discoverSessions: async () => [{ path: '/x/a.json', project: 'p', provider: 'good' }],
+    })
+    const report = await collectDoctorReport('all', { providers: [boom, good], cache: emptyCache() })
+
+    const b = only(report, 'boom')
+    expect(b.status).toBe('error')
+    expect(b.error).toContain('disk on fire')
+    expect(b.verdict).toMatch(/^ERROR \(/)
+    expect(only(report, 'good').status).toBe('ok')
+  })
+
+  it('a parser that throws is counted and downgrades the verdict to ERRORS', async () => {
+    const src: SessionSource = { path: '/x/a.json', project: 'p', provider: 'flaky' }
+    const flaky = fakeProvider({
+      name: 'flaky',
+      discoverSessions: async () => [src],
+      createSessionParser: () => ({
+        // eslint-disable-next-line require-yield
+        async *parse() { throw new Error('bad json') },
+      }),
+    })
+    const r = only(await collectDoctorReport('all', { providers: [flaky], cache: emptyCache() }), 'flaky')
+
+    expect(r.status).toBe('errors')
+    expect(r.parseFailed).toBe(1)
+    expect(r.parsedOk).toBe(0)
+    expect(r.verdict).toMatch(/^ERRORS \(/)
+  })
+
+  it('network providers are never parsed offline', async () => {
+    let parserCreated = false
+    const net = fakeProvider({
+      name: 'net',
+      network: true,
+      discoverSessions: async () => [{ path: 'net:report', project: 'p', provider: 'net' }],
+      createSessionParser: () => { parserCreated = true; return { async *parse() {} } },
+    })
+    const r = only(await collectDoctorReport('all', { providers: [net], cache: emptyCache() }), 'net')
+
+    expect(parserCreated).toBe(false)
+    expect(r.status).toBe('network')
+    expect(r.sampled).toBe(0)
+    expect(r.verdict).toContain('NETWORK')
+  })
+
+  it('bounds the parse sample and flags it', async () => {
+    const sources: SessionSource[] = Array.from({ length: 5 }, (_, i) => ({ path: `/x/${i}.json`, project: 'p', provider: 'many' }))
+    const many = fakeProvider({
+      name: 'many',
+      discoverSessions: async () => sources,
+      createSessionParser: () => ({ async *parse() { yield undefined as never } }),
+    })
+    const r = only(await collectDoctorReport('all', { providers: [many], cache: emptyCache(), sampleLimit: 2 }), 'many')
+
+    expect(r.candidatesFound).toBe(5)
+    expect(r.sampled).toBe(2)
+    expect(r.bounded).toBe(true)
+    expect(r.status).toBe('ok')
+  })
+
+  it('reports cache state from the injected snapshot', async () => {
+    const cache: SessionCache = emptyCache()
+    cache.providers['cached'] = {
+      envFingerprint: 'x',
+      files: {
+        '/a.jsonl': { fingerprint: { dev: 1, ino: 1, mtimeMs: 1, sizeBytes: 1 }, mcpInventory: [], turns: [] },
+        '/b.jsonl': { fingerprint: { dev: 1, ino: 2, mtimeMs: 1, sizeBytes: 1 }, mcpInventory: [], turns: [], failed: true },
+      },
+    }
+    const provider = fakeProvider({ name: 'cached', discoverSessions: async () => [] })
+    const r = only(await collectDoctorReport('all', { providers: [provider], cache }), 'cached')
+
+    expect(r.cachedFiles).toBe(2)
+    expect(r.cachedFailed).toBe(1)
+  })
+
+  it('filters to a single provider by name', async () => {
+    const a = fakeProvider({ name: 'a' })
+    const b = fakeProvider({ name: 'b' })
+    const report = await collectDoctorReport('b', { providers: [a, b], cache: emptyCache() })
+    expect(report.providers.map(p => p.provider)).toEqual(['b'])
+  })
+})
+
+// ── Rendering ──────────────────────────────────────────────────────────────
+
+describe('doctor rendering', () => {
+  it('renders a plain-text table naming the override and missing path', async () => {
+    const provider = fakeProvider({
+      name: 'claude',
+      displayName: 'Claude',
+      probeRoots: async (): Promise<ProbeRoot[]> => [{ path: '/nonexistent/projects', label: 'projects' }],
+      discoverSessions: async () => [],
+    })
+    const prev = process.env['CLAUDE_CONFIG_DIR']
+    process.env['CLAUDE_CONFIG_DIR'] = '/nonexistent'
+    try {
+      const report = await collectDoctorReport('all', { providers: [provider], cache: emptyCache() })
+      const out = renderDoctorTable(report, { color: false })
+      expect(out).toContain('CodeBurn doctor')
+      expect(out).toContain('NOTHING FOUND')
+      expect(out).toContain('CLAUDE_CONFIG_DIR=/nonexistent')
+      expect(out).toContain('/nonexistent/projects')
+      expect(out).toContain('missing')
+      // no-color mode emits no ANSI escapes
+      // eslint-disable-next-line no-control-regex
+      expect(out).not.toMatch(/\[/)
+    } finally {
+      if (prev === undefined) delete process.env['CLAUDE_CONFIG_DIR']
+      else process.env['CLAUDE_CONFIG_DIR'] = prev
+    }
+  })
+
+  it('emits valid, round-trippable JSON', async () => {
+    const provider = fakeProvider({ name: 'a', discoverSessions: async () => [] })
+    const report = await collectDoctorReport('all', { providers: [provider], cache: emptyCache() })
+    const parsed = JSON.parse(renderDoctorJson(report))
+    expect(parsed.providers[0].provider).toBe('a')
+    expect(typeof parsed.generatedAt).toBe('string')
+  })
+})

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -274,3 +274,57 @@ describe('doctor rendering', () => {
     expect(typeof parsed.generatedAt).toBe('string')
   })
 })
+
+// ── Re-review hardening (#685): inert-diagnostic guarantees ────────────────
+
+describe('doctor is inert', () => {
+  it('sets the cache-write suppression flag while collecting and restores it after', async () => {
+    let flagDuringParse: string | undefined
+    const spy = fakeProvider({
+      name: 'spy',
+      discoverSessions: async () => [{ path: '/tmp/x', project: 'p', provider: 'spy' }],
+      createSessionParser: () => ({
+        async *parse() {
+          flagDuringParse = process.env['CODEBURN_SUPPRESS_CACHE_WRITES']
+        },
+      }),
+    })
+    delete process.env['CODEBURN_SUPPRESS_CACHE_WRITES']
+    await collectDoctorReport('spy', { providers: [spy], cache: emptyCache() })
+    expect(flagDuringParse).toBe('1')
+    expect(process.env['CODEBURN_SUPPRESS_CACHE_WRITES']).toBeUndefined()
+  })
+
+  it('never sample-parses a provider whose parse spawns processes (antigravity)', async () => {
+    let parsed = false
+    const ag = fakeProvider({
+      name: 'antigravity',
+      discoverSessions: async () => [{ path: '/tmp/cascade-x.pb', project: 'p', provider: 'antigravity' }],
+      createSessionParser: () => ({
+        async *parse() {
+          parsed = true
+        },
+      }),
+    })
+    const report = await collectDoctorReport('antigravity', { providers: [ag], cache: emptyCache() })
+    expect(parsed).toBe(false)
+    const row = only(report, 'antigravity')
+    expect(row.status).toBe('ok')
+    expect(row.verdict).toContain('parse sample skipped')
+    expect(row.candidatesFound).toBe(1)
+  })
+
+  it('does not blame CODEBURN_CACHE_DIR for an empty provider', async () => {
+    const prev = process.env['CODEBURN_CACHE_DIR']
+    process.env['CODEBURN_CACHE_DIR'] = '/tmp/some-cache'
+    try {
+      const empty = fakeProvider({ name: 'antigravity' })
+      const report = await collectDoctorReport('antigravity', { providers: [empty], cache: emptyCache() })
+      const row = only(report, 'antigravity')
+      expect(row.verdict).not.toContain('CODEBURN_CACHE_DIR')
+    } finally {
+      if (prev === undefined) delete process.env['CODEBURN_CACHE_DIR']
+      else process.env['CODEBURN_CACHE_DIR'] = prev
+    }
+  })
+})


### PR DESCRIPTION
## Problem

When a provider shows zero, users have no way to see why codeburn found nothing, so it becomes a support issue (#675 and friends: wrong env override, tool not installed, empty custom dir, stale npm build). Closes #642.

## What it does

`codeburn doctor` (and `--provider <name>`, `--json`) prints one row per provider: sessions discovered, a bounded parse sample (up to 8 sources, 500 calls each, so huge histories stay fast), cached-file counts, and an honest verdict: OK (n sessions), NOTHING FOUND with the likely cause, or ERRORS. A Details section lists the exact probed paths with existence, any env override that is set next to the path it resolved to, and the provider parse version. Example diagnosis with a wrong override:

    Claude | 0 | - | 0 | NOTHING FOUND (override CLAUDE_CONFIG_DIR set; /nonexistent/projects does not exist)

## Design

- collect/render split: collectDoctorReport is pure and injectable (providers, cache, sample limit); the table and JSON renderers only format.
- No duplicated path logic: providers expose an optional probeRoots() (claude, codex, opencode implement it today) that reuses their existing resolution helpers; everything else reports from discovered sources plus env-override state.
- Every provider is wrapped in its own try/catch, so one thrower becomes an ERROR row instead of killing the report. Fully offline: the one network provider is discovered but never called. Strictly read-only: doctor never writes caches or config (verified by comparing cache mtimes across a run).

## Verification

- 12 unit tests over the collect logic with fixture dirs (found, empty, missing, override, error, render). Mutation-checked twice: breaking the exists-check fails 3 tests; blanking the override reporting fails exactly the override test.
- Real machine run shows real numbers (Claude 16, Codex 408 sessions, correct verdicts) and doctor --json parses.
- tsc clean; full suite green apart from the two pre-existing app/electron/cli.test.ts failures on unbuilt checkouts (#681).

## Notes

The Cached column shows 0 on a checkout whose CACHE_VERSION is ahead of the on-disk cache; that is faithful (this build would re-parse), not a bug.