### PR TITLE
fix: clean build stamp + splash without hash + About update check

### DIFF
--- a/app/renderer/components/AboutModal.test.tsx
+++ b/app/renderer/components/AboutModal.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AboutModal } from './AboutModal'
+import type { UpdateStatus } from '../lib/types'
+
+const mocks = vi.hoisted(() => ({
+  getUpdateStatus: vi.fn<() => Promise<UpdateStatus>>(),
+  onUpdateStatus: vi.fn<(cb: (s: UpdateStatus) => void) => () => void>(() => () => {}),
+  openExternal: vi.fn<(url: string) => Promise<void>>(),
+}))
+vi.mock('../lib/ipc', async orig => {
+  const actual = await orig<typeof import('../lib/ipc')>()
+  return { ...actual, codeburn: mocks }
+})
+
+const NEWER: UpdateStatus = { currentVersion: '0.9.16', latestVersion: '0.9.17', updateAvailable: true, tag: 'desktop-v0.9.17' }
+const SAME: UpdateStatus = { currentVersion: '0.9.17', latestVersion: '0.9.17', updateAvailable: false, tag: null }
+const UNKNOWN: UpdateStatus = { currentVersion: '0.9.17', latestVersion: null, updateAvailable: false, tag: null }
+
+function renderAbout() {
+  return render(<AboutModal socials={[]} onClose={() => {}} />)
+}
+
+describe('AboutModal update check', () => {
+  beforeEach(() => {
+    mocks.getUpdateStatus.mockReset()
+    mocks.openExternal.mockReset().mockResolvedValue(undefined)
+    mocks.onUpdateStatus.mockReset().mockReturnValue(() => {})
+  })
+  afterEach(cleanup)
+
+  it('shows no note until the button is clicked', async () => {
+    mocks.getUpdateStatus.mockResolvedValue(SAME)
+    renderAbout()
+    await waitFor(() => expect(mocks.getUpdateStatus).toHaveBeenCalled())
+    expect(screen.queryByText(/latest version/i)).toBeNull()
+  })
+
+  it('reports up to date on the current version', async () => {
+    mocks.getUpdateStatus.mockResolvedValue(SAME)
+    renderAbout()
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }))
+    expect(await screen.findByText("You're on the latest version")).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Download' })).toBeNull()
+  })
+
+  it('reports an available update with a Download link that opens the release page', async () => {
+    mocks.getUpdateStatus.mockResolvedValue(NEWER)
+    renderAbout()
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }))
+
+    const note = await screen.findByRole('status')
+    expect(note).toHaveTextContent('Update available: 0.9.17')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download' }))
+    expect(mocks.openExternal).toHaveBeenCalledWith('https://github.com/getagentseal/codeburn/releases/tag/desktop-v0.9.17')
+  })
+
+  it('degrades gracefully when the status is unknown (offline)', async () => {
+    mocks.getUpdateStatus.mockResolvedValue(UNKNOWN)
+    renderAbout()
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }))
+    expect(await screen.findByText('Unable to check right now')).toBeInTheDocument()
+  })
+})

--- a/app/renderer/components/AboutModal.tsx
+++ b/app/renderer/components/AboutModal.tsx
@@ -1,8 +1,9 @@
-import { useEffect, type MouseEvent, type ReactNode } from 'react'
+import { useEffect, useState, type MouseEvent, type ReactNode } from 'react'
 
 import { version } from '../../package.json'
 import { FlameMark } from './FlameMark'
 import { BUILD_STAMP } from '../lib/build'
