### PR TITLE
test: cli-emitters expects the title field sessions rows now carry

### DIFF
--- a/tests/cli-emitters.test.ts
+++ b/tests/cli-emitters.test.ts
@@ -87,7 +87,7 @@ describe('CLI JSON emitters', () => {
       const rows = JSON.parse(result.stdout) as Array<Record<string, unknown>>
       expect(rows).toHaveLength(2)
       expect(Object.keys(rows[0]!)).toEqual([
-        'sessionId', 'project', 'provider', 'models', 'cost', 'savingsUSD', 'calls', 'turns',
+        'sessionId', 'title', 'project', 'provider', 'models', 'cost', 'savingsUSD', 'calls', 'turns',
         'inputTokens', 'outputTokens', 'cacheReadTokens', 'cacheWriteTokens',
         'startedAt', 'endedAt', 'durationMs',
       ])


### PR DESCRIPTION
Main has one red test: #782 added title to sessions JSON rows and updated sessions-report.test.ts but missed the key-list assertion in cli-emitters.test.ts. Test-only, restores a green main.