### PR TITLE
fix: telemetry flush drops 4xx-rejected batches

### DIFF
--- a/app/electron/telemetry.test.ts
+++ b/app/electron/telemetry.test.ts
@@ -137,15 +137,23 @@ describe('events', () => {
     expect(telemetry.queueLength).toBe(before + 1)
   })
 
-  it('keeps the queue on a failed POST and clears it on success', async () => {
+  it('keeps the queue on a transient failure (5xx) and clears it on success', async () => {
     let ok = false
-    const fetchFn = vi.fn(async () => ({ ok })) as unknown as typeof fetch
+    const fetchFn = vi.fn(async () => ({ ok, status: 503 })) as unknown as typeof fetch
     const { telemetry } = make({ fetchFn })
     telemetry.completeOnboarding(true)
     expect(await telemetry.flush()).toBe(false)
     expect(telemetry.queueLength).toBe(1)
     ok = true
     expect(await telemetry.flush()).toBe(true)
+    expect(telemetry.queueLength).toBe(0)
+  })
+
+  it('drops a permanently rejected batch (4xx) instead of wedging the queue', async () => {
+    const fetchFn = vi.fn(async () => ({ ok: false, status: 400 })) as unknown as typeof fetch
+    const { telemetry } = make({ fetchFn })
+    telemetry.completeOnboarding(true)
+    expect(await telemetry.flush()).toBe(false)
     expect(telemetry.queueLength).toBe(0)
   })
 

--- a/app/electron/telemetry.ts
+++ b/app/electron/telemetry.ts
@@ -244,7 +244,13 @@ export class Telemetry {
         headers: { 'content-type': 'application/json' },
         body,
       })
-      if (!res.ok) return false
+      if (!res.ok) {
+        // 4xx is a permanent rejection of this batch (schema drift, bad shape):
+        // retrying the same payload forever would wedge the queue at its cap.
+        // Drop it. 5xx/network are transient — keep the batch for the next beat.
+        if (res.status >= 400 && res.status < 500) this.queue = this.queue.filter(e => !events.includes(e))
+        return false
+      }
       // Only drop what was sent; events tracked mid-flight stay queued.
       this.queue = this.queue.filter(e => !events.includes(e))
       return true


### PR DESCRIPTION
4xx means permanent rejection; retrying identical payloads wedges the bounded queue. Drop on 4xx, retry only 5xx/network. Verified end-to-end against the real DB-backed server. 317/317.