### PR TITLE
optimize: bound zero-edit low-worth savings estimate to a recovery fraction

### DIFF
--- a/src/optimize.ts
+++ b/src/optimize.ts
@@ -102,6 +102,9 @@ const CONTEXT_BLOAT_GROWTH_MAX_GAP_MS = 7 * 24 * 60 * 60 * 1000
 const CONTEXT_BLOAT_RATIO_DISPLAY_CAP = 1000
 const WORTH_IT_MIN_COST_USD = 2
 const WORTH_IT_NO_EDIT_MIN_COST_USD = 3
+// A zero-edit session's full cost is an upper bound on recoverable waste, not
+// a point estimate, so use a bounded fraction for honest savings numbers.
+const WORTH_IT_NO_EDIT_RECOVERY_FRACTION = 0.5
 const WORTH_IT_MIN_RETRIES = 3
 const WORTH_IT_RETRY_WITH_EDIT_MIN_RETRIES = 2
 const WORTH_IT_PREVIEW = 5
@@ -1961,8 +1964,9 @@ function sessionTotalTurns(session: ProjectSummary['sessions'][number]): number 
 }
 
 // Token-savings estimate for a low-worth candidate. Two regimes:
-//   - No-edit sessions: full session tokens are at risk (the session produced
-//     no apparent output to weigh against the spend).
+//   - No-edit sessions: a bounded fraction of full session tokens is counted
+//     as recoverable. Full cost is an upper bound, not a point estimate:
+//     read-only work may still contain useful exploration or analysis.
 //   - Sessions with edits but with retries / no one-shot: only the retry
 //     fraction is counted as recoverable. Edits may still have been useful;
 //     we credit the model with that and only flag the retry overhead.
