### PR TITLE
docs: desktop release flow + Linux build targets

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 This document describes the actual steps a maintainer takes to cut a CLI or macOS menubar release. CLI releases are run by hand with `npm publish`; macOS menubar releases are automated by `.github/workflows/release-menubar.yml` when a `mac-v*` tag is pushed.
 
-The Electron desktop app (`app/`) is not part of either flow yet — it has no version tag pattern or CI automation. See `app/DISTRIBUTION.md` for how to build and distribute it as an ad-hoc-signed, non-notarized macOS build.
+The Electron desktop app (`app/`) has no CI automation yet, but it is released manually under `desktop-v<version>` tags: build the artifacts on a macOS host (see `app/DISTRIBUTION.md`) and `gh release upload desktop-v<version> … --clobber` them onto the release. See `app/DISTRIBUTION.md` for how to build and distribute it as an ad-hoc-signed, non-notarized macOS build (plus unsigned Windows and Linux builds).
 
 ## Versioning
 

--- a/app/DISTRIBUTION.md
+++ b/app/DISTRIBUTION.md
@@ -69,6 +69,23 @@ npm --prefix app run package:win      # Windows NSIS installer, x64
 npm --prefix app run package:linux    # Linux AppImage, x64
 ```
 
+The Linux targets and arches can be widened by calling `electron-builder`
+directly, all from the same macOS host:
+
+```sh
+cd app
+npx electron-builder --linux AppImage deb        # x64 AppImage + deb
+npx electron-builder --linux AppImage deb --x64  # force x64 on an arm64 mac
+npx electron-builder --linux AppImage deb --arm64
+npx electron-builder --linux rpm --x64           # rpm; needs `brew install rpm` (rpmbuild)
+```
+
+The `rpm` target is the only one with an extra prerequisite — `fpm` (bundled by
+electron-builder) shells out to `rpmbuild`, so `brew install rpm` must be present
+or the build fails with "executable rpmbuild is required". It emits
+`codeburn-desktop-<version>.x86_64.rpm`, the name the website's Fedora/RHEL
+download links.
+
 `package` runs `npm run stage-cli` (rebuilds the root CLI and stages the
 self-contained bundle into `app/build/cli`; see "The bundled CLI" above), then
 `npm run build` (compiles `electron/` with `tsc`, builds the renderer with


### PR DESCRIPTION
Corrects two stale claims: the desktop app IS released manually (under `desktop-v<version>` tags), and Linux builds cover deb/rpm/both arches from a macOS host, with the rpm caveat that it needs `brew install rpm`.