### PR TITLE
fix: cold_start telemetry emits once per launch

### DIFF
--- a/app/electron/main.test.ts
+++ b/app/electron/main.test.ts
@@ -371,6 +371,62 @@ describe('createBridgeHandlers (telemetry wiring)', () => {
     expect(typeof (coldStarts[0]![1] as { ms: number }).ms).toBe('number')
   })
 
+  it('records cold_start exactly once across coalesced re-polls, with the first-attempt duration (no cumulative ladder)', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    try {
+      const telemetry = fakeTelemetry()
+      // Coalescing: every same-arg cold re-poll joins the ONE in-flight child.
+      let release!: (v: unknown) => void
+      const shared = new Promise(res => { release = res })
+      const spawnCli = vi.fn(() => shared)
+      const handlers = createBridgeHandlers({ ...deps(telemetry), spawnCli })
+
+      const p1 = handlers['codeburn:getOverview']!('30days', 'all') // anchors cold clock at t=0
+      vi.setSystemTime(30_000)
+      const p2 = handlers['codeburn:getOverview']!('30days', 'all')
+      vi.setSystemTime(60_000)
+      const p3 = handlers['codeburn:getOverview']!('30days', 'all')
+
+      // The stuck child finally settles ~102.8s after launch.
+      vi.setSystemTime(102_801)
+      release({ current: { cost: 1 } })
+      await Promise.all([p1, p2, p3])
+
+      const coldStarts = telemetry.track.mock.calls.filter(([name]) => name === 'cold_start')
+      expect(coldStarts.length).toBe(1)
+      // One row, first-attempt duration — not the old 42801→72800→102801 ladder.
+      expect(coldStarts[0]![1]).toMatchObject({ ms: 102_801, timedOut: false })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('records cold_start with timedOut:true when the first (cold) overview attempt times out', async () => {
+    const telemetry = fakeTelemetry()
+    const spawnCli = vi.fn(async () => { throw new CliError('timeout', 'timed out') })
+    const handlers = createBridgeHandlers({ ...deps(telemetry), spawnCli })
+    await handlers['codeburn:getOverview']!('30days', 'all')
+    const coldStarts = telemetry.track.mock.calls.filter(([name]) => name === 'cold_start')
+    expect(coldStarts.length).toBe(1)
+    expect(coldStarts[0]![1]).toMatchObject({ timedOut: true })
+  })
+
+  it('does not re-emit cold_start on a warmup re-arm, keeping the first attempt timedOut:true', async () => {
+    const telemetry = fakeTelemetry()
+    let n = 0
+    const spawnCli = vi.fn(async () => {
+      if (++n === 1) throw new CliError('timeout', 'timed out') // first cold attempt: final timeout
+      return { current: { cost: 1 } } // re-armed cold attempt succeeds
+    })
+    const handlers = createBridgeHandlers({ ...deps(telemetry), spawnCli })
+    await handlers['codeburn:getOverview']!('30days', 'all')
+    await handlers['codeburn:getOverview']!('30days', 'all')
+    const coldStarts = telemetry.track.mock.calls.filter(([name]) => name === 'cold_start')
+    expect(coldStarts.length).toBe(1)
+    expect(coldStarts[0]![1]).toMatchObject({ timedOut: true })
+  })
+
   it('tracks cli_error kinds from failing handlers', async () => {
     const telemetry = fakeTelemetry()
     const failing = {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -152,6 +152,18 @@ export function createBridgeHandlers(deps: Deps = { spawnCli, spawnCliAction, re
   // overview fetch runs cold (long timeout + progress streaming); the shared
   // spawnCli coalescing means concurrent same-arg re-polls join one child.
   let overviewWarmed = false
+  // cold_start is a once-per-launch metric. Because coalesced re-polls each
+  // re-enter the cold branch (and overviewWarmed only flips on success, so it
+  // never guards a still-failing warmup), emitting inline would record one row
+  // per poll — each with a launch-relative, cumulative elapsed time. Latch the
+  // emit and anchor the duration to the FIRST cold attempt instead.
+  let coldStartEmitted = false
+  let coldStartBegan: number | null = null
+  const emitColdStart = (timedOut: boolean): void => {
+    if (coldStartEmitted) return
+    coldStartEmitted = true
+    telemetry?.track('cold_start', { ms: Date.now() - (coldStartBegan ?? Date.now()), timedOut })
+  }
 
   const run = (build: (...args: any[]) => string[]): Handler => async (...args: any[]) => {
     try {
@@ -172,7 +184,7 @@ export function createBridgeHandlers(deps: Deps = { spawnCli, spawnCliAction, re
   ]
 
   const getOverview: Handler = async (period: string, provider: string, range?: DateRange, configSource?: string | null) => {
-    const startedAt = Date.now()
+    coldStartBegan ??= Date.now()
     try {
       const args = buildOverviewArgs(period, provider, range, configSource)
       if (overviewWarmed) return { ok: true, value: await deps.spawnCli(args) }
@@ -183,11 +195,11 @@ export function createBridgeHandlers(deps: Deps = { spawnCli, spawnCliAction, re
       })
       overviewWarmed = true
       emitProgress({ kind: 'done' })
-      telemetry?.track('cold_start', { ms: Date.now() - startedAt, timedOut: false })
+      emitColdStart(false)
       return { ok: true, value }
     } catch (err) {
       const error = toEnvelopeError(err)
-      if (!overviewWarmed) telemetry?.track('cold_start', { ms: Date.now() - startedAt, timedOut: error.kind === 'timeout' })
+      if (!overviewWarmed) emitColdStart(error.kind === 'timeout')
       telemetry?.track('cli_error', { kind: error.kind })
       return { ok: false, error }
     }

--- a/app/electron/telemetry.test.ts
+++ b/app/electron/telemetry.test.ts
@@ -128,6 +128,24 @@ describe('events', () => {
     expect(body.events[0]!.day).toMatch(/^\d{4}-\d{2}-\d{2}$/)
   })
 
+  it('stamps events with the LOCAL calendar day, not the UTC day', async () => {
+    const savedTZ = process.env.TZ
+    process.env.TZ = 'America/Los_Angeles' // UTC-07/08
+    try {
+      // 05:00Z is still the previous local day in LA (22:00). UTC-bucketing would
+      // stamp 2026-07-17; the local calendar day is 2026-07-16.
+      const instant = new Date('2026-07-17T05:00:00Z')
+      const { telemetry, posts } = make({ now: () => instant })
+      telemetry.completeOnboarding(true) // queues app_open at `instant`
+      await telemetry.flush()
+      const body = posts[0]!.body as { events: Array<{ day: string }> }
+      expect(body.events[0]!.day).toBe('2026-07-16')
+    } finally {
+      if (savedTZ === undefined) delete process.env.TZ
+      else process.env.TZ = savedTZ
+    }
+  })
+
   it('caps usage_snapshot at one per calendar day', () => {
     const { telemetry } = make()
     telemetry.completeOnboarding(true)


### PR DESCRIPTION
The observed 42801/72800/102801 ms ladder was coalesced polls each emitting on one shared child settle. Launch-scoped latch; fail-without-fix tests; timedOut and local-day confirmed correct and regression-locked. 324/324.