### PR TITLE
fix: Lifetime period end to end in the desktop app, compact menubar labels

### DIFF
--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -133,7 +133,7 @@ function configSourceArgs(source: string | null): string[] {
 // Renderer-supplied strings become argv, so reject anything that could smuggle a
 // flag or shell metacharacter before it reaches the CLI. Thrown from the argv
 // builders, these surface through the same error envelope as any CliError.
-const PERIODS = new Set(['today', 'week', '30days', 'month', 'all'])
+const PERIODS = new Set(['today', 'week', '30days', 'month', 'all', 'lifetime'])
 function vPeriod(period: string): string {
   if (!PERIODS.has(period)) throw new CliError('bad-args', 'invalid period')
   return period

--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -1502,12 +1502,15 @@ enum InsightMode: String, CaseIterable, Identifiable {
 }
 
 enum Period: String, CaseIterable, Identifiable {
+    // Compact labels: six segments plus the calendar button share one narrow
+    // popover row, so the longer names ("6 Months", "Lifetime") wrapped.
+    // Matches the desktop app's strip (Today / 7D / 30D / Month / 6M / Life).
     case today = "Today"
-    case sevenDays = "7 Days"
-    case thirtyDays = "30 Days"
+    case sevenDays = "7D"
+    case thirtyDays = "30D"
     case month = "Month"
-    case all = "6 Months"
-    case lifetime = "Lifetime"
+    case all = "6M"
+    case lifetime = "Life"
 
     var id: String { rawValue }
 


### PR DESCRIPTION
From live 0.9.19 screenshots: the desktop Life tab errored with invalid period because the electron IPC allowlist (app/electron/main.ts PERIODS) never learned lifetime even though the renderer and CLI both did; and the menubar period row wrapped once Lifetime joined (6 Months broke onto two lines). The allowlist gains lifetime; menubar labels compact to Today / 7D / 30D / Month / 6M / Life, matching the desktop strip. Selection is not persisted by raw value. Swift 113 tests and app 413 tests green. Suggested follow-up in the commit: derive the allowlist from the renderer's period module so three layers cannot drift again.