### PR TITLE
desktop: ship .deb and .rpm for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@
       <img src="https://raw.githubusercontent.com/getagentseal/codeburn/main/assets/desktop.jpg" alt="CodeBurn Desktop" /><br/>
       <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-0.9.16-arm64.dmg"><img src="https://img.shields.io/badge/macOS-Apple_Silicon-F97316?logo=apple&logoColor=white" alt="Download for macOS (Apple Silicon)" /></a>
       <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-0.9.16.dmg"><img src="https://img.shields.io/badge/macOS-Intel-F97316?logo=apple&logoColor=white" alt="Download for macOS (Intel)" /></a>
-      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-0.9.16.AppImage"><img src="https://img.shields.io/badge/Linux-AppImage-F97316?logo=linux&logoColor=white" alt="Download for Linux" /></a>
       <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-Setup-0.9.16.exe"><img src="https://img.shields.io/badge/Windows-Setup-F97316?logoColor=white" alt="Download for Windows" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/codeburn-desktop_0.9.16_amd64.deb"><img src="https://img.shields.io/badge/Linux-.deb-F97316?logo=debian&logoColor=white" alt="Download for Linux (.deb)" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/codeburn-desktop-0.9.16.x86_64.rpm"><img src="https://img.shields.io/badge/Linux-.rpm-F97316?logo=redhat&logoColor=white" alt="Download for Linux (.rpm)" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-0.9.16.AppImage"><img src="https://img.shields.io/badge/Linux-AppImage-F97316?logo=linux&logoColor=white" alt="Download for Linux (AppImage)" /></a>
     </td>
     <td align="center" width="50%">
       <strong>Web</strong><br/>

--- a/app/package.json
+++ b/app/package.json
@@ -107,6 +107,18 @@
           "arch": [
             "x64"
           ]
+        },
+        {
+          "target": "deb",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "rpm",
+          "arch": [
+            "x64"
+          ]
         }
       ],
       "category": "Development",
@@ -114,5 +126,7 @@
       "maintainer": "AgentSeal <hello@agentseal.org>",
       "executableName": "codeburn"
     }
-  }
+  },
+  "homepage": "https://github.com/getagentseal/codeburn",
+  "author": "AgentSeal <hello@agentseal.org>"
 }


### PR DESCRIPTION
Linux users on the AppImage-only build hit a no-application-installed error on double-click: AppImages do not self-register and need chmod plus libfuse2 on Ubuntu 22.04+/Debian 12. This adds native packages that avoid all of that.

- electron-builder now targets AppImage + deb + rpm for Linux (adds a homepage/description/author to app/package.json, which fpm requires). The deb was verified to ship /usr/share/applications/codeburn.desktop, so it appears in the app menu with no manual steps, and bundles the CLI as before.
- Both artifacts built locally and attached to the desktop-v0.9.16 release (codeburn-desktop_0.9.16_amd64.deb, codeburn-desktop-0.9.16.x86_64.rpm).
- README hero grid lists Debian/.deb, Fedora/.rpm, and AppImage next to macOS and Windows; release notes now explain the deb/rpm install path and the AppImage FUSE requirement.
- package:linux emits all three automatically for future releases.