### PR TITLE
chore: release 0.9.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.9.18 - 2026-07-20
+
+One version across every surface again: CLI, macOS menubar, and the desktop app all ship as 0.9.18.
+
+### Accuracy
+- **Every surface now shows the same numbers.** CLI, TUI, menubar, desktop app, and web dashboard totals all come from one durable aggregation path and match exactly, including history whose session logs have since been deleted; the terminal overview notes how much was preserved from expired logs. (#755, #760, #759)
+- **Never lose history again.** The daily cache carries forward every (day, provider) slice a re-parse can no longer derive, and adopts days from older cache generations instead of wiping them on schema changes. (#755)
+- **True Lifetime period** on the CLI, dashboard, desktop app, and menubar. The desktop tab formerly labeled "All time" showed a 6-month window; it now says "Last 6 months", and Lifetime is the real all-time view. (#753, #759)
+- Yield repo grouping is case-correct on macOS/Windows; skills usage is attributed regardless of turn category; daily-activity history scans are bounded. (#751, #745, #727)
+
+### Added (CLI)
+- **Quick Desktop provider** — Amazon Quick Desktop usage from `~/.quickwork`, with real metered costs and multi-profile discovery. (#735, thanks @gjmveloso, @Enclavet)
+- **Kimi Code provider** — Kimi Code CLI (kimi-k3) wire sessions from `~/.kimi-code`. (#750, #747)
+- **Workflow intelligence** in `optimize` and the payload: user-correction rate, median time to first edit, most-reworked files, pricing coverage, and coaching notes. (#756)
+- **Richer session capture**: git branch, lines added/removed (counted from diffs, never stored as text), interruptions, tool errors, session titles, and PR links now land in the local cache for upcoming per-branch and code-impact reports. (#758)
+- Provider-agnostic quota window model with provenance; `doctor` warns when transcript retention is about to expire history. (#740, #757)
+
+### Performance
+- Large-line session parsing is ~2x faster (single-pass field extraction), and files that grew by append are parsed incrementally from the cached offset instead of from byte 0. (#752, #749)
+
+### Desktop app
+- **Windows fixed**: the CLI is now found on every Windows install (path handling was POSIX-only, breaking 100% of Windows installs). (#733)
+- **In-app update notifications** and an About-dialog update check; this is the first release existing 0.9.17 installs will be notified about. (#722, #738)
+- Faster and calmer on data-heavy machines: CLI spawns are capped and prioritized so clicks never queue behind background work, provider prefetch is paced, and the default period is Today. (#748)
+- Telemetry (opt-in, anonymous) reports per-provider spend buckets, richer error detail with a per-kind daily cap, and a reliable session-close beat. (#736, #742, #746)
+
+### Menubar
+- Codex quota windows show linear pace: deficit/reserve, projection, and run-out ETA. (#728, #726)
+
 ## 0.9.15 - 2026-07-02
 
 ### Added (CLI)

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeburn-desktop",
-  "version": "0.1.0",
+  "version": "0.9.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeburn-desktop",
-      "version": "0.1.0",
+      "version": "0.9.18",
       "dependencies": {
         "@gsap/react": "^2.1.2",
         "gsap": "^3.15.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,8 +1,8 @@
 {
   "name": "codeburn-desktop",
   "private": true,
-  "version": "0.9.17",
-  "description": "CodeBurn Desktop \u2014 Electron app fed by the codeburn CLI",
+  "version": "0.9.18",
+  "description": "CodeBurn Desktop — Electron app fed by the codeburn CLI",
   "main": "dist/electron/main.js",
   "scripts": {
     "build:electron": "tsc -p tsconfig.electron.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeburn",
-  "version": "0.9.15",
+  "version": "0.9.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeburn",
-      "version": "0.9.15",
+      "version": "0.9.18",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeburn",
-  "version": "0.9.16",
+  "version": "0.9.18",
   "description": "See where your AI spend goes - by task, tool, model, and project",
   "type": "module",
   "main": "./dist/cli.js",


### PR DESCRIPTION
Version bump to 0.9.18 across CLI and desktop app (menubar shares the CLI semver), plus the changelog for everything since 0.9.16. Release steps after merge: npm publish, v0.9.18 + mac-v0.9.18 tags, desktop build + upload, Homebrew tap bump.