### PR TITLE
Desktop: cold-start fix — single warmup, incremental cache saves, first-run progress

### DIFF
--- a/app/electron/cli.ts
+++ b/app/electron/cli.ts
@@ -217,7 +217,7 @@ export function resolveCodeburnPath(): string | null {
   return target.kind === 'bundled' ? target.entry : target.bin
 }
 
-function runCli(spec: SpawnSpec, cmdLabel: string, timeoutMs: number): Promise<unknown> {
+function runCli(spec: SpawnSpec, cmdLabel: string, timeoutMs: number, onStderr?: (chunk: string) => void): Promise<unknown> {
   return new Promise<unknown>((resolve, reject) => {
     const child = spawn(spec.bin, spec.args, { shell: false, stdio: ['ignore', 'pipe', 'pipe'], env: spec.env })
     activeChildren.add(child)
@@ -252,7 +252,13 @@ function runCli(spec: SpawnSpec, cmdLabel: string, timeoutMs: number): Promise<u
     }
 
     child.stdout.on('data', chunk => { stdout += chunk; bump(chunk.length) })
-    child.stderr.on('data', chunk => { stderr += chunk; bump(chunk.length) })
+    child.stderr.on('data', chunk => {
+      stderr += chunk
+      bump(chunk.length)
+      // Live stderr for the cold-start warmup: forwards CLI scan-progress lines
+      // to the splash. Never fires for ordinary reads (onStderr unset).
+      if (onStderr) { try { onStderr(chunk.toString()) } catch { /* forwarder must not kill the read */ } }
+    })
 
     child.on('error', err => {
       finish(() => reject(new CliError('not-found', err.message)))
@@ -286,18 +292,24 @@ function runCli(spec: SpawnSpec, cmdLabel: string, timeoutMs: number): Promise<u
  * Read-only, so concurrent identical calls share one child and a 5s result cache
  * absorbs same-cadence pollers. Never use this for config-mutating commands.
  */
-export function spawnCli(args: string[], opts: { timeoutMs?: number } = {}): Promise<unknown> {
+export function spawnCli(
+  args: string[],
+  opts: { timeoutMs?: number; onStderr?: (chunk: string) => void; extraEnv?: NodeJS.ProcessEnv } = {},
+): Promise<unknown> {
   const target = resolveTarget()
   if (!target) return Promise.reject(new CliError('not-found', 'codeburn CLI not found'))
   const spec = spawnSpecFor(target, args)
+  if (opts.extraEnv) spec.env = { ...spec.env, ...opts.extraEnv }
 
   const key = JSON.stringify([spec.bin, ...spec.args])
   const cached = readCache.get(key)
   if (cached && Date.now() - cached.at < COALESCE_TTL_MS) return Promise.resolve(cached.value)
   const existing = readInflight.get(key)
+  // A same-cadence re-poll during a slow cold warmup coalesces onto the one
+  // in-flight child (which already carries onStderr); no second cold parse.
   if (existing) return existing
 
-  const flight = runCli(spec, args[0] ?? '', opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+  const flight = runCli(spec, args[0] ?? '', opts.timeoutMs ?? DEFAULT_TIMEOUT_MS, opts.onStderr)
     .then(value => { readCache.set(key, { at: Date.now(), value }); return value })
     .finally(() => { readInflight.delete(key) })
   readInflight.set(key, flight)

--- a/app/electron/main.test.ts
+++ b/app/electron/main.test.ts
@@ -63,8 +63,8 @@ const CHANNELS = [
 ] as const
 
 const ARGV_CASES: Array<{ channel: string; args: unknown[]; argv: string[] }> = [
-  { channel: 'codeburn:getOverview', args: ['30days', 'claude'], argv: ['status', '--format', 'menubar-json', '--period', '30days', '--provider', 'claude'] },
-  { channel: 'codeburn:getOverview', args: ['30days', 'all'], argv: ['status', '--format', 'menubar-json', '--period', '30days'] },
+  { channel: 'codeburn:getOverview', args: ['30days', 'claude'], argv: ['status', '--format', 'menubar-json', '--period', '30days', '--no-timeline', '--provider', 'claude'] },
+  { channel: 'codeburn:getOverview', args: ['30days', 'all'], argv: ['status', '--format', 'menubar-json', '--period', '30days', '--no-timeline'] },
   { channel: 'codeburn:getPlans', args: ['week'], argv: ['status', '--format', 'json', '--period', 'week'] },
   { channel: 'codeburn:getActReport', args: [], argv: ['act', 'report', '--json'] },
   { channel: 'codeburn:getModels', args: ['week', 'claude', true], argv: ['models', '--format', 'json', '--period', 'week', '--provider', 'claude', '--by-task'] },
@@ -77,9 +77,9 @@ const ARGV_CASES: Array<{ channel: string; args: unknown[]; argv: string[] }> = 
   { channel: 'codeburn:getYield', args: ['today', 'claude'], argv: ['yield', '--format', 'json', '--period', 'today', '--provider', 'claude'] },
   { channel: 'codeburn:getSpendFlow', args: ['month', 'openai'], argv: ['spend', '--format', 'flow-json', '--period', 'month', '--provider', 'openai'] },
   { channel: 'codeburn:getOptimizeReport', args: ['month', 'openai'], argv: ['optimize', '--format', 'json', '--period', 'month', '--provider', 'openai'] },
-  { channel: 'codeburn:getOverview', args: ['30days', 'all', { from: '2026-07-01', to: '2026-07-11' }], argv: ['status', '--format', 'menubar-json', '--period', '30days', '--from', '2026-07-01', '--to', '2026-07-11'] },
-  { channel: 'codeburn:getOverview', args: ['30days', 'all', undefined, 'claude-config:91dda17e8cf35193'], argv: ['status', '--format', 'menubar-json', '--period', '30days', '--claude-config-source', 'claude-config:91dda17e8cf35193'] },
-  { channel: 'codeburn:getOverview', args: ['month', 'claude', { from: '2026-07-01', to: '2026-07-11' }, 'claude-desktop:980e1e488a654830'], argv: ['status', '--format', 'menubar-json', '--period', 'month', '--provider', 'claude', '--from', '2026-07-01', '--to', '2026-07-11', '--claude-config-source', 'claude-desktop:980e1e488a654830'] },
+  { channel: 'codeburn:getOverview', args: ['30days', 'all', { from: '2026-07-01', to: '2026-07-11' }], argv: ['status', '--format', 'menubar-json', '--period', '30days', '--no-timeline', '--from', '2026-07-01', '--to', '2026-07-11'] },
+  { channel: 'codeburn:getOverview', args: ['30days', 'all', undefined, 'claude-config:91dda17e8cf35193'], argv: ['status', '--format', 'menubar-json', '--period', '30days', '--no-timeline', '--claude-config-source', 'claude-config:91dda17e8cf35193'] },
+  { channel: 'codeburn:getOverview', args: ['month', 'claude', { from: '2026-07-01', to: '2026-07-11' }, 'claude-desktop:980e1e488a654830'], argv: ['status', '--format', 'menubar-json', '--period', 'month', '--no-timeline', '--provider', 'claude', '--from', '2026-07-01', '--to', '2026-07-11', '--claude-config-source', 'claude-desktop:980e1e488a654830'] },
   { channel: 'codeburn:getModels', args: ['week', 'claude', true, { from: '2026-07-01', to: '2026-07-11' }], argv: ['models', '--format', 'json', '--period', 'week', '--provider', 'claude', '--by-task', '--from', '2026-07-01', '--to', '2026-07-11'] },
   { channel: 'codeburn:getYield', args: ['today', 'all', { from: '2026-07-01', to: '2026-07-11' }], argv: ['yield', '--format', 'json', '--period', 'today', '--from', '2026-07-01', '--to', '2026-07-11'] },
   { channel: 'codeburn:getSpendFlow', args: ['month', 'all', { from: '2026-07-01', to: '2026-07-11' }], argv: ['spend', '--format', 'flow-json', '--period', 'month', '--from', '2026-07-01', '--to', '2026-07-11'] },
@@ -154,7 +154,7 @@ describe('createBridgeHandlers (IPC wiring)', () => {
     const { spawnCli, spawnCliAction, calls } = fakeSpawn()
     const handlers = createBridgeHandlers(withQuota({ spawnCli, spawnCliAction, resolveCodeburnPath: () => '/bin/codeburn' }))
     const res = await handlers['codeburn:getOverview']!('30days', 'all')
-    expect(calls[0]).toEqual(['status', '--format', 'menubar-json', '--period', '30days'])
+    expect(calls[0]).toEqual(['status', '--format', 'menubar-json', '--period', '30days', '--no-timeline'])
     expect(res).toEqual({ ok: true, value: { current: { cost: 12.34 } } })
   })
 
@@ -266,5 +266,57 @@ describe('createApplicationMenuTemplate', () => {
     expect(roles).toContain('toggleDevTools')
     expect(roles).not.toContain('reload')
     expect(roles).not.toContain('forceReload')
+  })
+})
+
+describe('createBridgeHandlers (cold-start warmup)', () => {
+  const base = (extra: object) => ({ spawnCli: vi.fn(), spawnCliAction: vi.fn(), resolveCodeburnPath: () => '/bin/codeburn', getQuota: vi.fn(async () => []), ...extra })
+
+  it('gives the first overview a long timeout + progress env, then reverts once warmed', async () => {
+    const opts: Array<Record<string, unknown> | undefined> = []
+    const spawnCli = vi.fn(async (_args: string[], o?: Record<string, unknown>) => { opts.push(o); return { current: { cost: 1 } } })
+    const emitProgress = vi.fn()
+    const handlers = createBridgeHandlers(base({ spawnCli, emitProgress }))
+
+    await handlers['codeburn:getOverview']!('30days', 'all')
+    expect(opts[0]?.timeoutMs).toBe(10 * 60_000)
+    expect((opts[0]?.extraEnv as Record<string, string> | undefined)?.CODEBURN_PROGRESS).toBe('1')
+    expect(typeof opts[0]?.onStderr).toBe('function')
+    expect(emitProgress).toHaveBeenCalledWith({ kind: 'done' })
+
+    await handlers['codeburn:getOverview']!('30days', 'all')
+    expect(opts[1]?.timeoutMs).toBeUndefined()
+    expect(opts[1]?.extraEnv).toBeUndefined()
+  })
+
+  it('re-arms the long timeout when the first overview fails (cache is still cold)', async () => {
+    const opts: Array<{ timeoutMs?: number } | undefined> = []
+    let n = 0
+    const spawnCli = vi.fn(async (_args: string[], o?: { timeoutMs?: number }) => {
+      opts.push(o)
+      if (++n === 1) throw new CliError('timeout', 'timed out')
+      return { current: { cost: 1 } }
+    })
+    const handlers = createBridgeHandlers(base({ spawnCli, emitProgress: vi.fn() }))
+
+    expect(await handlers['codeburn:getOverview']!('30days', 'all')).toMatchObject({ ok: false })
+    expect(await handlers['codeburn:getOverview']!('30days', 'all')).toMatchObject({ ok: true })
+    expect(opts[0]?.timeoutMs).toBe(10 * 60_000)
+    expect(opts[1]?.timeoutMs).toBe(10 * 60_000)
+  })
+
+  it('parses CLI scan-progress stderr lines and forwards them to emitProgress', async () => {
+    const spawnCli = vi.fn(async (_args: string[], o?: { onStderr?: (chunk: string) => void }) => {
+      // A split line proves the reader buffers across chunks.
+      o?.onStderr?.('CODEBURN_PROGRESS {"kind":"providers","providers":["claude","codex"]}\nCODEBURN_PROG')
+      o?.onStderr?.('RESS {"kind":"tick","provider":"claude","done":5,"total":10}\nnoise line\n')
+      return { current: { cost: 1 } }
+    })
+    const emitProgress = vi.fn()
+    const handlers = createBridgeHandlers(base({ spawnCli, emitProgress }))
+    await handlers['codeburn:getOverview']!('30days', 'all')
+
+    expect(emitProgress).toHaveBeenCalledWith({ kind: 'providers', providers: ['claude', 'codex'] })
+    expect(emitProgress).toHaveBeenCalledWith({ kind: 'tick', provider: 'claude', done: 5, total: 10 })
   })
 })

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -8,6 +8,41 @@ import { getQuota, sanitizeError } from './quota'
 // `kind` survives contextBridge serialization. preload.ts unwraps it.
 export type Envelope<T = unknown> = { ok: true; value: T } | { ok: false; error: { kind: string; message: string } }
 
+// The first overview fetch after boot hydrates a cold cache from scratch (a full
+// history parse). That can far exceed the 45s read timeout, and killing it means
+// the cache never persists, so every later poll restarts the scan — perpetual
+// slowness. Give the first (cold) overview a long window; revert to the default
+// once it succeeds. Sections gate their own first poll on this one resolving so
+// the cold hydration runs ONCE, not once per section in parallel.
+const WARMUP_TIMEOUT_MS = 10 * 60_000
+// Wire marker for CLI scan-progress lines (src/parser.ts: PROGRESS_LINE_PREFIX).
+const PROGRESS_LINE_PREFIX = 'CODEBURN_PROGRESS '
+// IPC channel carrying cold-start scan-progress events to the splash.
+export const PROGRESS_CHANNEL = 'codeburn:progress'
+
+/** Line-buffer a spawn's stderr and forward each parsed scan-progress event. */
+export function makeProgressReader(emit: (event: unknown) => void): (chunk: string) => void {
+  let buffer = ''
+  return chunk => {
+    buffer += chunk
+    let nl = buffer.indexOf('\n')
+    while (nl >= 0) {
+      const line = buffer.slice(0, nl)
+      buffer = buffer.slice(nl + 1)
+      if (line.startsWith(PROGRESS_LINE_PREFIX)) {
+        try { emit(JSON.parse(line.slice(PROGRESS_LINE_PREFIX.length))) } catch { /* ignore malformed line */ }
+      }
+      nl = buffer.indexOf('\n')
+    }
+  }
+}
+
+function broadcastProgress(event: unknown): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.webContents.send(PROGRESS_CHANNEL, event)
+  }
+}
+
 function providerArgs(provider: string | undefined): string[] {
   return provider && provider !== 'all' ? ['--provider', provider] : []
 }
@@ -86,10 +121,12 @@ function toEnvelopeError(err: unknown): { kind: string; message: string } {
 }
 
 type Deps = {
-  spawnCli: (args: string[], opts?: { timeoutMs?: number }) => Promise<unknown>
+  spawnCli: (args: string[], opts?: { timeoutMs?: number; onStderr?: (chunk: string) => void; extraEnv?: NodeJS.ProcessEnv }) => Promise<unknown>
   spawnCliAction: (args: string[], opts?: { timeoutMs?: number }) => Promise<ActionResult>
   resolveCodeburnPath: () => string | null
   getQuota: typeof getQuota
+  /** Forward cold-start scan-progress events to the renderer splash. */
+  emitProgress?: (event: unknown) => void
 }
 
 type Handler = (...args: any[]) => Promise<Envelope>
@@ -99,10 +136,41 @@ type Handler = (...args: any[]) => Promise<Envelope>
  * shell) and returns a result envelope. Pure + injectable so the wiring is
  * unit-testable without launching Electron.
  */
-export function createBridgeHandlers(deps: Deps = { spawnCli, spawnCliAction, resolveCodeburnPath, getQuota }): Record<string, Handler> {
+export function createBridgeHandlers(deps: Deps = { spawnCli, spawnCliAction, resolveCodeburnPath, getQuota, emitProgress: broadcastProgress }): Record<string, Handler> {
+  const emitProgress = deps.emitProgress ?? (() => {})
+  // Flips true after the first overview fetch succeeds. Until then, every
+  // overview fetch runs cold (long timeout + progress streaming); the shared
+  // spawnCli coalescing means concurrent same-arg re-polls join one child.
+  let overviewWarmed = false
+
   const run = (build: (...args: any[]) => string[]): Handler => async (...args: any[]) => {
     try {
       return { ok: true, value: await deps.spawnCli(build(...args)) }
+    } catch (err) {
+      return { ok: false, error: toEnvelopeError(err) }
+    }
+  }
+
+  // The desktop never renders the granular timeline, so it always passes
+  // --no-timeline (skips buildGranularHistory on every poll). The Swift menubar
+  // omits the flag and keeps the timeline unchanged.
+  const buildOverviewArgs = (period: string, provider: string, range?: DateRange, configSource?: string | null): string[] => [
+    'status', '--format', 'menubar-json', '--period', vPeriod(period), '--no-timeline',
+    ...providerArgs(vProvider(provider)), ...rangeArgs(vRange(range)), ...configSourceArgs(vConfigSource(configSource)),
+  ]
+
+  const getOverview: Handler = async (period: string, provider: string, range?: DateRange, configSource?: string | null) => {
+    try {
+      const args = buildOverviewArgs(period, provider, range, configSource)
+      if (overviewWarmed) return { ok: true, value: await deps.spawnCli(args) }
+      const value = await deps.spawnCli(args, {
+        timeoutMs: WARMUP_TIMEOUT_MS,
+        extraEnv: { CODEBURN_PROGRESS: '1' },
+        onStderr: makeProgressReader(emitProgress),
+      })
+      overviewWarmed = true
+      emitProgress({ kind: 'done' })
+      return { ok: true, value }
     } catch (err) {
       return { ok: false, error: toEnvelopeError(err) }
     }
@@ -121,9 +189,7 @@ export function createBridgeHandlers(deps: Deps = { spawnCli, spawnCliAction, re
       try { return { ok: true, value: await deps.getQuota({ force: Boolean(force) }) } }
       catch (error) { return { ok: false, error: { kind: 'nonzero', message: sanitizeError(error) } } }
     },
-    'codeburn:getOverview': run((period: string, provider: string, range?: DateRange, configSource?: string | null) => [
-      'status', '--format', 'menubar-json', '--period', vPeriod(period), ...providerArgs(vProvider(provider)), ...rangeArgs(vRange(range)), ...configSourceArgs(vConfigSource(configSource)),
-    ]),
+    'codeburn:getOverview': getOverview,
     'codeburn:getPlans': run((period: string) => ['status', '--format', 'json', '--period', vPeriod(period)]),
     'codeburn:getActReport': run(() => ['act', 'report', '--json']),
     'codeburn:getModels': run((period: string, provider: string, byTask: boolean, range?: DateRange) => [

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -51,6 +51,12 @@ const bridge = {
   chooseDirectory: () => invoke('codeburn:chooseDirectory'),
   cliStatus: () => invoke('codeburn:cliStatus'),
   openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
+  // Cold-start scan progress (main → renderer). Returns an unsubscribe fn.
+  onProgress: (cb: (event: unknown) => void) => {
+    const listener = (_e: unknown, event: unknown) => cb(event)
+    ipcRenderer.on('codeburn:progress', listener)
+    return () => { ipcRenderer.removeListener('codeburn:progress', listener) }
+  },
   platform: process.platform,
 }
 

--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -112,6 +112,13 @@ export function App() {
   )
   const refreshOverview = overview.refresh
 
+  // Boot readiness: the overview poll is the single cold-cache warmer (long
+  // timeout + progress). Other sections gate their first CLI spawn on this so a
+  // cold first run hydrates ONCE here instead of fanning out into a parallel
+  // full-history parse per section. Flips true the moment overview has data OR a
+  // (resolved) error; after that everything polls normally.
+  const ready = overview.data != null || overview.error != null
+
   useEffect(() => {
     let saved: string | null = null
     try { saved = globalThis.localStorage?.getItem('codeburn.theme') ?? null } catch { /* storage can be unavailable */ }
@@ -235,7 +242,7 @@ export function App() {
         <DailyBudgetBanner payload={overview.data ?? null} provider={provider} />
         <ErrorBoundary key={section}>
         {section === 'plans' ? (
-          <Plans period={period} refreshToken={refreshToken} onNavigate={navigate} />
+          <Plans period={period} refreshToken={refreshToken} onNavigate={navigate} ready={ready} />
         ) : section === 'settings' ? (
           <Settings period={period} refreshToken={refreshToken} onNavigate={navigate} initialPane={settingsPane} claudeConfigs={claudeConfigs} claudeConfigSource={claudeConfigSource} />
         ) : (
@@ -257,17 +264,17 @@ export function App() {
             />
             <div className={motionClass('body', 'section-fade')}>
               {section === 'overview' ? (
-                <OverviewContent period={period} provider={provider} range={customRange} overview={overview} onNavigate={navigate} />
+                <OverviewContent period={period} provider={provider} range={customRange} overview={overview} onNavigate={navigate} ready={ready} />
               ) : section === 'sessions' ? (
-                <Sessions period={period} provider={provider} range={customRange} refreshToken={refreshToken} detectedProviders={detectedProviders} onProviderChange={onProviderSelect} />
+                <Sessions period={period} provider={provider} range={customRange} refreshToken={refreshToken} detectedProviders={detectedProviders} onProviderChange={onProviderSelect} ready={ready} />
               ) : section === 'spend' ? (
-                <SpendContent period={period} provider={provider} range={customRange} overview={overview} refreshToken={refreshToken} />
+                <SpendContent period={period} provider={provider} range={customRange} overview={overview} refreshToken={refreshToken} ready={ready} />
               ) : section === 'optimize' ? (
-                <OptimizeContent period={period} provider={provider} range={customRange} overview={overview} refreshToken={refreshToken} />
+                <OptimizeContent period={period} provider={provider} range={customRange} overview={overview} refreshToken={refreshToken} ready={ready} />
               ) : section === 'models' ? (
-                <Models period={period} provider={provider} range={customRange} refreshToken={refreshToken} onNavigate={navigate} />
+                <Models period={period} provider={provider} range={customRange} refreshToken={refreshToken} onNavigate={navigate} ready={ready} />
               ) : section === 'compare' ? (
-                <Compare period={period} provider={provider} range={customRange} refreshToken={refreshToken} />
+                <Compare period={period} provider={provider} range={customRange} refreshToken={refreshToken} ready={ready} />
               ) : (
                 <SectionPlaceholder title={SECTION_TITLES[section]} />
               )}

--- a/app/renderer/components/Splash.test.tsx
+++ b/app/renderer/components/Splash.test.tsx
@@ -2,6 +2,14 @@
 import { act, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+// The splash captures `codeburn` at import; mock it so a test can drive the
+// progress callback the splash subscribes with.
+let progressCb: ((event: unknown) => void) | undefined
+vi.mock('../lib/ipc', () => ({
+  codeburn: { onProgress: (cb: (event: unknown) => void) => { progressCb = cb; return () => { progressCb = undefined } } },
+  normalizeCliError: (err: unknown) => err,
+}))
+
 import { Splash } from './Splash'
 import { mockMatchMedia as mockReducedMotion } from '../lib/testMatchMedia'
 
@@ -70,6 +78,32 @@ describe('Splash', () => {
     expect(splashEl()).not.toBeInTheDocument()
     rerender(<Splash hasData hasError={false} />)
     expect(splashEl()).not.toBeInTheDocument()
+  })
+
+  it('reveals the per-provider indexing list on real cold-scan progress', () => {
+    render(<Splash hasData={false} hasError={false} />)
+    expect(splashEl()).toBeInTheDocument()
+    // No detail before any progress arrives.
+    expect(document.querySelector('.splash-status')).toBeNull()
+
+    act(() => {
+      progressCb?.({ kind: 'providers', providers: ['claude', 'codex'] })
+      progressCb?.({ kind: 'provider', provider: 'claude', state: 'start' })
+      // A nonzero-total tick means the cache is genuinely cold: reveal at once.
+      progressCb?.({ kind: 'tick', provider: 'claude', done: 120, total: 480 })
+    })
+
+    const status = document.querySelector('.splash-status')
+    expect(status).toBeInTheDocument()
+    expect(status?.textContent).toContain('First run: indexing your usage history')
+    expect(status?.textContent).toContain('Ingesting Claude…')
+    expect(status?.textContent).toContain('120/480')
+    // Both detected providers render a row; claude is active, codex pending.
+    expect(document.querySelectorAll('.splash-prov').length).toBe(2)
+    expect(document.querySelector('.splash-prov.active')?.textContent).toContain('Claude')
+
+    act(() => { progressCb?.({ kind: 'provider', provider: 'claude', state: 'done' }) })
+    expect(document.querySelector('.splash-prov.done')?.textContent).toContain('Claude')
   })
 
   it('swaps instantly under reduced motion (no fade, no min-time)', () => {

--- a/app/renderer/components/Splash.tsx
+++ b/app/renderer/components/Splash.tsx
@@ -2,14 +2,61 @@ import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import { FlameMark } from './FlameMark'
+import { ProviderLogo } from './ProviderLogo'
 import { motionClass, motionEnabled, reducedMotion } from '../lib/motion'
+import { codeburn } from '../lib/ipc'
+import type { ScanProgressEvent } from '../lib/types'
 import { version } from '../../package.json'
 import loaderVideo from '../assets/splash-loader.webm'
 
 const MIN_ON_SCREEN_MS = 600
 const CROSSFADE_MS = 250
+// If the first scan is still running this long after boot, reveal the per-provider
+// indexing detail. Warm launches resolve well before this, so they never show it.
+const REVEAL_FALLBACK_MS = 3500
 
 type Phase = 'lit' | 'out' | 'done'
+type ProvStatus = 'pending' | 'active' | 'done'
+
+type Progress = {
+  /** Detected providers, in the order the CLI reports them. */
+  order: string[]
+  status: Record<string, ProvStatus>
+  claudeDone: number
+  claudeTotal: number
+  /** A tick with a nonzero total — the cache is genuinely cold and parsing. */
+  realWork: boolean
+  /** Any progress event at all has arrived (distinguishes a new CLI from old). */
+  seen: boolean
+}
+
+const EMPTY: Progress = { order: [], status: {}, claudeDone: 0, claudeTotal: 0, realWork: false, seen: false }
+
+function reduceProgress(state: Progress, event: ScanProgressEvent): Progress {
+  switch (event.kind) {
+    case 'providers': {
+      const status: Record<string, ProvStatus> = {}
+      for (const p of event.providers) status[p] = state.status[p] ?? 'pending'
+      return { ...state, order: event.providers, status, seen: true }
+    }
+    case 'provider': {
+      const order = state.order.includes(event.provider) ? state.order : [...state.order, event.provider]
+      const next: ProvStatus = event.state === 'done' ? 'done' : 'active'
+      return { ...state, order, status: { ...state.status, [event.provider]: next }, seen: true }
+    }
+    case 'tick':
+      return { ...state, claudeDone: event.done, claudeTotal: event.total, realWork: state.realWork || event.total > 0, seen: true }
+    case 'done': {
+      const status = { ...state.status }
+      for (const p of state.order) status[p] = 'done'
+      return { ...state, status }
+    }
+  }
+}
+
+function providerLabel(id: string): string {
+  return id.split(/[-\s]+/).filter(Boolean).map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+}
 
 /**
  * Full-window branded startup loader -- the same scanning moment as the menubar
@@ -20,11 +67,36 @@ type Phase = 'lit' | 'out' | 'done'
  * never trapped behind branding; reduced motion swaps instantly with no fade.
  * A `done` latch means later loading states -- polls, filter changes -- never
  * bring it back.
+ *
+ * On a genuinely cold first run the overview warmup streams per-provider scan
+ * progress (main.ts forwards the CLI's stderr). Once real parse work is detected
+ * (or the scan simply outlasts REVEAL_FALLBACK_MS), the splash reveals a "first
+ * run: indexing" line and a per-provider ingest list. A warm launch resolves
+ * before that threshold and never shows it.
  */
 export function Splash({ hasData, hasError }: { hasData: boolean; hasError: boolean }) {
   const [phase, setPhase] = useState<Phase>('lit')
+  const [progress, setProgress] = useState<Progress>(EMPTY)
+  const [reveal, setReveal] = useState(false)
   const shownAt = useRef(Date.now())
   const done = useRef(false)
+  const seenRef = useRef(false)
+
+  // Subscribe once to cold-start progress. `codeburn` is undefined outside the
+  // Electron preload (e.g. unit tests); guard so the splash still renders.
+  useEffect(() => {
+    if (!codeburn || typeof codeburn.onProgress !== 'function') return
+    return codeburn.onProgress(event => setProgress(prev => reduceProgress(prev, event)))
+  }, [])
+
+  useEffect(() => { seenRef.current = progress.seen }, [progress.seen])
+
+  // Real parse work reveals the detail at once; otherwise a slow-scan fallback.
+  useEffect(() => { if (progress.realWork) setReveal(true) }, [progress.realWork])
+  useEffect(() => {
+    const timer = setTimeout(() => { if (seenRef.current) setReveal(true) }, REVEAL_FALLBACK_MS)
+    return () => clearTimeout(timer)
+  }, [])
 
   useEffect(() => {
     if (done.current) return
@@ -54,6 +126,7 @@ export function Splash({ hasData, hasError }: { hasData: boolean; hasError: bool
   if (phase === 'done' || typeof document === 'undefined') return null
 
   const base = phase === 'out' ? 'splash splash-out' : 'splash'
+  const showDetail = reveal && phase === 'lit'
   return createPortal(
     <div className={motionClass(base, 'splash-lit')} aria-hidden="true">
       {motionEnabled() ? (
@@ -67,6 +140,31 @@ export function Splash({ hasData, hasError }: { hasData: boolean; hasError: bool
       )}
       <div className="splash-word">CodeBurn</div>
       <div className="splash-version">v{version}</div>
+      {showDetail && (
+        <div className="splash-status">
+          <div className="splash-status-line">
+            First run: indexing your usage history. This one-time scan can take a few minutes; future launches are instant.
+          </div>
+          {progress.order.length > 0 && (
+            <ul className="splash-providers">
+              {progress.order.map(id => {
+                const status = progress.status[id] ?? 'pending'
+                const count = id === 'claude' && status === 'active' && progress.claudeTotal > 0
+                  ? ` ${progress.claudeDone.toLocaleString('en-US')}/${progress.claudeTotal.toLocaleString('en-US')}`
+                  : ''
+                const text = status === 'active' ? `Ingesting ${providerLabel(id)}…${count}` : providerLabel(id)
+                return (
+                  <li key={id} className={`splash-prov ${status}`}>
+                    <ProviderLogo provider={id} size={16} />
+                    <span className="splash-prov-name">{text}</span>
+                    {status === 'done' && <span className="splash-prov-check">✓</span>}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      )}
     </div>,
     document.body,
   )

--- a/app/renderer/hooks/usePolled.test.ts
+++ b/app/renderer/hooks/usePolled.test.ts
@@ -37,6 +37,27 @@ describe('usePolled', () => {
     expect(result.current.data).toBe('B-fresh')
   })
 
+  it('does not fetch while disabled, then fires once enabled flips true', async () => {
+    const resolvers: Array<(v: string) => void> = []
+    const fetcher = vi.fn(() => new Promise<string>(resolve => { resolvers.push(resolve) }))
+
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => usePolled(fetcher, ['x'], { enabled }),
+      { initialProps: { enabled: false } },
+    )
+
+    // Gated: no spawn, still in the initial loading state (splash/skeleton stays).
+    expect(fetcher).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(true)
+    expect(result.current.data).toBeNull()
+
+    // Gate opens (first overview resolved): the fetch fires exactly once.
+    rerender({ enabled: true })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    await act(async () => { resolvers[0]!('ready') })
+    expect(result.current.data).toBe('ready')
+  })
+
   it('keeps last-good data and exposes the error when a background reload fails', async () => {
     const calls: Array<{ resolve: (v: string) => void; reject: (e: unknown) => void }> = []
     const fetcher = vi.fn(() => new Promise<string>((resolve, reject) => { calls.push({ resolve, reject }) }))

--- a/app/renderer/hooks/usePolled.ts
+++ b/app/renderer/hooks/usePolled.ts
@@ -17,8 +17,20 @@ export type Polled<T> = {
  * Generic CLI-backed data hook: fetches on mount + whenever `deps` change, then
  * re-polls every `intervalMs`. Errors are normalized to the CliError shape so
  * sections can branch on `error.kind`. Last-good data is retained on error.
+ *
+ * `enabled` (default true) gates fetching: while false the hook stays in its
+ * initial loading state and issues no CLI spawn. The app boot flow sets it false
+ * on every section poll until the first overview resolves, so the one-time cold
+ * cache hydration happens ONCE (via overview) instead of fanning out into a
+ * parallel full-history parse per section.
  */
-export function usePolled<T>(fetcher: () => Promise<T>, deps: unknown[], intervalMs = 30_000): Polled<T> {
+export function usePolled<T>(
+  fetcher: () => Promise<T>,
+  deps: unknown[],
+  opts: { intervalMs?: number; enabled?: boolean } = {},
+): Polled<T> {
+  const intervalMs = opts.intervalMs ?? 30_000
+  const enabled = opts.enabled ?? true
   const [data, setData] = useState<T | null>(null)
   const [error, setError] = useState<CliError | null>(null)
   const [loading, setLoading] = useState(true)
@@ -30,6 +42,7 @@ export function usePolled<T>(fetcher: () => Promise<T>, deps: unknown[], interva
   const epochRef = useRef(0)
 
   const load = useCallback(() => {
+    if (!enabled) return
     const epoch = ++epochRef.current
     setLoading(true)
     // Clear any prior error at the start of each attempt so a fresh poll never
@@ -50,9 +63,10 @@ export function usePolled<T>(fetcher: () => Promise<T>, deps: unknown[], interva
         if (epochRef.current !== epoch) return
         setLoading(false)
       })
-    // deps are intentionally the caller-provided dependency list.
+    // deps are intentionally the caller-provided dependency list; `enabled`
+    // is prepended so flipping the gate re-creates load and fires immediately.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps)
+  }, [enabled, ...deps])
 
   useEffect(() => {
     load()

--- a/app/renderer/lib/types.ts
+++ b/app/renderer/lib/types.ts
@@ -549,7 +549,16 @@ export type PriceRates = { input?: number; output?: number; cacheRead?: number; 
 
 // ————— IPC surface (preload contextBridge → window.codeburn) —————
 
+/** Cold-start scan progress streamed from the CLI warmup (src/parser.ts). */
+export type ScanProgressEvent =
+  | { kind: 'providers'; providers: string[] }
+  | { kind: 'provider'; provider: string; state: 'start' | 'done'; files?: number }
+  | { kind: 'tick'; provider: string; done: number; total: number }
+  | { kind: 'done' }
+
 export interface CodeburnBridge {
+  /** Subscribe to cold-start scan progress; returns an unsubscribe fn. */
+  onProgress(cb: (event: ScanProgressEvent) => void): () => void
   getQuota(force?: boolean): Promise<QuotaProvider[]>
   getOverview(period: Period, provider: string, range?: DateRange, configSource?: string | null): Promise<MenubarPayload>
   getPlans(period: Period): Promise<StatusJson>

--- a/app/renderer/sections/Compare.tsx
+++ b/app/renderer/sections/Compare.tsx
@@ -33,15 +33,18 @@ export function Compare({
   provider,
   range = null,
   refreshToken = 0,
+  ready = true,
 }: {
   period: Period
   provider: string
   range?: DateRange | null
   refreshToken?: number
+  ready?: boolean
 }) {
   const models = usePolled<ModelStats[]>(
     () => codeburn.getCompareModels(period, provider),
     [period, provider, refreshToken],
+    { enabled: ready },
   )
   const [modelA, setModelA] = useState<string | null>(null)
   const [modelB, setModelB] = useState<string | null>(null)

--- a/app/renderer/sections/Models.tsx
+++ b/app/renderer/sections/Models.tsx
@@ -36,12 +36,14 @@ export function Models({
   range = null,
   refreshToken = 0,
   onNavigate,
+  ready = true,
 }: {
   period: Period
   provider: string
   range?: DateRange | null
   refreshToken?: number
   onNavigate?: (section: Section, pane?: SettingsPane) => void
+  ready?: boolean
 }) {
   const [lens, setLens] = useState<ModelsLens>('model')
   const onAddAlias = () => onNavigate?.('settings', 'aliases')
@@ -57,7 +59,7 @@ export function Models({
         )}
       </div>
       {lens === 'audit' ? (
-        <AuditLens period={period} provider={provider} range={range} refreshToken={refreshToken} />
+        <AuditLens period={period} provider={provider} range={range} refreshToken={refreshToken} ready={ready} />
       ) : (
         <ModelsUsage
           period={period}
@@ -66,6 +68,7 @@ export function Models({
           byTask={lens === 'task'}
           refreshToken={refreshToken}
           onAddAlias={onAddAlias}
+          ready={ready}
         />
       )}
     </>
@@ -79,6 +82,7 @@ function ModelsUsage({
   byTask,
   refreshToken,
   onAddAlias,
+  ready,
 }: {
   period: Period
   provider: string
@@ -86,10 +90,12 @@ function ModelsUsage({
   byTask: boolean
   refreshToken: number
   onAddAlias: () => void
+  ready: boolean
 }) {
   const report = usePolled<ModelReportRow[]>(
     () => range ? codeburn.getModels(period, provider, byTask, range) : codeburn.getModels(period, provider, byTask),
     [period, provider, byTask, range?.from, range?.to, refreshToken],
+    { enabled: ready },
   )
 
   if (!report.data) {
@@ -124,15 +130,18 @@ function AuditLens({
   provider,
   range,
   refreshToken,
+  ready,
 }: {
   period: Period
   provider: string
   range: DateRange | null
   refreshToken: number
+  ready: boolean
 }) {
   const report = usePolled<AuditRow[]>(
     () => range ? codeburn.getAudit(period, provider, range) : codeburn.getAudit(period, provider),
     [period, provider, range?.from, range?.to, refreshToken],
+    { enabled: ready },
   )
 
   if (!report.data) {

--- a/app/renderer/sections/Optimize.tsx
+++ b/app/renderer/sections/Optimize.tsx
@@ -27,20 +27,26 @@ export function OptimizeContent({
   range = null,
   overview,
   refreshToken = 0,
+  ready = true,
 }: {
   period: Period
   provider?: string
   range?: DateRange | null
   overview: Polled<MenubarPayload>
   refreshToken?: number
+  ready?: boolean
 }) {
+  // Gate on app-level readiness so boot hydrates the cache once (default true
+  // keeps standalone renders/tests polling normally).
   const optimizeReport = usePolled<OptimizeJsonReport>(
     () => range ? codeburn.getOptimizeReport(period, provider, range) : codeburn.getOptimizeReport(period, provider),
     [period, provider, range?.from, range?.to, refreshToken],
+    { enabled: ready },
   )
   const yieldReport = usePolled<YieldJsonReport>(
     () => range ? codeburn.getYield(period, provider, range) : codeburn.getYield(period, provider),
     [period, provider, range?.from, range?.to, refreshToken],
+    { enabled: ready },
   )
   const [tab, setTab] = useState<OptimizeTab>('waste')
 

--- a/app/renderer/sections/Overview.tsx
+++ b/app/renderer/sections/Overview.tsx
@@ -563,15 +563,20 @@ export function OverviewContent({
   range = null,
   overview,
   onNavigate,
+  ready = true,
 }: {
   period: Period
   provider?: string
   range?: DateRange | null
   overview: Polled<MenubarPayload>
   onNavigate?: (section: 'optimize' | 'sessions') => void
+  ready?: boolean
 }) {
-  const actReport = usePolled<ActReportJson>(() => codeburn.getActReport(), [])
-  const yieldReport = usePolled<YieldJsonReport>(() => codeburn.getYield(period, provider), [period, provider])
+  // Gate secondary spawns on the app-level readiness (first overview resolved),
+  // so the cold hydration runs once (via overview) rather than 3 parses at once
+  // on boot. Defaults true so standalone renders/tests poll normally.
+  const actReport = usePolled<ActReportJson>(() => codeburn.getActReport(), [], { enabled: ready })
+  const yieldReport = usePolled<YieldJsonReport>(() => codeburn.getYield(period, provider), [period, provider], { enabled: ready })
   const { data, error } = overview
   const modelIndex = useMemo(() => data ? buildModelIndex(data) : new Map<string, string>(), [data])
 

--- a/app/renderer/sections/Plans.tsx
+++ b/app/renderer/sections/Plans.tsx
@@ -62,7 +62,7 @@ function manualPlanSummaries(status: StatusJson): JsonPlanSummary[] {
   return planSummaries(status).filter(plan => plan.provider !== 'claude' && plan.provider !== 'codex')
 }
 
-export function Plans({ period, refreshToken = 0, onNavigate }: { period: Period; refreshToken?: number; onNavigate?: (section: Section, pane?: SettingsPane) => void }) {
+export function Plans({ period, refreshToken = 0, onNavigate, ready = true }: { period: Period; refreshToken?: number; onNavigate?: (section: Section, pane?: SettingsPane) => void; ready?: boolean }) {
   // Force a fresh fetch (bypassing QuotaService's 2-min cache, and its keychain
   // guard) when the user hits ⌘R or clicks Refresh in the Connect affordance;
   // the steady 30s poll keeps serving cached quota.
@@ -75,7 +75,7 @@ export function Plans({ period, refreshToken = 0, onNavigate }: { period: Period
     return codeburn.getQuota(force)
   }, [refreshToken, reconnectNonce])
   const reconnect = () => setReconnectNonce(value => value + 1)
-  const budgetReport = usePolled<StatusJson>(() => codeburn.getPlans(period), [period, refreshToken])
+  const budgetReport = usePolled<StatusJson>(() => codeburn.getPlans(period), [period, refreshToken], { enabled: ready })
   const manualPlans = budgetReport.data ? manualPlanSummaries(budgetReport.data) : []
 
   return (

--- a/app/renderer/sections/Sessions.tsx
+++ b/app/renderer/sections/Sessions.tsx
@@ -66,6 +66,7 @@ export function Sessions({
   refreshToken = 0,
   detectedProviders = [],
   onProviderChange = () => {},
+  ready = true,
 }: {
   period: Period
   provider: string
@@ -73,6 +74,7 @@ export function Sessions({
   refreshToken?: number
   detectedProviders?: Array<{ id: string; label: string }>
   onProviderChange?: (value: string) => void
+  ready?: boolean
 }) {
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [query, setQuery] = useState('')
@@ -82,6 +84,7 @@ export function Sessions({
   const report = usePolled<SessionRow[]>(
     () => range ? codeburn.getSessions(period, provider, range) : codeburn.getSessions(period, provider),
     [period, provider, range?.from, range?.to, refreshToken],
+    { enabled: ready },
   )
   const rows = report.data ?? []
   const q = query.trim().toLowerCase()

--- a/app/renderer/sections/Spend.tsx
+++ b/app/renderer/sections/Spend.tsx
@@ -47,16 +47,21 @@ export function SpendContent({
   range = null,
   overview,
   refreshToken = 0,
+  ready = true,
 }: {
   period: Period
   provider: string
   range?: DateRange | null
   overview: Polled<MenubarPayload>
   refreshToken?: number
+  ready?: boolean
 }) {
+  // Gate on app-level readiness so boot hydrates the cache once (default true
+  // keeps standalone renders/tests polling normally).
   const flow = usePolled<SpendFlow>(
     () => range ? codeburn.getSpendFlow(period, provider, range) : codeburn.getSpendFlow(period, provider),
     [period, provider, range?.from, range?.to, refreshToken],
+    { enabled: ready },
   )
 
   if (!overview.data) {

--- a/app/renderer/styles/plain.css
+++ b/app/renderer/styles/plain.css
@@ -900,8 +900,35 @@ td:first-child { font-size: var(--fs-body); font-weight: var(--fw-body); }
   to { opacity: 1; transform: none; }
 }
 
+/* First-run indexing detail: framing line + per-provider ingest list. Colors are
+   fixed to the dark splash canvas (like .splash-word/.splash-version), not the theme. */
+.splash-status {
+  margin-top: 8px; display: flex; flex-direction: column; align-items: center; gap: 16px;
+  max-width: 420px; text-align: center;
+  animation: splash-word-in 400ms ease-out both;
+}
+.splash-status-line { font-size: var(--fs-label); line-height: 1.5; color: #b3a595; }
+.splash-providers {
+  list-style: none; margin: 0; padding: 0; width: 100%;
+  display: flex; flex-direction: column; gap: 7px;
+}
+.splash-prov {
+  display: flex; align-items: center; gap: 9px;
+  font-size: var(--fs-label); color: #6f665c; padding: 0 6px;
+}
+.splash-prov .provider-logo { opacity: 0.4; flex: none; }
+.splash-prov-name { flex: 1; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.splash-prov.active { color: #f4f1ec; }
+.splash-prov.active .provider-logo { opacity: 1; animation: splash-prov-pulse 1.4s ease-in-out infinite; }
+.splash-prov.done { color: #b3a595; }
+.splash-prov.done .provider-logo { opacity: 0.85; }
+.splash-prov-check { color: #7ec98f; font-size: 0.85em; flex: none; }
+@keyframes splash-prov-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+
 @media (prefers-reduced-motion: reduce) {
   .fm-flicker,
   .splash-lit .splash-mark, .splash-lit .splash-mark::before, .splash-lit .splash-word { animation: none; }
   .splash { transition: none; }
+  .splash-status { animation: none; }
+  .splash-prov.active .provider-logo { animation: none; }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -776,6 +776,7 @@ program
   .option('--to <date>', 'End date (YYYY-MM-DD) for custom range')
   .option('--days <dates>', 'Comma-separated dates (YYYY-MM-DD) for multi-day selection')
   .option('--no-optimize', 'Skip optimize findings (menubar-json only, faster)')
+  .option('--no-timeline', 'Skip the granular timeline (menubar-json only, faster)')
   .addOption(new Option('--claude-config-source <id>').hideHelp())
   .action(async (opts) => {
     assertFormat(opts.format, ['terminal', 'menubar-json', 'json'], 'status')
@@ -826,6 +827,7 @@ program
         exclude: opts.exclude,
         daysSelection,
         optimize: opts.optimize !== false,
+        timeline: opts.timeline !== false,
         claudeConfigSourceId: opts.claudeConfigSource,
       })
       if (opts.scope === 'combined') {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1657,6 +1657,10 @@ async function scanProjectDirs(
   seenMsgIds: Set<string>,
   diskCache: SessionCache,
   dateRange?: DateRange,
+  // Cold-run robustness: called after every parsed Claude file so a throttled
+  // caller (parseAllSessions) can persist partial progress. A run killed
+  // mid-scan then resumes from a warm cache instead of re-parsing from zero.
+  onFileParsed?: () => Promise<void>,
 ): Promise<ProjectSummary[]> {
   const section = getOrCreateProviderSection(diskCache, 'claude')
   const allDiscoveredFiles = new Set<string>()
@@ -1696,7 +1700,9 @@ async function scanProjectDirs(
   }
 
   const parseProgress = createScanProgress('parsing changed claude sessions', changedFiles.length)
+  const progressTotal = changedFiles.length
   let filesDone = 0
+  emitScanProgress({ kind: 'tick', provider: 'claude', done: 0, total: progressTotal })
   for (const { filePath, info } of changedFiles) {
     delete section.files[filePath]
 
@@ -1730,6 +1736,12 @@ async function scanProjectDirs(
     }
     filesDone++
     await parseProgress.tick(filesDone)
+    // Machine-readable tick for the app splash (throttled to ~every 50 files so
+    // a large cold run doesn't flood stderr), plus a partial-progress save.
+    if (filesDone % 50 === 0 || filesDone === progressTotal) {
+      emitScanProgress({ kind: 'tick', provider: 'claude', done: filesDone, total: progressTotal })
+    }
+    if (onFileParsed) await onFileParsed()
   }
   parseProgress.finish()
 
@@ -2151,6 +2163,28 @@ let interactiveScanUI = false
 export function setInteractiveScanUI(active = true): void {
   interactiveScanUI = active
 }
+
+// Machine-readable scan progress for the desktop app's first-run splash. Plain
+// CLI/terminal usage is untouched: emission is gated on CODEBURN_PROGRESS=1,
+// which only the app's cold-start warmup spawn sets. Each event is one
+// newline-delimited JSON object behind a sentinel prefix so the reader can pick
+// it out of stderr that may also carry provider warnings. This is orthogonal to
+// createScanProgress's `\r` TTY line (that one never fires under a piped spawn).
+export const PROGRESS_LINE_PREFIX = 'CODEBURN_PROGRESS '
+export type ScanProgressEvent =
+  | { kind: 'providers'; providers: string[] }
+  | { kind: 'provider'; provider: string; state: 'start' | 'done'; files?: number }
+  | { kind: 'tick'; provider: string; done: number; total: number }
+
+export function emitScanProgress(event: ScanProgressEvent): void {
+  if (process.env['CODEBURN_PROGRESS'] !== '1') return
+  try { process.stderr.write(`${PROGRESS_LINE_PREFIX}${JSON.stringify(event)}\n`) } catch { /* stderr closed */ }
+}
+
+// Minimum spacing between partial-progress saves during a cold parse. Low enough
+// that an interrupted long run loses little work, high enough that repeated
+// full-cache writes never dominate a fast warm run.
+const PROGRESS_SAVE_THROTTLE_MS = 5000
 
 export function createScanProgress(label: string, total: number) {
   const show = !interactiveScanUI && total > 20 && process.stderr.isTTY === true
@@ -2611,15 +2645,6 @@ export async function parseAllSessions(dateRange?: DateRange, providerFilter?: s
   const claudeSources = allSources.filter(s => s.provider === 'claude')
   const nonClaudeSources = allSources.filter(s => s.provider !== 'claude')
 
-  const claudeDirs = claudeSources.map(s => ({
-    path: s.path,
-    name: s.project,
-    source: s.sourceId && s.sourceLabel && s.sourcePath && s.sourceKind
-      ? { id: s.sourceId, label: s.sourceLabel, path: s.sourcePath, kind: s.sourceKind }
-      : undefined,
-  }))
-  const claudeProjects = await scanProjectDirs(claudeDirs, seenMsgIds, diskCache, dateRange)
-
   const providerGroups = new Map<string, SessionSource[]>()
   for (const source of nonClaudeSources) {
     const existing = providerGroups.get(source.provider) ?? []
@@ -2627,10 +2652,41 @@ export async function parseAllSessions(dateRange?: DateRange, providerFilter?: s
     providerGroups.set(source.provider, existing)
   }
 
+  // Cold-run robustness: persist partial progress during a long parse (throttled)
+  // so a run interrupted before the single end-of-parse save still leaves a warm
+  // cache behind. saveCache is atomic (temp + rename) and clears `_dirty`, so this
+  // never races the final save below.
+  let lastSaveAt = Date.now()
+  const saveProgress = async (): Promise<void> => {
+    if (!(diskCache as { _dirty?: boolean })._dirty) return
+    if (Date.now() - lastSaveAt < PROGRESS_SAVE_THROTTLE_MS) return
+    lastSaveAt = Date.now()
+    try { await saveCache(diskCache) } catch { /* best-effort partial save */ }
+  }
+
+  emitScanProgress({ kind: 'providers', providers: [
+    ...(claudeSources.length > 0 ? ['claude'] : []),
+    ...providerGroups.keys(),
+  ] })
+
+  const claudeDirs = claudeSources.map(s => ({
+    path: s.path,
+    name: s.project,
+    source: s.sourceId && s.sourceLabel && s.sourcePath && s.sourceKind
+      ? { id: s.sourceId, label: s.sourceLabel, path: s.sourcePath, kind: s.sourceKind }
+      : undefined,
+  }))
+  if (claudeSources.length > 0) emitScanProgress({ kind: 'provider', provider: 'claude', state: 'start' })
+  const claudeProjects = await scanProjectDirs(claudeDirs, seenMsgIds, diskCache, dateRange, saveProgress)
+  if (claudeSources.length > 0) emitScanProgress({ kind: 'provider', provider: 'claude', state: 'done', files: claudeSources.length })
+
   const otherProjects: ProjectSummary[] = []
   for (const [providerName, sources] of providerGroups) {
+    emitScanProgress({ kind: 'provider', provider: providerName, state: 'start' })
     const projects = await parseProviderSources(providerName, sources, seenKeys, diskCache, dateRange)
+    emitScanProgress({ kind: 'provider', provider: providerName, state: 'done', files: sources.length })
     otherProjects.push(...projects)
+    await saveProgress()
   }
 
   // Durable providers with cached data but NO discovered sources (all files pruned

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -96,6 +96,10 @@ export type AggregateOpts = {
   daysSelection?: { range: DateRange; label: string; days: Set<string> } | null
   optimize?: boolean
   claudeConfigSourceId?: string | null
+  /// Build the granular per-bucket timeline (`history.timeline`). Defaults to
+  /// true. The desktop app never renders it, so it passes `--no-timeline` to
+  /// skip the buildGranularHistory pass on every menubar poll.
+  timeline?: boolean
 }
 
 type ConfigOption = { id: string; label: string; path: string }
@@ -525,6 +529,6 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
 
   const optimize = opts.optimize === false ? null : await scanAndDetect(scanProjects, scanRange)
   const granularRange = opts.daysSelection?.range ?? scanRange
-  const granularHistory = buildGranularHistory(scanProjects, granularRange)
+  const granularHistory = opts.timeline === false ? undefined : buildGranularHistory(scanProjects, granularRange)
   return buildMenubarPayload(currentData, providers, optimize, dailyHistory, retryTax, routingWaste, breakdowns, claudeConfigs, granularHistory)
 }

--- a/tests/cache-persistence-coldstart.test.ts
+++ b/tests/cache-persistence-coldstart.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { parseAllSessions, clearSessionCache } from '../src/parser.js'
+import { CACHE_VERSION } from '../src/session-cache.js'
+
+let tmpDir: string
+let cacheDir: string
+
+beforeEach(async () => {
+  clearSessionCache()
+  tmpDir = await mkdtemp(join(tmpdir(), 'coldstart-'))
+  cacheDir = join(tmpDir, 'cache')
+  process.env['CLAUDE_CONFIG_DIR'] = tmpDir
+  process.env['CODEBURN_CACHE_DIR'] = cacheDir
+  process.env['CODEBURN_DESKTOP_SESSIONS_DIR'] = join(tmpDir, 'desktop-sessions')
+})
+
+afterEach(async () => {
+  clearSessionCache()
+  delete process.env['CODEBURN_PROGRESS']
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+async function writeSession(): Promise<void> {
+  const dir = join(tmpDir, 'projects', 'proj')
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'sess.jsonl'), JSON.stringify({
+    type: 'assistant',
+    sessionId: 'sess',
+    timestamp: '2026-05-15T10:00:00Z',
+    cwd: '/tmp/proj',
+    message: {
+      id: 'msg-1', type: 'message', role: 'assistant', model: 'claude-sonnet-4-5',
+      content: [], usage: { input_tokens: 100, output_tokens: 50 },
+    },
+  }) + '\n')
+}
+
+describe('cold-start cache persistence', () => {
+  // The desktop cold-start bug is "the cache never persists". This pins the
+  // invariant the fix depends on: a run that reaches the end of parseAllSessions
+  // writes the current-version session cache to disk, so the next launch is warm.
+  it('a completed parseAllSessions persists the current-version cache to disk', async () => {
+    await writeSession()
+    const projects = await parseAllSessions()
+    expect(projects.length).toBeGreaterThan(0)
+
+    const raw = JSON.parse(await readFile(join(cacheDir, 'session-cache.json'), 'utf-8'))
+    expect(raw.version).toBe(CACHE_VERSION)
+    const claudeFiles = Object.keys(raw.providers?.claude?.files ?? {})
+    expect(claudeFiles.length).toBeGreaterThan(0)
+    // The persisted entry carries the parsed turn, so a warm reload serves it
+    // without re-reading the source file.
+    expect(raw.providers.claude.files[claudeFiles[0]!].turns.length).toBeGreaterThan(0)
+  })
+
+  it('streams per-provider scan progress only when CODEBURN_PROGRESS=1', async () => {
+    await writeSession()
+    const lines: string[] = []
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+      lines.push(String(chunk)); return true
+    }) as typeof process.stderr.write)
+    try {
+      // Off by default: plain CLI/terminal output is untouched.
+      await parseAllSessions()
+      expect(lines.filter(l => l.startsWith('CODEBURN_PROGRESS ')).length).toBe(0)
+
+      clearSessionCache()
+      process.env['CODEBURN_PROGRESS'] = '1'
+      await parseAllSessions()
+      const progress = lines.filter(l => l.startsWith('CODEBURN_PROGRESS '))
+      expect(progress.some(l => l.includes('"providers"'))).toBe(true)
+      expect(progress.some(l => l.includes('"provider":"claude"') && l.includes('"start"'))).toBe(true)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})

--- a/tests/cli-status-menubar.test.ts
+++ b/tests/cli-status-menubar.test.ts
@@ -108,6 +108,32 @@ describe('codeburn status --format menubar-json', () => {
     }
   })
 
+  it('omits history.timeline with --no-timeline, includes it by default', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-menubar-tl-'))
+    try {
+      const projectDir = join(home, '.claude', 'projects', 'myapp')
+      await mkdir(projectDir, { recursive: true })
+      const base = new Date(Date.now() - 3600_000)
+      const ts = (offset: number) => new Date(base.getTime() + offset).toISOString().replace(/\.\d+Z$/, 'Z')
+      await writeFile(
+        join(projectDir, 'session.jsonl'),
+        [userLine('s1', ts(0)), assistantLine('s1', ts(60_000), 'msg-1')].join('\n'),
+      )
+
+      const withTimeline = runCli(['status', '--format', 'menubar-json', '--period', 'today', '--no-optimize'], home)
+      expect(withTimeline.status, `stderr: ${withTimeline.stderr}`).toBe(0)
+      const withHistory = (JSON.parse(withTimeline.stdout) as { history: Record<string, unknown> }).history
+      expect(withHistory).toHaveProperty('timeline')
+
+      const noTimeline = runCli(['status', '--format', 'menubar-json', '--period', 'today', '--no-optimize', '--no-timeline'], home)
+      expect(noTimeline.status, `stderr: ${noTimeline.stderr}`).toBe(0)
+      const noHistory = (JSON.parse(noTimeline.stdout) as { history: Record<string, unknown> }).history
+      expect(noHistory).not.toHaveProperty('timeline')
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
   it('filters menubar payloads to a selected review day with --day', async () => {
     const home = await mkdtemp(join(tmpdir(), 'codeburn-menubar-day-'))
 


### PR DESCRIPTION
Field bug: first launch timed out at 45000ms and the app stayed slow forever. Six sections spawned six different full-history parses concurrently on a cold cache; the 45s timeout killed them all before the cache could save, restarting the cycle every poll.

- CLI: incremental atomic cache saves during hydration; CODEBURN_PROGRESS stderr protocol; status --no-timeline
- App: first overview is a 10-minute warmup that gates all other section polls; splash renders per-provider ingestion progress with logos; overview skips timeline computation
- No computed numbers change; the shared cache design is preserved

Timings on real data: cold 31s once, warm 2.6s, warm packaged-app run 2.6s. App 295/295, root 1797.