### PR TITLE
release: desktop 0.9.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@
     <td align="center" width="50%">
       <strong>Desktop</strong><br/>
       <img src="https://raw.githubusercontent.com/getagentseal/codeburn/main/assets/desktop.jpg" alt="CodeBurn Desktop" /><br/>
-      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.15/CodeBurn-0.9.15-arm64.dmg"><img src="https://img.shields.io/badge/macOS-Apple_Silicon-F97316?logo=apple&logoColor=white" alt="Download for macOS (Apple Silicon)" /></a>
-      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.15/CodeBurn-0.9.15.dmg"><img src="https://img.shields.io/badge/macOS-Intel-F97316?logo=apple&logoColor=white" alt="Download for macOS (Intel)" /></a>
-      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.15/CodeBurn-0.9.15.AppImage"><img src="https://img.shields.io/badge/Linux-AppImage-F97316?logo=linux&logoColor=white" alt="Download for Linux" /></a>
-      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.15/CodeBurn-Setup-0.9.15.exe"><img src="https://img.shields.io/badge/Windows-Setup-F97316?logoColor=white" alt="Download for Windows" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-0.9.16-arm64.dmg"><img src="https://img.shields.io/badge/macOS-Apple_Silicon-F97316?logo=apple&logoColor=white" alt="Download for macOS (Apple Silicon)" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-0.9.16.dmg"><img src="https://img.shields.io/badge/macOS-Intel-F97316?logo=apple&logoColor=white" alt="Download for macOS (Intel)" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-0.9.16.AppImage"><img src="https://img.shields.io/badge/Linux-AppImage-F97316?logo=linux&logoColor=white" alt="Download for Linux" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-Setup-0.9.16.exe"><img src="https://img.shields.io/badge/Windows-Setup-F97316?logoColor=white" alt="Download for Windows" /></a>
     </td>
     <td align="center" width="50%">
       <strong>Web</strong><br/>

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codeburn-desktop",
   "private": true,
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "CodeBurn Desktop \u2014 Electron app fed by the codeburn CLI",
   "main": "dist/electron/main.js",
   "scripts": {


### PR DESCRIPTION
Desktop app version bump to 0.9.16 (the published desktop-v0.9.16 assets were built from this bump) and the README hero download badges now point at the new release. Menubar zip already shipped via CI on the mac-v0.9.16 tag; Homebrew tap updated and checksum-verified.