### PR TITLE
fix(classifier): attribute skills to skillBreakdown regardless of turn category

### DIFF
--- a/src/classifier.ts
+++ b/src/classifier.ts
@@ -208,10 +208,8 @@ export function classifyTurn(turn: ParsedTurn): ClassifiedTurn {
 
   const result: ClassifiedTurn = { ...turn, category, retries: countRetries(turn), hasEdits: turnHasEdits(turn) }
 
-  if (category === 'general') {
-    const skills = getAllSkills(turn)
-    if (skills.length > 0) result.subCategory = skills[0]
-  }
+  const skills = getAllSkills(turn)
+  if (skills.length > 0) result.subCategory = skills[0]
 
   return result
 }

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -141,7 +141,7 @@ export const DURABLE_PROVIDER_NAMES: ReadonlySet<string> = new Set(['copilot'])
 // re-parse, which lands the flag too, and durable orphans now survive
 // fingerprint changes (the carry-forward in getOrCreateProviderSection).
 export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
-  claude: 'advisor-usage-v1',
+  claude: 'advisor-usage-v1-skills',
   cline: 'worktree-project-grouping-v1',
   codewhale: 'aggregate-session-v1-est-cost',
   // Bump when the Codex parser changes attribution so unchanged, already-cached

--- a/tests/classifier.test.ts
+++ b/tests/classifier.test.ts
@@ -79,11 +79,11 @@ describe('classifyTurn — Skill subCategory', () => {
     expect(c.subCategory).toBeUndefined()
   })
 
-  it('does not attach subCategory when category is not general (e.g. Skill alongside Edit promotes to coding)', () => {
+  it('attaches subCategory without changing the category when Skill fires alongside Edit', () => {
     const turn = makeTurn([makeCall({ tools: ['Skill', 'Edit'], skills: ['init'] })])
     const c = classifyTurn(turn)
     expect(c.category).toBe('coding')
-    expect(c.subCategory).toBeUndefined()
+    expect(c.subCategory).toBe('init')
   })
 
   it('does not attach subCategory for non-Skill general turns', () => {

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -455,3 +455,36 @@ describe('(f) durable orphans survive a parse-version bump', () => {
     expect(again).toBe(200)
   })
 })
+
+// ═══════════════════════════════════════════════════════════════════════════
+// (g) Skill attribution is independent of turn category
+// ═══════════════════════════════════════════════════════════════════════════
+describe('(g) skill attribution is independent of turn category', () => {
+  it('puts a Skill + Edit turn in skillBreakdown while preserving coding category', async () => {
+    const synthFile = join(tmpHome, 'synth-skill.txt')
+    await writeFile(synthFile, 'placeholder')
+
+    _synthSources = [{ path: synthFile, project: 'test', provider: 'test-synthetic' }]
+    _synthYields = [{
+      provider: 'test-synthetic', model: 'gpt-4o',
+      inputTokens: 10, outputTokens: 5,
+      cacheCreationInputTokens: 0, cacheReadInputTokens: 0,
+      cachedInputTokens: 0, reasoningTokens: 0, webSearchRequests: 0,
+      costUSD: 0.001, tools: ['Skill', 'Edit'], bashCommands: [],
+      skills: ['telemetry-review'],
+      timestamp: '2026-07-18T12:00:00.000Z',
+      speed: 'standard',
+      deduplicationKey: 'synth-skill-edit',
+      userMessage: '', sessionId: 'synth-skill-session',
+    }]
+
+    const projects = await parseAllSessions(undefined, 'test-synthetic')
+    const session = projects.flatMap(project => project.sessions)[0]
+
+    expect(session).toBeDefined()
+    expect(session!.turns[0]!.category).toBe('coding')
+    expect(session!.turns[0]!.subCategory).toBe('telemetry-review')
+    expect(session!.categoryBreakdown.coding.turns).toBe(1)
+    expect(session!.skillBreakdown['telemetry-review']?.turns).toBe(1)
+  })
+})


### PR DESCRIPTION
Part of #741 (the "skills came back empty in all 25 snapshots" item).

## Root cause

`skillBreakdown` is populated exclusively from `turn.subCategory` (src/parser.ts ~1368), and the classifier only set `subCategory` when the turn classified as `general` (src/classifier.ts ~211). `classifyByToolPattern` checks `hasSkill` last, so any turn that invoked the Skill tool alongside Read/Bash/Edit/MCP/search got a real category (coding, exploration, delegation, ...) and its skill attribution was silently dropped. Skill invocations virtually always trigger other tools in the same turn, hence skills empty in every snapshot while `mcpServers` (populated unconditionally per call) worked.

Verified end to end before the fix on a skills-heavy profile (dozens of Claude Code skills, 11 session files with real `Skill` tool_use in the last 7 days): `status --format menubar-json --period today` returned `mcpServers` populated and `skills: []`.

## Fix

- `subCategory` is now set for any turn whose calls carry Skill tool_use, regardless of the category assigned. Category computation is untouched (the Skill+Edit fixture still classifies as `coding`, now with `subCategory` populated).
- `PROVIDER_PARSE_VERSIONS.claude` bumped to `advisor-usage-v1-skills` so cached session summaries (which lack skill attribution) re-parse on upgrade.

## Validation

- New tests: Skill+Edit turn lands in `skillBreakdown` under the skill name while keeping the `coding` category (classifier and parser level); Skill-only and no-skill turns unchanged.
- Real-data check after the fix on the same profile: weekly menubar payload now returns non-empty `skills` with positive turn counts.
- `npx tsc --noEmit` clean; classifier, parser, and full `tests/` suites green.

## Known follow-up (out of scope here)

The TUI dashboard's By Activity panel nests skill sub-rows under the `general` category row only (src/dashboard.tsx ~486). With skills now attributed across categories, that panel can omit skill rows when no `general` turns exist. Data is correct (the dedicated Skills & Agents panel reads `skillBreakdown` directly); it is a small display follow-up if you want the sub-rows relocated.
