### PR TITLE
currency: honor CODEBURN_CACHE_DIR for the exchange-rate cache

### DIFF
--- a/src/currency.ts
+++ b/src/currency.ts
@@ -73,7 +73,10 @@ export function roundForActiveCurrency(value: number): number {
 }
 
 function getCacheDir(): string {
-  return join(homedir(), '.cache', 'codeburn')
+  // Honor the same relocation override every other cache module uses
+  // (session-cache, daily-cache, codex-cache, models); this was the one
+  // straggler still hardcoding the default path.
+  return process.env['CODEBURN_CACHE_DIR'] ?? join(homedir(), '.cache', 'codeburn')
 }
 
 function getRateCachePath(): string {


### PR DESCRIPTION
Found by the pre-release functional sweep: currency.ts was the only cache module ignoring CODEBURN_CACHE_DIR, so relocating the cache dir left exchange-rate.json behind in the default location. One line, aligned with session-cache/daily-cache/codex-cache/models. Suite green.