### PR TITLE
copilot: extract skill invocations so Skills & Agents populates

### DIFF
--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -96,6 +96,7 @@ const modelDisplayNames: Record<string, string> = {
 const toolNameMap: Record<string, string> = {
   // JSONL session-state tool names
   bash: 'Bash',
+  skill: 'Skill',
   read_file: 'Read',
   write_file: 'Edit',
   edit_file: 'Edit',
@@ -873,6 +874,14 @@ function createJsonlParser(
             })
             .filter((t): t is string => t !== null)
 
+          const skills = toolRequests.flatMap((t) => {
+            if (typeof t !== 'object' || t === null) return []
+            const name = (t.name ?? t.toolName) ?? ''
+            if (name !== 'skill') return []
+            const skill = t.arguments?.['skill']
+            return typeof skill === 'string' && skill.trim().length > 0 ? [skill.trim()] : []
+          })
+
           // Extract base command names from bash-type tool requests, routing the
           // raw command through the shared extractBashCommands helper so chained
           // commands are normalised the same way as every other provider
@@ -904,6 +913,7 @@ function createJsonlParser(
             costUSD,
             tools,
             bashCommands,
+            skills: skills.length > 0 ? skills : undefined,
             subagentTypes: currentSubagentType ? [currentSubagentType] : undefined,
             timestamp: event.timestamp ?? '',
             speed: 'standard' as const,

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -133,7 +133,7 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   codex: 'mcp-attribution-v2-est-cost',
   cursor: 'composer-anchored-crediting-v1-est-cost',
   'cursor-agent': 'workspaceless-transcript-v1',
-  copilot: 'cli-shutdown-cost-v1',
+  copilot: 'cli-shutdown-cost-v1-skills',
   grok: 'estimated-cost-v1',
   hermes: 'reasoning-output-accounting-v1-est-cost',
   'lingtai-tui': 'token-ledger-registry-activity-v3',

--- a/tests/providers/copilot-skills.test.ts
+++ b/tests/providers/copilot-skills.test.ts
@@ -1,0 +1,100 @@
+// Regression test for issue #654: Copilot JSONL parser drops skill invocations,
+// leaving the Skills & Agents section empty for Copilot CLI sessions.
+//
+// Copilot CLI (~/.copilot/session-state/<id>/events.jsonl) records skill usage
+// as assistant.message toolRequests with name === 'skill' and the skill name in
+// arguments.skill. The parser must:
+//   1. normalise the tool name to 'Skill' (classifier's hasSkillTool matches
+//      exactly 'Skill', which makes the turn 'general'), and
+//   2. populate ParsedProviderCall.skills with the invoked skill name(s)
+//      (getAllSkills -> turn.subCategory -> skillBreakdown -> Skills report).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { copilot } from '../../src/providers/copilot.js'
+import type { ParsedProviderCall } from '../../src/providers/types.js'
+
+let tmpDir: string
+
+async function createSessionDir(sessionId: string, lines: string[], cwd = '/home/user/myproject') {
+  const sessionDir = join(tmpDir, sessionId)
+  await mkdir(sessionDir, { recursive: true })
+  await writeFile(join(sessionDir, 'workspace.yaml'), `id: ${sessionId}\ncwd: ${cwd}\n`)
+  await writeFile(join(sessionDir, 'events.jsonl'), lines.join('\n') + '\n')
+  return join(sessionDir, 'events.jsonl')
+}
+
+function modelChange(newModel: string) {
+  return JSON.stringify({ type: 'session.model_change', timestamp: '2026-07-09T16:18:00Z', data: { newModel } })
+}
+
+function userMessage(content: string) {
+  return JSON.stringify({ type: 'user.message', timestamp: '2026-07-09T16:18:05Z', data: { content, interactionId: 'int-1' } })
+}
+
+// Mirrors the real Copilot CLI event shape reported in issue #654.
+function assistantMessageWithSkill(opts: { messageId: string; skill: string }) {
+  return JSON.stringify({
+    type: 'assistant.message',
+    timestamp: '2026-07-09T16:18:12.463Z',
+    data: {
+      messageId: opts.messageId,
+      model: 'claude-sonnet-4.6',
+      outputTokens: 111,
+      toolRequests: [
+        {
+          toolCallId: 'toolu_bdrk_01FrUw1ya3xi7MNK5aRK8LVc',
+          name: 'skill',
+          arguments: { skill: opts.skill },
+          type: 'function',
+        },
+      ],
+    },
+  })
+}
+
+async function collectCalls(eventsPath: string) {
+  const source = { path: eventsPath, project: 'myproject', provider: 'copilot' }
+  const calls: ParsedProviderCall[] = []
+  for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+  return calls
+}
+
+describe('copilot provider - skill invocations (issue #654)', () => {
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'copilot-skills-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('normalizes the "skill" tool name to "Skill" so the classifier recognises it', async () => {
+    const eventsPath = await createSessionDir('sess-skill-1', [
+      modelChange('claude-sonnet-4.6'),
+      userMessage('use the deploy skill'),
+      assistantMessageWithSkill({ messageId: 'msg-1', skill: 'deploy-checklist' }),
+    ])
+
+    const calls = await collectCalls(eventsPath)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.tools).toContain('Skill')
+  })
+
+  it('populates skills[] with the skill name from arguments.skill', async () => {
+    const eventsPath = await createSessionDir('sess-skill-2', [
+      modelChange('claude-sonnet-4.6'),
+      userMessage('use the deploy skill'),
+      assistantMessageWithSkill({ messageId: 'msg-1', skill: 'deploy-checklist' }),
+    ])
+
+    const calls = await collectCalls(eventsPath)
+
+    expect(calls).toHaveLength(1)
+    // Feeds getAllSkills() -> turn.subCategory -> skillBreakdown -> Skills & Agents section.
+    expect(calls[0]!.skills).toEqual(['deploy-checklist'])
+  })
+})


### PR DESCRIPTION
## Problem

The Copilot parser has no notion of skills: the tool-name map lacks a `skill` entry (the shared classifier matches exact `Skill`), and the JSONL `assistant.message` branch never reads `arguments.skill` from toolRequests into `skills[]`. Everything downstream (`getAllSkills` → `subCategory` → `skillBreakdown` → the Skills & Agents section) is permanently empty for Copilot CLI sessions, as @rfsmart-mmann reported. (#654)

## Fix

- `skill: 'Skill'` added to the copilot tool-name map.
- Skill names extracted from `toolRequests` where the tool is `skill`, reading `arguments.skill` (handles `name`/`toolName`, trims and drops empties — mirroring the claude parser's extraction); yielded as `skills` when non-empty.
- Subagent handling untouched (already worked via `subagent.selected`).
- Copilot parse version bumped (`cli-shutdown-cost-v1` → `cli-shutdown-cost-v1-skills`) so cached sessions re-parse once. Rebased on current main over #684's bump.

## Tests

- New `tests/providers/copilot-skills.test.ts` (written red-first: `expected [ 'skill' ] to include 'Skill'` and `expected undefined to deeply equal [ 'deploy-checklist' ]` before the fix).
- `npx tsc --noEmit` clean; full suite green except the three pre-existing `app/electron/cli.test.ts` failures already noted as environmental in the #677 review (expect a built `dist/cli.js`).

Fixes #654