### PR TITLE
Propagate costIsEstimated end-to-end; mark estimated costs in all output surfaces

### DIFF
--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -5,7 +5,14 @@ import { homedir } from 'os'
 import { join } from 'path'
 import type { DateRange, ProjectSummary } from './types.js'
 
-// Bumped to 11: kiro cost accounting changed (metered credits pass through
+// Bumped to 12: estimated-cost propagation (#639) added estimatedCostUSD to
+// day/model/category rollups. Days finalized at v11 were built before the
+// field existed, so estimated provider spend (cursor, warp, grok, copilot,
+// kiro fallback paths) would silently read as fully measured. Raising
+// MIN_SUPPORTED_VERSION forces the one-time re-hydration that backfills the
+// estimated portion.
+//
+// v11: kiro cost accounting changed (metered credits pass through
 // the session cache instead of being re-priced from estimated tokens), so
 // days finalized at v10 carry token-estimated kiro costs that were off by up
 // to 16× per model. Raising MIN_SUPPORTED_VERSION forces the one-time full
@@ -20,13 +27,14 @@ import type { DateRange, ProjectSummary } from './types.js'
 // that older binaries skipped. v8 added local-model savings to the daily
 // rollup; the `savingsConfigHash` field is invalidated separately when the
 // user changes their `localModelSavings` mapping.
