### PR TITLE
fix(menubar): route Codex plan retry to refreshCodex and fix loading copy

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
@@ -1709,12 +1709,12 @@ private struct PlanInsight: View {
                     message: "CodeBurn will read your Claude Code credentials once. macOS will ask permission. After that, the live quota bar shows next to the Claude tab and updates automatically."
                 ) { Task { await store.bootstrapSubscription() } }
             case .bootstrapping:
-                PlanLoadingView()
+                PlanLoadingView(message: "Reading Claude credentials...")
             case .loading:
                 if let usage {
                     loadedBody(usage: usage)
                 } else {
-                    PlanLoadingView()
+                    PlanLoadingView(message: "Reading Claude credentials...")
                 }
             case .noCredentials:
                 PlanNoCredentialsView(
@@ -1722,12 +1722,16 @@ private struct PlanInsight: View {
                     message: "Sign in with Claude Code first: open `claude` in your terminal and type `/login`. Then click Try Again."
                 ) { Task { await store.bootstrapSubscription() } }
             case .failed:
-                PlanFailedView(error: store.subscriptionError)
+                PlanFailedView(
+                    error: store.subscriptionError
+                ) { Task { await store.refreshSubscription() } }
             case .transientFailure:
                 if let usage {
                     loadedBody(usage: usage)
                 } else {
-                    PlanFailedView(error: store.subscriptionError ?? "Anthropic temporarily unreachable — retrying.")
+                    PlanFailedView(
+                        error: store.subscriptionError ?? "Anthropic temporarily unreachable — retrying."
+                    ) { Task { await store.refreshSubscription() } }
                 }
             case let .terminalFailure(reason):
                 PlanReconnectView(
@@ -1739,7 +1743,7 @@ private struct PlanInsight: View {
                 if let usage {
                     loadedBody(usage: usage)
                 } else {
-                    PlanLoadingView()
+                    PlanLoadingView(message: "Reading Claude credentials...")
                 }
             }
         }
@@ -1847,10 +1851,12 @@ private struct PlanInsight: View {
 // MARK: - Plan empty/loading/failure states
 
 private struct PlanLoadingView: View {
+    let message: String
+
     var body: some View {
         VStack(spacing: 8) {
             ProgressView().scaleEffect(0.8)
-            Text("Reading Claude credentials...")
+            Text(message)
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(.secondary)
         }
@@ -1888,8 +1894,8 @@ private struct PlanNoCredentialsView: View {
 }
 
 private struct PlanFailedView: View {
-    @Environment(AppStore.self) private var store
     let error: String?
+    let onRetry: () -> Void
 
     var body: some View {
         VStack(spacing: 8) {
@@ -1907,9 +1913,7 @@ private struct PlanFailedView: View {
                     .frame(maxWidth: 280)
                     .lineLimit(3)
             }
-            Button("Retry") {
-                Task { await store.refreshSubscription() }
-            }
+            Button("Retry", action: onRetry)
             .controlSize(.small)
             .buttonStyle(.borderedProminent)
             .tint(Theme.brandAccent)
@@ -2004,12 +2008,12 @@ private struct CodexPlanInsight: View {
                     message: "CodeBurn will read your Codex CLI credentials once. After that, the live quota bar shows next to the Codex tab and updates automatically."
                 ) { Task { await store.bootstrapCodex() } }
             case .bootstrapping:
-                PlanLoadingView()
+                PlanLoadingView(message: "Reading Codex CLI credentials...")
             case .loading:
                 if let usage = store.codexUsage {
                     loadedBody(usage: usage)
                 } else {
-                    PlanLoadingView()
+                    PlanLoadingView(message: "Reading Codex CLI credentials...")
                 }
             case .noCredentials:
                 PlanNoCredentialsView(
@@ -2017,12 +2021,16 @@ private struct CodexPlanInsight: View {
                     message: "Sign in with Codex first: run `codex login` in your terminal. Then click Try Again."
                 ) { Task { await store.bootstrapCodex() } }
             case .failed:
-                PlanFailedView(error: store.codexError)
+                PlanFailedView(
+                    error: store.codexError
+                ) { Task { await store.refreshCodex() } }
             case .transientFailure:
                 if let usage = store.codexUsage {
                     loadedBody(usage: usage)
                 } else {
-                    PlanFailedView(error: store.codexError ?? "ChatGPT temporarily unreachable — retrying.")
+                    PlanFailedView(
+                        error: store.codexError ?? "ChatGPT temporarily unreachable — retrying."
+                    ) { Task { await store.refreshCodex() } }
                 }
             case let .terminalFailure(reason):
                 PlanReconnectView(
@@ -2034,7 +2042,7 @@ private struct CodexPlanInsight: View {
                 if let usage = store.codexUsage {
                     loadedBody(usage: usage)
                 } else {
-                    PlanLoadingView()
+                    PlanLoadingView(message: "Reading Codex CLI credentials...")
                 }
             }
         }


### PR DESCRIPTION
Closes #678.

## Problem

On the Codex tab's Plan section, the connect flow still behaved as Claude in two shared views:

- `PlanLoadingView` hardcoded "Reading Claude credentials..." and is rendered by `CodexPlanInsight` for `.bootstrapping` / `.loading` / `.loaded`-without-usage.
- `PlanFailedView`'s Retry called `store.refreshSubscription()` (the Claude refresh) internally, and is reused for Codex `.failed` / `.transientFailure`, so `store.refreshCodex()` was unreachable from this UI.

## Fix

Extends the 61209bd parameterization to the two remaining shared views:

- `PlanLoadingView(message:)` - Claude call sites keep the exact current copy; Codex call sites pass "Reading Codex CLI credentials...".
- `PlanFailedView(error:onRetry:)` - drops the internal `AppStore` dependency; the Claude PlanInsight passes `refreshSubscription()`, `CodexPlanInsight` passes `refreshCodex()`.

Claude-side copy and behavior are byte-identical to before. The failed-state accent stays `Theme.brandAccent`: every sibling plan view on both tabs uses it and the section documents a single-palette convention, so a provider-colored failed state would have been the odd one out (considered and reverted during review).

## Verification

- `swift build --package-path mac` green.
- All 10 call sites of the two views covered (no default parameter values, so a missed site would not compile).
- No test added: `mac/Tests` has no SwiftUI view-testing precedent (verified by search).