+import { releasePageUrl, useUpdateStatus } from '../hooks/useUpdateStatus'
 import { codeburn } from '../lib/ipc'
 
 export type SocialLink = {
@@ -11,14 +12,15 @@ export type SocialLink = {
   icon: ReactNode
 }
 
-const RELEASES_URL = 'https://github.com/getagentseal/codeburn/releases'
-
 function openExternal(event: MouseEvent<HTMLAnchorElement>, url: string): void {
   event.preventDefault()
   void codeburn.openExternal(url)
 }
 
 export function AboutModal({ socials, onClose }: { socials: SocialLink[]; onClose: () => void }) {
+  const status = useUpdateStatus()
+  const [checked, setChecked] = useState(false)
+
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') onClose()
@@ -67,10 +69,30 @@ export function AboutModal({ socials, onClose }: { socials: SocialLink[]; onClos
               <button
                 className="about-modal-update-button"
                 type="button"
-                onClick={() => { void codeburn.openExternal(RELEASES_URL) }}
+                onClick={() => setChecked(true)}
               >
                 Check for updates
               </button>
+              {checked && (
+                <p className="about-modal-update-note" role="status">
+                  {status?.updateAvailable && status.tag ? (
+                    <>
+                      Update available: {status.latestVersion} ·{' '}
+                      <button
+                        type="button"
+                        className="set-text-button"
+                        onClick={() => { void codeburn.openExternal(releasePageUrl(status.tag!)) }}
+                      >
+                        Download
+                      </button>
+                    </>
+                  ) : status?.latestVersion ? (
+                    "You're on the latest version"
+                  ) : (
+                    'Unable to check right now'
+                  )}
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/app/renderer/components/Splash.tsx
+++ b/app/renderer/components/Splash.tsx
@@ -6,7 +6,6 @@ import { ProviderLogo } from './ProviderLogo'
 import { motionClass, motionEnabled, reducedMotion } from '../lib/motion'
 import { codeburn } from '../lib/ipc'
 import type { ScanProgressEvent } from '../lib/types'
-import { BUILD_STAMP } from '../lib/build'
 import { version } from '../../package.json'
 import loaderVideo from '../assets/splash-loader.webm'
 
@@ -165,7 +164,6 @@ export function Splash({ hasData, hasError }: { hasData: boolean; hasError: bool
       )}
       <div className="splash-word">CodeBurn</div>
       <div className="splash-version">v{version}</div>
-      <div className="splash-build">{BUILD_STAMP}</div>
       {showDetail && <SplashStatus progress={progress} />}
     </div>,
     document.body,

--- a/app/renderer/styles/plain.css
+++ b/app/renderer/styles/plain.css
@@ -187,6 +187,7 @@ body { overflow: hidden; background: var(--bg); color: var(--ink); }
   background: var(--panel); color: var(--ink); font: inherit; font-size: 11.5px; font-weight: 540; cursor: pointer;
 }
 .about-modal-update-button:hover { border-color: var(--accent); color: var(--accent); }
+.about-modal-update-note { margin-top: 9px; color: var(--mut); font-size: 11.5px; line-height: 1.4; }
 .about-modal-credit {
   padding: 13px 18px; border-top: 1px solid var(--line2); color: var(--mut2);
   font-size: 10.5px; text-align: center;
@@ -895,9 +896,6 @@ html.page-hidden *::after {
 }
 .splash-version {
   margin-top: 2px; font-size: var(--fs-label); font-weight: var(--fw-body); color: #b3a595;
-}
-.splash-build {
-  margin-top: 1px; font-size: var(--fs-label); font-weight: var(--fw-body); color: #6f665c; font-variant-numeric: tabular-nums;
 }
 
 .splash-lit .splash-mark {

--- a/app/scripts/buildStamp.test.ts
+++ b/app/scripts/buildStamp.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { GENERATED_DATA_FILES, isDirtyIgnoringGenerated } from './buildStamp'
+
+describe('isDirtyIgnoringGenerated', () => {
+  it('reads clean on an empty status', () => {
+    expect(isDirtyIgnoringGenerated('')).toBe(false)
+    expect(isDirtyIgnoringGenerated('\n')).toBe(false)
+  })
+
+  it('reads clean when only the regenerated pricing snapshots differ', () => {
+    const porcelain = GENERATED_DATA_FILES.map(f => ` M ${f}`).join('\n')
+    expect(isDirtyIgnoringGenerated(porcelain)).toBe(false)
+  })
+
+  it('reads clean for a single regenerated data file', () => {
+    expect(isDirtyIgnoringGenerated(' M src/data/litellm-snapshot.json')).toBe(false)
+  })
+
+  it('reads dirty when a source file also differs', () => {
+    const porcelain = ' M src/data/litellm-snapshot.json\n M app/renderer/components/AboutModal.tsx'
+    expect(isDirtyIgnoringGenerated(porcelain)).toBe(true)
+  })
+
+  it('reads dirty for a staged source change', () => {
+    expect(isDirtyIgnoringGenerated('M  src/cli.ts')).toBe(true)
+  })
+
+  it('reads dirty for an untracked file', () => {
+    expect(isDirtyIgnoringGenerated('?? some-new-file.ts')).toBe(true)
+  })
+
+  it('counts a rename by its destination path', () => {
+    expect(isDirtyIgnoringGenerated('R  old/path.ts -> src/data/other.ts')).toBe(true)
+  })
+})

--- a/app/scripts/buildStamp.ts
+++ b/app/scripts/buildStamp.ts
@@ -1,0 +1,33 @@
+// The build stamp's dirty check, factored out so it is unit-testable.
+//
+// Packaging regenerates the pricing-snapshot files from a live feed
+// (scripts/bundle-litellm.mjs) DURING the build, so an otherwise-clean release
+// checkout shows those two tracked files as modified at stamp time. Treating that
+// as "-dirty" is a false positive: the committed source is clean. The dirty flag
+// must therefore ignore exactly these regenerated files.
+
+/** Tracked files the packaging build rewrites from a live feed. Changes limited
+ *  to these must NOT flip the build stamp to "-dirty". */
+export const GENERATED_DATA_FILES = [
+  'src/data/litellm-snapshot.json',
+  'src/data/pricing-fallback.json',
+]
+
+/**
+ * True when `git status --porcelain` reports any change OTHER than the
+ * regenerated pricing snapshots. Porcelain lines are `XY <path>` (path from
+ * column 3); a rename is `XY old -> new`, counted by its destination. Quoted
+ * paths (special chars) are unquoted before comparison.
+ */
+export function isDirtyIgnoringGenerated(porcelain: string): boolean {
+  const generated = new Set(GENERATED_DATA_FILES)
+  for (const line of porcelain.split('\n')) {
+    if (!line.trim()) continue
+    let path = line.slice(3).trim()
+    const arrow = path.indexOf(' -> ')
+    if (arrow !== -1) path = path.slice(arrow + 4)
+    path = path.replace(/^"(.*)"$/, '$1')
+    if (!generated.has(path)) return true
+  }
+  return false
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -16,5 +16,5 @@
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["renderer", "electron", "vite.config.ts", "vitest.config.ts"]
+  "include": ["renderer", "electron", "scripts", "vite.config.ts", "vitest.config.ts"]
 }

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -3,16 +3,19 @@ import { execSync } from 'node:child_process'
 import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// Build stamp baked in at package/build time so About + the splash footer can
-// name the exact commit running. Best-effort: a non-git checkout still builds.
+import { isDirtyIgnoringGenerated } from './scripts/buildStamp'
+
+// Build stamp baked in at package/build time so the About modal can name the
+// exact commit running. Best-effort: a non-git checkout still builds.
 function buildStamp(): { sha: string; date: string } {
   let sha = 'unknown'
   try {
     sha = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim() || 'unknown'
     // A build off a dirty tree (local fix build) must never read as the clean
     // release of the same commit — that ambiguity is exactly what a build stamp
-    // exists to kill.
-    if (execSync('git status --porcelain', { encoding: 'utf8' }).trim()) sha += '-dirty'
+    // exists to kill. But packaging regenerates the pricing snapshots mid-build,
+    // so ignore those: a change limited to them is not a dirty source tree.
+    if (isDirtyIgnoringGenerated(execSync('git status --porcelain', { encoding: 'utf8' }))) sha += '-dirty'
   } catch { /* not a git checkout */ }
   return { sha, date: new Date().toISOString().slice(0, 10) }
 }

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
     environment: 'node',
     globals: false,
     setupFiles: ['./renderer/test/setup.ts'],
-    include: ['renderer/**/*.test.{ts,tsx}', 'electron/**/*.test.ts'],
+    include: ['renderer/**/*.test.{ts,tsx}', 'electron/**/*.test.ts', 'scripts/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
Kills the false -dirty (ignore regenerated pricing snapshots), removes the commit-hash line from the splash (keeps it in About, clean), and wires About 'Check for updates' to the in-app checker with inline status. 392/392.