-export const DAILY_CACHE_VERSION = 11
-const MIN_SUPPORTED_VERSION = 11
+export const DAILY_CACHE_VERSION = 12
+const MIN_SUPPORTED_VERSION = 12
 const DAILY_CACHE_FILENAME = 'daily-cache.json'
 
 export type DailyEntry = {
   date: string
   cost: number
+  estimatedCostUSD?: number
   savingsUSD: number
   calls: number
   sessions: number
@@ -39,14 +47,15 @@ export type DailyEntry = {
   models: Record<string, {
     calls: number
     cost: number
+    estimatedCostUSD?: number
     savingsUSD: number
     inputTokens: number
     outputTokens: number
     cacheReadTokens: number
     cacheWriteTokens: number
   }>
-  categories: Record<string, { turns: number; cost: number; savingsUSD: number; editTurns: number; oneShotTurns: number }>
-  providers: Record<string, { calls: number; cost: number; savingsUSD: number }>
+  categories: Record<string, { turns: number; cost: number; estimatedCostUSD?: number; savingsUSD: number; editTurns: number; oneShotTurns: number }>
+  providers: Record<string, { calls: number; cost: number; estimatedCostUSD?: number; savingsUSD: number }>
 }
 
 export type DailyCache = {
@@ -84,6 +93,7 @@ function migrateDays(days: Record<string, unknown>[]): DailyEntry[] {
   return days.map(d => ({
     date: d.date as string,
     cost: (d.cost as number) ?? 0,
+    estimatedCostUSD: (d.estimatedCostUSD as number) ?? 0,
     savingsUSD: (d.savingsUSD as number) ?? 0,
     calls: (d.calls as number) ?? 0,
     sessions: (d.sessions as number) ?? 0,

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -126,6 +126,10 @@ function getLayout(columns?: number): Layout {
   return { dashWidth, wide, halfWidth, barWidth }
 }
 
+function formatEstimatedCost(cost: number, estimatedCostUSD: number): string {
+  return estimatedCostUSD > 0 ? `~${formatCost(cost)}` : formatCost(cost)
+}
+
 function HBar({ value, max, width }: { value: number; max: number; width: number }) {
   if (max === 0) return <Text color={DIM}>{'░'.repeat(width)}</Text>
   const filled = Math.round((value / max) * width)
@@ -192,6 +196,7 @@ function planStatusText(planUsage: PlanUsage): string {
 
 function Overview({ projects, label, width, planUsages }: { projects: ProjectSummary[]; label: string; width: number; planUsages?: PlanUsage[] }) {
   const totalCost = projects.reduce((s, p) => s + p.totalCostUSD, 0)
+  const totalEstimatedCost = projects.reduce((s, p) => s + (p.estimatedCostUSD ?? 0), 0)
   const totalSavings = projects.reduce((s, p) => s + p.totalSavingsUSD, 0)
   const totalCalls = projects.reduce((s, p) => s + p.totalApiCalls, 0)
   const totalSessions = projects.reduce((s, p) => s + p.sessions.length, 0)
@@ -212,7 +217,7 @@ function Overview({ projects, label, width, planUsages }: { projects: ProjectSum
         <Text dimColor>  {label}</Text>
       </Text>
       <Text wrap="truncate-end">
-        <Text bold color={GOLD}>{formatCost(totalCost)}</Text>
+        <Text bold color={GOLD}>{formatEstimatedCost(totalCost, totalEstimatedCost)}</Text>
         <Text dimColor> cost   </Text>
         <Text bold>{totalCalls.toLocaleString()}</Text>
         <Text dimColor> calls   </Text>
@@ -255,6 +260,7 @@ function Overview({ projects, label, width, planUsages }: { projects: ProjectSum
 
 function DailyActivity({ projects, days = 14, pw, bw }: { projects: ProjectSummary[]; days?: number; pw: number; bw: number }) {
   const dailyCosts: Record<string, number> = {}
+  const dailyEstimatedCosts: Record<string, number> = {}
   const dailyCalls: Record<string, number> = {}
   for (const project of projects) {
     for (const session of project.sessions) {
@@ -262,6 +268,7 @@ function DailyActivity({ projects, days = 14, pw, bw }: { projects: ProjectSumma
         if (!turn.timestamp) continue
         const day = dateKey(turn.timestamp)
         dailyCosts[day] = (dailyCosts[day] ?? 0) + turn.assistantCalls.reduce((s, c) => s + c.costUSD, 0)
+        dailyEstimatedCosts[day] = (dailyEstimatedCosts[day] ?? 0) + turn.assistantCalls.reduce((s, c) => s + (c.estimatedCostUSD ?? 0), 0)
         dailyCalls[day] = (dailyCalls[day] ?? 0) + turn.assistantCalls.length
       }
     }
@@ -276,7 +283,7 @@ function DailyActivity({ projects, days = 14, pw, bw }: { projects: ProjectSumma
         <Text key={day} wrap="truncate-end">
           <Text dimColor>{day.slice(5)} </Text>
           <HBar value={dailyCosts[day] ?? 0} max={maxCost} width={bw} />
-          <Text color={GOLD}>{formatCost(dailyCosts[day] ?? 0).padStart(8)}</Text>
+          <Text color={GOLD}>{formatEstimatedCost(dailyCosts[day] ?? 0, dailyEstimatedCosts[day] ?? 0).padStart(8)}</Text>
           <Text>{String(dailyCalls[day] ?? 0).padStart(6)}</Text>
         </Text>
       ))}
@@ -317,13 +324,13 @@ function ProjectBreakdown({ projects, pw, bw, budgets, rows = 14 }: { projects: 
       {projects.slice(0, rows).map((project, i) => {
         const budget = budgets?.get(project.project)
         const avgCost = project.sessions.length > 0
-          ? formatCost(project.totalCostUSD / project.sessions.length)
+          ? formatEstimatedCost(project.totalCostUSD / project.sessions.length, project.estimatedCostUSD ?? 0)
           : '-'
         return (
           <Text key={`${project.project}-${i}`} wrap="truncate-end">
             <HBar value={project.totalCostUSD} max={maxCost} width={bw} />
             <Text dimColor> {fit(shortProject(project.projectPath), nw)}</Text>
-            <Text color={GOLD}>{formatCost(project.totalCostUSD).padStart(8)}</Text>
+            <Text color={GOLD}>{formatEstimatedCost(project.totalCostUSD, project.estimatedCostUSD ?? 0).padStart(8)}</Text>
             <Text color={GOLD}>{avgCost.padStart(PROJECT_COL_AVG)}</Text>
             <Text>{String(project.sessions.length).padStart(6)}</Text>
             {hasBudgets && <Text color="#7B9EF5">{(budget ? formatTokens(budget.total) : '-').padStart(10)}</Text>}
@@ -342,14 +349,15 @@ const MODEL_NAME_WIDTH = 14
 const MIN_EDIT_TURNS_FOR_RATE = 5
 
 function ModelBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; pw: number; bw: number }) {
-  const modelTotals: Record<string, { calls: number; costUSD: number; freshInput: number; cacheRead: number; cacheWrite: number }> = {}
+  const modelTotals: Record<string, { calls: number; costUSD: number; estimatedCostUSD: number; freshInput: number; cacheRead: number; cacheWrite: number }> = {}
   const modelEfficiency = aggregateModelEfficiency(projects)
   for (const project of projects) {
     for (const session of project.sessions) {
       for (const [model, data] of Object.entries(session.modelBreakdown)) {
-        if (!modelTotals[model]) modelTotals[model] = { calls: 0, costUSD: 0, freshInput: 0, cacheRead: 0, cacheWrite: 0 }
+        if (!modelTotals[model]) modelTotals[model] = { calls: 0, costUSD: 0, estimatedCostUSD: 0, freshInput: 0, cacheRead: 0, cacheWrite: 0 }
         modelTotals[model].calls += data.calls
         modelTotals[model].costUSD += data.costUSD
+        modelTotals[model].estimatedCostUSD += data.estimatedCostUSD ?? 0
         modelTotals[model].freshInput += data.tokens.inputTokens
         modelTotals[model].cacheRead += data.tokens.cacheReadInputTokens
         modelTotals[model].cacheWrite += data.tokens.cacheCreationInputTokens
@@ -380,7 +388,7 @@ function ModelBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; pw: 
           <Text key={`${model}-${i}`} wrap="truncate-end">
             <HBar value={data.costUSD} max={maxCost} width={bw} />
             <Text> {fit(model, MODEL_NAME_WIDTH)}</Text>
-            <Text color={GOLD}>{formatCost(data.costUSD).padStart(MODEL_COL_COST)}</Text>
+            <Text color={GOLD}>{formatEstimatedCost(data.costUSD, data.estimatedCostUSD).padStart(MODEL_COL_COST)}</Text>
             <Text>{cacheLabel.padStart(MODEL_COL_CACHE)}</Text>
             <Text>{String(data.calls).padStart(MODEL_COL_CALLS)}</Text>
             <Text>{oneShotLabel.padStart(MODEL_COL_ONESHOT)}</Text>
@@ -399,21 +407,23 @@ function ModelBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; pw: 
 const SKILL_SUB_ROWS_LIMIT = 5
 
 function ActivityBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; pw: number; bw: number }) {
-  const categoryTotals: Record<string, { turns: number; costUSD: number; editTurns: number; oneShotTurns: number }> = {}
-  const skillTotals: Record<string, { turns: number; costUSD: number; editTurns: number; oneShotTurns: number }> = {}
+  const categoryTotals: Record<string, { turns: number; costUSD: number; estimatedCostUSD: number; editTurns: number; oneShotTurns: number }> = {}
+  const skillTotals: Record<string, { turns: number; costUSD: number; estimatedCostUSD: number; editTurns: number; oneShotTurns: number }> = {}
   for (const project of projects) {
     for (const session of project.sessions) {
       for (const [cat, data] of Object.entries(session.categoryBreakdown)) {
-        if (!categoryTotals[cat]) categoryTotals[cat] = { turns: 0, costUSD: 0, editTurns: 0, oneShotTurns: 0 }
+        if (!categoryTotals[cat]) categoryTotals[cat] = { turns: 0, costUSD: 0, estimatedCostUSD: 0, editTurns: 0, oneShotTurns: 0 }
         categoryTotals[cat].turns += data.turns
         categoryTotals[cat].costUSD += data.costUSD
+        categoryTotals[cat].estimatedCostUSD += data.estimatedCostUSD ?? 0
         categoryTotals[cat].editTurns += data.editTurns
         categoryTotals[cat].oneShotTurns += data.oneShotTurns
       }
       for (const [skill, data] of Object.entries(session.skillBreakdown ?? {})) {
-        if (!skillTotals[skill]) skillTotals[skill] = { turns: 0, costUSD: 0, editTurns: 0, oneShotTurns: 0 }
+        if (!skillTotals[skill]) skillTotals[skill] = { turns: 0, costUSD: 0, estimatedCostUSD: 0, editTurns: 0, oneShotTurns: 0 }
         skillTotals[skill].turns += data.turns
         skillTotals[skill].costUSD += data.costUSD
+        skillTotals[skill].estimatedCostUSD += data.estimatedCostUSD ?? 0
         skillTotals[skill].editTurns += data.editTurns
         skillTotals[skill].oneShotTurns += data.oneShotTurns
       }
@@ -431,7 +441,7 @@ function ActivityBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; p
           <Text key={cat} wrap="truncate-end">
             <HBar value={data.costUSD} max={maxCost} width={bw} />
             <Text color={CATEGORY_COLORS[cat as TaskCategory] ?? '#666666'}> {fit(CATEGORY_LABELS[cat as TaskCategory] ?? cat, 13)}</Text>
-            <Text color={GOLD}>{formatCost(data.costUSD).padStart(8)}</Text>
+            <Text color={GOLD}>{formatEstimatedCost(data.costUSD, data.estimatedCostUSD).padStart(8)}</Text>
             <Text>{String(data.turns).padStart(6)}</Text>
             <Text color={data.editTurns === 0 ? DIM : oneShotPct === '100%' ? '#5BF58C' : ORANGE}>{String(oneShotPct).padStart(7)}</Text>
           </Text>,
@@ -443,7 +453,7 @@ function ActivityBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; p
               <Text key={`${cat}:${skill}`} wrap="truncate-end" dimColor>
                 <HBar value={sd.costUSD} max={maxCost} width={bw} />
                 <Text> {fit(`  /${skill}`, 13)}</Text>
-                <Text>{formatCost(sd.costUSD).padStart(8)}</Text>
+                <Text>{formatEstimatedCost(sd.costUSD, sd.estimatedCostUSD).padStart(8)}</Text>
                 <Text>{String(sd.turns).padStart(6)}</Text>
                 <Text>{String(subPct).padStart(7)}</Text>
               </Text>,
@@ -523,10 +533,10 @@ function BashBreakdown({ projects, pw, bw }: { projects: ProjectSummary[]; pw: n
 }
 
 function SkillsAndAgents({ projects, pw, bw }: { projects: ProjectSummary[]; pw: number; bw: number }) {
-  const merged: Record<string, { uses: number; cost: number }> = {}
+  const merged: Record<string, { uses: number; cost: number; estimatedCostUSD: number }> = {}
   for (const project of projects) { for (const session of project.sessions) {
-    for (const [skill, d] of Object.entries(session.skillBreakdown)) { const e = merged[skill] ?? { uses: 0, cost: 0 }; e.uses += d.turns; e.cost += d.costUSD; merged[skill] = e }
-    for (const [agent, d] of Object.entries(session.subagentBreakdown)) { const e = merged[agent] ?? { uses: 0, cost: 0 }; e.uses += d.calls; e.cost += d.costUSD; merged[agent] = e }
+    for (const [skill, d] of Object.entries(session.skillBreakdown)) { const e = merged[skill] ?? { uses: 0, cost: 0, estimatedCostUSD: 0 }; e.uses += d.turns; e.cost += d.costUSD; e.estimatedCostUSD += d.estimatedCostUSD ?? 0; merged[skill] = e }
+    for (const [agent, d] of Object.entries(session.subagentBreakdown)) { const e = merged[agent] ?? { uses: 0, cost: 0, estimatedCostUSD: 0 }; e.uses += d.calls; e.cost += d.costUSD; e.estimatedCostUSD += d.estimatedCostUSD ?? 0; merged[agent] = e }
   } }
   const sorted = Object.entries(merged).sort(([, a], [, b]) => b.cost - a.cost)
   if (sorted.length === 0) return <Panel title="Skills & Agents" color={PANEL_COLORS.skills} width={pw}><Text dimColor>No skill/agent usage</Text></Panel>
@@ -536,7 +546,7 @@ function SkillsAndAgents({ projects, pw, bw }: { projects: ProjectSummary[]; pw:
     <Panel title="Skills & Agents" color={PANEL_COLORS.skills} width={pw}>
       <Text dimColor wrap="truncate-end">{''.padEnd(bw + 1 + nw)}{'uses'.padStart(6)}{'cost'.padStart(8)}</Text>
       {sorted.slice(0, 10).map(([name, d]) => (
-        <Text key={name} wrap="truncate-end"><HBar value={d.cost} max={maxCost} width={bw} /><Text> {fit(name, nw)}</Text><Text>{String(d.uses).padStart(6)}</Text><Text color={GOLD}>{formatCost(d.cost).padStart(8)}</Text></Text>
+        <Text key={name} wrap="truncate-end"><HBar value={d.cost} max={maxCost} width={bw} /><Text> {fit(name, nw)}</Text><Text>{String(d.uses).padStart(6)}</Text><Text color={GOLD}>{formatEstimatedCost(d.cost, d.estimatedCostUSD).padStart(8)}</Text></Text>
       ))}
     </Panel>
   )
@@ -546,11 +556,11 @@ function SkillsAndAgents({ projects, pw, bw }: { projects: ProjectSummary[]; pw:
 // (workflow-subagent / Explore / general-purpose / …). Returns null when there
 // are no agent transcripts, so it never shows for other providers.
 function ClaudeAgentTypes({ projects, pw, bw }: { projects: ProjectSummary[]; pw: number; bw: number }) {
-  const merged: Record<string, { uses: number; cost: number }> = {}
+  const merged: Record<string, { uses: number; cost: number; estimatedCostUSD: number }> = {}
   for (const project of projects) { for (const session of project.sessions) {
     if (!session.agentType) continue
-    const e = merged[session.agentType] ?? { uses: 0, cost: 0 }
-    e.uses += session.apiCalls; e.cost += session.totalCostUSD; merged[session.agentType] = e
+    const e = merged[session.agentType] ?? { uses: 0, cost: 0, estimatedCostUSD: 0 }
+    e.uses += session.apiCalls; e.cost += session.totalCostUSD; e.estimatedCostUSD += session.estimatedCostUSD ?? 0; merged[session.agentType] = e
   } }
   const sorted = Object.entries(merged).sort(([, a], [, b]) => b.cost - a.cost)
   if (sorted.length === 0) return null
@@ -560,7 +570,7 @@ function ClaudeAgentTypes({ projects, pw, bw }: { projects: ProjectSummary[]; pw
     <Panel title="Claude Agent Types" color={PANEL_COLORS.skills} width={pw}>
       <Text dimColor wrap="truncate-end">{''.padEnd(bw + 1 + nw)}{'calls'.padStart(6)}{'cost'.padStart(8)}</Text>
       {sorted.slice(0, 10).map(([name, d]) => (
-        <Text key={name} wrap="truncate-end"><HBar value={d.cost} max={maxCost} width={bw} /><Text> {fit(name, nw)}</Text><Text>{String(d.uses).padStart(6)}</Text><Text color={GOLD}>{formatCost(d.cost).padStart(8)}</Text></Text>
+        <Text key={name} wrap="truncate-end"><HBar value={d.cost} max={maxCost} width={bw} /><Text> {fit(name, nw)}</Text><Text>{String(d.uses).padStart(6)}</Text><Text color={GOLD}>{formatEstimatedCost(d.cost, d.estimatedCostUSD).padStart(8)}</Text></Text>
       ))}
     </Panel>
   )

--- a/src/day-aggregator.ts
+++ b/src/day-aggregator.ts
@@ -6,6 +6,7 @@ function emptyEntry(date: string): DailyEntry {
   return {
     date,
     cost: 0,
+    estimatedCostUSD: 0,
     savingsUSD: 0,
     calls: 0,
     sessions: 0,
@@ -47,14 +48,16 @@ export function aggregateProjectsIntoDays(projects: ProjectSummary[]): DailyEntr
         const editTurns = turn.hasEdits ? 1 : 0
         const oneShotTurns = turn.hasEdits && turn.retries === 0 ? 1 : 0
         const turnCost = turn.assistantCalls.reduce((s, c) => s + c.costUSD, 0)
+        const turnEstimatedCost = turn.assistantCalls.reduce((s, c) => s + (c.estimatedCostUSD ?? 0), 0)
         const turnSavings = turn.assistantCalls.reduce((s, c) => s + (c.savingsUSD ?? 0), 0)
 
         turnDay.editTurns += editTurns
         turnDay.oneShotTurns += oneShotTurns
 
-        const cat = turnDay.categories[turn.category] ?? { turns: 0, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
+        const cat = turnDay.categories[turn.category] ?? { turns: 0, cost: 0, estimatedCostUSD: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
         cat.turns += 1
         cat.cost += turnCost
+        cat.estimatedCostUSD = (cat.estimatedCostUSD ?? 0) + turnEstimatedCost
         cat.savingsUSD += turnSavings
         cat.editTurns += editTurns
         cat.oneShotTurns += oneShotTurns
@@ -66,6 +69,7 @@ export function aggregateProjectsIntoDays(projects: ProjectSummary[]): DailyEntr
           const callSavings = call.savingsUSD ?? 0
 
           callDay.cost += call.costUSD
+          callDay.estimatedCostUSD = (callDay.estimatedCostUSD ?? 0) + (call.estimatedCostUSD ?? 0)
           callDay.savingsUSD += callSavings
           callDay.calls += 1
           callDay.inputTokens += call.usage.inputTokens
@@ -74,12 +78,13 @@ export function aggregateProjectsIntoDays(projects: ProjectSummary[]): DailyEntr
           callDay.cacheWriteTokens += call.usage.cacheCreationInputTokens
 
           const model = callDay.models[call.model] ?? {
-            calls: 0, cost: 0, savingsUSD: 0,
+            calls: 0, cost: 0, estimatedCostUSD: 0, savingsUSD: 0,
             inputTokens: 0, outputTokens: 0,
             cacheReadTokens: 0, cacheWriteTokens: 0,
           }
           model.calls += 1
           model.cost += call.costUSD
+          model.estimatedCostUSD = (model.estimatedCostUSD ?? 0) + (call.estimatedCostUSD ?? 0)
           model.savingsUSD += callSavings
           model.inputTokens += call.usage.inputTokens
           model.outputTokens += call.usage.outputTokens
@@ -87,9 +92,10 @@ export function aggregateProjectsIntoDays(projects: ProjectSummary[]): DailyEntr
           model.cacheWriteTokens += call.usage.cacheCreationInputTokens
           callDay.models[call.model] = model
 
-          const provider = callDay.providers[call.provider] ?? { calls: 0, cost: 0, savingsUSD: 0 }
+          const provider = callDay.providers[call.provider] ?? { calls: 0, cost: 0, estimatedCostUSD: 0, savingsUSD: 0 }
           provider.calls += 1
           provider.cost += call.costUSD
+          provider.estimatedCostUSD = (provider.estimatedCostUSD ?? 0) + (call.estimatedCostUSD ?? 0)
           provider.savingsUSD += callSavings
           callDay.providers[call.provider] = provider
         }
@@ -101,13 +107,14 @@ export function aggregateProjectsIntoDays(projects: ProjectSummary[]): DailyEntr
 }
 
 export function buildPeriodDataFromDays(days: DailyEntry[], label: string): PeriodData {
-  let cost = 0, savingsUSD = 0, calls = 0, sessions = 0
+  let cost = 0, estimatedCostUSD = 0, savingsUSD = 0, calls = 0, sessions = 0
   let inputTokens = 0, outputTokens = 0, cacheReadTokens = 0, cacheWriteTokens = 0
-  const catTotals: Record<string, { turns: number; cost: number; savingsUSD: number; editTurns: number; oneShotTurns: number }> = {}
-  const modelTotals: Record<string, { calls: number; cost: number; savingsUSD: number }> = {}
+  const catTotals: Record<string, { turns: number; cost: number; estimatedCostUSD: number; savingsUSD: number; editTurns: number; oneShotTurns: number }> = {}
+  const modelTotals: Record<string, { calls: number; cost: number; estimatedCostUSD: number; savingsUSD: number }> = {}
 
   for (const d of days) {
     cost += d.cost
+    estimatedCostUSD += d.estimatedCostUSD ?? 0
     savingsUSD += d.savingsUSD
     calls += d.calls
     sessions += d.sessions
@@ -117,16 +124,18 @@ export function buildPeriodDataFromDays(days: DailyEntry[], label: string): Peri
     cacheWriteTokens += d.cacheWriteTokens
 
     for (const [name, m] of Object.entries(d.models)) {
-      const acc = modelTotals[name] ?? { calls: 0, cost: 0, savingsUSD: 0 }
+      const acc = modelTotals[name] ?? { calls: 0, cost: 0, estimatedCostUSD: 0, savingsUSD: 0 }
       acc.calls += m.calls
       acc.cost += m.cost
+      acc.estimatedCostUSD += m.estimatedCostUSD ?? 0
       acc.savingsUSD += (m.savingsUSD ?? 0)
       modelTotals[name] = acc
     }
     for (const [cat, c] of Object.entries(d.categories)) {
-      const acc = catTotals[cat] ?? { turns: 0, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
+      const acc = catTotals[cat] ?? { turns: 0, cost: 0, estimatedCostUSD: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
       acc.turns += c.turns
       acc.cost += c.cost
+      acc.estimatedCostUSD += c.estimatedCostUSD ?? 0
       acc.savingsUSD += (c.savingsUSD ?? 0)
       acc.editTurns += c.editTurns
       acc.oneShotTurns += c.oneShotTurns
@@ -137,6 +146,7 @@ export function buildPeriodDataFromDays(days: DailyEntry[], label: string): Peri
   return {
     label,
     cost,
+    estimatedCostUSD,
     savingsUSD,
     calls,
     sessions,

--- a/src/export.ts
+++ b/src/export.ts
@@ -36,6 +36,7 @@ function pct(n: number, total: number): number {
 
 type DailyAgg = {
   cost: number
+  estimatedCostUSD: number
   savings: number
   calls: number
   input: number
@@ -53,11 +54,12 @@ function buildDailyRows(projects: ProjectSummary[], period: string): Row[] {
         if (!turn.timestamp) continue
         const day = dateKey(turn.timestamp)
         if (!daily[day]) {
-          daily[day] = { cost: 0, savings: 0, calls: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, sessions: new Set() }
+          daily[day] = { cost: 0, estimatedCostUSD: 0, savings: 0, calls: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, sessions: new Set() }
         }
         daily[day].sessions.add(session.sessionId)
         for (const call of turn.assistantCalls) {
           daily[day].cost += call.costUSD
+          daily[day].estimatedCostUSD += call.estimatedCostUSD ?? 0
           daily[day].savings += call.savingsUSD ?? 0
           daily[day].calls++
           daily[day].input += call.usage.inputTokens
@@ -73,6 +75,7 @@ function buildDailyRows(projects: ProjectSummary[], period: string): Row[] {
     Period: period,
     Date: date,
     [`Cost (${code})`]: roundForActiveCurrency(convertCost(d.cost)),
+    [`Estimated Cost (${code})`]: roundForActiveCurrency(convertCost(d.estimatedCostUSD)),
     [`Saved (${code})`]: roundForActiveCurrency(convertCost(d.savings)),
     'API Calls': d.calls,
     Sessions: d.sessions.size,
@@ -84,13 +87,14 @@ function buildDailyRows(projects: ProjectSummary[], period: string): Row[] {
 }
 
 function buildActivityRows(projects: ProjectSummary[], period: string): Row[] {
-  const catTotals: Record<string, { turns: number; cost: number }> = {}
+  const catTotals: Record<string, { turns: number; cost: number; estimatedCostUSD: number }> = {}
   for (const project of projects) {
     for (const session of project.sessions) {
       for (const [cat, d] of Object.entries(session.categoryBreakdown)) {
-        if (!catTotals[cat]) catTotals[cat] = { turns: 0, cost: 0 }
+        if (!catTotals[cat]) catTotals[cat] = { turns: 0, cost: 0, estimatedCostUSD: 0 }
         catTotals[cat].turns += d.turns
         catTotals[cat].cost += d.costUSD
+        catTotals[cat].estimatedCostUSD += d.estimatedCostUSD ?? 0
       }
     }
   }
@@ -102,20 +106,22 @@ function buildActivityRows(projects: ProjectSummary[], period: string): Row[] {
       Period: period,
       Activity: CATEGORY_LABELS[cat as TaskCategory] ?? cat,
       [`Cost (${code})`]: roundForActiveCurrency(convertCost(d.cost)),
+      [`Estimated Cost (${code})`]: roundForActiveCurrency(convertCost(d.estimatedCostUSD)),
       'Share (%)': pct(d.cost, totalCost),
       Turns: d.turns,
     }))
 }
 
 function buildModelRows(projects: ProjectSummary[], period: string): Row[] {
-  const modelTotals: Record<string, { calls: number; cost: number; savings: number; input: number; output: number; cacheRead: number; cacheWrite: number }> = {}
+  const modelTotals: Record<string, { calls: number; cost: number; estimatedCostUSD: number; savings: number; input: number; output: number; cacheRead: number; cacheWrite: number }> = {}
   const modelEfficiency = aggregateModelEfficiency(projects)
   for (const project of projects) {
     for (const session of project.sessions) {
       for (const [model, d] of Object.entries(session.modelBreakdown)) {
-        if (!modelTotals[model]) modelTotals[model] = { calls: 0, cost: 0, savings: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+        if (!modelTotals[model]) modelTotals[model] = { calls: 0, cost: 0, estimatedCostUSD: 0, savings: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
         modelTotals[model].calls += d.calls
         modelTotals[model].cost += d.costUSD
+        modelTotals[model].estimatedCostUSD += d.estimatedCostUSD ?? 0
         modelTotals[model].savings += d.savingsUSD
         modelTotals[model].input += d.tokens.inputTokens
         modelTotals[model].output += d.tokens.outputTokens
@@ -135,6 +141,7 @@ function buildModelRows(projects: ProjectSummary[], period: string): Row[] {
         Period: period,
         Model: model,
         [`Cost (${code})`]: roundForActiveCurrency(convertCost(d.cost)),
+        [`Estimated Cost (${code})`]: roundForActiveCurrency(convertCost(d.estimatedCostUSD)),
         [`Saved (${code})`]: roundForActiveCurrency(convertCost(d.savings)),
         'Share (%)': pct(d.cost, totalCost),
         'API Calls': d.calls,
@@ -218,6 +225,7 @@ function buildProjectRows(projects: ProjectSummary[]): Row[] {
     .map(p => ({
       Project: p.projectPath,
       [`Cost (${code})`]: roundForActiveCurrency(convertCost(p.totalCostUSD)),
+      [`Estimated Cost (${code})`]: roundForActiveCurrency(convertCost(p.estimatedCostUSD ?? 0)),
       [`Saved (${code})`]: roundForActiveCurrency(convertCost(p.totalSavingsUSD)),
       [`Avg/Session (${code})`]: p.sessions.length > 0 ? roundForActiveCurrency(convertCost(p.totalCostUSD / p.sessions.length)) : '',
       'Share (%)': pct(p.totalCostUSD, total),
@@ -236,6 +244,7 @@ function buildSessionRows(projects: ProjectSummary[]): Row[] {
         'Session ID': s.sessionId,
         'Started At': s.firstTimestamp ?? '',
         [`Cost (${code})`]: roundForActiveCurrency(convertCost(s.totalCostUSD)),
+        [`Estimated Cost (${code})`]: roundForActiveCurrency(convertCost(s.estimatedCostUSD ?? 0)),
         [`Saved (${code})`]: roundForActiveCurrency(convertCost(s.totalSavingsUSD)),
         'API Calls': s.apiCalls,
         Turns: s.turns.length,
@@ -254,6 +263,7 @@ function buildSummaryRows(periods: PeriodExport[]): Row[] {
   const { code } = getCurrency()
   return periods.map(p => {
     const cost = p.projects.reduce((s, proj) => s + proj.totalCostUSD, 0)
+    const estimatedCostUSD = p.projects.reduce((s, proj) => s + (proj.estimatedCostUSD ?? 0), 0)
     const savings = p.projects.reduce((s, proj) => s + proj.totalSavingsUSD, 0)
     const calls = p.projects.reduce((s, proj) => s + proj.totalApiCalls, 0)
     const sessions = p.projects.reduce((s, proj) => s + proj.sessions.length, 0)
@@ -261,6 +271,7 @@ function buildSummaryRows(periods: PeriodExport[]): Row[] {
     return {
       Period: p.label,
       [`Cost (${code})`]: roundForActiveCurrency(convertCost(cost)),
+      [`Estimated Cost (${code})`]: roundForActiveCurrency(convertCost(estimatedCostUSD)),
       [`Saved (${code})`]: roundForActiveCurrency(convertCost(savings)),
       'API Calls': calls,
       Sessions: sessions,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,12 +20,13 @@ const INSTRUCTIONS =
   'unless include_project_names is true. All data is read locally from this machine; last_6_months is the widest ' +
   'window. Numbers reflect the most recent scan and may lag the current session by up to a few minutes.'
 
-function breakdownRows(p: MenubarPayload, by: BreakdownBy, limit: number): Array<{ name: string; costUSD: number }> {
+function breakdownRows(p: MenubarPayload, by: BreakdownBy, limit: number): Array<{ name: string; costUSD: number; estimatedCostUSD: number }> {
   const c = p.current
-  if (by === 'model') return c.topModels.slice(0, limit).map(m => ({ name: m.name, costUSD: m.cost }))
-  if (by === 'project') return c.topProjects.slice(0, limit).map(x => ({ name: x.name, costUSD: x.cost }))
-  if (by === 'task') return c.topActivities.slice(0, limit).map(a => ({ name: a.name, costUSD: a.cost }))
-  return Object.entries(c.providers).sort(([, a], [, b]) => b - a).slice(0, limit).map(([name, cost]) => ({ name, costUSD: cost }))
+  if (by === 'model') return c.topModels.slice(0, limit).map(m => ({ name: m.name, costUSD: m.cost, estimatedCostUSD: m.estimatedCostUSD ?? 0 }))
+  if (by === 'project') return c.topProjects.slice(0, limit).map(x => ({ name: x.name, costUSD: x.cost, estimatedCostUSD: x.estimatedCostUSD ?? 0 }))
+  if (by === 'task') return c.topActivities.slice(0, limit).map(a => ({ name: a.name, costUSD: a.cost, estimatedCostUSD: a.estimatedCostUSD ?? 0 }))
+  const estimatedProviders = c.estimatedProviders ?? {}
+  return Object.entries(c.providers).sort(([, a], [, b]) => b - a).slice(0, limit).map(([name, cost]) => ({ name, costUSD: cost, estimatedCostUSD: estimatedProviders[name] ?? 0 }))
 }
 
 export function createServer(deps: { version: string; aggregate?: Aggregate }): McpServer {
@@ -60,8 +61,8 @@ export function createServer(deps: { version: string; aggregate?: Aggregate }): 
       outputSchema: {
         period: z.string(),
         empty: z.boolean(),
-        totals: z.object({ costUSD: z.number(), calls: z.number(), sessions: z.number(), cacheHitPercent: z.number(), oneShotRate: z.number().nullable() }),
-        breakdown: z.array(z.object({ name: z.string(), costUSD: z.number() })).nullable(),
+        totals: z.object({ costUSD: z.number(), estimatedCostUSD: z.number(), calls: z.number(), sessions: z.number(), cacheHitPercent: z.number(), oneShotRate: z.number().nullable() }),
+        breakdown: z.array(z.object({ name: z.string(), costUSD: z.number(), estimatedCostUSD: z.number() })).nullable(),
       },
       annotations: { title: 'CodeBurn — usage & cost', readOnlyHint: true, openWorldHint: false, idempotentHint: true },
     },
@@ -69,7 +70,7 @@ export function createServer(deps: { version: string; aggregate?: Aggregate }): 
       try {
         const payload = redactProjectNames(await getPayload(period, false), include_project_names)
         const c = payload.current
-        const totals = { costUSD: c.cost, calls: c.calls, sessions: c.sessions, cacheHitPercent: c.cacheHitPercent, oneShotRate: c.oneShotRate }
+        const totals = { costUSD: c.cost, estimatedCostUSD: c.estimatedCostUSD ?? 0, calls: c.calls, sessions: c.sessions, cacheHitPercent: c.cacheHitPercent, oneShotRate: c.oneShotRate }
         if (c.calls === 0) {
           return {
             content: [{ type: 'text' as const, text: `No usage recorded for ${c.label} yet — run some coding sessions and try again.` }],
@@ -85,7 +86,7 @@ export function createServer(deps: { version: string; aggregate?: Aggregate }): 
       } catch (err) {
         return {
           content: [{ type: 'text' as const, text: `codeburn: failed to read usage — ${err instanceof Error ? err.message : String(err)}` }],
-          structuredContent: { period: 'unknown', empty: true, totals: { costUSD: 0, calls: 0, sessions: 0, cacheHitPercent: 0, oneShotRate: null }, breakdown: null },
+          structuredContent: { period: 'unknown', empty: true, totals: { costUSD: 0, estimatedCostUSD: 0, calls: 0, sessions: 0, cacheHitPercent: 0, oneShotRate: null }, breakdown: null },
           isError: true,
         }
       }

--- a/src/mcp/tables.ts
+++ b/src/mcp/tables.ts
@@ -12,31 +12,33 @@ function mdTable(headers: string[], rows: string[][]): string {
 
 const pct = (n: number) => `${Math.round(n)}%`
 const oneShot = (r: number | null) => (r === null ? 'n/a' : pct(r * 100))
+const estimatedCost = (cost: number, estimatedCostUSD = 0) => estimatedCostUSD > 0 ? `~${formatCost(cost)}` : formatCost(cost)
 
 export function renderSummaryTable(p: MenubarPayload): string {
   const c = p.current
   const unpriced = c.unpricedModels ?? []
   return [
-    `**${c.label}** — ${formatCost(c.cost)} · ${c.calls} calls · ${c.sessions} sessions`,
+    `**${c.label}** — ${estimatedCost(c.cost, c.estimatedCostUSD)} · ${c.calls} calls · ${c.sessions} sessions`,
     `cache hit ${pct(c.cacheHitPercent)} · one-shot ${oneShot(c.oneShotRate)} · in ${formatTokens(c.inputTokens)} / out ${formatTokens(c.outputTokens)}`,
     ...(unpriced.length > 0
       ? [`⚠ ${unpriced.length} model${unpriced.length === 1 ? '' : 's'} unpriced, counted at $0: ${unpriced.map(u => `${u.model} (${u.calls} calls)`).join(', ')}. Cost above understates real spend; fix with \`codeburn model-alias\` or \`codeburn price-override\`.`]
       : []),
     '',
     '_Top models_',
-    mdTable(['Model', 'Cost', 'Calls'], c.topModels.slice(0, 5).map(m => [m.name, formatCost(m.cost), String(m.calls)])),
+    mdTable(['Model', 'Cost', 'Calls'], c.topModels.slice(0, 5).map(m => [m.name, estimatedCost(m.cost, m.estimatedCostUSD), String(m.calls)])),
     '',
     '_Top projects_',
-    mdTable(['Project', 'Cost', 'Sessions'], c.topProjects.slice(0, 5).map(x => [x.name, formatCost(x.cost), String(x.sessions)])),
+    mdTable(['Project', 'Cost', 'Sessions'], c.topProjects.slice(0, 5).map(x => [x.name, estimatedCost(x.cost, x.estimatedCostUSD), String(x.sessions)])),
   ].join('\n')
 }
 
 export function renderBreakdownTable(p: MenubarPayload, by: BreakdownBy, limit: number): string {
   const c = p.current
-  if (by === 'model') return mdTable(['Model', 'Cost', 'Calls'], c.topModels.slice(0, limit).map(m => [m.name, formatCost(m.cost), String(m.calls)]))
-  if (by === 'project') return mdTable(['Project', 'Cost', 'Sessions'], c.topProjects.slice(0, limit).map(x => [x.name, formatCost(x.cost), String(x.sessions)]))
-  if (by === 'task') return mdTable(['Task', 'Cost', 'Turns', 'One-shot'], c.topActivities.slice(0, limit).map(a => [a.name, formatCost(a.cost), String(a.turns), oneShot(a.oneShotRate)]))
-  return mdTable(['Provider', 'Cost'], Object.entries(c.providers).sort(([, a], [, b]) => b - a).slice(0, limit).map(([name, cost]) => [name, formatCost(cost)]))
+  if (by === 'model') return mdTable(['Model', 'Cost', 'Calls'], c.topModels.slice(0, limit).map(m => [m.name, estimatedCost(m.cost, m.estimatedCostUSD), String(m.calls)]))
+  if (by === 'project') return mdTable(['Project', 'Cost', 'Sessions'], c.topProjects.slice(0, limit).map(x => [x.name, estimatedCost(x.cost, x.estimatedCostUSD), String(x.sessions)]))
+  if (by === 'task') return mdTable(['Task', 'Cost', 'Turns', 'One-shot'], c.topActivities.slice(0, limit).map(a => [a.name, estimatedCost(a.cost, a.estimatedCostUSD), String(a.turns), oneShot(a.oneShotRate)]))
+  const estimatedProviders = c.estimatedProviders ?? {}
+  return mdTable(['Provider', 'Cost'], Object.entries(c.providers).sort(([, a], [, b]) => b - a).slice(0, limit).map(([name, cost]) => [name, estimatedCost(cost, estimatedProviders[name])]))
 }
 
 export function renderSavingsTable(p: MenubarPayload): string {

--- a/src/menubar-json.ts
+++ b/src/menubar-json.ts
@@ -4,6 +4,7 @@
 export type PeriodData = {
   label: string
   cost: number
+  estimatedCostUSD?: number
   /// Counterfactual USD the same tokens would have cost on the paid
   /// baseline configured for each local model. Stays `0` when no
   /// `codeburn model-savings` mappings are active. Always shown
@@ -19,20 +20,21 @@ export type PeriodData = {
   /// Total Codex credits consumed in the period (issues #408/#495). Optional so
   /// non-menubar PeriodData producers don't have to compute it.
   codexCredits?: number
-  categories: Array<{ name: string; cost: number; savingsUSD: number; turns: number; editTurns: number; oneShotTurns: number }>
-  models: Array<{ name: string; cost: number; savingsUSD: number; calls: number }>
+  categories: Array<{ name: string; cost: number; estimatedCostUSD?: number; savingsUSD: number; turns: number; editTurns: number; oneShotTurns: number }>
+  models: Array<{ name: string; cost: number; estimatedCostUSD?: number; savingsUSD: number; calls: number }>
   /// Models with usage in the period whose pricing lookup fails against the
   /// current tables (#638): their calls contribute $0 to `cost`. Optional so
   /// PeriodData producers that predate the field keep compiling.
   unpricedModels?: Array<{ model: string; calls: number; tokens: number }>
-  projects?: Array<{ name: string; cost: number; savingsUSD: number; sessions: number; sessionDetails?: Array<{ cost: number; savingsUSD: number; calls: number; inputTokens: number; outputTokens: number; date: string; models: Array<{ name: string; cost: number; savingsUSD: number }> }> }>
+  projects?: Array<{ name: string; cost: number; estimatedCostUSD?: number; savingsUSD: number; sessions: number; sessionDetails?: Array<{ cost: number; estimatedCostUSD?: number; savingsUSD: number; calls: number; inputTokens: number; outputTokens: number; date: string; models: Array<{ name: string; cost: number; estimatedCostUSD?: number; savingsUSD: number }> }> }>
   modelEfficiency?: Array<{ name: string; costPerEdit: number | null; oneShotRate: number | null }>
-  topSessions?: Array<{ project: string; cost: number; savingsUSD: number; calls: number; date: string }>
+  topSessions?: Array<{ project: string; cost: number; estimatedCostUSD?: number; savingsUSD: number; calls: number; date: string }>
 }
 
 export type ProviderCost = {
   name: string
   cost: number
+  estimatedCostUSD?: number
 }
 import type { OptimizeResult } from './optimize.js'
 import type { GranularHistory } from './granular-history.js'
@@ -49,6 +51,7 @@ const MODEL_EFFICIENCY_LIMIT = 5
 export type DailyModelBreakdown = {
   name: string
   cost: number
+  estimatedCostUSD?: number
   savingsUSD: number
   calls: number
   inputTokens: number
@@ -58,6 +61,7 @@ export type DailyModelBreakdown = {
 export type DailyHistoryEntry = {
   date: string
   cost: number
+  estimatedCostUSD?: number
   savingsUSD: number
   calls: number
   inputTokens: number
@@ -129,6 +133,7 @@ export type MenubarPayload = {
   current: {
     label: string
     cost: number
+    estimatedCostUSD?: number
     calls: number
     sessions: number
     oneShotRate: number | null
@@ -145,6 +150,7 @@ export type MenubarPayload = {
     topActivities: Array<{
       name: string
       cost: number
+      estimatedCostUSD?: number
       savingsUSD: number
       turns: number
       oneShotRate: number | null
@@ -152,6 +158,7 @@ export type MenubarPayload = {
     topModels: Array<{
       name: string
       cost: number
+      estimatedCostUSD?: number
       savingsUSD: number
       savingsBaselineModel: string
       calls: number
@@ -167,20 +174,23 @@ export type MenubarPayload = {
     /// `codeburn model-savings`.
     localModelSavings: LocalModelSavings
     providers: Record<string, number>
+    estimatedProviders?: Record<string, number>
     topProjects: Array<{
       name: string
       cost: number
+      estimatedCostUSD?: number
       savingsUSD: number
       sessions: number
       avgCostPerSession: number
       sessionDetails: Array<{
         cost: number
+        estimatedCostUSD?: number
         savingsUSD: number
         calls: number
         inputTokens: number
         outputTokens: number
         date: string
-        models: Array<{ name: string; cost: number; savingsUSD: number }>
+        models: Array<{ name: string; cost: number; estimatedCostUSD?: number; savingsUSD: number }>
       }>
     }>
     modelEfficiency: Array<{
@@ -191,6 +201,7 @@ export type MenubarPayload = {
     topSessions: Array<{
       project: string
       cost: number
+      estimatedCostUSD?: number
       savingsUSD: number
       calls: number
       date: string
@@ -269,6 +280,7 @@ function buildTopActivities(categories: PeriodData['categories']): MenubarPayloa
   return categories.slice(0, TOP_ACTIVITIES_LIMIT).map(cat => ({
     name: cat.name,
     cost: cat.cost,
+    estimatedCostUSD: cat.estimatedCostUSD ?? 0,
     savingsUSD: cat.savingsUSD,
     turns: cat.turns,
     oneShotRate: oneShotRateFor(cat.editTurns, cat.oneShotTurns),
@@ -279,7 +291,7 @@ function buildTopModels(models: PeriodData['models']): MenubarPayload['current']
   return models
     .filter(m => m.name !== SYNTHETIC_MODEL_NAME)
     .slice(0, TOP_MODELS_LIMIT)
-    .map(m => ({ name: m.name, cost: m.cost, calls: m.calls, savingsUSD: m.savingsUSD, savingsBaselineModel: '' }))
+    .map(m => ({ name: m.name, cost: m.cost, estimatedCostUSD: m.estimatedCostUSD ?? 0, calls: m.calls, savingsUSD: m.savingsUSD, savingsBaselineModel: '' }))
 }
 
 function buildOptimize(optimize: OptimizeResult | null): MenubarPayload['optimize'] {
@@ -309,6 +321,15 @@ function buildProviders(providers: ProviderCost[]): Record<string, number> {
   return map
 }
 
+function buildEstimatedProviders(providers: ProviderCost[]): Record<string, number> {
+  const map: Record<string, number> = {}
+  for (const p of providers) {
+    if ((p.estimatedCostUSD ?? 0) <= 0) continue
+    map[p.name.toLowerCase()] = p.estimatedCostUSD ?? 0
+  }
+  return map
+}
+
 function buildHistory(daily: DailyHistoryEntry[] | undefined, timeline?: GranularHistory): MenubarPayload['history'] {
   if (!daily || daily.length === 0) return { daily: [], ...(timeline ? { timeline } : {}) }
   const sorted = [...daily].sort((a, b) => a.date.localeCompare(b.date))
@@ -324,17 +345,19 @@ function buildTopProjects(projects: PeriodData['projects']): MenubarPayload['cur
     .map(p => ({
       name: p.name,
       cost: p.cost,
+      estimatedCostUSD: p.estimatedCostUSD ?? 0,
       savingsUSD: p.savingsUSD,
       sessions: p.sessions,
       avgCostPerSession: p.sessions > 0 ? p.cost / p.sessions : 0,
       sessionDetails: (p.sessionDetails ?? []).map(s => ({
         cost: s.cost,
+        estimatedCostUSD: s.estimatedCostUSD ?? 0,
         savingsUSD: s.savingsUSD,
         calls: s.calls,
         inputTokens: s.inputTokens,
         outputTokens: s.outputTokens,
         date: s.date,
-        models: s.models,
+        models: s.models.map(m => ({ ...m, estimatedCostUSD: m.estimatedCostUSD ?? 0 })),
       })),
     }))
 }
@@ -351,7 +374,7 @@ function buildTopSessions(sessions: PeriodData['topSessions']): MenubarPayload['
   return (sessions ?? [])
     .sort((a, b) => (b.cost + b.savingsUSD) - (a.cost + a.savingsUSD))
     .slice(0, TOP_SESSIONS_LIMIT)
-    .map(s => ({ project: s.project, cost: s.cost, savingsUSD: s.savingsUSD, calls: s.calls, date: s.date }))
+    .map(s => ({ project: s.project, cost: s.cost, estimatedCostUSD: s.estimatedCostUSD ?? 0, savingsUSD: s.savingsUSD, calls: s.calls, date: s.date }))
 }
 
 export type BreakdownArrays = {
@@ -383,6 +406,7 @@ export function buildMenubarPayload(
     current: {
       label: current.label,
       cost: current.cost,
+      estimatedCostUSD: current.estimatedCostUSD ?? 0,
       calls: current.calls,
       sessions: current.sessions,
       oneShotRate: aggregateOneShotRate(current.categories),
@@ -397,6 +421,7 @@ export function buildMenubarPayload(
       unpricedModels: current.unpricedModels ?? [],
       localModelSavings: breakdowns?.localModelSavings ?? { totalUSD: 0, calls: 0, byModel: [], byProvider: [] },
       providers: buildProviders(providers),
+      estimatedProviders: buildEstimatedProviders(providers),
       topProjects: buildTopProjects(current.projects ?? []),
       modelEfficiency: buildModelEfficiency(current.modelEfficiency ?? []),
       topSessions: buildTopSessions(current.topSessions ?? []),

--- a/src/overview.ts
+++ b/src/overview.ts
@@ -23,6 +23,9 @@ function formatTokens(n: number): string {
 function formatCount(n: number): string {
   return n.toLocaleString('en-US')
 }
+function formatEstimatedCost(cost: number, estimatedCostUSD: number): string {
+  return estimatedCostUSD > 0 ? `~${formatCost(cost)}` : formatCost(cost)
+}
 function isAbsoluteProjectPath(path: string): boolean {
   return path.startsWith('/') || path.startsWith('\\') || /^[a-zA-Z]:[/\\]/.test(path)
 }
@@ -88,23 +91,25 @@ export function renderOverview(
     return out.join('\n') + '\n'
   }
 
-  let cost = 0, savings = 0, calls = 0, sessions = 0
+  let cost = 0, estimatedCost = 0, savings = 0, calls = 0, sessions = 0
   let inTok = 0, outTok = 0, cacheR = 0, cacheW = 0
-  const byProvider = new Map<string, { cost: number; tokens: number }>()
-  const byModel = new Map<string, { cost: number; calls: number; tokens: number }>()
-  const byCat = new Map<string, { cost: number; turns: number }>()
+  const byProvider = new Map<string, { cost: number; estimatedCostUSD: number; tokens: number }>()
+  const byModel = new Map<string, { cost: number; estimatedCostUSD: number; calls: number; tokens: number }>()
+  const byCat = new Map<string, { cost: number; estimatedCostUSD: number; turns: number }>()
   const byTool = new Map<string, number>()
-  const byDay = new Map<string, { cost: number; tokens: number; providers: Set<string> }>()
-  const byProject = new Map<string, { cost: number; sessions: number }>()
+  const byDay = new Map<string, { cost: number; estimatedCostUSD: number; tokens: number; providers: Set<string> }>()
+  const byProject = new Map<string, { cost: number; estimatedCostUSD: number; sessions: number }>()
 
   for (const p of projects) {
     cost += p.totalCostUSD
+    estimatedCost += p.estimatedCostUSD ?? 0
     savings += p.totalSavingsUSD
     calls += p.totalApiCalls
     sessions += p.sessions.length
     const pname = projectName(p)
-    const pe = byProject.get(pname) ?? { cost: 0, sessions: 0 }
+    const pe = byProject.get(pname) ?? { cost: 0, estimatedCostUSD: 0, sessions: 0 }
     pe.cost += p.totalCostUSD
+    pe.estimatedCostUSD += p.estimatedCostUSD ?? 0
     pe.sessions += p.sessions.length
     byProject.set(pname, pe)
     for (const s of p.sessions) {
@@ -113,15 +118,17 @@ export function renderOverview(
       cacheR += s.totalCacheReadTokens
       cacheW += s.totalCacheWriteTokens
       for (const [m, d] of Object.entries(s.modelBreakdown)) {
-        const e = byModel.get(m) ?? { cost: 0, calls: 0, tokens: 0 }
+        const e = byModel.get(m) ?? { cost: 0, estimatedCostUSD: 0, calls: 0, tokens: 0 }
         e.cost += d.costUSD
+        e.estimatedCostUSD += d.estimatedCostUSD ?? 0
         e.calls += d.calls
         e.tokens += d.tokens.inputTokens + d.tokens.outputTokens + d.tokens.cacheReadInputTokens + d.tokens.cacheCreationInputTokens
         byModel.set(m, e)
       }
       for (const [cat, d] of Object.entries(s.categoryBreakdown)) {
-        const e = byCat.get(cat) ?? { cost: 0, turns: 0 }
+        const e = byCat.get(cat) ?? { cost: 0, estimatedCostUSD: 0, turns: 0 }
         e.cost += d.costUSD
+        e.estimatedCostUSD += d.estimatedCostUSD ?? 0
         e.turns += d.turns
         byCat.set(cat, e)
       }
@@ -132,13 +139,15 @@ export function renderOverview(
         const day = dateKey(t.timestamp || t.assistantCalls[0]?.timestamp || '')
         for (const call of t.assistantCalls) {
           const tk = call.usage.inputTokens + call.usage.outputTokens + call.usage.cacheReadInputTokens + call.usage.cacheCreationInputTokens
-          const pv = byProvider.get(call.provider) ?? { cost: 0, tokens: 0 }
+          const pv = byProvider.get(call.provider) ?? { cost: 0, estimatedCostUSD: 0, tokens: 0 }
           pv.cost += call.costUSD
+          pv.estimatedCostUSD += call.estimatedCostUSD ?? 0
           pv.tokens += tk
           byProvider.set(call.provider, pv)
           if (day) {
-            const dd = byDay.get(day) ?? { cost: 0, tokens: 0, providers: new Set<string>() }
+            const dd = byDay.get(day) ?? { cost: 0, estimatedCostUSD: 0, tokens: 0, providers: new Set<string>() }
             dd.cost += call.costUSD
+            dd.estimatedCostUSD += call.estimatedCostUSD ?? 0
             dd.tokens += tk
             dd.providers.add(call.provider)
             byDay.set(day, dd)
@@ -155,7 +164,7 @@ export function renderOverview(
   // Totals
   out.push(heading('Totals'))
   const kv = (k: string, v: string): string => '  ' + c.dim(k.padEnd(11)) + v
-  out.push(kv('Cost', c.bold(formatCost(cost))))
+  out.push(kv('Cost', c.bold(formatEstimatedCost(cost, estimatedCost))))
   out.push(kv('Tokens', formatTokens(totalTokens) + c.dim('   (breakdown below)')))
   out.push(kv('Calls', formatCount(calls) + c.dim('   sessions ') + formatCount(sessions)))
   out.push(kv('Cache hit', `${cacheHit.toFixed(1)}%`))
@@ -198,7 +207,7 @@ export function renderOverview(
     out.push(heading('By tool'))
     out.push(renderTable(c,
       [{ header: 'Tool' }, { header: 'Cost', right: true }, { header: 'Tokens', right: true }, { header: 'Share', right: true }],
-      providerRows.map(([name, v]) => [name, formatCost(v.cost), formatTokens(v.tokens), cost > 0 ? `${Math.round((v.cost / cost) * 100)}%` : '0%']),
+      providerRows.map(([name, v]) => [name, formatEstimatedCost(v.cost, v.estimatedCostUSD), formatTokens(v.tokens), cost > 0 ? `${Math.round((v.cost / cost) * 100)}%` : '0%']),
     ))
     out.push('')
   }
@@ -209,7 +218,7 @@ export function renderOverview(
     out.push(heading('Top models'))
     out.push(renderTable(c,
       [{ header: 'Model' }, { header: 'Cost', right: true }, { header: 'Calls', right: true }, { header: 'Tokens', right: true }],
-      modelRows.map(([m, v]) => [getShortModelName(m), formatCost(v.cost), formatCount(v.calls), formatTokens(v.tokens)]),
+      modelRows.map(([m, v]) => [getShortModelName(m), formatEstimatedCost(v.cost, v.estimatedCostUSD), formatCount(v.calls), formatTokens(v.tokens)]),
     ))
     out.push('')
   }
@@ -220,7 +229,7 @@ export function renderOverview(
     out.push(heading('Highest-value days'))
     out.push(renderTable(c,
       [{ header: '#' }, { header: 'Date' }, { header: 'Cost', right: true }, { header: 'Tokens', right: true }],
-      topDays.map(([d, v], i) => [String(i + 1), d, formatCost(v.cost), formatTokens(v.tokens)]),
+      topDays.map(([d, v], i) => [String(i + 1), d, formatEstimatedCost(v.cost, v.estimatedCostUSD), formatTokens(v.tokens)]),
     ))
     out.push('')
   }
@@ -231,7 +240,7 @@ export function renderOverview(
     out.push(heading('Top projects'))
     out.push(renderTable(c,
       [{ header: 'Project' }, { header: 'Cost', right: true }, { header: 'Sessions', right: true }],
-      projRows.map(([name, v]) => [name, formatCost(v.cost), formatCount(v.sessions)]),
+      projRows.map(([name, v]) => [name, formatEstimatedCost(v.cost, v.estimatedCostUSD), formatCount(v.sessions)]),
     ))
     out.push('')
   }
@@ -242,7 +251,7 @@ export function renderOverview(
     out.push(heading('Daily'))
     out.push(renderTable(c,
       [{ header: 'Date' }, { header: 'Cost', right: true }, { header: 'Tokens', right: true }, { header: 'Providers' }],
-      dailyRows.map(([d, v]) => [d, formatCost(v.cost), formatTokens(v.tokens), [...v.providers].sort().join(', ')]),
+      dailyRows.map(([d, v]) => [d, formatEstimatedCost(v.cost, v.estimatedCostUSD), formatTokens(v.tokens), [...v.providers].sort().join(', ')]),
     ))
     out.push('')
   }
@@ -253,7 +262,7 @@ export function renderOverview(
     out.push(heading('By activity'))
     out.push(renderTable(c,
       [{ header: 'Activity' }, { header: 'Cost', right: true }, { header: 'Turns', right: true }],
-      catRows.map(([cat, v]) => [CATEGORY_LABELS[cat as TaskCategory] ?? cat, formatCost(v.cost), formatCount(v.turns)]),
+      catRows.map(([cat, v]) => [CATEGORY_LABELS[cat as TaskCategory] ?? cat, formatEstimatedCost(v.cost, v.estimatedCostUSD), formatCount(v.turns)]),
     ))
     out.push('')
   }
@@ -272,7 +281,7 @@ export function renderOverview(
   const topTool = providerRows[0]?.[0]
   const topModel = modelRows[0] ? getShortModelName(modelRows[0][0]) : ''
   const mostly = topTool ? `, mostly ${topTool}${topModel ? ` / ${topModel}` : ''}` : ''
-  out.push(c.dim('Bottom line: ') + `${opts.label} totals ${formatCost(cost)} across ${formatTokens(totalTokens)} tokens${mostly}.`)
+  out.push(c.dim('Bottom line: ') + `${opts.label} totals ${formatEstimatedCost(cost, estimatedCost)} across ${formatTokens(totalTokens)} tokens${mostly}.`)
 
   return out.join('\n') + '\n'
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1134,6 +1134,7 @@ export function parseApiCall(entry: JournalEntry): ParsedApiCall | null {
     model: msg.model,
     usage: tokens,
     costUSD,
+    estimatedCostUSD: 0,
     tools,
     mcpTools: extractMcpTools(tools),
     skills,
@@ -1286,6 +1287,7 @@ function buildSessionSummary(
   const subagentBreakdown: SessionSummary['subagentBreakdown'] = Object.create(null)
 
   let totalCost = 0
+  let totalEstimatedCost = 0
   let totalSavings = 0
   let totalInput = 0
   let totalOutput = 0
@@ -1298,13 +1300,15 @@ function buildSessionSummary(
 
   for (const turn of turns) {
     const turnCost = turn.assistantCalls.reduce((s, c) => s + c.costUSD, 0)
+    const turnEstimatedCost = turn.assistantCalls.reduce((s, c) => s + (c.estimatedCostUSD ?? 0), 0)
     const turnSavings = turn.assistantCalls.reduce((s, c) => s + (c.savingsUSD ?? 0), 0)
 
     if (!categoryBreakdown[turn.category]) {
-      categoryBreakdown[turn.category] = { turns: 0, costUSD: 0, savingsUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 }
+      categoryBreakdown[turn.category] = { turns: 0, costUSD: 0, estimatedCostUSD: 0, savingsUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 }
     }
     categoryBreakdown[turn.category].turns++
     categoryBreakdown[turn.category].costUSD += turnCost
+    categoryBreakdown[turn.category].estimatedCostUSD = (categoryBreakdown[turn.category].estimatedCostUSD ?? 0) + turnEstimatedCost
     categoryBreakdown[turn.category].savingsUSD += turnSavings
     if (turn.hasEdits) {
       categoryBreakdown[turn.category].editTurns++
@@ -1315,10 +1319,11 @@ function buildSessionSummary(
     if (turn.subCategory) {
       const skillKey = turn.subCategory
       if (!skillBreakdown[skillKey]) {
-        skillBreakdown[skillKey] = { turns: 0, costUSD: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
+        skillBreakdown[skillKey] = { turns: 0, costUSD: 0, estimatedCostUSD: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
       }
       skillBreakdown[skillKey].turns++
       skillBreakdown[skillKey].costUSD += turnCost
+      skillBreakdown[skillKey].estimatedCostUSD = (skillBreakdown[skillKey].estimatedCostUSD ?? 0) + turnEstimatedCost
       skillBreakdown[skillKey].savingsUSD += turnSavings
       if (turn.hasEdits) {
         skillBreakdown[skillKey].editTurns++
@@ -1329,6 +1334,7 @@ function buildSessionSummary(
     for (const call of turn.assistantCalls) {
       const callSavings = call.savingsUSD ?? 0
       totalCost += call.costUSD
+      totalEstimatedCost += call.estimatedCostUSD ?? 0
       totalSavings += callSavings
       totalInput += call.usage.inputTokens
       totalOutput += call.usage.outputTokens
@@ -1343,11 +1349,13 @@ function buildSessionSummary(
           calls: 0,
           costUSD: 0,
           savingsUSD: 0,
+          estimatedCostUSD: 0,
           tokens: { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0, webSearchRequests: 0 },
         }
       }
       modelBreakdown[modelKey].calls++
       modelBreakdown[modelKey].costUSD += call.costUSD
+      modelBreakdown[modelKey].estimatedCostUSD = (modelBreakdown[modelKey].estimatedCostUSD ?? 0) + (call.estimatedCostUSD ?? 0)
       modelBreakdown[modelKey].savingsUSD += callSavings
       modelBreakdown[modelKey].tokens.inputTokens += call.usage.inputTokens
       modelBreakdown[modelKey].tokens.outputTokens += call.usage.outputTokens
@@ -1369,9 +1377,10 @@ function buildSessionSummary(
         bashBreakdown[cmd].calls++
       }
       for (const sat of call.subagentTypes) {
-        subagentBreakdown[sat] = subagentBreakdown[sat] ?? { calls: 0, costUSD: 0, savingsUSD: 0 }
+        subagentBreakdown[sat] = subagentBreakdown[sat] ?? { calls: 0, costUSD: 0, estimatedCostUSD: 0, savingsUSD: 0 }
         subagentBreakdown[sat].calls++
         subagentBreakdown[sat].costUSD += call.costUSD
+        subagentBreakdown[sat].estimatedCostUSD = (subagentBreakdown[sat].estimatedCostUSD ?? 0) + (call.estimatedCostUSD ?? 0)
         subagentBreakdown[sat].savingsUSD += callSavings
       }
 
@@ -1386,6 +1395,7 @@ function buildSessionSummary(
     firstTimestamp: firstTs || turns[0]?.timestamp || '',
     lastTimestamp: lastTs || turns[turns.length - 1]?.timestamp || '',
     totalCostUSD: totalCost,
+    estimatedCostUSD: totalEstimatedCost,
     totalSavingsUSD: totalSavings,
     totalInputTokens: totalInput,
     totalOutputTokens: totalOutput,
@@ -1695,6 +1705,7 @@ function summarizeProject(project: string, projectPath: string, sessions: Sessio
     projectPath,
     sessions,
     totalCostUSD,
+    estimatedCostUSD: sessions.reduce((s, sess) => s + (sess.estimatedCostUSD ?? 0), 0),
     totalSavingsUSD: sessions.reduce((s, sess) => s + sess.totalSavingsUSD, 0),
     totalApiCalls: sessions.reduce((s, sess) => s + sess.apiCalls, 0),
     totalProxiedCostUSD: isProxiedPath(projectPath) ? totalCostUSD : 0,
@@ -1718,6 +1729,7 @@ function providerCallToTurn(call: ParsedProviderCall): ParsedTurn {
     model: call.model,
     usage,
     costUSD: call.costUSD,
+    estimatedCostUSD: call.costIsEstimated ? call.costUSD : 0,
     tools,
     mcpTools: extractMcpTools(tools),
     skills: call.skills ?? [],
@@ -1755,6 +1767,7 @@ function providerCallToCachedCall(call: ParsedProviderCall): CachedCall {
       cacheCreationOneHourTokens: 0,
     },
     costUSD: (call.provider === 'mistral-vibe' || call.provider === 'antigravity' || call.provider === 'devin' || call.provider === 'vercel-gateway' || call.provider === 'hermes' || call.provider === 'kiro') ? call.costUSD : undefined,
+    estimatedCostUSD: call.costIsEstimated ? call.costUSD : 0,
     speed: call.speed,
     timestamp: call.timestamp,
     tools: call.tools,
@@ -1793,6 +1806,7 @@ function apiCallToCachedCall(call: ParsedApiCall): CachedCall {
     skills: call.skills,
     subagentTypes: call.subagentTypes,
     deduplicationKey: call.deduplicationKey,
+    estimatedCostUSD: call.estimatedCostUSD,
     toolSequence: call.toolSequence,
   }
 }
@@ -1866,6 +1880,7 @@ function cachedCallToApiCall(call: CachedCall): ParsedApiCall {
       webSearchRequests: u.webSearchRequests,
     },
     costUSD: call.costUSD ?? costUSD,
+    estimatedCostUSD: call.estimatedCostUSD ?? 0,
     tools: call.tools,
     mcpTools: extractMcpTools(call.tools),
     skills: call.skills,

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -24,6 +24,7 @@ export type CachedCall = {
   model: string
   usage: CachedUsage
   costUSD?: number
+  estimatedCostUSD?: number
   speed: 'standard' | 'fast'
   timestamp: string
   tools: string[]
@@ -82,11 +83,16 @@ export type SessionCache = {
 
 // ── Constants ──────────────────────────────────────────────────────────
 
+// v6: estimated-cost propagation (#639) added estimatedCostUSD to cached
+// calls. v5 entries from estimating providers (cursor, warp, grok, copilot,
+// kiro fallback paths) carry no estimated marker and would silently reload
+// as fully measured. Bump forces a one-time re-parse from source.
+//
 // v5: kiro joined the costUSD pass-through allowlist (credit-based pricing).
 // Cached kiro entries from v4 carry costUSD: undefined and would keep being
 // re-priced from estimated tokens forever, since historical session files
 // never change. Bump forces a one-time re-parse so metered credit costs land.
-export const CACHE_VERSION = 5
+export const CACHE_VERSION = 6
 
 const CACHE_FILE = 'session-cache.json'
 const TEMP_FILE_MAX_AGE_MS = 5 * 60 * 1000
@@ -211,6 +217,7 @@ function validateCall(c: unknown): c is CachedCall {
     && typeof o['timestamp'] === 'string'
     && (o['speed'] === 'standard' || o['speed'] === 'fast')
     && isOptionalNum(o['costUSD'])
+    && isOptionalNum(o['estimatedCostUSD'])
     && isStringArray(o['tools'])
     && isStringArray(o['bashCommands'])
     && isStringArray(o['skills'])

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export type ParsedApiCall = {
   model: string
   usage: TokenUsage
   costUSD: number
+  estimatedCostUSD: number
   tools: string[]
   mcpTools: string[]
   skills: string[]
@@ -141,6 +142,7 @@ export type SessionSummary = {
   firstTimestamp: string
   lastTimestamp: string
   totalCostUSD: number
+  estimatedCostUSD: number
   totalSavingsUSD: number
   totalInputTokens: number
   totalOutputTokens: number
@@ -149,13 +151,13 @@ export type SessionSummary = {
   totalCacheWriteTokens: number
   apiCalls: number
   turns: ClassifiedTurn[]
-  modelBreakdown: Record<string, { calls: number; costUSD: number; tokens: TokenUsage; savingsUSD: number }>
+  modelBreakdown: Record<string, { calls: number; costUSD: number; estimatedCostUSD?: number; tokens: TokenUsage; savingsUSD: number }>
   toolBreakdown: Record<string, { calls: number }>
   mcpBreakdown: Record<string, { calls: number }>
   bashBreakdown: Record<string, { calls: number }>
-  categoryBreakdown: Record<TaskCategory, { turns: number; costUSD: number; savingsUSD: number; retries: number; editTurns: number; oneShotTurns: number }>
-  skillBreakdown: Record<string, { turns: number; costUSD: number; savingsUSD: number; editTurns: number; oneShotTurns: number }>
-  subagentBreakdown: Record<string, { calls: number; costUSD: number; savingsUSD: number }>
+  categoryBreakdown: Record<TaskCategory, { turns: number; costUSD: number; estimatedCostUSD?: number; savingsUSD: number; retries: number; editTurns: number; oneShotTurns: number }>
+  skillBreakdown: Record<string, { turns: number; costUSD: number; estimatedCostUSD?: number; savingsUSD: number; editTurns: number; oneShotTurns: number }>
+  subagentBreakdown: Record<string, { calls: number; costUSD: number; estimatedCostUSD?: number; savingsUSD: number }>
   // Observed MCP tools available in this session, captured from
   // `attachment.deferred_tools_delta.addedNames` entries. Union across all
   // turns. Each name is a fully-qualified `mcp__<server>__<tool>` identifier.
@@ -169,6 +171,7 @@ export type ProjectSummary = {
   projectPath: string
   sessions: SessionSummary[]
   totalCostUSD: number
+  estimatedCostUSD: number
   totalSavingsUSD: number
   totalApiCalls: number
   // Portion of `totalCostUSD` served through a subscription-backed proxy

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -15,8 +15,8 @@ import { buildGranularHistory } from './granular-history.js'
 
 export function buildPeriodData(label: string, projects: ProjectSummary[]): PeriodData {
   const sessions = projects.flatMap(p => p.sessions)
-  const catTotals: Record<string, { turns: number; cost: number; savingsUSD: number; editTurns: number; oneShotTurns: number }> = {}
-  const modelTotals: Record<string, { calls: number; cost: number; savingsUSD: number; tokens: number }> = {}
+  const catTotals: Record<string, { turns: number; cost: number; estimatedCostUSD: number; savingsUSD: number; editTurns: number; oneShotTurns: number }> = {}
+  const modelTotals: Record<string, { calls: number; cost: number; estimatedCostUSD: number; savingsUSD: number; tokens: number }> = {}
   let inputTokens = 0, outputTokens = 0, cacheReadTokens = 0, cacheWriteTokens = 0
 
   for (const sess of sessions) {
@@ -25,17 +25,19 @@ export function buildPeriodData(label: string, projects: ProjectSummary[]): Peri
     cacheReadTokens += sess.totalCacheReadTokens
     cacheWriteTokens += sess.totalCacheWriteTokens
     for (const [cat, d] of Object.entries(sess.categoryBreakdown)) {
-      if (!catTotals[cat]) catTotals[cat] = { turns: 0, cost: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
+      if (!catTotals[cat]) catTotals[cat] = { turns: 0, cost: 0, estimatedCostUSD: 0, savingsUSD: 0, editTurns: 0, oneShotTurns: 0 }
       catTotals[cat].turns += d.turns
       catTotals[cat].cost += d.costUSD
+      catTotals[cat].estimatedCostUSD += d.estimatedCostUSD ?? 0
       catTotals[cat].savingsUSD += d.savingsUSD
       catTotals[cat].editTurns += d.editTurns
       catTotals[cat].oneShotTurns += d.oneShotTurns
     }
     for (const [model, d] of Object.entries(sess.modelBreakdown)) {
-      if (!modelTotals[model]) modelTotals[model] = { calls: 0, cost: 0, savingsUSD: 0, tokens: 0 }
+      if (!modelTotals[model]) modelTotals[model] = { calls: 0, cost: 0, estimatedCostUSD: 0, savingsUSD: 0, tokens: 0 }
       modelTotals[model].calls += d.calls
       modelTotals[model].cost += d.costUSD
+      modelTotals[model].estimatedCostUSD += d.estimatedCostUSD ?? 0
       modelTotals[model].savingsUSD += d.savingsUSD
       modelTotals[model].tokens += d.tokens.inputTokens + d.tokens.outputTokens + d.tokens.cacheReadInputTokens + d.tokens.cacheCreationInputTokens
     }
@@ -44,6 +46,7 @@ export function buildPeriodData(label: string, projects: ProjectSummary[]): Peri
   return {
     label,
     cost: projects.reduce((s, p) => s + p.totalCostUSD, 0),
+    estimatedCostUSD: projects.reduce((s, p) => s + (p.estimatedCostUSD ?? 0), 0),
     savingsUSD: projects.reduce((s, p) => s + p.totalSavingsUSD, 0),
     calls: projects.reduce((s, p) => s + p.totalApiCalls, 0),
     sessions: projects.reduce((s, p) => s + p.sessions.length, 0),
@@ -53,7 +56,7 @@ export function buildPeriodData(label: string, projects: ProjectSummary[]): Peri
       .map(([cat, d]) => ({ name: CATEGORY_LABELS[cat as TaskCategory] ?? cat, ...d })),
     models: Object.entries(modelTotals)
       .sort(([, a], [, b]) => b.cost - a.cost)
-      .map(([name, d]) => ({ name, calls: d.calls, cost: d.cost, savingsUSD: d.savingsUSD })),
+      .map(([name, d]) => ({ name, calls: d.calls, cost: d.cost, estimatedCostUSD: d.estimatedCostUSD, savingsUSD: d.savingsUSD })),
     unpricedModels: findUnpricedModels(Object.entries(modelTotals)
       .map(([model, d]) => ({ model, calls: d.calls, cost: d.cost, tokens: d.tokens }))),
   }
@@ -141,6 +144,7 @@ function dailyEntriesToHistory(days: ReturnType<typeof aggregateProjectsIntoDays
       .map(([name, m]) => ({
         name,
         cost: m.cost,
+        estimatedCostUSD: m.estimatedCostUSD ?? 0,
         savingsUSD: m.savingsUSD,
         calls: m.calls,
         inputTokens: m.inputTokens,
@@ -149,6 +153,7 @@ function dailyEntriesToHistory(days: ReturnType<typeof aggregateProjectsIntoDays
     return {
       date: d.date,
       cost: d.cost,
+      estimatedCostUSD: d.estimatedCostUSD ?? 0,
       savingsUSD: d.savingsUSD,
       calls: d.calls,
       inputTokens: d.inputTokens,
@@ -280,17 +285,20 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
   const displayNameByName = new Map(allProviders.map(p => [p.name, p.displayName]))
   const providers: ProviderCost[] = []
   if (isClaudeConfigScoped) {
-    const providerTotals: Record<string, number> = {}
+    const providerTotals: Record<string, { cost: number; estimatedCostUSD: number }> = {}
     for (const d of aggregateProjectsIntoDays(scanProjects)) {
       for (const [name, p] of Object.entries(d.providers)) {
-        providerTotals[name] = (providerTotals[name] ?? 0) + p.cost
+        const total = providerTotals[name] ?? { cost: 0, estimatedCostUSD: 0 }
+        total.cost += p.cost
+        total.estimatedCostUSD += p.estimatedCostUSD ?? 0
+        providerTotals[name] = total
       }
     }
-    for (const [name, cost] of Object.entries(providerTotals)) {
-      providers.push({ name: displayNameByName.get(name) ?? name, cost })
+    for (const [name, total] of Object.entries(providerTotals)) {
+      providers.push({ name: displayNameByName.get(name) ?? name, cost: total.cost, estimatedCostUSD: total.estimatedCostUSD })
     }
     if (providers.length === 0 && claudeConfigs?.selectedId) {
-      providers.push({ name: displayNameByName.get('claude') ?? 'Claude', cost: 0 })
+      providers.push({ name: displayNameByName.get('claude') ?? 'Claude', cost: 0, estimatedCostUSD: 0 })
     }
   } else if (isAllProviders) {
     const unfilteredProviderDays = [
@@ -298,14 +306,17 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
       ...(await getTodayAllDays()).filter(d => d.date >= rangeStartStr && d.date <= rangeEndStr),
     ]
     const allDaysForProviders = daysSelection ? unfilteredProviderDays.filter(d => daysSelection.days.has(d.date)) : unfilteredProviderDays
-    const providerTotals: Record<string, number> = {}
+    const providerTotals: Record<string, { cost: number; estimatedCostUSD: number }> = {}
     for (const d of allDaysForProviders) {
       for (const [name, p] of Object.entries(d.providers)) {
-        providerTotals[name] = (providerTotals[name] ?? 0) + p.cost
+        const total = providerTotals[name] ?? { cost: 0, estimatedCostUSD: 0 }
+        total.cost += p.cost
+        total.estimatedCostUSD += p.estimatedCostUSD ?? 0
+        providerTotals[name] = total
       }
     }
-    for (const [name, cost] of Object.entries(providerTotals)) {
-      providers.push({ name: displayNameByName.get(name) ?? name, cost })
+    for (const [name, total] of Object.entries(providerTotals)) {
+      providers.push({ name: displayNameByName.get(name) ?? name, cost: total.cost, estimatedCostUSD: total.estimatedCostUSD })
     }
     for (const p of allProviders) {
       if (providers.some(pc => pc.name === p.displayName)) continue
@@ -314,7 +325,7 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
     }
   } else {
     const display = displayNameByName.get(pf) ?? pf
-    providers.push({ name: display, cost: currentData.cost })
+    providers.push({ name: display, cost: currentData.cost, estimatedCostUSD: currentData.estimatedCostUSD ?? 0 })
   }
 
   // DAILY HISTORY (last 365 days)
@@ -342,10 +353,11 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
   } else {
     const emptyModels = [] as { name: string; cost: number; savingsUSD: number; calls: number; inputTokens: number; outputTokens: number }[]
     const historyFromCache = allCacheDays.map(d => {
-      const prov = d.providers[pf] ?? { calls: 0, cost: 0, savingsUSD: 0 }
+      const prov = d.providers[pf] ?? { calls: 0, cost: 0, estimatedCostUSD: 0, savingsUSD: 0 }
       return {
         date: d.date,
         cost: prov.cost,
+        estimatedCostUSD: prov.estimatedCostUSD ?? 0,
         savingsUSD: prov.savingsUSD,
         calls: prov.calls,
         inputTokens: 0,
@@ -358,10 +370,11 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
     const todayFromParse = aggregateProjectsIntoDays(scanProjects)
       .filter(d => d.date === todayStr)
       .map(d => {
-        const prov = d.providers[pf] ?? { calls: 0, cost: 0, savingsUSD: 0 }
+        const prov = d.providers[pf] ?? { calls: 0, cost: 0, estimatedCostUSD: 0, savingsUSD: 0 }
         return {
           date: d.date,
           cost: prov.cost,
+          estimatedCostUSD: prov.estimatedCostUSD ?? 0,
           savingsUSD: prov.savingsUSD,
           calls: prov.calls,
           inputTokens: 0,
@@ -384,6 +397,7 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
   currentData.projects = scanProjects.map(p => ({
     name: friendlyProject(p),
     cost: p.totalCostUSD,
+    estimatedCostUSD: p.estimatedCostUSD ?? 0,
     savingsUSD: p.totalSavingsUSD,
     sessions: p.sessions.length,
     sessionDetails: [...p.sessions]
@@ -391,13 +405,14 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
       .slice(0, 10)
       .map(s => ({
         cost: s.totalCostUSD,
+        estimatedCostUSD: s.estimatedCostUSD ?? 0,
         savingsUSD: s.totalSavingsUSD,
         calls: s.apiCalls,
         inputTokens: s.totalInputTokens,
         outputTokens: s.totalOutputTokens,
         date: s.firstTimestamp?.split('T')[0] ?? '',
         models: Object.entries(s.modelBreakdown)
-          .map(([name, m]) => ({ name, cost: m.costUSD, savingsUSD: m.savingsUSD }))
+          .map(([name, m]) => ({ name, cost: m.costUSD, estimatedCostUSD: m.estimatedCostUSD ?? 0, savingsUSD: m.savingsUSD }))
           .sort((a, b) => b.cost - a.cost)
           .slice(0, 3),
       })),
@@ -430,6 +445,7 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
     p.sessions.map(s => ({
       project: friendlyProject(p),
       cost: s.totalCostUSD,
+      estimatedCostUSD: s.estimatedCostUSD ?? 0,
       savingsUSD: s.totalSavingsUSD,
       calls: s.apiCalls,
       date: s.firstTimestamp?.split('T')[0] ?? '',

--- a/tests/daily-cache.test.ts
+++ b/tests/daily-cache.test.ts
@@ -22,6 +22,7 @@ function emptyDay(date: string, cost = 0, calls = 0): DailyEntry {
   return {
     date,
     cost,
+    estimatedCostUSD: 0,
     savingsUSD: 0,
     calls,
     sessions: 0,

--- a/tests/day-aggregator.test.ts
+++ b/tests/day-aggregator.test.ts
@@ -127,6 +127,7 @@ describe('aggregateProjectsIntoDays', () => {
     expect(day.categories['coding']).toEqual({
       turns: 1,
       cost: 3,
+      estimatedCostUSD: 0,
       savingsUSD: 0,
       editTurns: 1,
       oneShotTurns: 1,
@@ -187,17 +188,17 @@ describe('aggregateProjectsIntoDays', () => {
     const days = aggregateProjectsIntoDays(projects)
     const day = days[0]!
     expect(day.models['Opus 4.7']).toEqual({
-      calls: 1, cost: 7, savingsUSD: 0,
+      calls: 1, cost: 7, estimatedCostUSD: 0, savingsUSD: 0,
       inputTokens: 100, outputTokens: 200,
       cacheReadTokens: 50, cacheWriteTokens: 0,
     })
     expect(day.models['gpt-5']).toEqual({
-      calls: 1, cost: 3, savingsUSD: 0,
+      calls: 1, cost: 3, estimatedCostUSD: 0, savingsUSD: 0,
       inputTokens: 100, outputTokens: 200,
       cacheReadTokens: 50, cacheWriteTokens: 0,
     })
-    expect(day.providers['claude']).toEqual({ calls: 1, cost: 7, savingsUSD: 0 })
-    expect(day.providers['codex']).toEqual({ calls: 1, cost: 3, savingsUSD: 0 })
+    expect(day.providers['claude']).toEqual({ calls: 1, cost: 7, estimatedCostUSD: 0, savingsUSD: 0 })
+    expect(day.providers['codex']).toEqual({ calls: 1, cost: 3, estimatedCostUSD: 0, savingsUSD: 0 })
   })
 })
 

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -113,6 +113,40 @@ function makeProject(projectPath: string): ProjectSummary {
 }
 
 describe('exportCsv', () => {
+  it('exports estimated costs in explicit columns', async () => {
+    const project = makeProject('estimated')
+    project.estimatedCostUSD = 0.23
+    const session = project.sessions[0]
+    if (!session) throw new Error('expected fixture session')
+    session.estimatedCostUSD = 0.23
+    const turn = session.turns[0]
+    if (!turn) throw new Error('expected fixture turn')
+    const call = turn.assistantCalls[0]
+    if (!call) throw new Error('expected fixture call')
+    call.estimatedCostUSD = 0.23
+    const model = session.modelBreakdown['+danger-model']
+    if (!model) throw new Error('expected fixture model')
+    model.estimatedCostUSD = 0.23
+    const category = session.categoryBreakdown.coding
+    if (!category) throw new Error('expected fixture category')
+    category.estimatedCostUSD = 0.23
+
+    const folder = await exportCsv([{ label: '30 Days', projects: [project] }], join(tmpDir, 'estimated.csv'))
+    const [summary, daily, models, projects, sessions] = await Promise.all([
+      readFile(join(folder, 'summary.csv'), 'utf-8'),
+      readFile(join(folder, 'daily.csv'), 'utf-8'),
+      readFile(join(folder, 'models.csv'), 'utf-8'),
+      readFile(join(folder, 'projects.csv'), 'utf-8'),
+      readFile(join(folder, 'sessions.csv'), 'utf-8'),
+    ])
+
+    for (const csv of [summary, daily, models, projects, sessions]) {
+      expect(csv).toContain('Estimated Cost')
+    }
+    expect(projects).toContain(',0.23,')
+    expect(sessions).toContain(',0.23,')
+  })
+
   it('prefixes formula-like cells to prevent CSV injection', async () => {
     const periods: PeriodExport[] = [
       {
@@ -208,6 +242,18 @@ describe('exportCsv', () => {
 })
 
 describe('exportJson', () => {
+  it('includes estimated cost as a numeric JSON field', async () => {
+    const project = makeProject('estimated-json')
+    project.estimatedCostUSD = 0.23
+    const saved = await exportJson([{ label: '30 Days', projects: [project] }], join(tmpDir, 'estimated.json'))
+    const data: { summary: Array<Record<string, unknown>> } = JSON.parse(await readFile(saved, 'utf-8'))
+    const summary = data.summary[0]
+    if (!summary) throw new Error('expected JSON summary row')
+    const estimatedField = Object.entries(summary).find(([key]) => key.startsWith('Estimated Cost'))?.[1]
+
+    expect(estimatedField).toBe(0.23)
+  })
+
   it('includes an mcp section with per-server usage', async () => {
     const project = makeProject('app')
     project.sessions[0]!.mcpBreakdown = { node_repl: { calls: 3 }, github: { calls: 1 } }

--- a/tests/mcp-tables.test.ts
+++ b/tests/mcp-tables.test.ts
@@ -38,4 +38,20 @@ describe('tables', () => {
     expect(t).toContain('Routing waste')
     expect(t).toContain('Trim system prompt')
   })
+  it('marks estimated totals and breakdown rows', () => {
+    const p = payload()
+    p.current.estimatedCostUSD = 0.5
+    p.current.estimatedProviders = { 'claude code': 0.5 }
+    const model = p.current.topModels[0]
+    const project = p.current.topProjects[0]
+    const activity = p.current.topActivities[0]
+    if (!model || !project || !activity) throw new Error('expected table fixture rows')
+    model.estimatedCostUSD = 0.5
+    project.estimatedCostUSD = 0.5
+    activity.estimatedCostUSD = 0.5
+
+    expect(renderSummaryTable(p)).toContain('~$12.50')
+    expect(renderBreakdownTable(p, 'provider', 20)).toContain('~$12.50')
+    expect(renderBreakdownTable(p, 'task', 20)).toContain('~$8.00')
+  })
 })

--- a/tests/menubar-json.test.ts
+++ b/tests/menubar-json.test.ts
@@ -344,4 +344,24 @@ describe('buildMenubarPayload', () => {
       ],
     })
   })
+
+  it('carries estimated cost fields through the menubar JSON contract', () => {
+    const payload = buildMenubarPayload({
+      ...emptyPeriod('Today'),
+      cost: 12.5,
+      estimatedCostUSD: 0.5,
+      categories: [{ name: 'Coding', cost: 12.5, estimatedCostUSD: 0.5, savingsUSD: 0, turns: 1, editTurns: 0, oneShotTurns: 0 }],
+      models: [{ name: 'Opus 4.8', cost: 12.5, estimatedCostUSD: 0.5, savingsUSD: 0, calls: 1 }],
+      projects: [{ name: 'repo', cost: 12.5, estimatedCostUSD: 0.5, savingsUSD: 0, sessions: 1, sessionDetails: [{ cost: 12.5, estimatedCostUSD: 0.5, savingsUSD: 0, calls: 1, inputTokens: 0, outputTokens: 0, date: '2026-07-16', models: [{ name: 'Opus 4.8', cost: 12.5, estimatedCostUSD: 0.5, savingsUSD: 0 }] }] }],
+      topSessions: [{ project: 'repo', cost: 12.5, estimatedCostUSD: 0.5, savingsUSD: 0, calls: 1, date: '2026-07-16' }],
+    }, [{ name: 'Claude', cost: 12.5, estimatedCostUSD: 0.5 }], null)
+
+    const model = payload.current.topModels[0]
+    const project = payload.current.topProjects[0]
+    if (!model || !project) throw new Error('expected estimated payload rows')
+    expect(payload.current.estimatedCostUSD).toBe(0.5)
+    expect(model.estimatedCostUSD).toBe(0.5)
+    expect(project.estimatedCostUSD).toBe(0.5)
+    expect(payload.current.estimatedProviders).toEqual({ claude: 0.5 })
+  })
 })

--- a/tests/overview.test.ts
+++ b/tests/overview.test.ts
@@ -8,6 +8,7 @@ function makeProject(opts: {
   projectPath: string
   cost: number
   calls: number
+  estimatedCost?: number
   model: string
   provider: string
   tokens: { input: number; output: number; cacheR: number; cacheW: number }
@@ -22,6 +23,7 @@ function makeProject(opts: {
     project: opts.project,
     projectPath: opts.projectPath,
     totalCostUSD: opts.cost,
+    estimatedCostUSD: opts.estimatedCost ?? 0,
     totalSavingsUSD: 0,
     totalProxiedCostUSD: 0,
     totalApiCalls: opts.calls,
@@ -33,8 +35,9 @@ function makeProject(opts: {
       totalCacheReadTokens: opts.tokens.cacheR,
       totalCacheWriteTokens: opts.tokens.cacheW,
       apiCalls: opts.calls,
-      modelBreakdown: { [opts.model]: { calls: opts.calls, costUSD: opts.cost, savingsUSD: 0, tokens: usage } },
-      categoryBreakdown: { coding: { turns: 1, costUSD: opts.cost, savingsUSD: 0, retries: 0, editTurns: 1, oneShotTurns: 1 } },
+      estimatedCostUSD: opts.estimatedCost ?? 0,
+      modelBreakdown: { [opts.model]: { calls: opts.calls, costUSD: opts.cost, estimatedCostUSD: opts.estimatedCost ?? 0, savingsUSD: 0, tokens: usage } },
+      categoryBreakdown: { coding: { turns: 1, costUSD: opts.cost, estimatedCostUSD: opts.estimatedCost ?? 0, savingsUSD: 0, retries: 0, editTurns: 1, oneShotTurns: 1 } },
       toolBreakdown: { Bash: { calls: 5 }, Read: { calls: 2 } },
       mcpBreakdown: {},
       bashBreakdown: {},
@@ -47,7 +50,7 @@ function makeProject(opts: {
         category: 'coding',
         retries: 0,
         hasEdits: true,
-        assistantCalls: [{ provider: opts.provider, model: opts.model, costUSD: opts.cost, usage }],
+        assistantCalls: [{ provider: opts.provider, model: opts.model, costUSD: opts.cost, estimatedCostUSD: opts.estimatedCost ?? 0, usage }],
       }],
     }],
   } as unknown as ProjectSummary
@@ -94,6 +97,22 @@ describe('renderOverview', () => {
     // no-color mode must not emit ANSI escape codes
     // eslint-disable-next-line no-control-regex
     expect(out).not.toMatch(/\[/)
+  })
+
+  it('marks estimated costs without changing the measured total', () => {
+    const out = renderOverview([makeProject({
+      project: 'estimated',
+      projectPath: '/Users/test/estimated',
+      cost: 12.5,
+      estimatedCost: 0.5,
+      calls: 1,
+      model: 'claude-opus-4-8',
+      provider: 'claude',
+      tokens: { input: 100, output: 50, cacheR: 0, cacheW: 0 },
+    })], { label: 'Today', color: false })
+
+    expect(out).toContain('~$12.50')
+    expect(out).toContain('Today totals ~$12.50')
   })
 
   it('reports no usage for an empty range', () => {

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -15,6 +15,7 @@ import { createRequire } from 'node:module'
 import { isSqliteAvailable } from '../src/sqlite.js'
 import { clearSessionCache, parseAllSessions } from '../src/parser.js'
 import { loadCache, saveCache } from '../src/session-cache.js'
+import { renderOverview } from '../src/overview.js'
 import type { SessionSource, SessionParser, ParsedProviderCall } from '../src/providers/types.js'
 
 // ── Synthetic provider state ───────────────────────────────────────────────
@@ -410,5 +411,60 @@ describe('(e) 90-day age-out for durable providers', () => {
     // Second parse: orphan with 89d timestamp → retained + counted via orphan pass
     const proj2 = await parseAllSessions(undefined, 'test-synthetic')
     expect(totalOutput(proj2)).toBe(7)
+  })
+})
+
+describe('estimated provider cost propagation', () => {
+  it('marks a session built from an estimated provider call downstream', async () => {
+    const synthFile = join(tmpHome, 'synth-estimated.txt')
+    await writeFile(synthFile, 'placeholder')
+
+    _synthSources = [{ path: synthFile, project: 'test', provider: 'test-synthetic' }]
+    _synthYields = [{
+      provider: 'test-synthetic', model: 'gpt-4o',
+      inputTokens: 100, outputTokens: 50,
+      cacheCreationInputTokens: 0, cacheReadInputTokens: 0,
+      cachedInputTokens: 0, reasoningTokens: 0, webSearchRequests: 0,
+      costUSD: 0.12, costIsEstimated: true, tools: [], bashCommands: [],
+      timestamp: '2026-07-16T10:00:00.000Z',
+      speed: 'standard', deduplicationKey: 'synth-estimated-cost',
+      userMessage: 'estimated cost', sessionId: 'synth-estimated-session',
+    }]
+
+    const projects = await parseAllSessions(undefined, 'test-synthetic')
+    const session = projects[0]?.sessions[0]
+
+    const overview = renderOverview(projects, { label: 'Today', color: false })
+    expect(overview.split('\n').find(line => line.includes('Cost'))).toContain('~')
+    expect(session?.estimatedCostUSD).toBe(0.12)
+  })
+
+  it('survives a session-cache round-trip', async () => {
+    const synthFile = join(tmpHome, 'synth-estimated-cached.txt')
+    await writeFile(synthFile, 'placeholder')
+
+    _synthDurable = false
+    _synthSources = [{ path: synthFile, project: 'test', provider: 'test-synthetic' }]
+    _synthYields = [{
+      provider: 'test-synthetic', model: 'gpt-4o',
+      inputTokens: 100, outputTokens: 50,
+      cacheCreationInputTokens: 0, cacheReadInputTokens: 0,
+      cachedInputTokens: 0, reasoningTokens: 0, webSearchRequests: 0,
+      costUSD: 0.12, costIsEstimated: true, tools: [], bashCommands: [],
+      timestamp: '2026-07-16T10:00:00.000Z',
+      speed: 'standard', deduplicationKey: 'synth-estimated-roundtrip',
+      userMessage: 'estimated cost', sessionId: 'synth-estimated-cached-session',
+    }]
+
+    // First parse populates the persistent cache from the provider.
+    const proj1 = await parseAllSessions(undefined, 'test-synthetic')
+    expect(proj1[0]?.sessions[0]?.estimatedCostUSD).toBe(0.12)
+
+    // Second parse must serve the same session from the cache (the provider
+    // yields nothing), and the estimated portion must survive the round-trip.
+    clearSessionCache()
+    _synthYields = []
+    const proj2 = await parseAllSessions(undefined, 'test-synthetic')
+    expect(proj2[0]?.sessions[0]?.estimatedCostUSD).toBe(0.12)
   })
 })


### PR DESCRIPTION
## Problem

Providers that estimate tokens/cost set `costIsEstimated: true` (kiro, cursor, warp, copilot, grok, hermes, codex proxy path), but the flag exists only on `ParsedProviderCall` and dies at the parser boundary. A Warp figure synthesized from prompt length renders with the same authority as a Claude measured figure in the dashboard, overview, exports, and MCP tables. (#639)

## Fix

- `estimatedCostUSD` propagated additively (always a subset of `costUSD`, never added into it) through parser → turn/category/skill/model breakdowns → `SessionSummary` → `ProjectSummary` → daily/period aggregates. Partial sessions (some calls measured, some estimated) are representable.
- Rendering: one convention on all text surfaces — `~$X` when the estimated portion > 0 (TUI dashboard, overview, MCP text tables). Machine formats get explicit numeric fields, not decorated strings: CSV `Estimated Cost` columns, JSON export field, MCP `structuredContent` totals + rows + zod schema, menubar JSON optional fields + `estimatedProviders` (Swift app decodes via explicit CodingKeys, so the new sibling keys are non-breaking).
- Cache correctness: session cache v5→6 and daily cache v11→12 with rationale comments — pre-existing cache entries from estimating providers carry no marker and must re-hydrate rather than silently reload as measured.

## Tests

- End-to-end invariant: a session built from an estimated provider call can never surface as fully measured — `tests/parser.test.ts` ("marks a session built from an estimated provider call downstream") plus per-surface assertions in overview/export/mcp-tables/menubar-json/daily-cache/day-aggregator tests.
- Red-before verified: with only this PR's test changes applied to main's source, exactly those 10 new assertions fail; green with the change.
- Session-cache round-trip test: estimated portion survives persist → clear → reload.
- `npx tsc --noEmit` clean; full suite 1717 passed / 0 failed.

Non-goals (follow-ups): the Swift menubar UI does not yet display the new fields; `web-dashboard` untouched.

Closes #639