### PR TITLE
chore(app): desktop 0.9.17

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codeburn-desktop",
   "private": true,
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "CodeBurn Desktop \u2014 Electron app fed by the codeburn CLI",
   "main": "dist/electron/main.js",
   "scripts": {


### PR DESCRIPTION
Version bump for the desktop patch release: Windows CLI fix (#733), enriched cli_error telemetry, solid-flame brand (#732). Desktop-only; CLI/menubar remain 0.9.16.