### PR TITLE
fix(yield): case-insensitive canonical repo grouping via realpathSync.native

### DIFF
--- a/src/yield.ts
+++ b/src/yield.ts
@@ -71,7 +71,7 @@ type RepoIdentity = {
 
 function canonicalPath(path: string): string {
   try {
-    return realpathSync(path)
+    return realpathSync.native(path)
   } catch {
     return path
   }
@@ -110,6 +110,9 @@ function resolveRepoIdentity(
       // common-dir as a realpath but the main worktree's as ".git" relative to
       // its (possibly symlinked) path, so both must be canonicalized to collapse
       // to one key.
+      // Accepted residual: moving the main repo after `git worktree add` leaves
+      // Git's linked-worktree metadata stale, so its worktrees may not unify;
+      // that is Git-state staleness, not a grouping bug.
       identity = { key: canonicalPath(resolve(dir, commonDir)), gitDir: dir }
     }
   }

--- a/tests/yield-repo-grouping.test.ts
+++ b/tests/yield-repo-grouping.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -81,6 +82,38 @@ const broadWindow = {
 }
 
 describe('yield repo grouping by canonical repository identity (issue #713)', () => {
+  it('groups path casing variants on case-insensitive filesystems', async () => {
+    const repoDir = await mkdtemp(join(tmpdir(), 'codeburn-yield-path-case-'))
+    try {
+      initRepo(repoDir)
+      await writeFile(join(repoDir, 'file.txt'), 'hello\n')
+      commitAt(repoDir, 'feat: shipped once', '2026-01-01T10:30:00Z')
+
+      const caseAlteredRepoDir = join(repoDir, '..', repoDir.split('/').pop()!.toUpperCase())
+      if (!existsSync(caseAlteredRepoDir)) return
+
+      const sessionOriginal = makeSession({ sessionId: 'case-original', project: 'app', ...tightWindow, totalCostUSD: 5 })
+      const sessionAltered = makeSession({ sessionId: 'case-altered', project: 'app', ...broadWindow, totalCostUSD: 3 })
+
+      parseAllSessionsMock.mockResolvedValue([
+        { project: 'app', projectPath: repoDir, sessions: [sessionOriginal] } as ProjectSummary,
+        { project: 'app', projectPath: caseAlteredRepoDir, sessions: [sessionAltered] } as ProjectSummary,
+      ])
+
+      const summary = await computeYield(range, repoDir)
+
+      const productive = summary.details.filter(d => d.category === 'productive')
+      expect(productive.map(d => d.sessionId)).toEqual(['case-original'])
+      expect(productive[0]!.commitCount).toBe(1)
+
+      const detailAltered = summary.details.find(d => d.sessionId === 'case-altered')!
+      expect(detailAltered.category).toBe('ambiguous')
+      expect(detailAltered.commitCount).toBe(0)
+    } finally {
+      await rm(repoDir, { recursive: true, force: true })
+    }
+  })
+
   it('credits one commit once across two monorepo subdirectory sessions', async () => {
     const repoDir = await mkdtemp(join(tmpdir(), 'codeburn-yield-monorepo-'))
     try {


### PR DESCRIPTION
The focused follow-up you invited in the #714 discussion, covering the two deltas over #719 — one of which turned out to be a live gap, not just missing coverage.

## Case-insensitivity was not actually covered

`fs.realpathSync` preserves the caller's path casing; only `fs.realpathSync.native` returns the on-disk casing. Verified empirically on macOS APFS:

```
fs.realpathSync('/tmp/CASETESTDIR')        -> /private/tmp/CASETESTDIR   (input casing kept)
fs.realpathSync.native('/tmp/CASETESTDIR') -> /private/tmp/CaseTestDir   (on-disk casing)
```

So #719's canonicalization still produced distinct keys for the same repo reached through differently cased paths (a shell tab-completed path vs a tool-emitted lowercase path, for example), splitting one repo into separate groups on macOS and Windows. The fix is the one-line switch to `realpathSync.native` inside the existing try/catch (failure fallback semantics unchanged), plus a regression test that creates a real repo, references it through altered casing, and asserts a single group — guarded so it only asserts strict equality on filesystems that are actually case-insensitive.

## The documented residual

The second delta from #714's writeup, now a short comment at the canonicalization site: a main repo moved on disk after `git worktree add` leaves git's own linked-worktree metadata stale, so its worktrees may not unify. That is git-state staleness, not a grouping bug.

`npx tsc --noEmit` clean, yield grouping suite green (4/4). Closes the delta discussed in #714.