@@ -1974,7 +1978,7 @@ function estimateLowWorthRecoverableTokens(
   retries: number,
 ): number {
   const tokens = sessionTokenTotal(session)
-  if (editTurns === 0) return tokens
+  if (editTurns === 0) return Math.round(tokens * WORTH_IT_NO_EDIT_RECOVERY_FRACTION)
   const totalTurns = sessionTotalTurns(session)
   if (totalTurns === 0) return 0
   const fraction = Math.min(1, Math.max(0, retries / totalTurns))
@@ -2054,8 +2058,8 @@ export function detectLowWorthSessions(projects: ProjectSummary[]): WasteFinding
     .map(s => `${s.project}/${s.sessionId} on ${s.date}: ${formatCost(s.cost)} (${s.reasons.join(', ')})`)
     .join('; ')
   const extra = candidates.length > preview.length ? `; +${candidates.length - preview.length} more` : ''
-  // Per-candidate `tokens` is already the recoverable estimate (full session
-  // for no-edit, retry-fraction for edit-with-retries). Sum across candidates.
+  // Per-candidate `tokens` is already the recoverable estimate (bounded
+  // no-edit fraction, retry-fraction for edit-with-retries). Sum across candidates.
   const tokensSaved = Math.round(candidates.reduce((sum, s) => sum + s.tokens, 0))
   const totalCost = candidates.reduce((sum, s) => sum + s.cost, 0)
 

--- a/tests/optimize-zero-edit-savings.test.ts
+++ b/tests/optimize-zero-edit-savings.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../src/providers/index.js', async (importOriginal) => {
+  type ProvidersModule = typeof import('../src/providers/index.js')
+  const actual = await importOriginal<ProvidersModule>()
+  return {
+    ...actual,
+    async discoverAllSessions() {
+      return []
+    },
+  }
+})
+
+import {
+  detectLowWorthSessions,
+  findLowWorthCandidates,
+} from '../src/optimize.js'
+import type { ProjectSummary } from '../src/types.js'
+
+type TestSession = ProjectSummary['sessions'][number]
+type LowWorthTurn = TestSession['turns'][number]
+
+function lowWorthTurn(overrides: Partial<LowWorthTurn> = {}): LowWorthTurn {
+  return {
+    userMessage: 'do the work',
+    assistantCalls: [],
+    timestamp: '2026-05-01T10:00:00Z',
+    sessionId: 's1',
+    category: 'coding',
+    retries: 0,
+    hasEdits: false,
+    ...overrides,
+  }
+}
+
+function lowWorthSession(cost: number, i: number, overrides: Partial<TestSession> = {}, project = 'app'): TestSession {
+  const tokens = Math.round(cost * 1000)
+  return {
+    sessionId: `s${i + 1}`,
+    project,
+    firstTimestamp: `2026-05-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
+    lastTimestamp: `2026-05-${String(i + 1).padStart(2, '0')}T10:30:00Z`,
+    totalCostUSD: cost,
+    totalInputTokens: tokens,
+    totalOutputTokens: tokens,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    apiCalls: 1,
+    turns: [],
+    modelBreakdown: {},
+    toolBreakdown: {},
+    mcpBreakdown: {},
+    bashBreakdown: {},
+    categoryBreakdown: {} as TestSession['categoryBreakdown'],
+    skillBreakdown: {},
+    ...overrides,
+  }
+}
+
+function projectWithLowWorthSessions(sessions: TestSession[], project = 'app'): ProjectSummary {
+  return {
+    project,
+    projectPath: `/tmp/${project}`,
+    sessions,
+    totalCostUSD: sessions.reduce((sum, s) => sum + s.totalCostUSD, 0),
+    totalApiCalls: sessions.reduce((sum, s) => sum + s.apiCalls, 0),
+  }
+}
+
+// Regression test for issue #640: a zero-edit (exploration/reading) session
+// flagged as low-worth must not claim its ENTIRE token spend as recoverable
+// savings. The full session total is an upper bound, not a point estimate —
+// presenting it as "Potential savings" tells the user 100% of an exploration
+// session's cost was waste. The retry branch already applies a bounded
+// recovery fraction; the no-edit branch should be bounded below 100% too.
+describe('zero-edit low-worth savings estimate (issue #640)', () => {
+  it('claims less than the full session token total for a no-edit session', () => {
+    // Expensive exploration session: 4 read-only turns, no edits, no retries.
+    // sessionTokenTotal = input + output + cacheRead + cacheWrite = 10K.
+    const session = lowWorthSession(5, 0, {
+      turns: [
+        lowWorthTurn({ hasEdits: false }),
+        lowWorthTurn({ hasEdits: false }),
+        lowWorthTurn({ hasEdits: false }),
+        lowWorthTurn({ hasEdits: false }),
+      ],
+    })
+    const fullSessionTokens = session.totalInputTokens
+      + session.totalOutputTokens
+      + session.totalCacheReadTokens
+      + session.totalCacheWriteTokens
+
+    const candidates = findLowWorthCandidates([projectWithLowWorthSessions([session])])
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0].reasons).toContain('no edit turns')
+    // The recoverable estimate must be a bounded fraction of the session,
+    // not the whole thing.
+    expect(candidates[0].tokens).toBeLessThan(fullSessionTokens)
+  })
+
+  it('does not headline 100% of a zero-edit session as tokensSaved', () => {
+    const session = lowWorthSession(5, 0, {
+      turns: [lowWorthTurn({ hasEdits: false })],
+    })
+    const fullSessionTokens = session.totalInputTokens
+      + session.totalOutputTokens
+      + session.totalCacheReadTokens
+      + session.totalCacheWriteTokens
+
+    const finding = detectLowWorthSessions([projectWithLowWorthSessions([session])])
+    expect(finding).not.toBeNull()
+    // tokensSaved feeds the "Potential savings: ~X tokens (~$Y, ~Z% of spend)"
+    // headline and the JSON potentialSavingsCostUSD / estimatedSavingsUSD
+    // fields; it must stay strictly below the session's full token total.
+    expect(finding!.tokensSaved).toBeLessThan(fullSessionTokens)
+  })
+})

--- a/tests/optimize.test.ts
+++ b/tests/optimize.test.ts
@@ -629,8 +629,9 @@ describe('detectLowWorthSessions', () => {
     expect(finding!.explanation).toContain('app/s1')
     expect(finding!.explanation).toContain('no edit turns')
     // sessionTokenTotal = input + output + cache. The lowWorthSession helper
-    // sets input=output=cost*1000, so the savings ceiling is 2x cost*1000.
-    expect(finding!.tokensSaved).toBe(8_000)
+    // sets input=output=cost*1000, so the full session total is 8K and the
+    // bounded no-edit recovery fraction gives a 4K savings estimate.
+    expect(finding!.tokensSaved).toBe(4_000)
   })
 
   it('flags retry-heavy sessions', () => {
@@ -667,13 +668,13 @@ describe('detectLowWorthSessions', () => {
     expect(finding!.tokensSaved).toBe(4_000)
   })
 
-  it('uses full session tokens as the savings ceiling for no-edit sessions', () => {
+  it('uses the bounded recovery fraction for no-edit sessions', () => {
     const project = projectWithLowWorthSessions([
       lowWorthSession(4, 0, { turns: [lowWorthTurn({ hasEdits: false })] }),
     ])
     const finding = detectLowWorthSessions([project])
-    // No edits at all -> entire session is at risk. sessionTokenTotal = 8K.
-    expect(finding!.tokensSaved).toBe(8_000)
+    // No edits at all -> bounded half-session estimate. sessionTokenTotal = 8K.
+    expect(finding!.tokensSaved).toBe(4_000)
   })
 
   it('keeps all reasons that apply to the same session', () => {


### PR DESCRIPTION
## Problem

`estimateLowWorthRecoverableTokens` returns the entire session token total when `editTurns === 0`, and that number flows into the headline "Potential savings: ~X tokens (~$Y, ~Z% of spend)" and the JSON `potentialSavingsCostUSD` / per-finding `estimatedSavingsUSD`. A zero-edit (exploration/reading) session claims 100% of its cost as recoverable — an upper bound presented as a point estimate. The retry path already applies a bounded fraction; only the no-edit branch claimed everything. (#640)

Note: the old behavior was documented as intentional in the comment above the function, so this is a deliberate behavior change, not a typo fix — the doc comment is rewritten accordingly.

## Fix

New `WORTH_IT_NO_EDIT_RECOVERY_FRACTION = 0.5` next to the other `WORTH_IT_*` constants (aligned with the existing `CAPABILITY_RELIABILITY_RECOVERY_FRACTION = 0.5` precedent): the no-edit branch now returns `round(tokens * 0.5)`. Retry branch untouched. The two existing tests pinning the old ceiling now pin the fraction.

## Tuning note

0.5 is a judgment call — read-only sessions may still contain useful exploration, so claiming half is conservative in both directions. Easy to adjust in one place, guarded by tests.

## Tests

- New `tests/optimize-zero-edit-savings.test.ts` (written red-first: both cases failed with `expected 10000 to be less than 10000` before the fix, pass after).
- Updated pins in `tests/optimize.test.ts` (8K → 4K for the no-edit cases).
- `npx tsc --noEmit` clean; full suite 1712 passed / 0 failed.

Closes #640