### PR TITLE
docs: complete 0.9.18 release notes and README links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ One version across every surface again: CLI, macOS menubar, and the desktop app 
 - **Never lose history again.** The daily cache carries forward every (day, provider) slice a re-parse can no longer derive, and adopts days from older cache generations instead of wiping them on schema changes. (#755)
 - **True Lifetime period** on the CLI, dashboard, desktop app, and menubar. The desktop tab formerly labeled "All time" showed a 6-month window; it now says "Last 6 months", and Lifetime is the real all-time view. (#753, #759)
 - Yield repo grouping is case-correct on macOS/Windows; skills usage is attributed regardless of turn category; daily-activity history scans are bounded. (#751, #745, #727)
+- **Days before recorded history render as "No data recorded"**, never as a currency zero, in the desktop heatmap, daily charts, and web dashboard. Genuinely idle days keep their true zeros. (#765)
+- Incremental append parsing falls back to a full re-parse when a streamed assistant message restates across the append boundary, fixing a rare over-count on image-heavy sessions. (#772)
+- Turn-level stats (edit turns, one-shot, category counts) attribute to exactly one provider slice, so per-provider sums always equal day totals. (#762, thanks @ozymandiashh)
+- Workflow-intelligence accuracy pass from review: corrections count only follow-up prompts, file-churn paths are separator-normalized so the payload's basename privacy redaction works on Windows, pricing coverage excludes deliberately-free local models and reports null (never a fabricated 100%) when not computable, and time-to-first-edit is null rather than mismeasured on unparseable timestamps. (#763, review by @ozymandiashh)
+- Daily-history retention extended from 2 to 10 years so carried days can never age out of the durable record; quota pace guards non-finite inputs; the exchange-rate cache honors CODEBURN_CACHE_DIR. (#764, #766)
 
 ### Added (CLI)
 - **Quick Desktop provider** — Amazon Quick Desktop usage from `~/.quickwork`, with real metered costs and multi-profile discovery. (#735, thanks @gjmveloso, @Enclavet)
@@ -19,6 +24,7 @@ One version across every surface again: CLI, macOS menubar, and the desktop app 
 
 ### Performance
 - Large-line session parsing is ~2x faster (single-pass field extraction), and files that grew by append are parsed incrementally from the cached offset instead of from byte 0. (#752, #749)
+- **Concurrent CLI, menubar, and MCP processes can no longer clobber each other's cache work**: the warm session-cache refresh runs under a strict cross-process gate with heartbeat, staleness takeover, and a publication fence; a timed-out waiter serves the prior complete snapshot read-only instead of racing. (#743, thanks @avs-io)
 
 ### Desktop app
 - **Windows fixed**: the CLI is now found on every Windows install (path handling was POSIX-only, breaking 100% of Windows installs). (#733)

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@
     <td align="center" width="50%">
       <strong>Desktop</strong><br/>
       <img src="https://raw.githubusercontent.com/getagentseal/codeburn/main/assets/desktop.jpg" alt="CodeBurn Desktop" /><br/>
-      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-0.9.16-arm64.dmg"><img src="https://img.shields.io/badge/macOS-Apple_Silicon-F97316?logo=apple&logoColor=white" alt="Download for macOS (Apple Silicon)" /></a>
-      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-0.9.16.dmg"><img src="https://img.shields.io/badge/macOS-Intel-F97316?logo=apple&logoColor=white" alt="Download for macOS (Intel)" /></a>
-      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-Setup-0.9.16.exe"><img src="https://img.shields.io/badge/Windows-Setup-F97316?logoColor=white" alt="Download for Windows" /></a>
-      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/codeburn-desktop_0.9.16_amd64.deb"><img src="https://img.shields.io/badge/Linux-.deb-F97316?logo=debian&logoColor=white" alt="Download for Linux (.deb)" /></a>
-      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/codeburn-desktop-0.9.16.x86_64.rpm"><img src="https://img.shields.io/badge/Linux-.rpm-F97316?logo=redhat&logoColor=white" alt="Download for Linux (.rpm)" /></a>
-      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.16/CodeBurn-0.9.16.AppImage"><img src="https://img.shields.io/badge/Linux-AppImage-F97316?logo=linux&logoColor=white" alt="Download for Linux (AppImage)" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.18/CodeBurn-0.9.18-arm64.dmg"><img src="https://img.shields.io/badge/macOS-Apple_Silicon-F97316?logo=apple&logoColor=white" alt="Download for macOS (Apple Silicon)" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.18/CodeBurn-0.9.18.dmg"><img src="https://img.shields.io/badge/macOS-Intel-F97316?logo=apple&logoColor=white" alt="Download for macOS (Intel)" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.18/CodeBurn-Setup-0.9.18.exe"><img src="https://img.shields.io/badge/Windows-Setup-F97316?logoColor=white" alt="Download for Windows" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.18/codeburn-desktop_0.9.18_amd64.deb"><img src="https://img.shields.io/badge/Linux-.deb-F97316?logo=debian&logoColor=white" alt="Download for Linux (.deb)" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.18/codeburn-desktop-0.9.18.x86_64.rpm"><img src="https://img.shields.io/badge/Linux-.rpm-F97316?logo=redhat&logoColor=white" alt="Download for Linux (.rpm)" /></a>
+      <a href="https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.18/CodeBurn-0.9.18.AppImage"><img src="https://img.shields.io/badge/Linux-AppImage-F97316?logo=linux&logoColor=white" alt="Download for Linux (AppImage)" /></a>
     </td>
     <td align="center" width="50%">
       <strong>Web</strong><br/>


### PR DESCRIPTION
Completes the 0.9.18 changelog entry with everything merged after the original cut (#743, #762, #763, #764, #765, #766, #772, with contributor credits) and moves the README download badges from 0.9.16 to 0.9.18 ahead of the recut. Docs only.