### PR TITLE
sessions: fold subagent runs into PR attribution

### DIFF
--- a/app/renderer/lib/types.ts
+++ b/app/renderer/lib/types.ts
@@ -245,6 +245,9 @@ export type MenubarPayload = {
       }>
       distinctCost: number
       distinctSessions: number
+      // Count of subagent (sidechain) runs folded into the PR-linked parent
+      // sessions. Optional (absent when none folded, or from an older producer).
+      subagentSessions?: number
       attributedCost?: number
       unattributedCost?: number
       otherPrCount?: number

--- a/app/renderer/sections/PullRequests.test.tsx
+++ b/app/renderer/sections/PullRequests.test.tsx
@@ -185,6 +185,23 @@ describe('PullRequests', () => {
     expect(screen.getByText(/Not tied to a specific PR/).textContent).toContain('$45.30')
   })
 
+  it('notes folded-in subagent runs in the footer when present', async () => {
+    getOverview.mockResolvedValue(makePayload({ ...SAMPLE, subagentSessions: 32 }))
+    render(<PullRequests period="lifetime" provider="all" />)
+
+    const note = await screen.findByText(/attributed to the rows above/)
+    expect(note.textContent).toContain('3 PR-linked sessions')
+    expect(note.textContent).toContain('32 folded-in subagent runs')
+  })
+
+  it('omits the subagent note when none were folded', async () => {
+    getOverview.mockResolvedValue(makePayload(SAMPLE))
+    render(<PullRequests period="lifetime" provider="all" />)
+
+    const note = await screen.findByText(/attributed to the rows above/)
+    expect(note.textContent).not.toContain('subagent')
+  })
+
   it('marks an approximate (legacy) row with a ~ prefix and a tooltip', async () => {
     const approxPayload: PrPayload = {
       rows: [

--- a/app/renderer/sections/PullRequests.tsx
+++ b/app/renderer/sections/PullRequests.tsx
@@ -83,7 +83,7 @@ function PullRequestsPage({ pullRequests, staleError }: { pullRequests?: PullReq
 }
 
 function PrTable({ pullRequests }: { pullRequests: PullRequests }) {
-  const { rows, distinctCost, distinctSessions, attributedCost, unattributedCost, otherPrCount, otherPrCost } = pullRequests
+  const { rows, distinctCost, distinctSessions, subagentSessions, attributedCost, unattributedCost, otherPrCount, otherPrCost } = pullRequests
   const [expandedUrl, setExpandedUrl] = useState<string | null>(null)
   // Reset any open expansion when the PR set changes (a period/provider switch or
   // a refresh that alters the list): a stale expandedUrl would otherwise linger
@@ -145,7 +145,8 @@ function PrTable({ pullRequests }: { pullRequests: PullRequests }) {
       </div>
       {summable ? (
         <p className="pr-footnote">
-          {formatUsd(displayedAttributed)} attributed to the rows above, across {distinctSessions.toLocaleString('en-US')} PR-linked {sessionWord(distinctSessions)}.
+          {formatUsd(displayedAttributed)} attributed to the rows above, across {distinctSessions.toLocaleString('en-US')} PR-linked {sessionWord(distinctSessions)}
+          {subagentSessions ? ` + ${subagentSessions.toLocaleString('en-US')} folded-in subagent ${subagentSessions === 1 ? 'run' : 'runs'}` : ''}.
           {' '}Each turn's cost goes to the PR it was working on, so the rows are summable.
         </p>
       ) : (

--- a/src/main.ts
+++ b/src/main.ts
@@ -2037,7 +2037,7 @@ program
         process.stdout.write('No sessions with captured PR links in this period. Links are captured as sessions are parsed; older transcripts gain them on their next re-parse.\n')
         return
       }
-      const { unattributedCost, sessions } = prLinkedTotals(projects)
+      const { unattributedCost, sessions, subagentSessions } = prLinkedTotals(projects)
       const { renderTable: renderTextTable } = await import('./text-table.js')
       const modelsCell = (models: string[]): string =>
         models.length === 0 ? '' : models.slice(0, 2).join(', ') + (models.length > 2 ? ` +${models.length - 2}` : '')
@@ -2069,7 +2069,10 @@ program
       const approxNote = prRows.some(r => r.approx)
         ? ' ~ marks rows estimated from a whole-session even split (transcript expired before per-turn capture).'
         : ''
-      process.stdout.write(table + `\nRows sum to $${shownAttributed.toFixed(2)} attributed across ${sessions} PR-linked session${sessions === 1 ? '' : 's'}. $${unattributedCost.toFixed(2)} of that spend was not tied to a specific PR.${approxNote}\n`)
+      const subagentNote = subagentSessions > 0
+        ? ` + ${subagentSessions} folded-in subagent run${subagentSessions === 1 ? '' : 's'}`
+        : ''
+      process.stdout.write(table + `\nRows sum to $${shownAttributed.toFixed(2)} attributed across ${sessions} PR-linked session${sessions === 1 ? '' : 's'}${subagentNote}. $${unattributedCost.toFixed(2)} of that spend was not tied to a specific PR.${approxNote}\n`)
       return
     }
     const rows = aggregateSessions(projects)

--- a/src/main.ts
+++ b/src/main.ts
@@ -2011,7 +2011,7 @@ program
   .action(async (opts) => {
     assertProvider(opts.provider, 'sessions')
     assertFormat(opts.format, ['table', 'json'], 'sessions')
-    const { aggregateSessions, aggregateByPr, prLinkedTotals, renderJson, renderTable } = await import('./sessions-report.js')
+    const { aggregateSessions, buildPrAttribution, renderJson, renderTable } = await import('./sessions-report.js')
     await loadPricing()
 
     let range
@@ -2028,16 +2028,16 @@ program
 
     const projects = await parseAllSessions(range, opts.provider)
     if (opts.byPr) {
-      const prRows = aggregateByPr(projects)
+      const { rows: prRows, totals } = buildPrAttribution(projects)
       if (opts.format === 'json') {
-        process.stdout.write(JSON.stringify({ prs: prRows, distinct: prLinkedTotals(projects) }, null, 2) + '\n')
+        process.stdout.write(JSON.stringify({ prs: prRows, distinct: totals }, null, 2) + '\n')
         return
       }
       if (prRows.length === 0) {
         process.stdout.write('No sessions with captured PR links in this period. Links are captured as sessions are parsed; older transcripts gain them on their next re-parse.\n')
         return
       }
-      const { unattributedCost, sessions, subagentSessions } = prLinkedTotals(projects)
+      const { unattributedCost, sessions, subagentSessions } = totals
       const { renderTable: renderTextTable } = await import('./text-table.js')
       const modelsCell = (models: string[]): string =>
         models.length === 0 ? '' : models.slice(0, 2).join(', ') + (models.length > 2 ? ` +${models.length - 2}` : '')

--- a/src/menubar-json.ts
+++ b/src/menubar-json.ts
@@ -57,10 +57,16 @@ export type PeriodData = {
 export type PullRequestsPayload = {
   /// Per-PR rows, cost-descending, capped at the top 20 by the producer.
   rows: PrRow[]
-  /// Distinct-session spend across every PR-linked session. Equals
-  /// `attributedCost + unattributedCost`; kept for backward compatibility.
+  /// PR-linked spend, now INCLUDING the subagent runs folded into those sessions
+  /// (so it can exceed the parents' own spend). Equals `attributedCost +
+  /// unattributedCost`; kept for backward compatibility.
   distinctCost: number
+  /// Count of distinct PR-linked PARENT sessions.
   distinctSessions: number
+  /// Count of subagent (sidechain) runs whose spend was folded into those parent
+  /// sessions. Each remains a standalone row in the sessions list; here it only
+  /// explains why the totals exceed the parents' own spend. 0 when none folded.
+  subagentSessions?: number
   /// Sum of EVERY PR's attributed cost (all rows, not just the sent top 20).
   attributedCost: number
   /// PR-linked spend not tied to any specific PR (pre-reference session

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1275,11 +1275,21 @@ export function collectSessionMeta(entry: JournalEntry, meta: SessionMeta): void
       const msg = entry.message
       const content = msg && typeof msg === 'object' ? (msg as { content?: unknown }).content : undefined
       if (Array.isArray(content)) {
-        for (const b of content) {
-          if (!b || typeof b !== 'object' || (b as { type?: unknown }).type !== 'tool_result') continue
-          const id = (b as { tool_use_id?: unknown }).tool_use_id
-          if (typeof id === 'string' && id) { meta.agentSpawnLinks[agentId] = id; break }
+        const results = content.filter((b): b is Record<string, unknown> =>
+          !!b && typeof b === 'object' && (b as { type?: unknown }).type === 'tool_result'
+          && typeof (b as { tool_use_id?: unknown }).tool_use_id === 'string' && !!(b as { tool_use_id?: unknown }).tool_use_id)
+        let spawnId: string | undefined
+        if (results.length === 1) {
+          spawnId = results[0]!['tool_use_id'] as string
+        } else if (results.length > 1) {
+          // Several batched tool results share one entry: pair the agentId with the
+          // block whose `content` is the spawn result (equals `toolUseResult.content`),
+          // so an unrelated sibling block cannot capture the id. Skip if ambiguous.
+          const turContent = JSON.stringify((tur as Record<string, unknown>)['content'])
+          const matches = results.filter(b => JSON.stringify(b['content']) === turContent)
+          if (matches.length === 1) spawnId = matches[0]!['tool_use_id'] as string
         }
+        if (spawnId) meta.agentSpawnLinks[agentId] = spawnId
       }
     }
   }
@@ -1549,6 +1559,22 @@ export function groupIntoTurns(entries: JournalEntry[], seenMsgIds: Set<string>,
   }
 
   return turns
+}
+
+// Map each subagent-spawn `tool_use` id to the PR set active at the turn that
+// emitted it, walking the FULL turn list in order. A turn's own `prRefs` apply to
+// spawns within it; otherwise the carried set does. First occurrence of a spawn id
+// wins deterministically (tool_use ids are unique in practice; this only guards a
+// pathological restatement). Drives cross-range subagent PR attribution.
+export function buildSpawnPrSets(turns: Array<{ prRefs?: string[]; spawnToolUseIds?: string[] }>): Record<string, string[]> {
+  const out: Record<string, string[]> = {}
+  let cur: string[] = []
+  for (const turn of turns) {
+    const active = turn.prRefs?.length ? turn.prRefs : cur
+    for (const id of turn.spawnToolUseIds ?? []) if (!(id in out)) out[id] = active
+    if (turn.prRefs?.length) cur = turn.prRefs
+  }
+  return out
 }
 
 /**
@@ -2144,6 +2170,12 @@ async function scanProjectDirs(
     // session's in-range unbranched spend as `null` instead of discarding it.
     const everHadBranch = carriedBranch !== undefined
 
+    // Built from the FULL (pre-slice) turn list: each subagent-spawn tool_use id ->
+    // the PR set active at the turn that emitted it. Lets a subagent fold into the
+    // right PR even when its launching turn is later sliced out of range. Only for
+    // sessions that both spawned subagents and referenced a PR.
+    const spawnPrSets = cachedFile.prLinks?.length ? buildSpawnPrSets(cachedFile.turns) : {}
+
     if (dateRange) {
       classifiedTurns = classifiedTurns.filter(turn => {
         if (turn.assistantCalls.length === 0) return false
@@ -2154,7 +2186,12 @@ async function scanProjectDirs(
       })
     }
 
-    if (classifiedTurns.length === 0) continue
+    // A PR-linked parent that spawned subagents is kept even when its OWN turns all
+    // fall out of range, as a 0-cost fold anchor: an in-range child (an async agent
+    // that outlived the parent's last in-range turn) still needs the parent's
+    // `prLinks` / `spawnPrSets` to attribute. It contributes no spend of its own.
+    const isSpawnAnchor = Object.keys(spawnPrSets).length > 0 && cachedFile.isSidechain !== true
+    if (classifiedTurns.length === 0 && !isSpawnAnchor) continue
 
     const sessionId = basename(filePath, '.jsonl')
     const projectPath = cachedFile.canonicalCwd ?? claudeSlugFallbackPath(dirName)
@@ -2174,12 +2211,13 @@ async function scanProjectDirs(
       if (cachedFile.parentSessionId) session.parentSessionId = cachedFile.parentSessionId
       session.agentId = sessionId.startsWith('agent-') ? sessionId.slice('agent-'.length) : sessionId
     }
-    // Parent linkage map (only present on sessions that spawned subagents).
+    // Parent linkage maps (only present on sessions that spawned subagents).
     if (cachedFile.agentSpawnLinks && Object.keys(cachedFile.agentSpawnLinks).length > 0) {
       session.agentSpawnLinks = cachedFile.agentSpawnLinks
     }
+    if (Object.keys(spawnPrSets).length > 0) session.spawnPrSets = spawnPrSets
 
-    if (session.apiCalls > 0) {
+    if (session.apiCalls > 0 || isSpawnAnchor) {
       const projectKey = cachedFile.canonicalCwd
         ? normalizeProjectPathKey(cachedFile.canonicalCwd)
         : `slug:${dirName}`

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,6 +3,7 @@ import { lstat, readFile, readdir, stat } from 'fs/promises'
 import { basename, dirname, join, resolve, sep } from 'path'
 import { readSessionLines } from './fs-utils.js'
 import { calculateCost, calculateLocalModelSavings, getShortModelName, isProxiedPath, getProxyPathsConfigHash } from './models.js'
+import { sessionIdentity } from './sessions-report.js'
 import { normalizeContentBlocks } from './content-utils.js'
 import { discoverAllSessions, getProvider } from './providers/index.js'
 import { flushCodexCache } from './codex-cache.js'
@@ -3166,17 +3167,22 @@ function recomputeRangeStartPrRefs(original: SessionSummary, sliceStartMs: numbe
   // The carried PR is the refs of the LATEST turn (by timestamp) strictly before the
   // slice that referenced any PR; a turn exactly on the boundary is inside the slice
   // and applies its own refs there. Selected by timestamp, not array position, so
-  // the result does not depend on turn ordering. Falls back to the original
-  // range-start state when nothing referenced a PR before the slice.
+  // the result does not depend on turn ordering. When two PR-bearing turns share the
+  // exact same millisecond (a degenerate case), break the tie deterministically by
+  // the lexicographically-LAST sorted-join of their refs, so the seed is stable
+  // regardless of input order (arbitrary but stable, not order-dependent). Falls back
+  // to the original range-start state when nothing referenced a PR before the slice.
   let current = original.prRefsAtRangeStart
   let bestMs = -Infinity
+  let bestKey = ''
   for (const turn of original.turns) {
     if (!turn.prRefs?.length) continue
     const ts = turn.assistantCalls[0]?.timestamp
     if (!ts) continue
     const tMs = new Date(ts).getTime()
     if (Number.isNaN(tMs) || tMs >= sliceStartMs) continue
-    if (tMs >= bestMs) { bestMs = tMs; current = turn.prRefs }
+    const key = [...turn.prRefs].sort().join(',')
+    if (tMs > bestMs || (tMs === bestMs && key > bestKey)) { bestMs = tMs; bestKey = key; current = turn.prRefs }
   }
   return current
 }
@@ -3188,15 +3194,44 @@ function applyRecomputedRangeStart(rebuilt: SessionSummary, original: SessionSum
   else delete rebuilt.prRefsAtRangeStart
 }
 
-// Local-midnight epoch of the EARLIEST selected day. Range-start PR state is
-// recomputed at this boundary. Non-contiguous day selections are treated as
-// CONTIGUOUS from the earliest day: a PR switch inside an unselected gap between two
-// selected days is not reflected in the carried state (a single session-level seed
-// cannot represent multiple segments). The menubar day selection is a single day or
-// a contiguous run, so this is exact in practice.
+// Local-midnight epoch of the EARLIEST selected day, used to seed the very-first
+// turn and the pre-first-turn grace fallback. Per-day seeding (below) handles every
+// later day, so non-contiguous selections are also correct.
 function earliestDayStartMs(days: Set<string>): number {
   const earliest = [...days].sort()[0]
   return earliest ? new Date(`${earliest}T00:00:00`).getTime() : NaN
+}
+
+// Per-day seeding for a (possibly non-contiguous) day selection. For the FIRST
+// in-slice turn of each selected day that does not already reference a PR, inject the
+// PR carried into that day, recomputed from the ORIGINAL full turn sequence up to the
+// day's local-midnight start. A PR switch on an UNSELECTED day between two selected
+// days is thus captured for the later day; a contiguous run is the special case and
+// stays correct. Turn order is preserved.
+function seedFilteredTurnsPerDay(original: SessionSummary, filteredTurns: ClassifiedTurn[]): ClassifiedTurn[] {
+  const out: ClassifiedTurn[] = []
+  let lastDay: string | null = null
+  for (const turn of filteredTurns) {
+    const day = turnDayString(turn)
+    if (day !== null && day !== lastDay) {
+      lastDay = day
+      if (!turn.prRefs?.length) {
+        const carried = recomputeRangeStartPrRefs(original, new Date(`${day}T00:00:00`).getTime())
+        if (carried?.length) { out.push({ ...turn, prRefs: carried }); continue }
+      }
+    }
+    out.push(turn)
+  }
+  return out
+}
+
+// An anchor is a duplicate of a surviving session ONLY when they share the full
+// provider-aware, fingerprint-qualified identity (a proven-identical record). A
+// different-provider session that shares a raw id, or a same-id/different-record
+// collision that SHOULD stay to trigger the neither-fold guard, is not dropped.
+function dedupeAnchors(anchors: SessionSummary[], survivingIdentities: Set<string>): SessionSummary[] {
+  if (survivingIdentities.size === 0) return anchors
+  return anchors.filter(a => !survivingIdentities.has(sessionIdentity(a)))
 }
 
 export function filterProjectsByDays(projects: ProjectSummary[], days: Set<string>): ProjectSummary[] {
@@ -3209,7 +3244,7 @@ export function filterProjectsByDays(projects: ProjectSummary[], days: Set<strin
     // so its surviving in-range child still resolves. The anchor contributes no
     // own spend either way.
     const anchors: SessionSummary[] = [...(project.subagentAnchors ?? [])]
-    const survivingIds = new Set<string>()
+    const survivingIdentities = new Set<string>()
     for (const session of project.sessions) {
       const turns = session.turns.filter(turn => {
         const ds = turnDayString(turn)
@@ -3219,15 +3254,16 @@ export function filterProjectsByDays(projects: ProjectSummary[], days: Set<strin
         if (isSpawnParent(session)) anchors.push(session)
         continue
       }
-      const rebuilt = buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory, session.source)
+      const seeded = seedFilteredTurnsPerDay(session, turns)
+      const rebuilt = buildSessionSummary(session.sessionId, session.project, seeded, session.mcpInventory, session.source)
       carryLinkageFields(rebuilt, session)
       if (!Number.isNaN(sliceStartMs)) applyRecomputedRangeStart(rebuilt, session, sliceStartMs)
-      survivingIds.add(session.sessionId)
+      // Identity of the ORIGINAL (pre-filter) session: a duplicate anchor matches the
+      // session as it appeared in the input, not the narrowed rebuild.
+      survivingIdentities.add(sessionIdentity(session))
       sessions.push(rebuilt)
     }
-    // A surviving session (real, in-range spend) supersedes any anchor with the same
-    // id: keep the session, drop the duplicate anchor (guards malformed merged input).
-    const dedupedAnchors = survivingIds.size ? anchors.filter(a => !survivingIds.has(a.sessionId)) : anchors
+    const dedupedAnchors = dedupeAnchors(anchors, survivingIdentities)
     if (sessions.length === 0 && dedupedAnchors.length === 0) continue
     filtered.push(summarizeProject(project.project, project.projectPath, sessions, dedupedAnchors))
   }
@@ -3289,7 +3325,7 @@ export function filterProjectsByDateRange(projects: ProjectSummary[], dateRange:
     // Carry existing anchors and convert a spawn parent whose in-range turns are all
     // filtered out into one (see filterProjectsByDays).
     const anchors: SessionSummary[] = [...(project.subagentAnchors ?? [])]
-    const survivingIds = new Set<string>()
+    const survivingIdentities = new Set<string>()
     for (const session of project.sessions) {
       const turns = session.turns.filter(turn => turnIsInDateRange(turn, dateRange))
       if (turns.length === 0) {
@@ -3299,10 +3335,10 @@ export function filterProjectsByDateRange(projects: ProjectSummary[], dateRange:
       const rebuilt = buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory, session.source)
       carryLinkageFields(rebuilt, session)
       applyRecomputedRangeStart(rebuilt, session, sliceStartMs)
-      survivingIds.add(session.sessionId)
+      survivingIdentities.add(sessionIdentity(session))
       sessions.push(rebuilt)
     }
-    const dedupedAnchors = survivingIds.size ? anchors.filter(a => !survivingIds.has(a.sessionId)) : anchors
+    const dedupedAnchors = dedupeAnchors(anchors, survivingIdentities)
     if (sessions.length === 0 && dedupedAnchors.length === 0) continue
     filtered.push(summarizeProject(project.project, project.projectPath, sessions, dedupedAnchors))
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1195,10 +1195,14 @@ export type SessionMeta = {
   // spawned it, read from the spawn result's `toolUseResult.agentId`. First value
   // per agentId wins. Empty for sessions that spawned no completed subagent.
   agentSpawnLinks: Record<string, string>
+  // Parent side: agent ids whose spawn result named them but whose exact launching
+  // tool_use could not be paired (an ambiguous multi-result record). Drives the
+  // grace-window fallback for a late child. Deduped.
+  ambiguousSpawnAgentIds: string[]
 }
 
 export function emptySessionMeta(): SessionMeta {
-  return { prLinks: [], isSidechain: false, agentSpawnLinks: {} }
+  return { prLinks: [], isSidechain: false, agentSpawnLinks: {}, ambiguousSpawnAgentIds: [] }
 }
 
 // Count added/removed lines from a Claude `toolUseResult.structuredPatch`. Each
@@ -1293,6 +1297,10 @@ export function collectSessionMeta(entry: JournalEntry, meta: SessionMeta): void
           if (matches.length === 1) spawnId = matches[0]!['tool_use_id'] as string
         }
         if (spawnId) meta.agentSpawnLinks[agentId] = spawnId
+        // We know this parent spawned `agentId` (its result named it) but could not
+        // pair the exact tool_use: record it as an AMBIGUOUS pairing so a late child
+        // can still fold via the grace window. Not the same as an absent spawn.
+        else if (!meta.ambiguousSpawnAgentIds.includes(agentId)) meta.ambiguousSpawnAgentIds.push(agentId)
       }
     }
   }
@@ -2050,6 +2058,7 @@ async function scanProjectDirs(
           const mergedSidechain = cached.isSidechain === true || sessionMeta.isSidechain
           const mergedParentSessionId = cached.parentSessionId ?? sessionMeta.parentSessionId
           const mergedSpawnLinks = { ...sessionMeta.agentSpawnLinks, ...cached.agentSpawnLinks }
+          const mergedAmbiguousIds = Array.from(new Set([...(cached.ambiguousSpawnAgentIds ?? []), ...sessionMeta.ambiguousSpawnAgentIds]))
 
           section.files[filePath] = {
             fingerprint: info.fp,
@@ -2064,6 +2073,7 @@ async function scanProjectDirs(
             ...(mergedSidechain ? { isSidechain: true } : {}),
             ...(mergedParentSessionId ? { parentSessionId: mergedParentSessionId } : {}),
             ...(Object.keys(mergedSpawnLinks).length > 0 ? { agentSpawnLinks: mergedSpawnLinks } : {}),
+            ...(mergedAmbiguousIds.length > 0 ? { ambiguousSpawnAgentIds: mergedAmbiguousIds } : {}),
           }
           ;(diskCache as { _dirty?: boolean })._dirty = true
           filesDone++
@@ -2099,6 +2109,7 @@ async function scanProjectDirs(
         ...(sessionMeta.isSidechain ? { isSidechain: true } : {}),
         ...(sessionMeta.parentSessionId ? { parentSessionId: sessionMeta.parentSessionId } : {}),
         ...(Object.keys(sessionMeta.agentSpawnLinks).length > 0 ? { agentSpawnLinks: sessionMeta.agentSpawnLinks } : {}),
+        ...(sessionMeta.ambiguousSpawnAgentIds.length > 0 ? { ambiguousSpawnAgentIds: sessionMeta.ambiguousSpawnAgentIds } : {}),
       }
       ;(diskCache as { _dirty?: boolean })._dirty = true
     } catch (err) {
@@ -2221,6 +2232,7 @@ async function scanProjectDirs(
     if (cachedFile.agentSpawnLinks && Object.keys(cachedFile.agentSpawnLinks).length > 0) {
       session.agentSpawnLinks = cachedFile.agentSpawnLinks
     }
+    if (cachedFile.ambiguousSpawnAgentIds?.length) session.ambiguousSpawnAgentIds = cachedFile.ambiguousSpawnAgentIds
     if (Object.keys(spawnPrSets).length > 0) session.spawnPrSets = spawnPrSets
 
     if (session.apiCalls > 0 || anchorOnly) {
@@ -3118,22 +3130,54 @@ function turnDayString(turn: ClassifiedTurn): string | null {
   return `${y}-${m}-${day}`
 }
 
+// A spawn parent (has spawnPrSets + prLinks) counts as a fold ANCHOR. Kept
+// verbatim (not rebuilt) so its spawnPrSets / prLinks / agentSpawnLinks survive.
+function isSpawnParent(session: SessionSummary): boolean {
+  return !!session.spawnPrSets && !!session.prLinks?.length
+}
+
+// buildSessionSummary rolls up ONLY turn-derived fields, so a rebuilt (date/day/
+// source-filtered) session loses its session-level PR + subagent-linkage metadata.
+// Carry those across so by-PR attribution and subagent folding still work on a
+// filtered slice (without this, a filtered CHILD loses its parentSessionId and can
+// never be linked, and a filtered parent loses its prLinks).
+function carryLinkageFields(rebuilt: SessionSummary, original: SessionSummary): void {
+  if (original.everHadBranch) rebuilt.everHadBranch = true
+  if (original.prLinks?.length) rebuilt.prLinks = original.prLinks
+  if (original.prRefsAtRangeStart?.length) rebuilt.prRefsAtRangeStart = original.prRefsAtRangeStart
+  if (original.parentSessionId) rebuilt.parentSessionId = original.parentSessionId
+  if (original.agentId) rebuilt.agentId = original.agentId
+  if (original.agentSpawnLinks) rebuilt.agentSpawnLinks = original.agentSpawnLinks
+  if (original.spawnPrSets) rebuilt.spawnPrSets = original.spawnPrSets
+  if (original.ambiguousSpawnAgentIds?.length) rebuilt.ambiguousSpawnAgentIds = original.ambiguousSpawnAgentIds
+  if (original.title) rebuilt.title = original.title
+  if (original.agentType) rebuilt.agentType = original.agentType
+}
+
 export function filterProjectsByDays(projects: ProjectSummary[], days: Set<string>): ProjectSummary[] {
   const filtered: ProjectSummary[] = []
   for (const project of projects) {
     const sessions: SessionSummary[] = []
+    // Existing anchors are date-EXEMPT (carried unchanged); a spawn parent whose
+    // OWN in-range turns all fall outside the day subset is CONVERTED to an anchor
+    // so its surviving in-range child still resolves. The anchor contributes no
+    // own spend either way.
+    const anchors: SessionSummary[] = [...(project.subagentAnchors ?? [])]
     for (const session of project.sessions) {
       const turns = session.turns.filter(turn => {
         const ds = turnDayString(turn)
         return ds !== null && days.has(ds)
       })
-      if (turns.length === 0) continue
+      if (turns.length === 0) {
+        if (isSpawnParent(session)) anchors.push(session)
+        continue
+      }
       const rebuilt = buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory, session.source)
-      if (session.everHadBranch) rebuilt.everHadBranch = true
+      carryLinkageFields(rebuilt, session)
       sessions.push(rebuilt)
     }
-    if (sessions.length === 0) continue
-    filtered.push(summarizeProject(project.project, project.projectPath, sessions))
+    if (sessions.length === 0 && anchors.length === 0) continue
+    filtered.push(summarizeProject(project.project, project.projectPath, sessions, anchors))
   }
   return filtered.sort((a, b) => b.totalCostUSD - a.totalCostUSD)
 }
@@ -3156,6 +3200,7 @@ export function mergeProjectsByCrossProviderKey(projects: ProjectSummary[]): Map
     const existing = mergedMap.get(key)
     if (existing) {
       existing.sessions.push(...p.sessions)
+      if (p.subagentAnchors?.length) existing.subagentAnchors = [...(existing.subagentAnchors ?? []), ...p.subagentAnchors]
       existing.totalCostUSD += p.totalCostUSD
       existing.totalEstimatedCostUSD = (existing.totalEstimatedCostUSD ?? 0) + (p.totalEstimatedCostUSD ?? 0)
       existing.totalApiCalls += p.totalApiCalls
@@ -3174,8 +3219,12 @@ export function filterProjectsByClaudeConfigSource(projects: ProjectSummary[], s
     const sessions = project.sessions.filter(session =>
       session.source?.id === sourceId
     )
-    if (sessions.length === 0) continue
-    filtered.push(summarizeProject(project.project, project.projectPath, sessions))
+    // Anchors get the SAME source scoping as sessions (a config-source filter is a
+    // provenance filter, not a date filter), so an anchor stays only with its own
+    // config's children.
+    const anchors = (project.subagentAnchors ?? []).filter(anchor => anchor.source?.id === sourceId)
+    if (sessions.length === 0 && anchors.length === 0) continue
+    filtered.push(summarizeProject(project.project, project.projectPath, sessions, anchors))
   }
   return filtered.sort((a, b) => b.totalCostUSD - a.totalCostUSD)
 }
@@ -3184,15 +3233,21 @@ export function filterProjectsByDateRange(projects: ProjectSummary[], dateRange:
   const filtered: ProjectSummary[] = []
   for (const project of projects) {
     const sessions: SessionSummary[] = []
+    // Carry existing anchors and convert a spawn parent whose in-range turns are all
+    // filtered out into one (see filterProjectsByDays).
+    const anchors: SessionSummary[] = [...(project.subagentAnchors ?? [])]
     for (const session of project.sessions) {
       const turns = session.turns.filter(turn => turnIsInDateRange(turn, dateRange))
-      if (turns.length === 0) continue
+      if (turns.length === 0) {
+        if (isSpawnParent(session)) anchors.push(session)
+        continue
+      }
       const rebuilt = buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory, session.source)
-      if (session.everHadBranch) rebuilt.everHadBranch = true
+      carryLinkageFields(rebuilt, session)
       sessions.push(rebuilt)
     }
-    if (sessions.length === 0) continue
-    filtered.push(summarizeProject(project.project, project.projectPath, sessions))
+    if (sessions.length === 0 && anchors.length === 0) continue
+    filtered.push(summarizeProject(project.project, project.projectPath, sessions, anchors))
   }
   return filtered.sort((a, b) => b.totalCostUSD - a.totalCostUSD)
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1188,10 +1188,17 @@ export type SessionMeta = {
   title?: string
   prLinks: string[]
   isSidechain: boolean
+  // Sidechain side: the parent session id (a sidechain entry's internal
+  // `sessionId`, which is the spawning session). First non-empty value wins.
+  parentSessionId?: string
+  // Parent side: agentId -> the `tool_use` id of the `Agent`/`Task` block that
+  // spawned it, read from the spawn result's `toolUseResult.agentId`. First value
+  // per agentId wins. Empty for sessions that spawned no completed subagent.
+  agentSpawnLinks: Record<string, string>
 }
 
 export function emptySessionMeta(): SessionMeta {
-  return { prLinks: [], isSidechain: false }
+  return { prLinks: [], isSidechain: false, agentSpawnLinks: {} }
 }
 
 // Count added/removed lines from a Claude `toolUseResult.structuredPatch`. Each
@@ -1249,7 +1256,33 @@ export function collectSessionMeta(entry: JournalEntry, meta: SessionMeta): void
     const url = (entry as Record<string, unknown>)['prUrl']
     if (typeof url === 'string' && url && !meta.prLinks.includes(url)) meta.prLinks.push(url)
   }
-  if (entry.isSidechain === true) meta.isSidechain = true
+  if (entry.isSidechain === true) {
+    meta.isSidechain = true
+    // A sidechain entry's own `sessionId` is the id of the session that spawned
+    // it (32/32 on real data; cross-checked against the owning directory at
+    // stamp time). First value wins; every entry in the file carries the same id.
+    const sid = (entry as Record<string, unknown>)['sessionId']
+    if (!meta.parentSessionId && typeof sid === 'string' && sid) meta.parentSessionId = sid
+  }
+  // Parent side: the `Agent`/`Task` spawn result records the spawned agent's id in
+  // `toolUseResult.agentId`; pair it with the `tool_result` block's `tool_use_id`
+  // (the spawn's `tool_use` id) so a child can be folded into the launching turn.
+  // Read from the RAW entry (compaction strips `toolUseResult`).
+  const tur = (entry as Record<string, unknown>)['toolUseResult']
+  if (tur && typeof tur === 'object') {
+    const agentId = (tur as Record<string, unknown>)['agentId']
+    if (typeof agentId === 'string' && agentId && !(agentId in meta.agentSpawnLinks)) {
+      const msg = entry.message
+      const content = msg && typeof msg === 'object' ? (msg as { content?: unknown }).content : undefined
+      if (Array.isArray(content)) {
+        for (const b of content) {
+          if (!b || typeof b !== 'object' || (b as { type?: unknown }).type !== 'tool_result') continue
+          const id = (b as { tool_use_id?: unknown }).tool_use_id
+          if (typeof id === 'string' && id) { meta.agentSpawnLinks[agentId] = id; break }
+        }
+      }
+    }
+  }
 }
 
 export function parseApiCall(entry: JournalEntry, toolResultMeta?: Map<string, ToolResultMeta>): ParsedApiCall | null {
@@ -1288,6 +1321,13 @@ export function parseApiCall(entry: JournalEntry, toolResultMeta?: Map<string, T
   )
 
   const bashCmds = extractBashCommandsFromContent(contentBlocks)
+
+  // Subagent-spawn `tool_use` ids in this message (`Agent`/`Task` blocks). Kept so
+  // groupIntoTurns can attach them to the turn and by-PR attribution can fold each
+  // spawned sidechain back into the turn that launched it.
+  const spawnIds = contentBlocks
+    .filter((b): b is ToolUseBlock => b.type === 'tool_use' && (b.name === 'Agent' || b.name === 'Task') && !!b.id)
+    .map(b => b.id)
 
   const toolSeq: ToolCall[][] = contentBlocks
     .filter((b): b is ToolUseBlock => b.type === 'tool_use')
@@ -1337,6 +1377,7 @@ export function parseApiCall(entry: JournalEntry, toolResultMeta?: Map<string, T
     deduplicationKey: msg.id ?? `claude:${entry.timestamp}`,
     cacheCreationOneHourTokens: cacheCreation.oneHourTokens || undefined,
     toolSequence: toolSeq.length > 0 ? toolSeq : undefined,
+    ...(spawnIds.length > 0 ? { spawnToolUseIds: spawnIds } : {}),
     ...(locAdded ? { locAdded } : {}),
     ...(locRemoved ? { locRemoved } : {}),
     ...(interrupted ? { interrupted: true } : {}),
@@ -1450,6 +1491,9 @@ export function groupIntoTurns(entries: JournalEntry[], seenMsgIds: Set<string>,
   // `pr-link` entry is emitted after the assistant creates/references a PR, so it
   // lands inside the same turn (before the next user message) and attaches here.
   let currentPrRefs: string[] = []
+  // Subagent-spawn `tool_use` ids emitted within the current turn (deduped),
+  // carried from each call's `spawnToolUseIds`.
+  let currentSpawnIds: string[] = []
 
   for (const entry of entries) {
     const entryBranch = typeof entry.gitBranch === 'string' && entry.gitBranch ? entry.gitBranch : undefined
@@ -1464,6 +1508,7 @@ export function groupIntoTurns(entries: JournalEntry[], seenMsgIds: Set<string>,
             sessionId: currentSessionId,
             ...(currentBranch ? { gitBranch: currentBranch } : {}),
             ...(currentPrRefs.length > 0 ? { prRefs: [...currentPrRefs].sort() } : {}),
+            ...(currentSpawnIds.length > 0 ? { spawnToolUseIds: currentSpawnIds } : {}),
           })
         }
         currentUserMessage = text
@@ -1472,6 +1517,7 @@ export function groupIntoTurns(entries: JournalEntry[], seenMsgIds: Set<string>,
         currentSessionId = entry.sessionId ?? ''
         currentBranch = entryBranch
         currentPrRefs = []
+        currentSpawnIds = []
       }
     } else if (entry.type === 'assistant') {
       if (entryBranch && !currentBranch) currentBranch = entryBranch
@@ -1479,7 +1525,10 @@ export function groupIntoTurns(entries: JournalEntry[], seenMsgIds: Set<string>,
       if (msgId && seenMsgIds.has(msgId)) continue
       if (msgId) seenMsgIds.add(msgId)
       const call = parseApiCall(entry, toolResultMeta)
-      if (call) currentCalls.push(call)
+      if (call) {
+        currentCalls.push(call)
+        if (call.spawnToolUseIds) for (const id of call.spawnToolUseIds) if (!currentSpawnIds.includes(id)) currentSpawnIds.push(id)
+      }
       for (const advisorCall of parseAdvisorCalls(entry)) currentCalls.push(advisorCall)
     } else if (entry.type === 'pr-link') {
       const url = (entry as Record<string, unknown>)['prUrl']
@@ -1495,6 +1544,7 @@ export function groupIntoTurns(entries: JournalEntry[], seenMsgIds: Set<string>,
       sessionId: currentSessionId,
       ...(currentBranch ? { gitBranch: currentBranch } : {}),
       ...(currentPrRefs.length > 0 ? { prRefs: [...currentPrRefs].sort() } : {}),
+      ...(currentSpawnIds.length > 0 ? { spawnToolUseIds: currentSpawnIds } : {}),
     })
   }
 
@@ -1932,6 +1982,10 @@ async function scanProjectDirs(
               // turn: union its refs in so the shortcut matches a full re-parse.
               const refs = Array.from(new Set([...(last.prRefs ?? []), ...(newTurns[0]!.prRefs ?? [])])).sort()
               if (refs.length > 0) last.prRefs = refs
+              // A subagent spawned in the appended continuation belongs to this
+              // same turn: union its spawn ids in for the same reason.
+              const spawnIds = Array.from(new Set([...(last.spawnToolUseIds ?? []), ...(newTurns[0]!.spawnToolUseIds ?? [])]))
+              if (spawnIds.length > 0) last.spawnToolUseIds = spawnIds
               startIdx = 1
             }
             for (let i = startIdx; i < newTurns.length; i++) mergedTurns.push(newTurns[i]!)
@@ -1960,9 +2014,13 @@ async function scanProjectDirs(
 
           // Session meta merges across the append boundary: title is last-wins
           // (prefer the newly-parsed tail), PR links union, isSidechain is sticky.
+          // parentSessionId is sticky (cached-first, it is the earliest region);
+          // agentSpawnLinks union (cached-first, first-seen spawn id per agent wins).
           const mergedTitle = sessionMeta.title ?? cached.title
           const mergedPrLinks = Array.from(new Set([...(cached.prLinks ?? []), ...sessionMeta.prLinks]))
           const mergedSidechain = cached.isSidechain === true || sessionMeta.isSidechain
+          const mergedParentSessionId = cached.parentSessionId ?? sessionMeta.parentSessionId
+          const mergedSpawnLinks = { ...sessionMeta.agentSpawnLinks, ...cached.agentSpawnLinks }
 
           section.files[filePath] = {
             fingerprint: info.fp,
@@ -1975,6 +2033,8 @@ async function scanProjectDirs(
             ...(mergedTitle ? { title: mergedTitle } : {}),
             ...(mergedPrLinks.length > 0 ? { prLinks: mergedPrLinks } : {}),
             ...(mergedSidechain ? { isSidechain: true } : {}),
+            ...(mergedParentSessionId ? { parentSessionId: mergedParentSessionId } : {}),
+            ...(Object.keys(mergedSpawnLinks).length > 0 ? { agentSpawnLinks: mergedSpawnLinks } : {}),
           }
           ;(diskCache as { _dirty?: boolean })._dirty = true
           filesDone++
@@ -2008,6 +2068,8 @@ async function scanProjectDirs(
         ...(sessionMeta.title ? { title: sessionMeta.title } : {}),
         ...(sessionMeta.prLinks.length > 0 ? { prLinks: sessionMeta.prLinks } : {}),
         ...(sessionMeta.isSidechain ? { isSidechain: true } : {}),
+        ...(sessionMeta.parentSessionId ? { parentSessionId: sessionMeta.parentSessionId } : {}),
+        ...(Object.keys(sessionMeta.agentSpawnLinks).length > 0 ? { agentSpawnLinks: sessionMeta.agentSpawnLinks } : {}),
       }
       ;(diskCache as { _dirty?: boolean })._dirty = true
     } catch (err) {
@@ -2104,6 +2166,18 @@ async function scanProjectDirs(
     if (cachedFile.prLinks?.length) session.prLinks = [...new Set(cachedFile.prLinks)].sort()
     if (prRefsAtRangeStart?.length) session.prRefsAtRangeStart = prRefsAtRangeStart
     if (cachedFile.title) session.title = cachedFile.title
+    // Sidechain linkage: carry the parent id (the transcript's internal
+    // `sessionId`, authoritative even when it disagrees with the owning directory
+    // on a resumed session) and derive the agent id from the `agent-<agentId>`
+    // filename. A sidechain whose parent id was never captured stays standalone.
+    if (cachedFile.isSidechain) {
+      if (cachedFile.parentSessionId) session.parentSessionId = cachedFile.parentSessionId
+      session.agentId = sessionId.startsWith('agent-') ? sessionId.slice('agent-'.length) : sessionId
+    }
+    // Parent linkage map (only present on sessions that spawned subagents).
+    if (cachedFile.agentSpawnLinks && Object.keys(cachedFile.agentSpawnLinks).length > 0) {
+      session.agentSpawnLinks = cachedFile.agentSpawnLinks
+    }
 
     if (session.apiCalls > 0) {
       const projectKey = cachedFile.canonicalCwd
@@ -2281,6 +2355,7 @@ function parsedTurnToCachedTurn(turn: ParsedTurn): CachedTurn {
     // Stored per-turn directly (already sorted/deduped in groupIntoTurns), unlike
     // gitBranch's change-detection dedup, so each turn's refs are self-contained.
     ...(turn.prRefs?.length ? { prRefs: turn.prRefs } : {}),
+    ...(turn.spawnToolUseIds?.length ? { spawnToolUseIds: turn.spawnToolUseIds } : {}),
   }
 }
 
@@ -2391,6 +2466,7 @@ function cachedTurnToClassified(turn: CachedTurn, resolvedBranch?: string): Clas
     sessionId: turn.sessionId,
     ...(branch ? { gitBranch: branch } : {}),
     ...(turn.prRefs?.length ? { prRefs: turn.prRefs } : {}),
+    ...(turn.spawnToolUseIds?.length ? { spawnToolUseIds: turn.spawnToolUseIds } : {}),
   }
   return classifyTurn(parsed)
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1284,7 +1284,10 @@ export function collectSessionMeta(entry: JournalEntry, meta: SessionMeta): void
         } else if (results.length > 1) {
           // Several batched tool results share one entry: pair the agentId with the
           // block whose `content` is the spawn result (equals `toolUseResult.content`),
-          // so an unrelated sibling block cannot capture the id. Skip if ambiguous.
+          // so an unrelated sibling block cannot capture the id. When the match is
+          // ambiguous (identical blocks, or none match) the spawn link is left
+          // unset ON PURPOSE: the child then folds via the timestamp-bucket fallback
+          // in resolveChild rather than risk pairing with the wrong id.
           const turContent = JSON.stringify((tur as Record<string, unknown>)['content'])
           const matches = results.filter(b => JSON.stringify(b['content']) === turContent)
           if (matches.length === 1) spawnId = matches[0]!['tool_use_id'] as string
@@ -2130,7 +2133,7 @@ async function scanProjectDirs(
     }
   }
 
-  const projectMap = new Map<string, { project: string; projectPath: string; sessions: SessionSummary[]; dirNames: Set<string> }>()
+  const projectMap = new Map<string, { project: string; projectPath: string; sessions: SessionSummary[]; anchors: SessionSummary[]; dirNames: Set<string> }>()
 
   const allFiles = [
     ...unchangedFiles.map(f => ({ filePath: f.filePath, dirName: f.dirName, source: f.source })),
@@ -2187,10 +2190,13 @@ async function scanProjectDirs(
     }
 
     // A PR-linked parent that spawned subagents is kept even when its OWN turns all
-    // fall out of range, as a 0-cost fold anchor: an in-range child (an async agent
+    // fall out of range, as a 0-cost fold ANCHOR: an in-range child (an async agent
     // that outlived the parent's last in-range turn) still needs the parent's
-    // `prLinks` / `spawnPrSets` to attribute. It contributes no spend of its own.
+    // `prLinks` / `spawnPrSets` to attribute. An anchor carries no in-range spend
+    // and is stored OUTSIDE `sessions` (see subagentAnchors) so it never
+    // contaminates session counts, averages, or any other per-session report.
     const isSpawnAnchor = Object.keys(spawnPrSets).length > 0 && cachedFile.isSidechain !== true
+    const anchorOnly = classifiedTurns.length === 0 && isSpawnAnchor
     if (classifiedTurns.length === 0 && !isSpawnAnchor) continue
 
     const sessionId = basename(filePath, '.jsonl')
@@ -2217,17 +2223,17 @@ async function scanProjectDirs(
     }
     if (Object.keys(spawnPrSets).length > 0) session.spawnPrSets = spawnPrSets
 
-    if (session.apiCalls > 0 || isSpawnAnchor) {
+    if (session.apiCalls > 0 || anchorOnly) {
       const projectKey = cachedFile.canonicalCwd
         ? normalizeProjectPathKey(cachedFile.canonicalCwd)
         : `slug:${dirName}`
       const existing = projectMap.get(projectKey)
-      if (existing) {
-        existing.sessions.push(session)
-        existing.dirNames.add(dirName)
-      } else {
-        projectMap.set(projectKey, { project: projectName, projectPath, sessions: [session], dirNames: new Set([dirName]) })
-      }
+      // An anchor (no in-range spend) goes into a separate bucket, never `sessions`.
+      const target = existing ?? { project: projectName, projectPath, sessions: [], anchors: [], dirNames: new Set([dirName]) }
+      if (anchorOnly) target.anchors.push(session)
+      else target.sessions.push(session)
+      target.dirNames.add(dirName)
+      if (!existing) projectMap.set(projectKey, target)
     }
   }
 
@@ -2245,12 +2251,13 @@ async function scanProjectDirs(
     if (!cwdKey) continue
     const target = projectMap.get(cwdKey)!
     target.sessions.push(...entry.sessions)
+    target.anchors.push(...entry.anchors)
     projectMap.delete(key)
   }
 
   const projects: ProjectSummary[] = []
-  for (const { project, projectPath, sessions } of projectMap.values()) {
-    projects.push(summarizeProject(project, projectPath, sessions))
+  for (const { project, projectPath, sessions, anchors } of projectMap.values()) {
+    projects.push(summarizeProject(project, projectPath, sessions, anchors))
   }
 
   return projects
@@ -2263,7 +2270,7 @@ async function scanProjectDirs(
 /// `totalProxiedCostUSD` (subscription-covered). All ProjectSummary callers go
 /// through here so the rule stays consistent across the fresh, cached, and
 /// date/day-filtered paths.
-function summarizeProject(project: string, projectPath: string, sessions: SessionSummary[]): ProjectSummary {
+function summarizeProject(project: string, projectPath: string, sessions: SessionSummary[], anchors: SessionSummary[] = []): ProjectSummary {
   const totalCostUSD = sessions.reduce((s, sess) => s + sess.totalCostUSD, 0)
   return {
     project,
@@ -2274,6 +2281,8 @@ function summarizeProject(project: string, projectPath: string, sessions: Sessio
     totalEstimatedCostUSD: sessions.reduce((s, sess) => s + (sess.totalEstimatedCostUSD ?? 0), 0),
     totalApiCalls: sessions.reduce((s, sess) => s + sess.apiCalls, 0),
     totalProxiedCostUSD: isProxiedPath(projectPath) ? totalCostUSD : 0,
+    // Fold anchors travel separately (0-cost, out of every per-session total).
+    ...(anchors.length > 0 ? { subagentAnchors: anchors } : {}),
   }
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3144,7 +3144,8 @@ function isSpawnParent(session: SessionSummary): boolean {
 function carryLinkageFields(rebuilt: SessionSummary, original: SessionSummary): void {
   if (original.everHadBranch) rebuilt.everHadBranch = true
   if (original.prLinks?.length) rebuilt.prLinks = original.prLinks
-  if (original.prRefsAtRangeStart?.length) rebuilt.prRefsAtRangeStart = original.prRefsAtRangeStart
+  // prRefsAtRangeStart is NOT copied here: a narrower slice needs it recomputed at
+  // the new boundary (see recomputeRangeStartPrRefs), not the wide range's value.
   if (original.parentSessionId) rebuilt.parentSessionId = original.parentSessionId
   if (original.agentId) rebuilt.agentId = original.agentId
   if (original.agentSpawnLinks) rebuilt.agentSpawnLinks = original.agentSpawnLinks
@@ -3154,7 +3155,52 @@ function carryLinkageFields(rebuilt: SessionSummary, original: SessionSummary): 
   if (original.agentType) rebuilt.agentType = original.agentType
 }
 
+// The "PR active entering this slice", recomputed by replaying the ORIGINAL full
+// turn sequence up to `sliceStartMs`, seeded from the original range-start state.
+// A narrower filter must NOT reuse the wide range's range-start PR: a PR switch
+// between the wide start and the slice start would otherwise be lost, mis-seeding
+// both spend attribution and the subagent grace fallback. A turn exactly ON the
+// boundary stays in the slice and applies its own prRefs there, so the walk stops
+// strictly before it.
+function recomputeRangeStartPrRefs(original: SessionSummary, sliceStartMs: number): string[] | undefined {
+  // The carried PR is the refs of the LATEST turn (by timestamp) strictly before the
+  // slice that referenced any PR; a turn exactly on the boundary is inside the slice
+  // and applies its own refs there. Selected by timestamp, not array position, so
+  // the result does not depend on turn ordering. Falls back to the original
+  // range-start state when nothing referenced a PR before the slice.
+  let current = original.prRefsAtRangeStart
+  let bestMs = -Infinity
+  for (const turn of original.turns) {
+    if (!turn.prRefs?.length) continue
+    const ts = turn.assistantCalls[0]?.timestamp
+    if (!ts) continue
+    const tMs = new Date(ts).getTime()
+    if (Number.isNaN(tMs) || tMs >= sliceStartMs) continue
+    if (tMs >= bestMs) { bestMs = tMs; current = turn.prRefs }
+  }
+  return current
+}
+
+// Apply a recomputed range-start PR state to a rebuilt session (or clear it).
+function applyRecomputedRangeStart(rebuilt: SessionSummary, original: SessionSummary, sliceStartMs: number): void {
+  const rs = recomputeRangeStartPrRefs(original, sliceStartMs)
+  if (rs?.length) rebuilt.prRefsAtRangeStart = rs
+  else delete rebuilt.prRefsAtRangeStart
+}
+
+// Local-midnight epoch of the EARLIEST selected day. Range-start PR state is
+// recomputed at this boundary. Non-contiguous day selections are treated as
+// CONTIGUOUS from the earliest day: a PR switch inside an unselected gap between two
+// selected days is not reflected in the carried state (a single session-level seed
+// cannot represent multiple segments). The menubar day selection is a single day or
+// a contiguous run, so this is exact in practice.
+function earliestDayStartMs(days: Set<string>): number {
+  const earliest = [...days].sort()[0]
+  return earliest ? new Date(`${earliest}T00:00:00`).getTime() : NaN
+}
+
 export function filterProjectsByDays(projects: ProjectSummary[], days: Set<string>): ProjectSummary[] {
+  const sliceStartMs = earliestDayStartMs(days)
   const filtered: ProjectSummary[] = []
   for (const project of projects) {
     const sessions: SessionSummary[] = []
@@ -3163,6 +3209,7 @@ export function filterProjectsByDays(projects: ProjectSummary[], days: Set<strin
     // so its surviving in-range child still resolves. The anchor contributes no
     // own spend either way.
     const anchors: SessionSummary[] = [...(project.subagentAnchors ?? [])]
+    const survivingIds = new Set<string>()
     for (const session of project.sessions) {
       const turns = session.turns.filter(turn => {
         const ds = turnDayString(turn)
@@ -3174,10 +3221,15 @@ export function filterProjectsByDays(projects: ProjectSummary[], days: Set<strin
       }
       const rebuilt = buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory, session.source)
       carryLinkageFields(rebuilt, session)
+      if (!Number.isNaN(sliceStartMs)) applyRecomputedRangeStart(rebuilt, session, sliceStartMs)
+      survivingIds.add(session.sessionId)
       sessions.push(rebuilt)
     }
-    if (sessions.length === 0 && anchors.length === 0) continue
-    filtered.push(summarizeProject(project.project, project.projectPath, sessions, anchors))
+    // A surviving session (real, in-range spend) supersedes any anchor with the same
+    // id: keep the session, drop the duplicate anchor (guards malformed merged input).
+    const dedupedAnchors = survivingIds.size ? anchors.filter(a => !survivingIds.has(a.sessionId)) : anchors
+    if (sessions.length === 0 && dedupedAnchors.length === 0) continue
+    filtered.push(summarizeProject(project.project, project.projectPath, sessions, dedupedAnchors))
   }
   return filtered.sort((a, b) => b.totalCostUSD - a.totalCostUSD)
 }
@@ -3230,12 +3282,14 @@ export function filterProjectsByClaudeConfigSource(projects: ProjectSummary[], s
 }
 
 export function filterProjectsByDateRange(projects: ProjectSummary[], dateRange: DateRange): ProjectSummary[] {
+  const sliceStartMs = dateRange.start.getTime()
   const filtered: ProjectSummary[] = []
   for (const project of projects) {
     const sessions: SessionSummary[] = []
     // Carry existing anchors and convert a spawn parent whose in-range turns are all
     // filtered out into one (see filterProjectsByDays).
     const anchors: SessionSummary[] = [...(project.subagentAnchors ?? [])]
+    const survivingIds = new Set<string>()
     for (const session of project.sessions) {
       const turns = session.turns.filter(turn => turnIsInDateRange(turn, dateRange))
       if (turns.length === 0) {
@@ -3244,10 +3298,13 @@ export function filterProjectsByDateRange(projects: ProjectSummary[], dateRange:
       }
       const rebuilt = buildSessionSummary(session.sessionId, session.project, turns, session.mcpInventory, session.source)
       carryLinkageFields(rebuilt, session)
+      applyRecomputedRangeStart(rebuilt, session, sliceStartMs)
+      survivingIds.add(session.sessionId)
       sessions.push(rebuilt)
     }
-    if (sessions.length === 0 && anchors.length === 0) continue
-    filtered.push(summarizeProject(project.project, project.projectPath, sessions, anchors))
+    const dedupedAnchors = survivingIds.size ? anchors.filter(a => !survivingIds.has(a.sessionId)) : anchors
+    if (sessions.length === 0 && dedupedAnchors.length === 0) continue
+    filtered.push(summarizeProject(project.project, project.projectPath, sessions, dedupedAnchors))
   }
   return filtered.sort((a, b) => b.totalCostUSD - a.totalCostUSD)
 }

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -109,6 +109,10 @@ export type CachedFile = {
   // optional; a file is typically one or the other (a nested agent can be both).
   parentSessionId?: string
   agentSpawnLinks?: Record<string, string>
+  // Parent file: agent ids whose spawn result named them but whose exact launching
+  // tool_use could not be paired (ambiguous multi-result record). Drives a
+  // grace-window fallback for a late child. Absent when no pairing was ambiguous.
+  ambiguousSpawnAgentIds?: string[]
 }
 
 export type ProviderSection = {
@@ -374,6 +378,7 @@ function validateCachedFile(f: unknown): f is CachedFile {
     && isOptionalBool(o['failed'])
     && isOptionalString(o['parentSessionId'])
     && isOptionalStringRecord(o['agentSpawnLinks'])
+    && (o['ambiguousSpawnAgentIds'] === undefined || isStringArray(o['ambiguousSpawnAgentIds']))
     && Array.isArray(o['turns'])
     && (o['turns'] as unknown[]).every(validateTurn)
 }

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -141,10 +141,12 @@ export type SessionCache = {
 // v6: per-turn `prRefs` capture for turn-level PR spend attribution. Existing
 // cache turns carry no prRefs; bumping forces a one-time re-parse so surviving
 // transcripts populate the field. (Daily-cache versioning is untouched.)
-// v7: sidechain->parent linkage — per-turn `spawnToolUseIds`, per-file
-// `parentSessionId` / `agentSpawnLinks` — so subagent spend folds into the parent
-// turn's PR set. v6 never shipped, so users cross v5->v7 in a single combined
-// bump; the v5 adoption path below still rescues expired-PR orphans.
+// v7: sidechain->parent linkage - per-turn `spawnToolUseIds`, per-file
+// `parentSessionId` / `agentSpawnLinks` - so subagent spend folds into the parent
+// turn's PR set. v6 never shipped, so users cross v5->v7 in a single combined bump.
+// INVARIANT: a version bump must extend `PRIOR_CACHE_VERSIONS` (the adoption path
+// below) to EVERY prior version that can still exist on disk, or expired-PR
+// history from the immediately preceding build silently vanishes.
 export const CACHE_VERSION = 7
 
 // The cache filename is version-suffixed so different binaries (e.g. an old
@@ -392,37 +394,43 @@ function validateCache(raw: unknown): raw is SessionCache {
   return Object.values(o['providers'] as Record<string, unknown>).every(validateProviderSection)
 }
 
-// The immediately-prior versioned file. On the 5 -> 6 bump we adopt its
-// still-relevant entries (see adoptV5Cache) rather than abandoning them; the
-// file itself is never written or deleted (old binaries still own it).
-const V5_CACHE_FILE = 'session-cache.v5.json'
+// Every prior versioned cache file that can still exist on disk from a shipped or
+// dev build, NEWEST first. On a bump we adopt the newest one present: its
+// expired-source PR orphans (transcripts since deleted) hold attributable spend
+// that can never be re-parsed, and each newer version already carried the older
+// versions' orphans forward, so the newest is a superset. INVARIANT: a
+// CACHE_VERSION bump MUST extend this list to every prior version that can still
+// exist on disk, or that history silently vanishes. (v5 was missed on the 5->6
+// bump; v6 on the 6->7 bump; both are listed here.)
+const PRIOR_CACHE_VERSIONS = [6, 5] as const
 
-// Lightweight top-level check: a version-5 cache with a providers object. The
-// individual files are validated per-entry in adoptV5Cache so one corrupt entry
-// cannot drop every valid expired-transcript PR session along with it.
-function isV5CacheEnvelope(raw: unknown): raw is { version: number; providers: Record<string, unknown> } {
+function priorCacheFile(version: number): string {
+  return `session-cache.v${version}.json`
+}
+
+// Lightweight top-level check: a specific prior-version cache envelope with a
+// providers object. Files are validated per-entry in adoptPriorCache so one
+// corrupt entry cannot drop every valid expired-transcript PR session.
+function isCacheEnvelope(raw: unknown, version: number): raw is { version: number; providers: Record<string, unknown> } {
   if (!raw || typeof raw !== 'object') return false
   const o = raw as Record<string, unknown>
-  return o['version'] === 5
+  return o['version'] === version
     && !!o['providers'] && typeof o['providers'] === 'object' && !Array.isArray(o['providers'])
 }
 
-// One-time migration for the 5 -> 6 bump (per-turn prRefs capture). A fresh v6
-// cache would abandon v5 wholesale, so any PR-linked session whose transcript was
-// since deleted would vanish instead of taking the by-PR legacy even-split path.
-// Carry forward exactly the v5 entries whose source no longer exists AND that
-// carry prLinks (they can never re-parse, but they hold attributable PR spend);
-// present sources are intentionally dropped so they re-parse fresh under v6 and
-// gain per-turn refs. Each file is validated individually, so a single corrupt
-// entry is skipped rather than discarding the whole cache. Each carried section
-// takes the CURRENT envFingerprint so the scan reuses it and appends the
-// freshly-parsed present sources. The daily cache (durable cost history) is not
-// touched.
-async function adoptV5Cache(): Promise<SessionCache | null> {
+// One-time migration on a version bump: carry forward exactly the prior-version
+// entries whose source no longer exists AND that carry prLinks (they can never
+// re-parse, but they hold attributable PR spend); present sources are dropped so
+// they re-parse fresh under the new version and gain the new fields. Each file is
+// validated individually, so a single corrupt entry is skipped rather than
+// discarding the whole cache. Each carried section takes the CURRENT
+// envFingerprint so the scan reuses it and appends the freshly-parsed present
+// sources. The daily cache (durable cost history) is not touched.
+async function adoptPriorCache(version: number): Promise<SessionCache | null> {
   try {
-    const raw = await readFile(join(getCacheDir(), V5_CACHE_FILE), 'utf-8')
+    const raw = await readFile(join(getCacheDir(), priorCacheFile(version)), 'utf-8')
     const parsed = JSON.parse(raw)
-    if (!isV5CacheEnvelope(parsed)) return null
+    if (!isCacheEnvelope(parsed, version)) return null
     const migrated: SessionCache = { version: CACHE_VERSION, providers: {}, complete: false }
     for (const [provider, section] of Object.entries(parsed.providers)) {
       if (!section || typeof section !== 'object') continue
@@ -446,6 +454,15 @@ async function adoptV5Cache(): Promise<SessionCache | null> {
   }
 }
 
+// Adopt the newest prior versioned cache present on disk (v6 before v5).
+async function adoptNewestPriorCache(): Promise<SessionCache | null> {
+  for (const version of PRIOR_CACHE_VERSIONS) {
+    const adopted = await adoptPriorCache(version)
+    if (adopted) return adopted
+  }
+  return null
+}
+
 export async function loadCache(): Promise<SessionCache> {
   try {
     const raw = await readFile(getCachePath(), 'utf-8')
@@ -457,12 +474,13 @@ export async function loadCache(): Promise<SessionCache> {
   }
 }
 
-// The versioned (v6) file is absent/unreadable. Prefer adopting the prior v5
-// file's expired-source PR orphans; failing that, fall back to the legacy
-// unversioned file. Either way the versioned file is minted on the next save.
+// The current versioned file is absent/unreadable. Prefer adopting the newest
+// prior versioned file's expired-source PR orphans (v6 before v5); failing that,
+// fall back to the legacy unversioned file. Either way the versioned file is
+// minted on the next save.
 async function afterMissingVersionedCache(): Promise<SessionCache> {
-  const v5 = await adoptV5Cache()
-  if (v5) return v5
+  const prior = await adoptNewestPriorCache()
+  if (prior) return prior
   // validateCache requires version === CACHE_VERSION, so a different-version
   // legacy file is ignored (left intact). We copy it into the versioned file once
   // via saveCache; the legacy file is never modified.

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -65,6 +65,10 @@ export type CachedTurn = {
   // Stored per-turn directly (unlike gitBranch, no change-detection), so a turn's
   // own refs are self-contained. Drives turn-level PR spend attribution. Optional.
   prRefs?: string[]
+  // Claude: `tool_use` ids of the `Agent`/`Task` subagent spawns in this turn.
+  // A spawned sidechain session is folded into the launching turn by matching its
+  // resolved spawn id against these. Stored per-turn directly. Optional.
+  spawnToolUseIds?: string[]
 }
 
 export type FileFingerprint = {
@@ -98,6 +102,13 @@ export type CachedFile = {
   title?: string
   prLinks?: string[]
   isSidechain?: boolean
+  // Subagent-attribution linkage (Claude only). On a SIDECHAIN file,
+  // `parentSessionId` is the spawning session's id (the transcript's internal
+  // `sessionId`). On a PARENT file, `agentSpawnLinks` maps each spawned subagent
+  // id to the `tool_use` id of the `Agent`/`Task` block that launched it. Both
+  // optional; a file is typically one or the other (a nested agent can be both).
+  parentSessionId?: string
+  agentSpawnLinks?: Record<string, string>
 }
 
 export type ProviderSection = {
@@ -130,7 +141,11 @@ export type SessionCache = {
 // v6: per-turn `prRefs` capture for turn-level PR spend attribution. Existing
 // cache turns carry no prRefs; bumping forces a one-time re-parse so surviving
 // transcripts populate the field. (Daily-cache versioning is untouched.)
-export const CACHE_VERSION = 6
+// v7: sidechain->parent linkage — per-turn `spawnToolUseIds`, per-file
+// `parentSessionId` / `agentSpawnLinks` — so subagent spend folds into the parent
+// turn's PR set. v6 never shipped, so users cross v5->v7 in a single combined
+// bump; the v5 adoption path below still rescues expired-PR orphans.
+export const CACHE_VERSION = 7
 
 // The cache filename is version-suffixed so different binaries (e.g. an old
 // launchd menubar on a prior release and a newer desktop app) each own a
@@ -268,6 +283,14 @@ function isOptionalBool(v: unknown): boolean {
   return v === undefined || typeof v === 'boolean'
 }
 
+// A plain object whose every value is a string (or undefined). Used for the
+// sidechain `agentSpawnLinks` map (agentId -> spawn tool_use id).
+function isOptionalStringRecord(v: unknown): boolean {
+  if (v === undefined) return true
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return false
+  return Object.values(v as Record<string, unknown>).every(e => typeof e === 'string')
+}
+
 function isToolCall(v: unknown): boolean {
   if (!v || typeof v !== 'object') return false
   const o = v as Record<string, unknown>
@@ -329,6 +352,7 @@ function validateTurn(t: unknown): t is CachedTurn {
     && typeof o['userMessage'] === 'string'
     && isOptionalString(o['gitBranch'])
     && (o['prRefs'] === undefined || isStringArray(o['prRefs']))
+    && (o['spawnToolUseIds'] === undefined || isStringArray(o['spawnToolUseIds']))
     && Array.isArray(o['calls'])
     && (o['calls'] as unknown[]).every(validateCall)
 }
@@ -346,6 +370,8 @@ function validateCachedFile(f: unknown): f is CachedFile {
     && isOptionalBool(o['isSidechain'])
     && isOptionalString(o['agentType'])
     && isOptionalBool(o['failed'])
+    && isOptionalString(o['parentSessionId'])
+    && isOptionalStringRecord(o['agentSpawnLinks'])
     && Array.isArray(o['turns'])
     && (o['turns'] as unknown[]).every(validateTurn)
 }

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -454,13 +454,28 @@ async function adoptPriorCache(version: number): Promise<SessionCache | null> {
   }
 }
 
-// Adopt the newest prior versioned cache present on disk (v6 before v5).
+// Adopt EVERY prior versioned cache present on disk, migrating OLDEST first and
+// merging per source path so a newer version wins per entry. Returning the newest
+// alone would be wrong: a sparse or partial newer file (e.g. v6 holding only some
+// orphans) would mask older-only orphans that still hold attributable spend. Newer
+// entries overwrite older ones for the same path; entries unique to an older
+// version survive.
 async function adoptNewestPriorCache(): Promise<SessionCache | null> {
-  for (const version of PRIOR_CACHE_VERSIONS) {
+  const oldestFirst = [...PRIOR_CACHE_VERSIONS].sort((a, b) => a - b)
+  let merged: SessionCache | null = null
+  for (const version of oldestFirst) {
     const adopted = await adoptPriorCache(version)
-    if (adopted) return adopted
+    if (!adopted) continue
+    if (!merged) { merged = adopted; continue }
+    for (const [provider, section] of Object.entries(adopted.providers)) {
+      const existing = merged.providers[provider]
+      if (!existing) { merged.providers[provider] = section; continue }
+      // Newer version's entries overwrite older ones for the same source path.
+      Object.assign(existing.files, section.files)
+      if (section.durable) existing.durable = true
+    }
   }
-  return null
+  return merged
 }
 
 export async function loadCache(): Promise<SessionCache> {

--- a/src/sessions-report.ts
+++ b/src/sessions-report.ts
@@ -216,15 +216,35 @@ function selfLinks(session: { prLinks?: string[] }): boolean {
 // only, and a fold ANCHOR has no in-range turns to infer a provider from, so a
 // linkage-bearing session is always attributed to 'claude'; this keeps a parent
 // and its child on the same key.
+// NUL delimiter for composite keys: it cannot appear in a provider name, project
+// name, or session id, so keys never collide (a plain space collides for a name
+// or id that contains a space).
+const KEY_SEP = String.fromCharCode(0)
+
 function linkageProvider(session: SessionSummary): string {
   if (session.parentSessionId || session.agentSpawnLinks || session.spawnPrSets) return 'claude'
   return inferProvider(session)
 }
 function providerSessionKey(session: SessionSummary): string {
-  return `${linkageProvider(session)} ${session.sessionId}`
+  return `${linkageProvider(session)}${KEY_SEP}${session.sessionId}`
 }
 function providerParentKey(session: SessionSummary): string {
-  return `${linkageProvider(session)} ${session.parentSessionId ?? ''}`
+  return `${linkageProvider(session)}${KEY_SEP}${session.parentSessionId ?? ''}`
+}
+
+// Row-level distinct-session key: provider + project + sessionId, NUL-delimited so a
+// project name or session id containing a space never collides (undercounting
+// distinct sessions in a PR row).
+function rowSessionKey(session: SessionSummary): string {
+  return `${linkageProvider(session)}${KEY_SEP}${session.project}${KEY_SEP}${session.sessionId}`
+}
+
+// Distinguishes two DIFFERENT records that happen to share a session id (duplicate
+// or imported data): identical copies produce the same fingerprint and fold once,
+// any difference (cost, calls, span, PR links) marks the key ambiguous so it folds
+// into NEITHER parent/subtree.
+function sessionFingerprint(s: SessionSummary): string {
+  return [s.totalCostUSD, s.apiCalls, s.firstTimestamp, s.lastTimestamp, (s.prLinks ?? []).join(',')].join(KEY_SEP)
 }
 
 /// Index every sidechain (subagent) session by the parent that spawned it, keyed
@@ -249,7 +269,7 @@ export function buildSubagentIndex(projects: ProjectSummary[]): Map<string, Sess
 // exactly once and a parent-link cycle terminates. A self-linking descendant is
 // skipped: it attributes standalone. `spawnAtMs` stays the TOP child's, since the
 // whole subtree resolves against the top parent.
-function buildChildFold(child: SessionSummary, index: Map<string, SessionSummary[]>, claimed: Set<string>): ChildFold {
+function buildChildFold(child: SessionSummary, index: Map<string, SessionSummary[]>, claimed: Set<string>, ambiguous: Set<string>): ChildFold {
   claimed.add(child.sessionId)
   const models = new Map<string, number>()
   const categories = new Map<string, number>()
@@ -269,8 +289,10 @@ function buildChildFold(child: SessionSummary, index: Map<string, SessionSummary
     models, categories, foldedSessions: 1,
   }
   for (const gc of index.get(providerSessionKey(child)) ?? []) {
-    if (claimed.has(gc.sessionId) || selfLinks(gc)) continue
-    const gcf = buildChildFold(gc, index, claimed)
+    // Skip a descendant whose id is ambiguous (two conflicting records share it):
+    // fold neither, consistent with the parent-level rule.
+    if (claimed.has(gc.sessionId) || selfLinks(gc) || ambiguous.has(providerSessionKey(gc))) continue
+    const gcf = buildChildFold(gc, index, claimed, ambiguous)
     fold.cost += gcf.cost; fold.calls += gcf.calls; fold.savingsUSD += gcf.savingsUSD
     fold.foldedSessions += gcf.foldedSessions
     for (const [m, c] of gcf.models) addToMap(fold.models, m, c)
@@ -289,6 +311,14 @@ export type ResolvedChild = { fold: ChildFold; prSet: string[] | null; unlinked:
 function turnStartTs(turn: { timestamp?: string; assistantCalls: Array<{ timestamp?: string }> }): string {
   return turn.assistantCalls[0]?.timestamp || turn.timestamp || ''
 }
+
+// Grace window for a child whose spawn pairing was AMBIGUOUS (the parent recorded
+// its agentId, so we KNOW it spawned this child, but the exact launching turn could
+// not be pinned) and whose first activity lands just after the parent's last turn.
+// The repo has no session-idle gap constant to reuse, so 30 minutes is used as a
+// conservative window: within it the child folds to the parent's last turn rather
+// than vanish; beyond it, it stays unlinked.
+const AMBIGUOUS_SPAWN_GRACE_MS = 30 * 60 * 1000
 
 /// Resolve a fold to the PR its launching parent turn was working on, using the
 /// parent's UNFILTERED turn data so a date range cannot misattribute:
@@ -309,7 +339,19 @@ function resolveChild(parent: SessionSummary, fold: ChildFold): ResolvedChild {
   const ms = fold.spawnAtMs
   if (Number.isNaN(ms)) return { fold, prSet: null, unlinked: true }
   const lastMs = parseMs(parent.lastTimestamp)
-  if (!Number.isNaN(lastMs) && ms > lastMs) return { fold, prSet: null, unlinked: true }
+  if (!Number.isNaN(lastMs) && ms > lastMs) {
+    // After the parent's last turn: normally unlinked. But if the spawn pairing was
+    // AMBIGUOUS (we know it was spawned here, just not which turn) and the child
+    // started within the grace window, extend the fallback to the parent's LAST
+    // turn rather than lose it. A truly-absent pairing (no agentId at all) does not
+    // qualify: we cannot confirm this parent spawned it.
+    const ambiguousPairing = !!parent.ambiguousSpawnAgentIds?.includes(fold.agentId)
+    if (!(ambiguousPairing && ms - lastMs <= AMBIGUOUS_SPAWN_GRACE_MS)) {
+      return { fold, prSet: null, unlinked: true }
+    }
+    // Fall through: every turn has start <= lastMs <= ms, so the walk below carries
+    // `current` to the last turn's PR set.
+  }
   let current: string[] | null = parent.prRefsAtRangeStart?.length ? parent.prRefsAtRangeStart : null
   for (const turn of parent.turns) {
     const tMs = parseMs(turnStartTs(turn))
@@ -329,31 +371,39 @@ export type SubagentAttribution = Map<string, ResolvedChild[]>
 
 export function resolveSubagentAttribution(projects: ProjectSummary[]): SubagentAttribution {
   const index = buildSubagentIndex(projects)
-  // Count PR-bearing parents per key (real sessions AND anchors) to detect an
-  // ambiguous key claimed by more than one distinct parent.
-  const parentCount = new Map<string, number>()
-  const bump = (s: SessionSummary): void => {
-    if (!s.prLinks?.length) return
+  // A provider+sessionId key is AMBIGUOUS when it is carried by more than one
+  // DISTINCT record (different fingerprint) across ALL candidate sessions and
+  // anchors, regardless of whether each has prLinks: a child pointing at that id
+  // cannot tell which record spawned it. Such a key folds into NEITHER parent and
+  // its subtree is skipped (correctness over coverage). Identical duplicates share
+  // a fingerprint, so they are not ambiguous and fold once.
+  const fpByKey = new Map<string, Set<string>>()
+  const note = (s: SessionSummary): void => {
     const k = providerSessionKey(s)
-    parentCount.set(k, (parentCount.get(k) ?? 0) + 1)
+    const set = fpByKey.get(k)
+    if (set) set.add(sessionFingerprint(s))
+    else fpByKey.set(k, new Set([sessionFingerprint(s)]))
   }
   for (const project of projects) {
-    for (const s of project.sessions) bump(s)
-    for (const a of project.subagentAnchors ?? []) bump(a)
+    for (const s of project.sessions) note(s)
+    for (const a of project.subagentAnchors ?? []) note(a)
   }
+  const ambiguous = new Set<string>()
+  for (const [k, fps] of fpByKey) if (fps.size > 1) ambiguous.add(k)
+
   const out: SubagentAttribution = new Map()
   const resolveParent = (parent: SessionSummary): void => {
     if (!parent.prLinks?.length) return
     const k = providerSessionKey(parent)
-    if (out.has(k)) return                                    // already resolved for this key
-    if ((parentCount.get(k) ?? 0) > 1) { out.set(k, []); return } // ambiguous: fold nothing
+    if (out.has(k)) return                          // already resolved for this key
+    if (ambiguous.has(k)) { out.set(k, []); return } // ambiguous parent id: fold nothing
     const direct = index.get(k)
     if (!direct?.length) return
-    const claimed = new Set<string>()                          // one claimed set across all direct children
+    const claimed = new Set<string>()               // one claimed set across all direct children
     const resolved: ResolvedChild[] = []
     for (const child of direct) {
-      if (claimed.has(child.sessionId) || selfLinks(child)) continue
-      resolved.push(resolveChild(parent, buildChildFold(child, index, claimed)))
+      if (claimed.has(child.sessionId) || selfLinks(child) || ambiguous.has(providerSessionKey(child))) continue
+      resolved.push(resolveChild(parent, buildChildFold(child, index, claimed, ambiguous)))
     }
     if (resolved.length) out.set(k, resolved)
   }
@@ -499,7 +549,7 @@ export function buildPrAttribution(projects: ProjectSummary[]): PrAttribution {
   // Fold one parent's resolved children into rows + totals. An unlinked child
   // contributes nothing; a child with no active PR goes to unattributed (no row).
   const foldChildren = (parent: SessionSummary): void => {
-    const sessionKey = `${parent.project} ${parent.sessionId}`
+    const sessionKey = rowSessionKey(parent)
     for (const rc of attribution.get(providerSessionKey(parent)) ?? []) {
       if (rc.unlinked) continue
       subagentSessions += rc.fold.foldedSessions
@@ -523,7 +573,7 @@ export function buildPrAttribution(projects: ProjectSummary[]): PrAttribution {
     for (const session of project.sessions) {
       if (!session.prLinks?.length) continue
       sessions += 1
-      const sessionKey = `${session.project} ${session.sessionId}`
+      const sessionKey = rowSessionKey(session)
       const { perUrl, unattributed } = attributeSessionPrSpend(session)
       for (const [url, c] of perUrl) {
         attributedCost += c.cost

--- a/src/sessions-report.ts
+++ b/src/sessions-report.ts
@@ -172,6 +172,126 @@ export function allocateEven(total: number, n: number): number[] {
   return Array.from({ length: n }, (_, i) => base + (i < extra ? 1 : 0))
 }
 
+/// A subagent (sidechain) session's spend, pre-aggregated for folding into the
+/// parent turn that launched it. `models` is keyed by RAW model name (the row
+/// builder collapses it to short names, exactly like a turn's own calls);
+/// `categories` by TaskCategory. Both maps sum to `cost` (all three derive from
+/// the same child turns), so folding a child in never introduces a rounding gap.
+export type ChildFold = {
+  agentId: string
+  cost: number
+  calls: number
+  savingsUSD: number
+  /// The child's first-activity timestamp, used by the timestamp-bucket fallback.
+  spawnAt: string
+  models: Map<string, number>
+  categories: Map<string, number>
+}
+
+function childFoldFromSession(child: SessionSummary): ChildFold {
+  const models = new Map<string, number>()
+  const categories = new Map<string, number>()
+  for (const turn of child.turns) {
+    let turnCost = 0
+    for (const call of turn.assistantCalls) {
+      turnCost += call.costUSD
+      if (call.model) addToMap(models, call.model, call.costUSD)
+    }
+    if (turn.category) addToMap(categories, turn.category, turnCost)
+  }
+  return {
+    agentId: child.agentId ?? child.sessionId,
+    cost: child.totalCostUSD,
+    calls: child.apiCalls,
+    savingsUSD: child.totalSavingsUSD,
+    spawnAt: child.firstTimestamp,
+    models,
+    categories,
+  }
+}
+
+// A sessionId can repeat across projects, so the parent index is keyed on
+// project + parentSessionId (a child and its parent share a project).
+function subagentKey(project: string, parentSessionId: string): string {
+  return `${project} ${parentSessionId}`
+}
+
+/// Index every sidechain (subagent) session by the parent that spawned it. Keyed
+/// on project + `parentSessionId`. Children whose parent id was never captured
+/// (or is absent from the scan) are simply never looked up, so they stay
+/// standalone sessions contributing nothing to by-PR — the orphan behavior.
+export function buildSubagentIndex(projects: ProjectSummary[]): Map<string, ChildFold[]> {
+  const index = new Map<string, ChildFold[]>()
+  for (const project of projects) {
+    for (const session of project.sessions) {
+      if (!session.parentSessionId) continue
+      const key = subagentKey(session.project, session.parentSessionId)
+      const list = index.get(key)
+      if (list) list.push(childFoldFromSession(session))
+      else index.set(key, [childFoldFromSession(session)])
+    }
+  }
+  return index
+}
+
+/// Children of one parent, resolved to the turn that launched each. `byTurnIndex`
+/// keys align with the parent's `turns` array indices; `unlinked` children
+/// resolved to no turn and fold into the parent's unattributed spend.
+export type TurnFolds = { byTurnIndex: Map<number, ChildFold[]>; unlinked: ChildFold[] }
+
+function turnStartTs(turn: { timestamp?: string; assistantCalls: Array<{ timestamp?: string }> }): string {
+  return turn.assistantCalls[0]?.timestamp || turn.timestamp || ''
+}
+
+/// Resolve each of a parent's children to the turn that launched it:
+///   (a) the child's spawn `tool_use` id (`parent.agentSpawnLinks[agentId]`)
+///       matched against a turn's `spawnToolUseIds` — the true launch point, so
+///       it WINS even when the child's first activity landed during a later turn
+///       (an async/background agent whose result returned under a different PR);
+///   (b) else the turn whose [start, next-start) span contains the child's first
+///       timestamp;
+///   (c) else unlinked (folded into the parent's unattributed spend).
+export function resolveChildFolds(
+  parent: { turns: Array<{ spawnToolUseIds?: string[]; timestamp?: string; assistantCalls: Array<{ timestamp?: string }> }>; agentSpawnLinks?: Record<string, string> },
+  children: ChildFold[],
+): TurnFolds {
+  const byTurnIndex = new Map<number, ChildFold[]>()
+  const unlinked: ChildFold[] = []
+  const turns = parent.turns
+  const spawnTurn = new Map<string, number>()
+  turns.forEach((turn, i) => {
+    for (const id of turn.spawnToolUseIds ?? []) if (!spawnTurn.has(id)) spawnTurn.set(id, i)
+  })
+  const push = (i: number, child: ChildFold): void => {
+    const list = byTurnIndex.get(i)
+    if (list) list.push(child)
+    else byTurnIndex.set(i, [child])
+  }
+  for (const child of children) {
+    const spawnId = parent.agentSpawnLinks?.[child.agentId]
+    if (spawnId !== undefined && spawnTurn.has(spawnId)) { push(spawnTurn.get(spawnId)!, child); continue }
+    const ts = child.spawnAt
+    let idx = -1
+    if (ts) {
+      for (let i = 0; i < turns.length; i++) {
+        const start = turnStartTs(turns[i]!)
+        if (!start) continue
+        if (start <= ts) idx = i
+        else break
+      }
+    }
+    if (idx >= 0) push(idx, child)
+    else unlinked.push(child)
+  }
+  return { byTurnIndex, unlinked }
+}
+
+function* allFolds(folds?: TurnFolds): Iterable<ChildFold> {
+  if (!folds) return
+  for (const list of folds.byTurnIndex.values()) yield* list
+  yield* folds.unlinked
+}
+
 /// Attribute a session's spend to the PRs it referenced, at TURN granularity.
 ///
 /// Walk the turns in order carrying `current` = the PR set of the most recent
@@ -188,7 +308,15 @@ export function allocateEven(total: number, n: number): number[] {
 /// to attribute by, split the whole session evenly across its prLinks, mark every
 /// portion `approx`, and carry the session's model union (its calls still name
 /// their models) but NO category breakdown, since none can be honestly assigned.
-export function attributeSessionPrSpend(session: AttributableSession): SessionPrAttribution {
+///
+/// Subagent folding: `folds` carries the spend of the sidechain sessions this one
+/// spawned, resolved to the launching turn (see resolveChildFolds). Each child's
+/// cost/calls/savings/models/categories are added into that turn BEFORE the PR
+/// split, so the child inherits the turn's PR set; a child on a pre-reference turn
+/// (or resolved to no turn) folds into `unattributed`. Children are folded exactly
+/// once here and never self-attribute (their own `prLinks` is empty), so no spend
+/// is double-counted.
+export function attributeSessionPrSpend(session: AttributableSession, folds?: TurnFolds): SessionPrAttribution {
   const perUrl = new Map<string, PrContribution>()
   const unattributed = { cost: 0, calls: 0, savingsUSD: 0 }
 
@@ -202,13 +330,21 @@ export function attributeSessionPrSpend(session: AttributableSession): SessionPr
           if (call.model) addToMap(legacyModels, call.model, call.costUSD)
         }
       }
+      // Fold subagent spend into the same even split so it is not dropped. Rare:
+      // a legacy (expired-transcript) parent almost never has live children, but
+      // if it does their spend must still land somewhere honest.
+      let extraCost = 0, extraCalls = 0, extraSavings = 0
+      for (const child of allFolds(folds)) {
+        extraCost += child.cost; extraCalls += child.calls; extraSavings += child.savingsUSD
+        for (const [m, mc] of child.models) addToMap(legacyModels, m, mc)
+      }
       const share = 1 / links.length
-      const callAlloc = allocateEven(session.apiCalls, links.length)
+      const callAlloc = allocateEven(session.apiCalls + extraCalls, links.length)
       links.forEach((url, i) => {
         const e = ensureContribution(perUrl, url)
-        e.cost += session.totalCostUSD * share
+        e.cost += (session.totalCostUSD + extraCost) * share
         e.calls += callAlloc[i]!
-        e.savingsUSD += session.totalSavingsUSD * share
+        e.savingsUSD += (session.totalSavingsUSD + extraSavings) * share
         e.approx = true
         for (const [m, mc] of legacyModels) addToMap(e.models, m, mc * share)
       })
@@ -217,21 +353,33 @@ export function attributeSessionPrSpend(session: AttributableSession): SessionPr
   }
 
   let current: string[] | null = session.prRefsAtRangeStart?.length ? session.prRefsAtRangeStart : null
-  for (const turn of session.turns) {
+  for (let index = 0; index < session.turns.length; index++) {
+    const turn = session.turns[index]!
     if (turn.prRefs?.length) current = turn.prRefs
-    const cost = turn.assistantCalls.reduce((s, c) => s + c.costUSD, 0)
-    const calls = turn.assistantCalls.length
-    const savings = turn.assistantCalls.reduce((s, c) => s + (c.savingsUSD ?? 0), 0)
+    let cost = 0, calls = 0, savings = 0
+    let ownCost = 0
+    const modelCostInTurn = new Map<string, number>()
+    const categoryCostInTurn = new Map<string, number>()
+    for (const call of turn.assistantCalls) {
+      cost += call.costUSD; ownCost += call.costUSD; calls += 1; savings += call.savingsUSD ?? 0
+      if (call.model) addToMap(modelCostInTurn, call.model, call.costUSD)
+    }
+    // The turn's own spend lands under its single classified category; each folded
+    // child contributes its OWN per-turn category breakdown (cheaply available
+    // from the child's turns), so opus/haiku work shows under the categories the
+    // subagent actually did rather than the parent turn's label.
+    if (turn.category) addToMap(categoryCostInTurn, turn.category, ownCost)
+    for (const child of folds?.byTurnIndex.get(index) ?? []) {
+      cost += child.cost; calls += child.calls; savings += child.savingsUSD
+      for (const [m, mc] of child.models) addToMap(modelCostInTurn, m, mc)
+      for (const [cat, cc] of child.categories) addToMap(categoryCostInTurn, cat, cc)
+    }
     if (cost === 0 && calls === 0 && savings === 0) continue
     if (current === null) {
       unattributed.cost += cost
       unattributed.calls += calls
       unattributed.savingsUSD += savings
       continue
-    }
-    const modelCostInTurn = new Map<string, number>()
-    for (const call of turn.assistantCalls) {
-      if (call.model) addToMap(modelCostInTurn, call.model, call.costUSD)
     }
     const share = 1 / current.length
     const callAlloc = allocateEven(calls, current.length)
@@ -240,9 +388,16 @@ export function attributeSessionPrSpend(session: AttributableSession): SessionPr
       e.cost += cost * share
       e.calls += callAlloc[i]!
       e.savingsUSD += savings * share
-      if (turn.category) addToMap(e.categories, turn.category, cost * share)
+      for (const [cat, cc] of categoryCostInTurn) addToMap(e.categories, cat, cc * share)
       for (const [m, mc] of modelCostInTurn) addToMap(e.models, m, mc * share)
     })
+  }
+  // A child that resolved to no turn (no spawn link and its first activity fell
+  // outside every turn span) is genuine parent-session overhead: unattributed.
+  for (const child of folds?.unlinked ?? []) {
+    unattributed.cost += child.cost
+    unattributed.calls += child.calls
+    unattributed.savingsUSD += child.savingsUSD
   }
   return { perUrl, unattributed }
 }
@@ -259,13 +414,16 @@ export function aggregateByPr(projects: ProjectSummary[]): PrRow[] {
     sessions: Set<string>; firstStarted: string; lastEnded: string
     models: Map<string, number>; categories: Map<string, number>
   }>()
+  const subagentIndex = buildSubagentIndex(projects)
   for (const project of projects) {
     for (const session of project.sessions) {
       if (!session.prLinks?.length) continue
       // Key on project + sessionId: a transcript basename (sessionId) can repeat
       // across projects, so sessionId alone would undercount distinct sessions.
       const sessionKey = `${session.project} ${session.sessionId}`
-      const { perUrl } = attributeSessionPrSpend(session)
+      const children = subagentIndex.get(subagentKey(session.project, session.sessionId))
+      const folds = children?.length ? resolveChildFolds(session, children) : undefined
+      const { perUrl } = attributeSessionPrSpend(session, folds)
       for (const [url, c] of perUrl) {
         if (c.cost === 0 && c.calls === 0 && c.savingsUSD === 0) continue
         const row = byUrl.get(url) ?? {
@@ -326,22 +484,30 @@ export function aggregateByPr(projects: ProjectSummary[]): PrRow[] {
 /// Totals across every PR-linked session. `attributedCost` is the sum of the
 /// per-PR rows (a summable total, unlike the old by-reference rows);
 /// `unattributedCost` is the pre-reference overhead not tied to any specific PR.
-/// `cost` = attributed + unattributed = the distinct-session spend that produced
-/// PRs. `sessions` counts distinct PR-linked sessions.
-export function prLinkedTotals(projects: ProjectSummary[]): { cost: number; sessions: number; attributedCost: number; unattributedCost: number } {
+/// `cost` = attributed + unattributed = the PR-linked spend, now INCLUDING the
+/// subagent runs folded into those sessions, so it exceeds the parents' own spend.
+/// `sessions` counts distinct PR-linked PARENT sessions; `subagentSessions` counts
+/// the child runs folded into them (each still a standalone row in the sessions
+/// list). Report both so the footer is honest about what the total covers.
+export function prLinkedTotals(projects: ProjectSummary[]): { cost: number; sessions: number; subagentSessions: number; attributedCost: number; unattributedCost: number } {
   let attributedCost = 0
   let unattributedCost = 0
   let sessions = 0
+  let subagentSessions = 0
+  const subagentIndex = buildSubagentIndex(projects)
   for (const project of projects) {
     for (const session of project.sessions) {
       if (!session.prLinks?.length) continue
       sessions += 1
-      const { perUrl, unattributed } = attributeSessionPrSpend(session)
+      const children = subagentIndex.get(subagentKey(session.project, session.sessionId))
+      const folds = children?.length ? resolveChildFolds(session, children) : undefined
+      if (children?.length) subagentSessions += children.length
+      const { perUrl, unattributed } = attributeSessionPrSpend(session, folds)
       for (const c of perUrl.values()) attributedCost += c.cost
       unattributedCost += unattributed.cost
     }
   }
-  return { cost: attributedCost + unattributedCost, sessions, attributedCost, unattributedCost }
+  return { cost: attributedCost + unattributedCost, sessions, subagentSessions, attributedCost, unattributedCost }
 }
 
 export type BranchRow = {

--- a/src/sessions-report.ts
+++ b/src/sessions-report.ts
@@ -179,13 +179,17 @@ export function allocateEven(total: number, n: number): number[] {
 /// three sum to `cost` (derived from the same sessions), so folding never adds a
 /// rounding gap. `foldedSessions` counts the subtree (self plus folded
 /// descendants); `spawnAtMs` is the TOP child's first-activity epoch (the whole
-/// subtree resolves against the top parent through the top child's spawn).
+/// subtree resolves against the top parent through the top child's spawn);
+/// `firstTs`/`lastTs` are the subtree's real activity span, used for the PR row's
+/// date range when the parent has no in-range turns of its own.
 export type ChildFold = {
   agentId: string
   cost: number
   calls: number
   savingsUSD: number
   spawnAtMs: number
+  firstTs: string
+  lastTs: string
   models: Map<string, number>
   categories: Map<string, number>
   foldedSessions: number
@@ -203,31 +207,50 @@ function selfLinks(session: { prLinks?: string[] }): boolean {
   return !!session.prLinks?.length
 }
 
+// A session id alone is NOT globally unique: imported or duplicated transcripts,
+// or two providers, can reuse one id, letting two parents claim one child and
+// corrupting the attribution map. Key parents (and a child's parent reference) by
+// provider + id so linkage stays one-to-one; the ambiguity skip in
+// resolveSubagentAttribution handles a genuine same-provider id collision.
+// Subagent linkage (parentSessionId / agentSpawnLinks / spawnPrSets) is Claude
+// only, and a fold ANCHOR has no in-range turns to infer a provider from, so a
+// linkage-bearing session is always attributed to 'claude'; this keeps a parent
+// and its child on the same key.
+function linkageProvider(session: SessionSummary): string {
+  if (session.parentSessionId || session.agentSpawnLinks || session.spawnPrSets) return 'claude'
+  return inferProvider(session)
+}
+function providerSessionKey(session: SessionSummary): string {
+  return `${linkageProvider(session)} ${session.sessionId}`
+}
+function providerParentKey(session: SessionSummary): string {
+  return `${linkageProvider(session)} ${session.parentSessionId ?? ''}`
+}
+
 /// Index every sidechain (subagent) session by the parent that spawned it, keyed
-/// by `parentSessionId` ALONE. Parent ids are UUIDs and subagent ids are
-/// `agent-<hex>`, both globally unique, so a composite project key is unnecessary
-/// and would drop a child whose worktree cwd resolves to a different
-/// ProjectSummary than its parent. (The base PR's project+sessionId composite key
-/// guards distinct-session COUNTING, a separate concern.) A child whose parent is
-/// absent from the scan is never looked up, so it stays a standalone orphan.
+/// by provider + `parentSessionId`. A child whose parent is absent from the scan
+/// is never looked up, so it stays a standalone orphan.
 export function buildSubagentIndex(projects: ProjectSummary[]): Map<string, SessionSummary[]> {
   const index = new Map<string, SessionSummary[]>()
   for (const project of projects)
     for (const session of project.sessions) {
       if (!session.parentSessionId) continue
-      const list = index.get(session.parentSessionId)
+      const key = providerParentKey(session)
+      const list = index.get(key)
       if (list) list.push(session)
-      else index.set(session.parentSessionId, [session])
+      else index.set(key, [session])
     }
   return index
 }
 
-// Aggregate a child session and its non-self-linking descendants, depth-first,
-// guarded by `visited` against cycles (and against a session being pulled twice).
-// A self-linking descendant is skipped: it attributes standalone. `spawnAtMs`
-// stays the TOP child's, since the whole subtree resolves against the top parent.
-function buildChildFold(child: SessionSummary, index: Map<string, SessionSummary[]>, visited: Set<string>): ChildFold {
-  visited.add(child.sessionId)
+// Aggregate a child session and its non-self-linking descendants, depth-first.
+// `claimed` is ONE set per parent resolution (shared across all direct children),
+// so a descendant reachable through two paths (duplicate/diamond ids) folds
+// exactly once and a parent-link cycle terminates. A self-linking descendant is
+// skipped: it attributes standalone. `spawnAtMs` stays the TOP child's, since the
+// whole subtree resolves against the top parent.
+function buildChildFold(child: SessionSummary, index: Map<string, SessionSummary[]>, claimed: Set<string>): ChildFold {
+  claimed.add(child.sessionId)
   const models = new Map<string, number>()
   const categories = new Map<string, number>()
   for (const turn of child.turns) {
@@ -241,15 +264,19 @@ function buildChildFold(child: SessionSummary, index: Map<string, SessionSummary
   const fold: ChildFold = {
     agentId: child.agentId ?? child.sessionId,
     cost: child.totalCostUSD, calls: child.apiCalls, savingsUSD: child.totalSavingsUSD,
-    spawnAtMs: parseMs(child.firstTimestamp), models, categories, foldedSessions: 1,
+    spawnAtMs: parseMs(child.firstTimestamp),
+    firstTs: child.firstTimestamp, lastTs: child.lastTimestamp,
+    models, categories, foldedSessions: 1,
   }
-  for (const gc of index.get(child.sessionId) ?? []) {
-    if (visited.has(gc.sessionId) || selfLinks(gc)) continue
-    const gcf = buildChildFold(gc, index, visited)
+  for (const gc of index.get(providerSessionKey(child)) ?? []) {
+    if (claimed.has(gc.sessionId) || selfLinks(gc)) continue
+    const gcf = buildChildFold(gc, index, claimed)
     fold.cost += gcf.cost; fold.calls += gcf.calls; fold.savingsUSD += gcf.savingsUSD
     fold.foldedSessions += gcf.foldedSessions
     for (const [m, c] of gcf.models) addToMap(fold.models, m, c)
     for (const [cat, c] of gcf.categories) addToMap(fold.categories, cat, c)
+    if (gcf.firstTs && (!fold.firstTs || gcf.firstTs < fold.firstTs)) fold.firstTs = gcf.firstTs
+    if (gcf.lastTs > fold.lastTs) fold.lastTs = gcf.lastTs
   }
   return fold
 }
@@ -293,38 +320,47 @@ function resolveChild(parent: SessionSummary, fold: ChildFold): ResolvedChild {
   return { fold, prSet: current, unlinked: false }
 }
 
-/// Resolve every folded child to its parent's PR set, ONCE. Both `aggregateByPr`
-/// and `prLinkedTotals` consume this instead of each rebuilding the index and
-/// re-resolving. Keyed by parent sessionId; only PR-bearing parents (the ones the
-/// consumers iterate) are resolved. A self-linking direct child is skipped (it
-/// attributes standalone); its own non-self-linking descendants fold into it when
-/// it is itself iterated as a PR-bearing parent.
+/// Resolve every folded child to its parent's PR set, once. Keyed by the parent's
+/// provider + sessionId. Parents come from each project's `sessions` AND its
+/// `subagentAnchors` (PR-linked parents kept only for folding). When two DISTINCT
+/// parents share a key (true duplicate data), the child is folded into NEITHER
+/// (deterministic skip, stays standalone): correctness over coverage.
 export type SubagentAttribution = Map<string, ResolvedChild[]>
 
-// Memoize by the `projects` array identity so `aggregateByPr` and `prLinkedTotals`
-// (called with the same array in one report render) resolve the subagent tree
-// once, not twice. Keyed weakly, so it is released with the array; a fresh report
-// builds a new array and recomputes. Public signature is unchanged.
-const attributionCache = new WeakMap<ProjectSummary[], SubagentAttribution>()
-
 export function resolveSubagentAttribution(projects: ProjectSummary[]): SubagentAttribution {
-  const memo = attributionCache.get(projects)
-  if (memo) return memo
   const index = buildSubagentIndex(projects)
+  // Count PR-bearing parents per key (real sessions AND anchors) to detect an
+  // ambiguous key claimed by more than one distinct parent.
+  const parentCount = new Map<string, number>()
+  const bump = (s: SessionSummary): void => {
+    if (!s.prLinks?.length) return
+    const k = providerSessionKey(s)
+    parentCount.set(k, (parentCount.get(k) ?? 0) + 1)
+  }
+  for (const project of projects) {
+    for (const s of project.sessions) bump(s)
+    for (const a of project.subagentAnchors ?? []) bump(a)
+  }
   const out: SubagentAttribution = new Map()
-  for (const project of projects)
-    for (const parent of project.sessions) {
-      if (!parent.prLinks?.length) continue
-      const direct = index.get(parent.sessionId)
-      if (!direct?.length) continue
-      const resolved: ResolvedChild[] = []
-      for (const child of direct) {
-        if (selfLinks(child)) continue
-        resolved.push(resolveChild(parent, buildChildFold(child, index, new Set<string>())))
-      }
-      if (resolved.length) out.set(parent.sessionId, resolved)
+  const resolveParent = (parent: SessionSummary): void => {
+    if (!parent.prLinks?.length) return
+    const k = providerSessionKey(parent)
+    if (out.has(k)) return                                    // already resolved for this key
+    if ((parentCount.get(k) ?? 0) > 1) { out.set(k, []); return } // ambiguous: fold nothing
+    const direct = index.get(k)
+    if (!direct?.length) return
+    const claimed = new Set<string>()                          // one claimed set across all direct children
+    const resolved: ResolvedChild[] = []
+    for (const child of direct) {
+      if (claimed.has(child.sessionId) || selfLinks(child)) continue
+      resolved.push(resolveChild(parent, buildChildFold(child, index, claimed)))
     }
-  attributionCache.set(projects, out)
+    if (resolved.length) out.set(k, resolved)
+  }
+  for (const project of projects) {
+    for (const parent of project.sessions) resolveParent(parent)
+    for (const anchor of project.subagentAnchors ?? []) resolveParent(anchor)
+  }
   return out
 }
 
@@ -403,12 +439,23 @@ export function attributeSessionPrSpend(session: AttributableSession): SessionPr
   return { perUrl, unattributed }
 }
 
-/// Spend attributed to each pull request at turn granularity (see
-/// attributeSessionPrSpend). Rows carry ATTRIBUTED cost/calls and ARE summable;
-/// `sessions` counts the distinct sessions that contributed any spend to the PR;
-/// `approx` marks rows fed by the legacy even-split fallback; `models` and
-/// `categories` are the attributed model/category breakdowns. Sorted by cost, desc.
-export function aggregateByPr(projects: ProjectSummary[]): PrRow[] {
+/// PR-attribution totals. `attributedCost` is the sum of the per-PR rows;
+/// `unattributedCost` is pre-reference overhead not tied to any specific PR;
+/// `cost` = attributed + unattributed = the PR-linked spend INCLUDING folded
+/// subagent runs, so it exceeds the parents' own spend. `sessions` counts distinct
+/// PR-linked PARENT sessions ONLY (0-cost fold anchors are excluded); it is
+/// `subagentSessions` (folded subtrees: children plus descendants) that explains
+/// the extra spend.
+export type PrTotals = { cost: number; sessions: number; subagentSessions: number; attributedCost: number; unattributedCost: number }
+export type PrAttribution = { rows: PrRow[]; totals: PrTotals }
+
+/// Spend by pull request, at turn granularity, with subagent runs folded into the
+/// PR each was working on. Computed in ONE pass so `aggregateByPr` (rows) and
+/// `prLinkedTotals` (totals) never disagree; the payload builder should call this
+/// once and read both. Rows carry ATTRIBUTED cost/calls and ARE summable; `approx`
+/// marks legacy even-split rows; `models`/`categories` are the attributed
+/// breakdowns. Sorted by cost, descending.
+export function buildPrAttribution(projects: ProjectSummary[]): PrAttribution {
   const byUrl = new Map<string, {
     cost: number; savingsUSD: number; calls: number; approx: boolean
     legacyCost: number
@@ -416,9 +463,16 @@ export function aggregateByPr(projects: ProjectSummary[]): PrRow[] {
     models: Map<string, number>; categories: Map<string, number>
   }>()
   const attribution = resolveSubagentAttribution(projects)
+  let attributedCost = 0
+  let unattributedCost = 0
+  let sessions = 0
+  let subagentSessions = 0
+
   // Add one contribution (a parent turn's share, or a folded child's share) to a
-  // PR row. `sessionKey` is the PARENT session identity, so a folded child does
-  // not inflate the row's distinct-session count beyond its parent.
+  // PR row. `sessionKey` is the contributing PARENT's identity, so a folded child
+  // does not inflate the row's distinct-session count beyond its parent. Empty
+  // timestamps (a 0-turn anchor) never widen the span; folded children pass their
+  // OWN activity span, which is what dates an anchor-only row.
   const addTo = (
     url: string, sessionKey: string, firstTs: string, lastTs: string,
     cost: number, savings: number, calls: number, approx: boolean,
@@ -437,41 +491,56 @@ export function aggregateByPr(projects: ProjectSummary[]): PrRow[] {
     if (approx) { row.approx = true; row.legacyCost += cost }
     for (const [m, mc] of models) addToMap(row.models, m, mc)
     for (const [cat, cc] of categories) addToMap(row.categories, cat, cc)
-    if (firstTs < row.firstStarted) row.firstStarted = firstTs
-    if (lastTs > row.lastEnded) row.lastEnded = lastTs
+    if (firstTs && (!row.firstStarted || firstTs < row.firstStarted)) row.firstStarted = firstTs
+    if (lastTs && lastTs > row.lastEnded) row.lastEnded = lastTs
     byUrl.set(url, row)
   }
+
+  // Fold one parent's resolved children into rows + totals. An unlinked child
+  // contributes nothing; a child with no active PR goes to unattributed (no row).
+  const foldChildren = (parent: SessionSummary): void => {
+    const sessionKey = `${parent.project} ${parent.sessionId}`
+    for (const rc of attribution.get(providerSessionKey(parent)) ?? []) {
+      if (rc.unlinked) continue
+      subagentSessions += rc.fold.foldedSessions
+      if (!rc.prSet?.length) { unattributedCost += rc.fold.cost; continue }
+      attributedCost += rc.fold.cost
+      const prs = rc.prSet
+      const share = 1 / prs.length
+      const callAlloc = allocateEven(rc.fold.calls, prs.length)
+      prs.forEach((url, i) => {
+        const models = new Map<string, number>()
+        for (const [m, mc] of rc.fold.models) models.set(m, mc * share)
+        const categories = new Map<string, number>()
+        for (const [cat, cc] of rc.fold.categories) categories.set(cat, cc * share)
+        addTo(url, sessionKey, rc.fold.firstTs, rc.fold.lastTs,
+          rc.fold.cost * share, rc.fold.savingsUSD * share, callAlloc[i]!, false, models, categories)
+      })
+    }
+  }
+
   for (const project of projects) {
     for (const session of project.sessions) {
       if (!session.prLinks?.length) continue
-      // Key on project + sessionId: a transcript basename (sessionId) can repeat
-      // across projects, so sessionId alone would undercount distinct sessions.
-      const sessionKey = `${session.project} ${session.sessionId}`
-      const { perUrl } = attributeSessionPrSpend(session)
+      sessions += 1
+      const sessionKey = `${session.project} ${session.sessionId}`
+      const { perUrl, unattributed } = attributeSessionPrSpend(session)
       for (const [url, c] of perUrl) {
+        attributedCost += c.cost
         addTo(url, sessionKey, session.firstTimestamp, session.lastTimestamp, c.cost, c.savingsUSD, c.calls, c.approx, c.models, c.categories)
       }
-      // Fold this session's resolved subagent children into the PR each was
-      // working on. A child resolved to no PR (unattributed) or after the parent's
-      // last turn (unlinked) creates no row; it surfaces only in prLinkedTotals.
-      // Folded children carry no `approx` (they have genuine per-turn categories).
-      for (const rc of attribution.get(session.sessionId) ?? []) {
-        if (rc.unlinked || !rc.prSet?.length) continue
-        const prs = rc.prSet
-        const share = 1 / prs.length
-        const callAlloc = allocateEven(rc.fold.calls, prs.length)
-        prs.forEach((url, i) => {
-          const models = new Map<string, number>()
-          for (const [m, mc] of rc.fold.models) models.set(m, mc * share)
-          const categories = new Map<string, number>()
-          for (const [cat, cc] of rc.fold.categories) categories.set(cat, cc * share)
-          addTo(url, sessionKey, session.firstTimestamp, session.lastTimestamp,
-            rc.fold.cost * share, rc.fold.savingsUSD * share, callAlloc[i]!, false, models, categories)
-        })
-      }
+      unattributedCost += unattributed.cost
+      foldChildren(session)
+    }
+    // Anchor parents: fold their children only. NOT counted in `sessions`, and no
+    // own spend (they have no in-range turns).
+    for (const anchor of project.subagentAnchors ?? []) {
+      if (!anchor.prLinks?.length) continue
+      foldChildren(anchor)
     }
   }
-  return [...byUrl.entries()]
+
+  const rows = [...byUrl.entries()]
     .map(([url, r]) => {
       // Collapse raw model names to short display names, summing costs that map
       // to the same short name, then order by attributed cost (name asc breaks
@@ -504,41 +573,18 @@ export function aggregateByPr(projects: ProjectSummary[]): PrRow[] {
       }
     })
     .sort((a, b) => b.cost - a.cost)
+
+  return { rows, totals: { cost: attributedCost + unattributedCost, sessions, subagentSessions, attributedCost, unattributedCost } }
 }
 
-/// Totals across every PR-linked session. `attributedCost` is the sum of the
-/// per-PR rows (a summable total, unlike the old by-reference rows);
-/// `unattributedCost` is the pre-reference overhead not tied to any specific PR.
-/// `cost` = attributed + unattributed = the PR-linked spend, now INCLUDING the
-/// subagent runs folded into those sessions, so it exceeds the parents' own spend.
-/// `sessions` counts distinct PR-linked PARENT sessions; `subagentSessions` counts
-/// the child runs folded into them (each still a standalone row in the sessions
-/// list). Report both so the footer is honest about what the total covers.
-export function prLinkedTotals(projects: ProjectSummary[]): { cost: number; sessions: number; subagentSessions: number; attributedCost: number; unattributedCost: number } {
-  let attributedCost = 0
-  let unattributedCost = 0
-  let sessions = 0
-  let subagentSessions = 0
-  const attribution = resolveSubagentAttribution(projects)
-  for (const project of projects) {
-    for (const session of project.sessions) {
-      if (!session.prLinks?.length) continue
-      sessions += 1
-      const { perUrl, unattributed } = attributeSessionPrSpend(session)
-      for (const c of perUrl.values()) attributedCost += c.cost
-      unattributedCost += unattributed.cost
-      // Fold resolved children: an unlinked child contributes nothing; otherwise
-      // count its whole folded subtree and add its spend to attributed (resolved to
-      // a PR) or unattributed (no active PR at its spawn).
-      for (const rc of attribution.get(session.sessionId) ?? []) {
-        if (rc.unlinked) continue
-        subagentSessions += rc.fold.foldedSessions
-        if (rc.prSet?.length) attributedCost += rc.fold.cost
-        else unattributedCost += rc.fold.cost
-      }
-    }
-  }
-  return { cost: attributedCost + unattributedCost, sessions, subagentSessions, attributedCost, unattributedCost }
+/// Spend attributed to each pull request (thin wrapper over buildPrAttribution).
+export function aggregateByPr(projects: ProjectSummary[]): PrRow[] {
+  return buildPrAttribution(projects).rows
+}
+
+/// Totals across every PR-linked session (thin wrapper over buildPrAttribution).
+export function prLinkedTotals(projects: ProjectSummary[]): PrTotals {
+  return buildPrAttribution(projects).totals
 }
 
 export type BranchRow = {

--- a/src/sessions-report.ts
+++ b/src/sessions-report.ts
@@ -239,36 +239,73 @@ function rowSessionKey(session: SessionSummary): string {
   return `${linkageProvider(session)}${KEY_SEP}${session.project}${KEY_SEP}${session.sessionId}`
 }
 
-// Sorted-key canonical serialization of a Record, so two records that map the same
-// entries fingerprint EQUAL regardless of insertion order.
-function canonicalRecord(rec: Record<string, string | string[]> | undefined): string {
-  if (!rec) return ''
-  return Object.keys(rec).sort().map(k => {
-    const v = rec[k]!
-    return `${k}=${Array.isArray(v) ? v.join(',') : v}`
-  }).join(';')
+// Recursive canonical normalizer: sorts every OBJECT's keys so serialization is
+// order-independent, and preserves ARRAY order (the caller pre-sorts arrays whose
+// semantics are set-like). Emitting the normalized structure through JSON.stringify
+// (rather than delimiter concatenation) means no separator can collide across
+// distinct inputs.
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      out[k] = canonicalize((value as Record<string, unknown>)[k])
+    }
+    return out
+  }
+  return value
+}
+
+const sortedCopy = (a: readonly string[] | undefined): string[] => [...(a ?? [])].sort()
+
+// A record whose value arrays are SET-semantic (sorted), for spawnPrSets.
+function sortedRecord(rec: Record<string, string[]> | undefined): Record<string, string[]> {
+  const out: Record<string, string[]> = {}
+  for (const k of Object.keys(rec ?? {})) out[k] = sortedCopy(rec![k])
+  return out
 }
 
 // Distinguishes two DIFFERENT records that happen to share a session id (duplicate
 // or imported data): identical copies produce the same fingerprint and fold once,
 // any difference marks the key ambiguous so it folds into NEITHER parent/subtree.
-// The fingerprint covers EVERY field that changes fold behavior, not just headline
-// stats: two parents mapping the same child to different spawns/PRs (agentSpawnLinks
-// / spawnPrSets) must differ here, or the ambiguity rule never fires and a stale
-// first-wins returns an order-dependent result.
+// The fingerprint serializes the COMPLETE fold-determining state, canonically:
+// session-level linkage AND the per-turn sequence (timestamp, prRefs, cost, calls,
+// savings, per-model cost). Set-semantic fields (PR-ref lists, ambiguous ids,
+// spawnPrSets values) are sorted; the turn list keeps its order (sequence-semantic).
 function sessionFingerprint(s: SessionSummary): string {
-  return JSON.stringify([
-    s.totalCostUSD, s.apiCalls, s.firstTimestamp, s.lastTimestamp,
-    s.parentSessionId ?? '', s.agentId ?? '',
-    (s.prLinks ?? []),
-    (s.prRefsAtRangeStart ?? []),
-    [...(s.ambiguousSpawnAgentIds ?? [])].sort(),
-    canonicalRecord(s.agentSpawnLinks),
-    canonicalRecord(s.spawnPrSets),
-    // The per-turn PR-ref timeline: the launch turn's PR is what a child inherits,
-    // so two records with different prRefs sequences are distinct folds.
-    s.turns.map(t => (t.prRefs ?? []).join('|')).join('>'),
-  ])
+  return JSON.stringify(canonicalize({
+    cost: s.totalCostUSD,
+    calls: s.apiCalls,
+    first: s.firstTimestamp,
+    last: s.lastTimestamp,
+    parent: s.parentSessionId ?? '',
+    agent: s.agentId ?? '',
+    prLinks: sortedCopy(s.prLinks),
+    rangeStart: sortedCopy(s.prRefsAtRangeStart),
+    ambiguous: sortedCopy(s.ambiguousSpawnAgentIds),
+    spawnLinks: s.agentSpawnLinks ?? {},
+    spawnPrSets: sortedRecord(s.spawnPrSets),
+    turns: s.turns.map(t => {
+      const modelCost: Record<string, number> = {}
+      for (const c of t.assistantCalls) if (c.model) modelCost[c.model] = (modelCost[c.model] ?? 0) + c.costUSD
+      return {
+        ts: t.assistantCalls[0]?.timestamp ?? t.timestamp ?? '',
+        prRefs: sortedCopy(t.prRefs),
+        cost: t.assistantCalls.reduce((n, c) => n + c.costUSD, 0),
+        calls: t.assistantCalls.length,
+        savings: t.assistantCalls.reduce((n, c) => n + (c.savingsUSD ?? 0), 0),
+        models: modelCost,
+      }
+    }),
+  }))
+}
+
+/// Provider-aware, fingerprint-qualified identity of a session: two sessions share
+/// it ONLY when they are the same provider+id AND a proven-identical record. Used to
+/// dedupe a fold anchor against a genuinely-identical surviving session without
+/// dropping a different-provider or different-record session that shares a raw id.
+export function sessionIdentity(session: SessionSummary): string {
+  return `${providerSessionKey(session)}${KEY_SEP}${sessionFingerprint(session)}`
 }
 
 /// Index every sidechain (subagent) session by the parent that spawned it, keyed
@@ -570,11 +607,17 @@ export function buildPrAttribution(projects: ProjectSummary[]): PrAttribution {
     byUrl.set(url, row)
   }
 
-  // Fold one parent's resolved children into rows + totals. An unlinked child
-  // contributes nothing; a child with no active PR goes to unattributed (no row).
+  // Fold one parent's resolved children into rows + totals, ONCE per parent key: two
+  // duplicate parent sessions share a provider+sessionId key and the SAME resolved
+  // children, so folding for each would double-count. An unlinked child contributes
+  // nothing; a child with no active PR goes to unattributed (no row).
+  const foldedKeys = new Set<string>()
   const foldChildren = (parent: SessionSummary): void => {
+    const key = providerSessionKey(parent)
+    if (foldedKeys.has(key)) return
+    foldedKeys.add(key)
     const sessionKey = rowSessionKey(parent)
-    for (const rc of attribution.get(providerSessionKey(parent)) ?? []) {
+    for (const rc of attribution.get(key) ?? []) {
       if (rc.unlinked) continue
       subagentSessions += rc.fold.foldedSessions
       if (!rc.prSet?.length) { unattributedCost += rc.fold.cost; continue }

--- a/src/sessions-report.ts
+++ b/src/sessions-report.ts
@@ -172,23 +172,62 @@ export function allocateEven(total: number, n: number): number[] {
   return Array.from({ length: n }, (_, i) => base + (i < extra ? 1 : 0))
 }
 
-/// A subagent (sidechain) session's spend, pre-aggregated for folding into the
-/// parent turn that launched it. `models` is keyed by RAW model name (the row
-/// builder collapses it to short names, exactly like a turn's own calls);
-/// `categories` by TaskCategory. Both maps sum to `cost` (all three derive from
-/// the same child turns), so folding a child in never introduces a rounding gap.
+/// A subagent (sidechain) session's spend plus its non-self-linking descendants,
+/// pre-aggregated for folding into the PR its launching parent turn was working
+/// on. `models` keys are RAW model names (the row builder collapses them to short
+/// names, exactly like a turn's own calls); `categories` are TaskCategory. All
+/// three sum to `cost` (derived from the same sessions), so folding never adds a
+/// rounding gap. `foldedSessions` counts the subtree (self plus folded
+/// descendants); `spawnAtMs` is the TOP child's first-activity epoch (the whole
+/// subtree resolves against the top parent through the top child's spawn).
 export type ChildFold = {
   agentId: string
   cost: number
   calls: number
   savingsUSD: number
-  /// The child's first-activity timestamp, used by the timestamp-bucket fallback.
-  spawnAt: string
+  spawnAtMs: number
   models: Map<string, number>
   categories: Map<string, number>
+  foldedSessions: number
 }
 
-function childFoldFromSession(child: SessionSummary): ChildFold {
+function parseMs(ts: string | undefined): number {
+  return ts ? Date.parse(ts) : NaN
+}
+
+// A child "self-links" when it referenced its own PR: it then attributes
+// standalone (its own turn-level attribution is more precise) and is NEVER folded
+// into a parent, so its spend is counted exactly once. A child with no links is
+// folded only. This mutual exclusion is what prevents a double-charge.
+function selfLinks(session: { prLinks?: string[] }): boolean {
+  return !!session.prLinks?.length
+}
+
+/// Index every sidechain (subagent) session by the parent that spawned it, keyed
+/// by `parentSessionId` ALONE. Parent ids are UUIDs and subagent ids are
+/// `agent-<hex>`, both globally unique, so a composite project key is unnecessary
+/// and would drop a child whose worktree cwd resolves to a different
+/// ProjectSummary than its parent. (The base PR's project+sessionId composite key
+/// guards distinct-session COUNTING, a separate concern.) A child whose parent is
+/// absent from the scan is never looked up, so it stays a standalone orphan.
+export function buildSubagentIndex(projects: ProjectSummary[]): Map<string, SessionSummary[]> {
+  const index = new Map<string, SessionSummary[]>()
+  for (const project of projects)
+    for (const session of project.sessions) {
+      if (!session.parentSessionId) continue
+      const list = index.get(session.parentSessionId)
+      if (list) list.push(session)
+      else index.set(session.parentSessionId, [session])
+    }
+  return index
+}
+
+// Aggregate a child session and its non-self-linking descendants, depth-first,
+// guarded by `visited` against cycles (and against a session being pulled twice).
+// A self-linking descendant is skipped: it attributes standalone. `spawnAtMs`
+// stays the TOP child's, since the whole subtree resolves against the top parent.
+function buildChildFold(child: SessionSummary, index: Map<string, SessionSummary[]>, visited: Set<string>): ChildFold {
+  visited.add(child.sessionId)
   const models = new Map<string, number>()
   const categories = new Map<string, number>()
   for (const turn of child.turns) {
@@ -199,97 +238,94 @@ function childFoldFromSession(child: SessionSummary): ChildFold {
     }
     if (turn.category) addToMap(categories, turn.category, turnCost)
   }
-  return {
+  const fold: ChildFold = {
     agentId: child.agentId ?? child.sessionId,
-    cost: child.totalCostUSD,
-    calls: child.apiCalls,
-    savingsUSD: child.totalSavingsUSD,
-    spawnAt: child.firstTimestamp,
-    models,
-    categories,
+    cost: child.totalCostUSD, calls: child.apiCalls, savingsUSD: child.totalSavingsUSD,
+    spawnAtMs: parseMs(child.firstTimestamp), models, categories, foldedSessions: 1,
   }
-}
-
-// A sessionId can repeat across projects, so the parent index is keyed on
-// project + parentSessionId (a child and its parent share a project).
-function subagentKey(project: string, parentSessionId: string): string {
-  return `${project} ${parentSessionId}`
-}
-
-/// Index every sidechain (subagent) session by the parent that spawned it. Keyed
-/// on project + `parentSessionId`. Children whose parent id was never captured
-/// (or is absent from the scan) are simply never looked up, so they stay
-/// standalone sessions contributing nothing to by-PR — the orphan behavior.
-export function buildSubagentIndex(projects: ProjectSummary[]): Map<string, ChildFold[]> {
-  const index = new Map<string, ChildFold[]>()
-  for (const project of projects) {
-    for (const session of project.sessions) {
-      if (!session.parentSessionId) continue
-      const key = subagentKey(session.project, session.parentSessionId)
-      const list = index.get(key)
-      if (list) list.push(childFoldFromSession(session))
-      else index.set(key, [childFoldFromSession(session)])
-    }
+  for (const gc of index.get(child.sessionId) ?? []) {
+    if (visited.has(gc.sessionId) || selfLinks(gc)) continue
+    const gcf = buildChildFold(gc, index, visited)
+    fold.cost += gcf.cost; fold.calls += gcf.calls; fold.savingsUSD += gcf.savingsUSD
+    fold.foldedSessions += gcf.foldedSessions
+    for (const [m, c] of gcf.models) addToMap(fold.models, m, c)
+    for (const [cat, c] of gcf.categories) addToMap(fold.categories, cat, c)
   }
-  return index
+  return fold
 }
 
-/// Children of one parent, resolved to the turn that launched each. `byTurnIndex`
-/// keys align with the parent's `turns` array indices; `unlinked` children
-/// resolved to no turn and fold into the parent's unattributed spend.
-export type TurnFolds = { byTurnIndex: Map<number, ChildFold[]>; unlinked: ChildFold[] }
+/// A folded child resolved against its parent: to a PR set (`prSet` non-empty), to
+/// the parent's unattributed spend (`prSet` null, `unlinked` false), or unlinked
+/// (`unlinked` true, contributes NOTHING to by-PR, the orphan semantics).
+export type ResolvedChild = { fold: ChildFold; prSet: string[] | null; unlinked: boolean }
 
 function turnStartTs(turn: { timestamp?: string; assistantCalls: Array<{ timestamp?: string }> }): string {
   return turn.assistantCalls[0]?.timestamp || turn.timestamp || ''
 }
 
-/// Resolve each of a parent's children to the turn that launched it:
-///   (a) the child's spawn `tool_use` id (`parent.agentSpawnLinks[agentId]`)
-///       matched against a turn's `spawnToolUseIds` — the true launch point, so
-///       it WINS even when the child's first activity landed during a later turn
-///       (an async/background agent whose result returned under a different PR);
-///   (b) else the turn whose [start, next-start) span contains the child's first
-///       timestamp;
-///   (c) else unlinked (folded into the parent's unattributed spend).
-export function resolveChildFolds(
-  parent: { turns: Array<{ spawnToolUseIds?: string[]; timestamp?: string; assistantCalls: Array<{ timestamp?: string }> }>; agentSpawnLinks?: Record<string, string> },
-  children: ChildFold[],
-): TurnFolds {
-  const byTurnIndex = new Map<number, ChildFold[]>()
-  const unlinked: ChildFold[] = []
-  const turns = parent.turns
-  const spawnTurn = new Map<string, number>()
-  turns.forEach((turn, i) => {
-    for (const id of turn.spawnToolUseIds ?? []) if (!spawnTurn.has(id)) spawnTurn.set(id, i)
-  })
-  const push = (i: number, child: ChildFold): void => {
-    const list = byTurnIndex.get(i)
-    if (list) list.push(child)
-    else byTurnIndex.set(i, [child])
+/// Resolve a fold to the PR its launching parent turn was working on, using the
+/// parent's UNFILTERED turn data so a date range cannot misattribute:
+///   1. spawn `tool_use` id to `parent.spawnPrSets` (built at assembly from the
+///      FULL turn list), so a spawn in a pre-range turn still yields the right PR;
+///      an empty set there means the spawn had no active PR, so unattributed.
+///   2. else the child's first-activity epoch bucketed into the parent's turn PR
+///      carry (seeded from `prRefsAtRangeStart`). Timestamps compare as epoch ms
+///      (mixed UTC offsets order correctly). Activity strictly AFTER the parent's
+///      last timestamp is unlinked (contributes nothing); before the first turn it
+///      carries the pre-range set (or unattributed).
+function resolveChild(parent: SessionSummary, fold: ChildFold): ResolvedChild {
+  const spawnId = parent.agentSpawnLinks?.[fold.agentId]
+  if (spawnId !== undefined && parent.spawnPrSets && Object.prototype.hasOwnProperty.call(parent.spawnPrSets, spawnId)) {
+    const prs = parent.spawnPrSets[spawnId]!
+    return { fold, prSet: prs.length ? prs : null, unlinked: false }
   }
-  for (const child of children) {
-    const spawnId = parent.agentSpawnLinks?.[child.agentId]
-    if (spawnId !== undefined && spawnTurn.has(spawnId)) { push(spawnTurn.get(spawnId)!, child); continue }
-    const ts = child.spawnAt
-    let idx = -1
-    if (ts) {
-      for (let i = 0; i < turns.length; i++) {
-        const start = turnStartTs(turns[i]!)
-        if (!start) continue
-        if (start <= ts) idx = i
-        else break
-      }
-    }
-    if (idx >= 0) push(idx, child)
-    else unlinked.push(child)
+  const ms = fold.spawnAtMs
+  if (Number.isNaN(ms)) return { fold, prSet: null, unlinked: true }
+  const lastMs = parseMs(parent.lastTimestamp)
+  if (!Number.isNaN(lastMs) && ms > lastMs) return { fold, prSet: null, unlinked: true }
+  let current: string[] | null = parent.prRefsAtRangeStart?.length ? parent.prRefsAtRangeStart : null
+  for (const turn of parent.turns) {
+    const tMs = parseMs(turnStartTs(turn))
+    if (Number.isNaN(tMs)) continue
+    if (tMs <= ms) { if (turn.prRefs?.length) current = turn.prRefs }
+    else break
   }
-  return { byTurnIndex, unlinked }
+  return { fold, prSet: current, unlinked: false }
 }
 
-function* allFolds(folds?: TurnFolds): Iterable<ChildFold> {
-  if (!folds) return
-  for (const list of folds.byTurnIndex.values()) yield* list
-  yield* folds.unlinked
+/// Resolve every folded child to its parent's PR set, ONCE. Both `aggregateByPr`
+/// and `prLinkedTotals` consume this instead of each rebuilding the index and
+/// re-resolving. Keyed by parent sessionId; only PR-bearing parents (the ones the
+/// consumers iterate) are resolved. A self-linking direct child is skipped (it
+/// attributes standalone); its own non-self-linking descendants fold into it when
+/// it is itself iterated as a PR-bearing parent.
+export type SubagentAttribution = Map<string, ResolvedChild[]>
+
+// Memoize by the `projects` array identity so `aggregateByPr` and `prLinkedTotals`
+// (called with the same array in one report render) resolve the subagent tree
+// once, not twice. Keyed weakly, so it is released with the array; a fresh report
+// builds a new array and recomputes. Public signature is unchanged.
+const attributionCache = new WeakMap<ProjectSummary[], SubagentAttribution>()
+
+export function resolveSubagentAttribution(projects: ProjectSummary[]): SubagentAttribution {
+  const memo = attributionCache.get(projects)
+  if (memo) return memo
+  const index = buildSubagentIndex(projects)
+  const out: SubagentAttribution = new Map()
+  for (const project of projects)
+    for (const parent of project.sessions) {
+      if (!parent.prLinks?.length) continue
+      const direct = index.get(parent.sessionId)
+      if (!direct?.length) continue
+      const resolved: ResolvedChild[] = []
+      for (const child of direct) {
+        if (selfLinks(child)) continue
+        resolved.push(resolveChild(parent, buildChildFold(child, index, new Set<string>())))
+      }
+      if (resolved.length) out.set(parent.sessionId, resolved)
+    }
+  attributionCache.set(projects, out)
+  return out
 }
 
 /// Attribute a session's spend to the PRs it referenced, at TURN granularity.
@@ -308,15 +344,7 @@ function* allFolds(folds?: TurnFolds): Iterable<ChildFold> {
 /// to attribute by, split the whole session evenly across its prLinks, mark every
 /// portion `approx`, and carry the session's model union (its calls still name
 /// their models) but NO category breakdown, since none can be honestly assigned.
-///
-/// Subagent folding: `folds` carries the spend of the sidechain sessions this one
-/// spawned, resolved to the launching turn (see resolveChildFolds). Each child's
-/// cost/calls/savings/models/categories are added into that turn BEFORE the PR
-/// split, so the child inherits the turn's PR set; a child on a pre-reference turn
-/// (or resolved to no turn) folds into `unattributed`. Children are folded exactly
-/// once here and never self-attribute (their own `prLinks` is empty), so no spend
-/// is double-counted.
-export function attributeSessionPrSpend(session: AttributableSession, folds?: TurnFolds): SessionPrAttribution {
+export function attributeSessionPrSpend(session: AttributableSession): SessionPrAttribution {
   const perUrl = new Map<string, PrContribution>()
   const unattributed = { cost: 0, calls: 0, savingsUSD: 0 }
 
@@ -330,21 +358,13 @@ export function attributeSessionPrSpend(session: AttributableSession, folds?: Tu
           if (call.model) addToMap(legacyModels, call.model, call.costUSD)
         }
       }
-      // Fold subagent spend into the same even split so it is not dropped. Rare:
-      // a legacy (expired-transcript) parent almost never has live children, but
-      // if it does their spend must still land somewhere honest.
-      let extraCost = 0, extraCalls = 0, extraSavings = 0
-      for (const child of allFolds(folds)) {
-        extraCost += child.cost; extraCalls += child.calls; extraSavings += child.savingsUSD
-        for (const [m, mc] of child.models) addToMap(legacyModels, m, mc)
-      }
       const share = 1 / links.length
-      const callAlloc = allocateEven(session.apiCalls + extraCalls, links.length)
+      const callAlloc = allocateEven(session.apiCalls, links.length)
       links.forEach((url, i) => {
         const e = ensureContribution(perUrl, url)
-        e.cost += (session.totalCostUSD + extraCost) * share
+        e.cost += session.totalCostUSD * share
         e.calls += callAlloc[i]!
-        e.savingsUSD += (session.totalSavingsUSD + extraSavings) * share
+        e.savingsUSD += session.totalSavingsUSD * share
         e.approx = true
         for (const [m, mc] of legacyModels) addToMap(e.models, m, mc * share)
       })
@@ -353,33 +373,21 @@ export function attributeSessionPrSpend(session: AttributableSession, folds?: Tu
   }
 
   let current: string[] | null = session.prRefsAtRangeStart?.length ? session.prRefsAtRangeStart : null
-  for (let index = 0; index < session.turns.length; index++) {
-    const turn = session.turns[index]!
+  for (const turn of session.turns) {
     if (turn.prRefs?.length) current = turn.prRefs
-    let cost = 0, calls = 0, savings = 0
-    let ownCost = 0
-    const modelCostInTurn = new Map<string, number>()
-    const categoryCostInTurn = new Map<string, number>()
-    for (const call of turn.assistantCalls) {
-      cost += call.costUSD; ownCost += call.costUSD; calls += 1; savings += call.savingsUSD ?? 0
-      if (call.model) addToMap(modelCostInTurn, call.model, call.costUSD)
-    }
-    // The turn's own spend lands under its single classified category; each folded
-    // child contributes its OWN per-turn category breakdown (cheaply available
-    // from the child's turns), so opus/haiku work shows under the categories the
-    // subagent actually did rather than the parent turn's label.
-    if (turn.category) addToMap(categoryCostInTurn, turn.category, ownCost)
-    for (const child of folds?.byTurnIndex.get(index) ?? []) {
-      cost += child.cost; calls += child.calls; savings += child.savingsUSD
-      for (const [m, mc] of child.models) addToMap(modelCostInTurn, m, mc)
-      for (const [cat, cc] of child.categories) addToMap(categoryCostInTurn, cat, cc)
-    }
+    const cost = turn.assistantCalls.reduce((s, c) => s + c.costUSD, 0)
+    const calls = turn.assistantCalls.length
+    const savings = turn.assistantCalls.reduce((s, c) => s + (c.savingsUSD ?? 0), 0)
     if (cost === 0 && calls === 0 && savings === 0) continue
     if (current === null) {
       unattributed.cost += cost
       unattributed.calls += calls
       unattributed.savingsUSD += savings
       continue
+    }
+    const modelCostInTurn = new Map<string, number>()
+    for (const call of turn.assistantCalls) {
+      if (call.model) addToMap(modelCostInTurn, call.model, call.costUSD)
     }
     const share = 1 / current.length
     const callAlloc = allocateEven(calls, current.length)
@@ -388,16 +396,9 @@ export function attributeSessionPrSpend(session: AttributableSession, folds?: Tu
       e.cost += cost * share
       e.calls += callAlloc[i]!
       e.savingsUSD += savings * share
-      for (const [cat, cc] of categoryCostInTurn) addToMap(e.categories, cat, cc * share)
+      if (turn.category) addToMap(e.categories, turn.category, cost * share)
       for (const [m, mc] of modelCostInTurn) addToMap(e.models, m, mc * share)
     })
-  }
-  // A child that resolved to no turn (no spawn link and its first activity fell
-  // outside every turn span) is genuine parent-session overhead: unattributed.
-  for (const child of folds?.unlinked ?? []) {
-    unattributed.cost += child.cost
-    unattributed.calls += child.calls
-    unattributed.savingsUSD += child.savingsUSD
   }
   return { perUrl, unattributed }
 }
@@ -414,35 +415,59 @@ export function aggregateByPr(projects: ProjectSummary[]): PrRow[] {
     sessions: Set<string>; firstStarted: string; lastEnded: string
     models: Map<string, number>; categories: Map<string, number>
   }>()
-  const subagentIndex = buildSubagentIndex(projects)
+  const attribution = resolveSubagentAttribution(projects)
+  // Add one contribution (a parent turn's share, or a folded child's share) to a
+  // PR row. `sessionKey` is the PARENT session identity, so a folded child does
+  // not inflate the row's distinct-session count beyond its parent.
+  const addTo = (
+    url: string, sessionKey: string, firstTs: string, lastTs: string,
+    cost: number, savings: number, calls: number, approx: boolean,
+    models: Map<string, number>, categories: Map<string, number>,
+  ): void => {
+    if (cost === 0 && calls === 0 && savings === 0) return
+    const row = byUrl.get(url) ?? {
+      cost: 0, savingsUSD: 0, calls: 0, approx: false, legacyCost: 0,
+      sessions: new Set<string>(), firstStarted: firstTs, lastEnded: lastTs,
+      models: new Map<string, number>(), categories: new Map<string, number>(),
+    }
+    row.cost += cost
+    row.savingsUSD += savings
+    row.calls += calls
+    row.sessions.add(sessionKey)
+    if (approx) { row.approx = true; row.legacyCost += cost }
+    for (const [m, mc] of models) addToMap(row.models, m, mc)
+    for (const [cat, cc] of categories) addToMap(row.categories, cat, cc)
+    if (firstTs < row.firstStarted) row.firstStarted = firstTs
+    if (lastTs > row.lastEnded) row.lastEnded = lastTs
+    byUrl.set(url, row)
+  }
   for (const project of projects) {
     for (const session of project.sessions) {
       if (!session.prLinks?.length) continue
       // Key on project + sessionId: a transcript basename (sessionId) can repeat
       // across projects, so sessionId alone would undercount distinct sessions.
       const sessionKey = `${session.project} ${session.sessionId}`
-      const children = subagentIndex.get(subagentKey(session.project, session.sessionId))
-      const folds = children?.length ? resolveChildFolds(session, children) : undefined
-      const { perUrl } = attributeSessionPrSpend(session, folds)
+      const { perUrl } = attributeSessionPrSpend(session)
       for (const [url, c] of perUrl) {
-        if (c.cost === 0 && c.calls === 0 && c.savingsUSD === 0) continue
-        const row = byUrl.get(url) ?? {
-          cost: 0, savingsUSD: 0, calls: 0, approx: false, legacyCost: 0,
-          sessions: new Set<string>(), firstStarted: session.firstTimestamp, lastEnded: session.lastTimestamp,
-          models: new Map<string, number>(), categories: new Map<string, number>(),
-        }
-        row.cost += c.cost
-        row.savingsUSD += c.savingsUSD
-        row.calls += c.calls
-        row.sessions.add(sessionKey)
-        // A legacy (approx) contribution carries no per-turn categories; track its
-        // cost so a mixed row can reconcile its category breakdown to the total.
-        if (c.approx) { row.approx = true; row.legacyCost += c.cost }
-        for (const [m, mc] of c.models) addToMap(row.models, m, mc)
-        for (const [cat, cc] of c.categories) addToMap(row.categories, cat, cc)
-        if (session.firstTimestamp < row.firstStarted) row.firstStarted = session.firstTimestamp
-        if (session.lastTimestamp > row.lastEnded) row.lastEnded = session.lastTimestamp
-        byUrl.set(url, row)
+        addTo(url, sessionKey, session.firstTimestamp, session.lastTimestamp, c.cost, c.savingsUSD, c.calls, c.approx, c.models, c.categories)
+      }
+      // Fold this session's resolved subagent children into the PR each was
+      // working on. A child resolved to no PR (unattributed) or after the parent's
+      // last turn (unlinked) creates no row; it surfaces only in prLinkedTotals.
+      // Folded children carry no `approx` (they have genuine per-turn categories).
+      for (const rc of attribution.get(session.sessionId) ?? []) {
+        if (rc.unlinked || !rc.prSet?.length) continue
+        const prs = rc.prSet
+        const share = 1 / prs.length
+        const callAlloc = allocateEven(rc.fold.calls, prs.length)
+        prs.forEach((url, i) => {
+          const models = new Map<string, number>()
+          for (const [m, mc] of rc.fold.models) models.set(m, mc * share)
+          const categories = new Map<string, number>()
+          for (const [cat, cc] of rc.fold.categories) categories.set(cat, cc * share)
+          addTo(url, sessionKey, session.firstTimestamp, session.lastTimestamp,
+            rc.fold.cost * share, rc.fold.savingsUSD * share, callAlloc[i]!, false, models, categories)
+        })
       }
     }
   }
@@ -494,17 +519,23 @@ export function prLinkedTotals(projects: ProjectSummary[]): { cost: number; sess
   let unattributedCost = 0
   let sessions = 0
   let subagentSessions = 0
-  const subagentIndex = buildSubagentIndex(projects)
+  const attribution = resolveSubagentAttribution(projects)
   for (const project of projects) {
     for (const session of project.sessions) {
       if (!session.prLinks?.length) continue
       sessions += 1
-      const children = subagentIndex.get(subagentKey(session.project, session.sessionId))
-      const folds = children?.length ? resolveChildFolds(session, children) : undefined
-      if (children?.length) subagentSessions += children.length
-      const { perUrl, unattributed } = attributeSessionPrSpend(session, folds)
+      const { perUrl, unattributed } = attributeSessionPrSpend(session)
       for (const c of perUrl.values()) attributedCost += c.cost
       unattributedCost += unattributed.cost
+      // Fold resolved children: an unlinked child contributes nothing; otherwise
+      // count its whole folded subtree and add its spend to attributed (resolved to
+      // a PR) or unattributed (no active PR at its spawn).
+      for (const rc of attribution.get(session.sessionId) ?? []) {
+        if (rc.unlinked) continue
+        subagentSessions += rc.fold.foldedSessions
+        if (rc.prSet?.length) attributedCost += rc.fold.cost
+        else unattributedCost += rc.fold.cost
+      }
     }
   }
   return { cost: attributedCost + unattributedCost, sessions, subagentSessions, attributedCost, unattributedCost }

--- a/src/sessions-report.ts
+++ b/src/sessions-report.ts
@@ -239,12 +239,36 @@ function rowSessionKey(session: SessionSummary): string {
   return `${linkageProvider(session)}${KEY_SEP}${session.project}${KEY_SEP}${session.sessionId}`
 }
 
+// Sorted-key canonical serialization of a Record, so two records that map the same
+// entries fingerprint EQUAL regardless of insertion order.
+function canonicalRecord(rec: Record<string, string | string[]> | undefined): string {
+  if (!rec) return ''
+  return Object.keys(rec).sort().map(k => {
+    const v = rec[k]!
+    return `${k}=${Array.isArray(v) ? v.join(',') : v}`
+  }).join(';')
+}
+
 // Distinguishes two DIFFERENT records that happen to share a session id (duplicate
 // or imported data): identical copies produce the same fingerprint and fold once,
-// any difference (cost, calls, span, PR links) marks the key ambiguous so it folds
-// into NEITHER parent/subtree.
+// any difference marks the key ambiguous so it folds into NEITHER parent/subtree.
+// The fingerprint covers EVERY field that changes fold behavior, not just headline
+// stats: two parents mapping the same child to different spawns/PRs (agentSpawnLinks
+// / spawnPrSets) must differ here, or the ambiguity rule never fires and a stale
+// first-wins returns an order-dependent result.
 function sessionFingerprint(s: SessionSummary): string {
-  return [s.totalCostUSD, s.apiCalls, s.firstTimestamp, s.lastTimestamp, (s.prLinks ?? []).join(',')].join(KEY_SEP)
+  return JSON.stringify([
+    s.totalCostUSD, s.apiCalls, s.firstTimestamp, s.lastTimestamp,
+    s.parentSessionId ?? '', s.agentId ?? '',
+    (s.prLinks ?? []),
+    (s.prRefsAtRangeStart ?? []),
+    [...(s.ambiguousSpawnAgentIds ?? [])].sort(),
+    canonicalRecord(s.agentSpawnLinks),
+    canonicalRecord(s.spawnPrSets),
+    // The per-turn PR-ref timeline: the launch turn's PR is what a child inherits,
+    // so two records with different prRefs sequences are distinct folds.
+    s.turns.map(t => (t.prRefs ?? []).join('|')).join('>'),
+  ])
 }
 
 /// Index every sidechain (subagent) session by the parent that spawned it, keyed

--- a/src/types.ts
+++ b/src/types.ts
@@ -220,6 +220,12 @@ export type SessionSummary = {
   /// turn falls outside the report's range. Empty array = spawn had no active PR
   /// (the child is then unattributed). Absent when the session spawned no subagent.
   spawnPrSets?: Record<string, string[]>
+  /// Claude Code only: on a PARENT session, the agent ids whose spawn result named
+  /// them (so we KNOW they were spawned here) but whose exact launching `tool_use`
+  /// id could not be paired (an ambiguous multi-result record). Such a child that
+  /// then lands just after the parent's last turn is folded to that turn within a
+  /// grace window rather than lost. Absent when no pairing was ambiguous.
+  ambiguousSpawnAgentIds?: string[]
   firstTimestamp: string
   lastTimestamp: string
   totalCostUSD: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -285,6 +285,13 @@ export type ProjectSummary = {
   // net out-of-pocket for the project is `totalCostUSD - totalProxiedCostUSD`.
   // 0 when the project is not under a configured proxy path.
   totalProxiedCostUSD: number
+  /// Claude Code only: PR-linked parent sessions whose OWN turns all fell outside
+  /// the report range but which spawned an in-range subagent. Kept ONLY as fold
+  /// anchors for by-PR subagent attribution; they carry no in-range spend and are
+  /// deliberately NOT in `sessions`, so they never touch session counts, averages,
+  /// or any other per-session report. Consumed only by the by-PR resolver. Absent
+  /// when none.
+  subagentAnchors?: SessionSummary[]
 }
 
 export type DateRange = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,11 @@ export type ParsedTurn = {
   // turn-level PR spend attribution; the session-level `prLinks` union is built
   // separately. Absent when the turn referenced no PR. Optional; Claude only.
   prRefs?: string[]
+  // Claude Code: the `tool_use` ids of the `Agent`/`Task` subagent spawns emitted
+  // in this turn. A spawned sidechain session is folded back into the turn that
+  // launched it by matching its resolved spawn id against these. Absent when the
+  // turn spawned no subagent. Optional; Claude only.
+  spawnToolUseIds?: string[]
 }
 
 export type ParsedApiCall = {
@@ -118,6 +123,10 @@ export type ParsedApiCall = {
   deduplicationKey: string
   cacheCreationOneHourTokens?: number
   toolSequence?: ToolCall[][]
+  /// Claude Code: `tool_use` ids of the `Agent`/`Task` subagent-spawn blocks in
+  /// this call's assistant message. Transient (built at parse time, aggregated
+  /// into the turn's `spawnToolUseIds`); never cached per-call.
+  spawnToolUseIds?: string[]
   /// When set, `costUSD` is the actual local call (forced to 0) and
   /// `savingsUSD` is the counterfactual cost the same tokens would have
   /// incurred against `savingsBaselineModel`. Set by the savings
@@ -189,6 +198,21 @@ export type SessionSummary = {
   // (`workflow-subagent`, `Explore`, `general-purpose`, …); undefined for
   // ordinary sessions. Drives the Claude-scoped agent-type breakdown.
   agentType?: string
+  /// Claude Code only: for a sidechain (subagent) transcript, the id of the
+  /// session that spawned it (the transcript's internal `sessionId`, which is the
+  /// parent, cross-checked against the owning directory). Lets by-PR attribution
+  /// fold this session's spend into the parent turn that launched it. Undefined
+  /// for ordinary (non-sidechain) sessions.
+  parentSessionId?: string
+  /// Claude Code only: the subagent id of a sidechain transcript (its filename
+  /// basename with the `agent-` prefix stripped), matching the parent's
+  /// `agentSpawnLinks` keys. Undefined for ordinary sessions.
+  agentId?: string
+  /// Claude Code only: on a PARENT session, maps each spawned subagent's id to the
+  /// `tool_use` id of the `Agent`/`Task` block that launched it (from the spawn's
+  /// `toolUseResult.agentId`). Resolves a child to the exact parent turn. Absent
+  /// when the session spawned no subagent that recorded a result.
+  agentSpawnLinks?: Record<string, string>
   firstTimestamp: string
   lastTimestamp: string
   totalCostUSD: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,9 +210,16 @@ export type SessionSummary = {
   agentId?: string
   /// Claude Code only: on a PARENT session, maps each spawned subagent's id to the
   /// `tool_use` id of the `Agent`/`Task` block that launched it (from the spawn's
-  /// `toolUseResult.agentId`). Resolves a child to the exact parent turn. Absent
-  /// when the session spawned no subagent that recorded a result.
+  /// `toolUseResult.agentId`). Combined with `spawnPrSets` it resolves a child to
+  /// the PR the launching turn was working on. Absent when the session spawned no
+  /// subagent that recorded a result.
   agentSpawnLinks?: Record<string, string>
+  /// Claude Code only: on a PARENT session, maps each spawn `tool_use` id to the PR
+  /// set active at the turn that emitted it, computed from the FULL (pre-date-slice)
+  /// turn list. This lets a subagent fold into the right PR even when its launching
+  /// turn falls outside the report's range. Empty array = spawn had no active PR
+  /// (the child is then unattributed). Absent when the session spawned no subagent.
+  spawnPrSets?: Record<string, string[]>
   firstTimestamp: string
   lastTimestamp: string
   totalCostUSD: number

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -10,7 +10,7 @@ import { aggregateProjectsIntoDays, buildPeriodDataFromDays } from './day-aggreg
 import { aggregateModelEfficiency } from './model-efficiency.js'
 import { aggregateModels } from './models-report.js'
 import { scanUserCorrections, medianTimeToFirstEditMs, aggregateFileChurn, computePricingCoverage } from './workflow-insights.js'
-import { aggregateByPr, prLinkedTotals, aggregateByBranch } from './sessions-report.js'
+import { buildPrAttribution, aggregateByBranch } from './sessions-report.js'
 import { scanAndDetect } from './optimize.js'
 import { getDaysInRange, ensureCacheHydrated, emptyCache, BACKFILL_DAYS, toDateString, type DailyCache, type DailyEntry } from './daily-cache.js'
 import { buildGranularHistory } from './granular-history.js'
@@ -663,9 +663,9 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
   // Claude-config-scoped path (which replaces scanProjects with one config's
   // sessions) so this stays the genuine unscoped all-provider aggregation.
   if (isAllProviders && !effectivelyScoped) {
-    const prRows = aggregateByPr(scanProjects)
+    // One pass yields both rows and totals, so they never disagree.
+    const { rows: prRows, totals: prTotals } = buildPrAttribution(scanProjects)
     if (prRows.length > 0) {
-      const prTotals = prLinkedTotals(scanProjects)
       const shownRows = prRows.slice(0, TOP_PULL_REQUESTS)
       const otherRows = prRows.slice(TOP_PULL_REQUESTS)
       currentData.pullRequests = {

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -676,6 +676,7 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
         unattributedCost: prTotals.unattributedCost,
         otherPrCount: otherRows.length,
         otherPrCost: otherRows.reduce((sum, r) => sum + r.cost, 0),
+        ...(prTotals.subagentSessions > 0 ? { subagentSessions: prTotals.subagentSessions } : {}),
       }
     }
     const branchRows = aggregateByBranch(scanProjects)

--- a/tests/parser-incremental-append.test.ts
+++ b/tests/parser-incremental-append.test.ts
@@ -207,6 +207,44 @@ describe('incremental append parsing', () => {
     await rm(warmCache, { recursive: true, force: true })
   })
 
+  it('SUBAGENT-LINKS: spawnToolUseIds + agentSpawnLinks survive the incremental append path', async () => {
+    const warmCache = await mkdtemp(join(tmpdir(), 'incr-spawn-'))
+    const agentBlock = (id: string) => ({ type: 'tool_use', name: 'Agent', id, input: {} })
+    const spawnResultLine = (ts: string, toolUseId: string, agentId: string): string =>
+      JSON.stringify({
+        type: 'user', sessionId: 'sess-1', timestamp: ts, cwd: CWD,
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUseId, content: 'agent done' }] },
+        toolUseResult: { status: 'completed', agentId },
+      })
+    // Base: one turn spawns agent1; its result records the agentId->tool_use link.
+    await writeFile(sessionPath,
+      userLine('2026-05-01T10:00:01.000Z', 'launch a reviewer') + '\n' +
+      asstLine('msg-a', '2026-05-01T10:00:02.000Z', { input_tokens: 100, output_tokens: 20 }, [agentBlock('toolu_a1')]) + '\n' +
+      spawnResultLine('2026-05-01T10:00:03.000Z', 'toolu_a1', 'agent1') + '\n')
+    await parseWith(warmCache)
+
+    // Append: a continuation of that same turn spawns agent2 (merged into turn 0),
+    // then a fresh turn spawns agent3.
+    await appendFile(sessionPath,
+      asstLine('msg-b', '2026-05-01T10:00:04.000Z', { input_tokens: 50, output_tokens: 10 }, [agentBlock('toolu_a2')]) + '\n' +
+      spawnResultLine('2026-05-01T10:00:05.000Z', 'toolu_a2', 'agent2') + '\n' +
+      userLine('2026-05-01T10:10:00.000Z', 'launch another') + '\n' +
+      asstLine('msg-c', '2026-05-01T10:10:02.000Z', { input_tokens: 80, output_tokens: 20 }, [agentBlock('toolu_a3')]) + '\n' +
+      spawnResultLine('2026-05-01T10:10:03.000Z', 'toolu_a3', 'agent3') + '\n')
+
+    readLineCalls.length = 0
+    const warm = await parseWith(warmCache)
+    expect(offsetsFor(sessionPath).some(o => o !== undefined && o > 0)).toBe(true) // took the append path
+    const cold = await coldFullReparse()
+    expect(warm).toEqual(cold)
+
+    const session = warm[0]!.sessions[0]!
+    expect(session.turns[0]!.spawnToolUseIds).toEqual(['toolu_a1', 'toolu_a2'])
+    expect(session.turns[1]!.spawnToolUseIds).toEqual(['toolu_a3'])
+    expect(session.agentSpawnLinks).toEqual({ agent1: 'toolu_a1', agent2: 'toolu_a2', agent3: 'toolu_a3' })
+    await rm(warmCache, { recursive: true, force: true })
+  })
+
   it('EDGE: append after a previously-torn line completes still equals cold', async () => {
     const warmCache = await mkdtemp(join(tmpdir(), 'incr-warm2-'))
 

--- a/tests/parser-rich-capture.test.ts
+++ b/tests/parser-rich-capture.test.ts
@@ -246,5 +246,71 @@ describe('collectSessionMeta', () => {
     expect(meta.title).toBeUndefined()
     expect(meta.prLinks).toEqual([])
     expect(meta.isSidechain).toBe(false)
+    expect(meta.parentSessionId).toBeUndefined()
+    expect(meta.agentSpawnLinks).toEqual({})
+  })
+})
+
+// ── subagent linkage: parentSessionId + agentSpawnLinks ────────────────
+
+describe('collectSessionMeta subagent linkage', () => {
+  it("captures a sidechain's parent id from its internal sessionId (first wins)", () => {
+    const meta = emptySessionMeta()
+    collectSessionMeta({ type: 'user', isSidechain: true, sessionId: 'parent-1' } as JournalEntry, meta)
+    // A later entry restating a different id must not override the first capture.
+    collectSessionMeta({ type: 'assistant', isSidechain: true, sessionId: 'parent-2' } as JournalEntry, meta)
+    expect(meta.isSidechain).toBe(true)
+    expect(meta.parentSessionId).toBe('parent-1')
+  })
+
+  it('maps agentId -> spawn tool_use id from a spawn result (toolUseResult.agentId)', () => {
+    const meta = emptySessionMeta()
+    const spawnResult = {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_spawn1', content: 'agent output' }] },
+      toolUseResult: { status: 'completed', agentId: 'a17e80ec626c9de38' },
+    } as JournalEntry
+    collectSessionMeta(spawnResult, meta)
+    expect(meta.agentSpawnLinks).toEqual({ a17e80ec626c9de38: 'toolu_spawn1' })
+    // A non-agent tool_result (no toolUseResult.agentId) adds nothing.
+    collectSessionMeta({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_edit', content: 'x' }] },
+      toolUseResult: { structuredPatch: [] },
+    } as JournalEntry, meta)
+    expect(meta.agentSpawnLinks).toEqual({ a17e80ec626c9de38: 'toolu_spawn1' })
+  })
+})
+
+// ── per-turn subagent spawn ids (spawnToolUseIds) ──────────────────────
+
+function spawnAssistant(id: string, blocks: Array<{ id: string; name: string }>): JournalEntry {
+  return {
+    type: 'assistant', timestamp: '2026-07-01T10:00:02Z', sessionId: 's1', gitBranch: 'main',
+    message: {
+      type: 'message', role: 'assistant', model: 'claude-sonnet-4-20250514', id,
+      content: blocks.map(b => ({ type: 'tool_use' as const, id: b.id, name: b.name, input: {} })),
+      usage: { input_tokens: 5, output_tokens: 5 },
+    },
+  }
+}
+
+describe('per-turn spawnToolUseIds capture', () => {
+  it('records only Agent/Task spawn ids per turn and survives caching', () => {
+    const entries = [
+      userText('launch reviewers', 'main'),
+      spawnAssistant('m1', [
+        { id: 'toolu_agent', name: 'Agent' },
+        { id: 'toolu_task', name: 'Task' },
+        { id: 'toolu_edit', name: 'Edit' }, // not a spawn -> excluded
+      ]),
+      userText('unrelated turn', 'main'), assistant('m2', 'main'),
+    ]
+    const turns = groupIntoTurns(entries, new Set())
+    expect(turns[0]!.spawnToolUseIds).toEqual(['toolu_agent', 'toolu_task'])
+    expect(turns[1]!.spawnToolUseIds).toBeUndefined()
+    const cached = parsedTurnsToCachedTurns(turns)
+    expect(cached[0]!.spawnToolUseIds).toEqual(['toolu_agent', 'toolu_task'])
+    expect(cached[1]!.spawnToolUseIds).toBeUndefined()
   })
 })

--- a/tests/parser-rich-capture.test.ts
+++ b/tests/parser-rich-capture.test.ts
@@ -311,6 +311,8 @@ describe('collectSessionMeta subagent linkage', () => {
       toolUseResult: { status: 'completed', agentId: 'a777', content: 'same' },
     } as JournalEntry, meta)
     expect(meta.agentSpawnLinks).toEqual({}) // no guess
+    // But we KNOW a777 was spawned here, so it is recorded as an ambiguous pairing.
+    expect(meta.ambiguousSpawnAgentIds).toEqual(['a777'])
   })
 })
 

--- a/tests/parser-rich-capture.test.ts
+++ b/tests/parser-rich-capture.test.ts
@@ -296,6 +296,22 @@ describe('collectSessionMeta subagent linkage', () => {
     } as JournalEntry, meta)
     expect(meta.agentSpawnLinks).toEqual({ a999: 'toolu_spawn' })
   })
+
+  it('omits the spawn link (deferring to the timestamp fallback) when blocks are ambiguous', () => {
+    const meta = emptySessionMeta()
+    collectSessionMeta({
+      type: 'user',
+      // Two tool_result blocks with IDENTICAL content: the content match cannot
+      // pick one, so the link is omitted on purpose (resolveChild's timestamp
+      // fallback then folds the child rather than risking the wrong id).
+      message: { role: 'user', content: [
+        { type: 'tool_result', tool_use_id: 'toolu_a', content: 'same' },
+        { type: 'tool_result', tool_use_id: 'toolu_b', content: 'same' },
+      ] },
+      toolUseResult: { status: 'completed', agentId: 'a777', content: 'same' },
+    } as JournalEntry, meta)
+    expect(meta.agentSpawnLinks).toEqual({}) // no guess
+  })
 })
 
 // ── per-turn subagent spawn ids (spawnToolUseIds) ──────────────────────

--- a/tests/parser-rich-capture.test.ts
+++ b/tests/parser-rich-capture.test.ts
@@ -8,6 +8,7 @@ import {
   parseApiCall,
   groupIntoTurns,
   parsedTurnsToCachedTurns,
+  buildSpawnPrSets,
   type ToolResultMeta,
 } from '../src/parser.js'
 import type { JournalEntry } from '../src/types.js'
@@ -280,6 +281,21 @@ describe('collectSessionMeta subagent linkage', () => {
     } as JournalEntry, meta)
     expect(meta.agentSpawnLinks).toEqual({ a17e80ec626c9de38: 'toolu_spawn1' })
   })
+
+  it('pairs the agentId with the matching block when a record batches several results (unrelated block first)', () => {
+    const meta = emptySessionMeta()
+    collectSessionMeta({
+      type: 'user',
+      message: { role: 'user', content: [
+        { type: 'tool_result', tool_use_id: 'toolu_unrelated', content: 'a bash result' },
+        { type: 'tool_result', tool_use_id: 'toolu_spawn', content: 'agent output' },
+      ] },
+      // The result's content identifies the spawn block, so the FIRST (unrelated)
+      // block must not capture the agentId.
+      toolUseResult: { status: 'completed', agentId: 'a999', content: 'agent output' },
+    } as JournalEntry, meta)
+    expect(meta.agentSpawnLinks).toEqual({ a999: 'toolu_spawn' })
+  })
 })
 
 // ── per-turn subagent spawn ids (spawnToolUseIds) ──────────────────────
@@ -312,5 +328,25 @@ describe('per-turn spawnToolUseIds capture', () => {
     const cached = parsedTurnsToCachedTurns(turns)
     expect(cached[0]!.spawnToolUseIds).toEqual(['toolu_agent', 'toolu_task'])
     expect(cached[1]!.spawnToolUseIds).toBeUndefined()
+  })
+})
+
+describe('buildSpawnPrSets', () => {
+  it('maps each spawn id to the PR set active at its turn, carrying refs forward', () => {
+    const sets = buildSpawnPrSets([
+      { spawnToolUseIds: ['s0'] },                       // before any PR -> empty
+      { prRefs: ['pr/A'], spawnToolUseIds: ['s1'] },     // spawn under A
+      { spawnToolUseIds: ['s2'] },                       // carries A
+      { prRefs: ['pr/B'], spawnToolUseIds: ['s3'] },     // spawn under B
+    ])
+    expect(sets).toEqual({ s0: [], s1: ['pr/A'], s2: ['pr/A'], s3: ['pr/B'] })
+  })
+
+  it('first occurrence of a spawn id wins deterministically', () => {
+    const sets = buildSpawnPrSets([
+      { prRefs: ['pr/A'], spawnToolUseIds: ['dup'] },
+      { prRefs: ['pr/B'], spawnToolUseIds: ['dup'] }, // restatement must not overwrite
+    ])
+    expect(sets['dup']).toEqual(['pr/A'])
   })
 })

--- a/tests/parser-subagent-range.test.ts
+++ b/tests/parser-subagent-range.test.ts
@@ -66,6 +66,12 @@ describe('subagent fold across a date-range boundary', () => {
     // The child session is present (its work is in range) as a standalone session.
     const childPresent = projects.some(p => p.sessions.some(s => s.sessionId === `agent-${AGENT}`))
     expect(childPresent).toBe(true)
+    // The anchor parent (0 in-range turns) must NOT contaminate the sessions list;
+    // it lives in subagentAnchors only.
+    const anchorInSessions = projects.some(p => p.sessions.some(s => s.sessionId === PARENT))
+    expect(anchorInSessions).toBe(false)
+    const anchorHeldSeparately = projects.some(p => (p.subagentAnchors ?? []).some(s => s.sessionId === PARENT))
+    expect(anchorHeldSeparately).toBe(true)
 
     const rows = aggregateByPr(projects)
     const row = rows.find(r => r.url === PR)

--- a/tests/parser-subagent-range.test.ts
+++ b/tests/parser-subagent-range.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
-import { parseAllSessions, clearSessionCache } from '../src/parser.js'
+import { parseAllSessions, filterProjectsByDays, clearSessionCache } from '../src/parser.js'
 import { loadPricing } from '../src/models.js'
 import { aggregateByPr, prLinkedTotals } from '../src/sessions-report.js'
 
@@ -84,5 +84,28 @@ describe('subagent fold across a date-range boundary', () => {
     const totals = prLinkedTotals(projects)
     expect(totals.subagentSessions).toBe(1)
     expect(totals.attributedCost).toBeCloseTo(row!.cost, 6)
+  })
+
+  it('survives a day filter: a parent whose in-range turns are day-filtered out becomes an anchor (menubar flow)', async () => {
+    await loadPricing()
+    await writeTranscripts()
+
+    // Wide parse: BOTH the parent (2026-07-19) and child (2026-07-20) are in range,
+    // so the parent is a normal session (no anchor yet).
+    const wide = { start: new Date('2026-07-18T00:00:00Z'), end: new Date('2026-07-21T23:59:59Z') }
+    const projects = await parseAllSessions(wide, 'claude')
+    expect(projects.some(p => p.sessions.some(s => s.sessionId === PARENT))).toBe(true) // parent is a real session here
+
+    // Now narrow to the child's day only. The parent's 2026-07-19 turns are filtered
+    // out, so it must be CONVERTED to a fold anchor rather than dropped.
+    const dayFiltered = filterProjectsByDays(projects, new Set(['2026-07-20']))
+    expect(dayFiltered.some(p => p.sessions.some(s => s.sessionId === PARENT))).toBe(false) // parent no longer a session
+    expect(dayFiltered.some(p => (p.subagentAnchors ?? []).some(s => s.sessionId === PARENT))).toBe(true) // kept as anchor
+
+    // The child's spend still folds to the PR through the anchor.
+    const row = aggregateByPr(dayFiltered).find(r => r.url === PR)
+    expect(row).toBeDefined()
+    expect(row!.cost).toBeGreaterThan(0)
+    expect(prLinkedTotals(dayFiltered).subagentSessions).toBe(1)
   })
 })

--- a/tests/parser-subagent-range.test.ts
+++ b/tests/parser-subagent-range.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { parseAllSessions, clearSessionCache } from '../src/parser.js'
+import { loadPricing } from '../src/models.js'
+import { aggregateByPr, prLinkedTotals } from '../src/sessions-report.js'
+
+// A parent that spawned an async subagent whose work landed inside the report
+// range, while the parent's OWN turns fall just before it. The parent must be kept
+// as a 0-cost fold anchor so the in-range child still attributes to the parent's
+// PR (finding: a parent with no in-range calls must not drop its child's spend).
+
+let tmpDir: string
+let configDir: string
+const CWD = '/tmp/anchor-proj'
+const PR = 'https://github.com/o/r/pull/1'
+const PARENT = '11111111-1111-4111-8111-111111111111'
+const AGENT = 'a1234567890abcdef'
+const SPAWN = 'toolu_spawn_anchor'
+
+beforeEach(async () => {
+  clearSessionCache()
+  tmpDir = await mkdtemp(join(tmpdir(), 'anchor-'))
+  configDir = join(tmpDir, 'claude')
+  process.env['CLAUDE_CONFIG_DIR'] = configDir
+  process.env['CODEBURN_CACHE_DIR'] = join(tmpDir, 'cache')
+})
+
+afterEach(async () => {
+  clearSessionCache()
+  delete process.env['CLAUDE_CONFIG_DIR']
+  delete process.env['CODEBURN_CACHE_DIR']
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+async function writeTranscripts(): Promise<void> {
+  const projDir = join(configDir, 'projects', 'anchor-proj')
+  const subDir = join(projDir, PARENT, 'subagents')
+  await mkdir(subDir, { recursive: true })
+
+  // Parent transcript: a turn that references the PR and spawns AGENT (tool_use
+  // SPAWN), then the spawn result recording agentId -> SPAWN. All dated just BEFORE
+  // the report range (within the 24h parse lookback so the spawn is still parsed).
+  await writeFile(join(projDir, `${PARENT}.jsonl`),
+    JSON.stringify({ type: 'user', sessionId: PARENT, timestamp: '2026-07-19T23:00:00.000Z', cwd: CWD, message: { role: 'user', content: 'ship the PR and launch a reviewer' } }) + '\n' +
+    JSON.stringify({ type: 'assistant', sessionId: PARENT, timestamp: '2026-07-19T23:00:01.000Z', cwd: CWD, message: { id: 'm1', type: 'message', role: 'assistant', model: 'claude-sonnet-4-5', content: [{ type: 'tool_use', id: SPAWN, name: 'Agent', input: {} }], usage: { input_tokens: 10, output_tokens: 5 } } }) + '\n' +
+    JSON.stringify({ type: 'pr-link', sessionId: PARENT, timestamp: '2026-07-19T23:00:02.000Z', cwd: CWD, prUrl: PR }) + '\n' +
+    JSON.stringify({ type: 'user', sessionId: PARENT, timestamp: '2026-07-19T23:05:00.000Z', cwd: CWD, message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: SPAWN, content: 'reviewer done' }] }, toolUseResult: { status: 'completed', agentId: AGENT, content: 'reviewer done' } }) + '\n')
+
+  // Child transcript: the subagent's own work, dated INSIDE the report range.
+  await writeFile(join(subDir, `agent-${AGENT}.jsonl`),
+    JSON.stringify({ type: 'user', isSidechain: true, sessionId: PARENT, agentId: AGENT, timestamp: '2026-07-20T10:00:00.000Z', cwd: CWD, message: { role: 'user', content: 'review this' } }) + '\n' +
+    JSON.stringify({ type: 'assistant', isSidechain: true, sessionId: PARENT, agentId: AGENT, timestamp: '2026-07-20T10:00:05.000Z', cwd: CWD, message: { id: 'c1', type: 'message', role: 'assistant', model: 'claude-opus-4-8', content: [], usage: { input_tokens: 1000, output_tokens: 500 } } }) + '\n')
+}
+
+describe('subagent fold across a date-range boundary', () => {
+  it('folds an in-range child into its parent PR even though the parent has no in-range turns', async () => {
+    await loadPricing()
+    await writeTranscripts()
+
+    const range = { start: new Date('2026-07-20T00:00:00Z'), end: new Date('2026-07-20T23:59:59Z') }
+    const projects = await parseAllSessions(range, 'claude')
+
+    // The child session is present (its work is in range) as a standalone session.
+    const childPresent = projects.some(p => p.sessions.some(s => s.sessionId === `agent-${AGENT}`))
+    expect(childPresent).toBe(true)
+
+    const rows = aggregateByPr(projects)
+    const row = rows.find(r => r.url === PR)
+    expect(row).toBeDefined()
+    // The parent contributed $0 own spend (turns out of range); the row is entirely
+    // the folded child, priced from its opus tokens.
+    expect(row!.cost).toBeGreaterThan(0)
+    expect(row!.models).toContain('Opus 4.8')
+
+    const totals = prLinkedTotals(projects)
+    expect(totals.subagentSessions).toBe(1)
+    expect(totals.attributedCost).toBeCloseTo(row!.cost, 6)
+  })
+})

--- a/tests/session-cache-rich-capture.test.ts
+++ b/tests/session-cache-rich-capture.test.ts
@@ -53,6 +53,7 @@ function richFile(): CachedFile {
     isSidechain: true,
     parentSessionId: 'parent-uuid',
     agentSpawnLinks: { a17e80ec626c9de38: 'toolu_spawn1' },
+    ambiguousSpawnAgentIds: ['a999abcdef0123456'],
     turns: [
       { timestamp: '2026-07-01T10:00:00Z', sessionId: 's1', userMessage: 'hi', gitBranch: 'feature/x', prRefs: ['https://github.com/o/r/pull/1'], spawnToolUseIds: ['toolu_spawn1'], calls: [richCall()] },
     ],
@@ -74,6 +75,7 @@ describe('session cache round-trip for rich-capture fields', () => {
     expect(file.isSidechain).toBe(true)
     expect(file.parentSessionId).toBe('parent-uuid')
     expect(file.agentSpawnLinks).toEqual({ a17e80ec626c9de38: 'toolu_spawn1' })
+    expect(file.ambiguousSpawnAgentIds).toEqual(['a999abcdef0123456'])
 
     const turn = file.turns[0]!
     expect(turn.gitBranch).toBe('feature/x')

--- a/tests/session-cache-rich-capture.test.ts
+++ b/tests/session-cache-rich-capture.test.ts
@@ -51,8 +51,10 @@ function richFile(): CachedFile {
     title: 'A rich session',
     prLinks: ['https://github.com/o/r/pull/1', 'https://github.com/o/r/pull/2'],
     isSidechain: true,
+    parentSessionId: 'parent-uuid',
+    agentSpawnLinks: { a17e80ec626c9de38: 'toolu_spawn1' },
     turns: [
-      { timestamp: '2026-07-01T10:00:00Z', sessionId: 's1', userMessage: 'hi', gitBranch: 'feature/x', prRefs: ['https://github.com/o/r/pull/1'], calls: [richCall()] },
+      { timestamp: '2026-07-01T10:00:00Z', sessionId: 's1', userMessage: 'hi', gitBranch: 'feature/x', prRefs: ['https://github.com/o/r/pull/1'], spawnToolUseIds: ['toolu_spawn1'], calls: [richCall()] },
     ],
   }
 }
@@ -70,10 +72,13 @@ describe('session cache round-trip for rich-capture fields', () => {
     expect(file.title).toBe('A rich session')
     expect(file.prLinks).toEqual(['https://github.com/o/r/pull/1', 'https://github.com/o/r/pull/2'])
     expect(file.isSidechain).toBe(true)
+    expect(file.parentSessionId).toBe('parent-uuid')
+    expect(file.agentSpawnLinks).toEqual({ a17e80ec626c9de38: 'toolu_spawn1' })
 
     const turn = file.turns[0]!
     expect(turn.gitBranch).toBe('feature/x')
     expect(turn.prRefs).toEqual(['https://github.com/o/r/pull/1'])
+    expect(turn.spawnToolUseIds).toEqual(['toolu_spawn1'])
 
     const call = turn.calls[0]!
     expect(call.locAdded).toBe(12)

--- a/tests/session-cache-v5-adoption.test.ts
+++ b/tests/session-cache-v5-adoption.test.ts
@@ -183,3 +183,53 @@ describe('v5 -> v6 cache adoption of expired PR sessions', () => {
     expect(urls).not.toContain('https://github.com/o/r/pull/8') // failed: 'yes' is corrupt, skipped
   })
 })
+
+function expiredPrEntry(cwd: string, name: string, prUrl: string): Record<string, unknown> {
+  return {
+    fingerprint: { dev: 1, ino: 2, mtimeMs: 3, sizeBytes: 4 },
+    mcpInventory: [], canonicalCwd: cwd, canonicalProjectName: name,
+    prLinks: [prUrl],
+    turns: [{ timestamp: '2026-07-20T10:00:00.000Z', sessionId: 'gone', userMessage: 'shipped', calls: [cachedCall('kk', 40)] }],
+  }
+}
+
+// The immediately-preceding versioned cache (v6) must also be adopted on the v7
+// bump, or the last build's expired-PR history vanishes (the same bug class that
+// dropped v5 on the 5->6 bump).
+describe('newest-prior cache adoption (v6 then v5)', () => {
+  it('adopts an expired PR entry from a v6-only file into v7 as legacy attribution', async () => {
+    await loadPricing()
+    const gonePath = join(configDir, 'projects', 'gone6', 'gone6.jsonl')
+    const v6 = {
+      version: 6, complete: true,
+      providers: { claude: { envFingerprint: 'stale-v6', files: { [gonePath]: expiredPrEntry('/gone6', 'gone6', 'https://github.com/o/r/pull/6') } } },
+    }
+    await writeFile(join(cacheDir, 'session-cache.v6.json'), JSON.stringify(v6))
+
+    const range = { start: new Date('2026-07-20T00:00:00Z'), end: new Date('2026-07-20T23:59:59Z') }
+    const rows = aggregateByPr(await parseAllSessions(range, 'claude'))
+    const row = rows.find(r => r.url === 'https://github.com/o/r/pull/6')
+    expect(row).toBeDefined()
+    expect(row!.approx).toBe(true)
+    expect(row!.cost).toBeCloseTo(40, 6)
+  })
+
+  it('prefers the newest prior file: v6 orphan is adopted, v5-only orphan is not', async () => {
+    await loadPricing()
+    const v6Path = join(configDir, 'projects', 'in6', 'in6.jsonl')
+    const v5Path = join(configDir, 'projects', 'in5', 'in5.jsonl')
+    await writeFile(join(cacheDir, 'session-cache.v6.json'), JSON.stringify({
+      version: 6, complete: true,
+      providers: { claude: { envFingerprint: 'v6', files: { [v6Path]: expiredPrEntry('/in6', 'in6', 'https://github.com/o/r/pull/60') } } },
+    }))
+    await writeFile(join(cacheDir, 'session-cache.v5.json'), JSON.stringify({
+      version: 5, complete: true,
+      providers: { claude: { envFingerprint: 'v5', files: { [v5Path]: expiredPrEntry('/in5', 'in5', 'https://github.com/o/r/pull/50') } } },
+    }))
+
+    const range = { start: new Date('2026-07-20T00:00:00Z'), end: new Date('2026-07-20T23:59:59Z') }
+    const urls = aggregateByPr(await parseAllSessions(range, 'claude')).map(r => r.url)
+    expect(urls).toContain('https://github.com/o/r/pull/60')      // v6 (newest) adopted
+    expect(urls).not.toContain('https://github.com/o/r/pull/50')  // v5 superseded by v6
+  })
+})

--- a/tests/session-cache-v5-adoption.test.ts
+++ b/tests/session-cache-v5-adoption.test.ts
@@ -214,7 +214,7 @@ describe('newest-prior cache adoption (v6 then v5)', () => {
     expect(row!.cost).toBeCloseTo(40, 6)
   })
 
-  it('prefers the newest prior file: v6 orphan is adopted, v5-only orphan is not', async () => {
+  it('merges prior versions: a v6-only orphan AND a v5-only orphan both survive', async () => {
     await loadPricing()
     const v6Path = join(configDir, 'projects', 'in6', 'in6.jsonl')
     const v5Path = join(configDir, 'projects', 'in5', 'in5.jsonl')
@@ -229,7 +229,27 @@ describe('newest-prior cache adoption (v6 then v5)', () => {
 
     const range = { start: new Date('2026-07-20T00:00:00Z'), end: new Date('2026-07-20T23:59:59Z') }
     const urls = aggregateByPr(await parseAllSessions(range, 'claude')).map(r => r.url)
-    expect(urls).toContain('https://github.com/o/r/pull/60')      // v6 (newest) adopted
-    expect(urls).not.toContain('https://github.com/o/r/pull/50')  // v5 superseded by v6
+    // A sparse newer file must NOT mask older-only orphans: BOTH survive.
+    expect(urls).toContain('https://github.com/o/r/pull/60') // from v6
+    expect(urls).toContain('https://github.com/o/r/pull/50') // from v5, not masked
+  })
+
+  it('a newer version wins per source path when both hold the same path', async () => {
+    await loadPricing()
+    const samePath = join(configDir, 'projects', 'dup', 'dup.jsonl')
+    // v5 attributes this path to PR 500; v6 (newer) to PR 600 for the SAME path.
+    await writeFile(join(cacheDir, 'session-cache.v5.json'), JSON.stringify({
+      version: 5, complete: true,
+      providers: { claude: { envFingerprint: 'v5', files: { [samePath]: expiredPrEntry('/dup', 'dup', 'https://github.com/o/r/pull/500') } } },
+    }))
+    await writeFile(join(cacheDir, 'session-cache.v6.json'), JSON.stringify({
+      version: 6, complete: true,
+      providers: { claude: { envFingerprint: 'v6', files: { [samePath]: expiredPrEntry('/dup', 'dup', 'https://github.com/o/r/pull/600') } } },
+    }))
+
+    const range = { start: new Date('2026-07-20T00:00:00Z'), end: new Date('2026-07-20T23:59:59Z') }
+    const urls = aggregateByPr(await parseAllSessions(range, 'claude')).map(r => r.url)
+    expect(urls).toContain('https://github.com/o/r/pull/600')     // newer v6 entry wins
+    expect(urls).not.toContain('https://github.com/o/r/pull/500')  // older v5 entry for same path superseded
   })
 })

--- a/tests/sessions-by-pr.test.ts
+++ b/tests/sessions-by-pr.test.ts
@@ -366,7 +366,7 @@ describe('prLinkedTotals', () => {
       session('b', 50, 10, [A]),       // legacy: 50 attributed
       session('c', 999, 1),            // no links → excluded
     ])])
-    expect(totals).toEqual({ cost: 150, sessions: 2, attributedCost: 150, unattributedCost: 0 })
+    expect(totals).toEqual({ cost: 150, sessions: 2, subagentSessions: 0, attributedCost: 150, unattributedCost: 0 })
   })
 
   it('captures the unattributed remainder from pre-reference overhead', () => {

--- a/tests/sessions-subagent-fold.test.ts
+++ b/tests/sessions-subagent-fold.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  aggregateByPr,
+  attributeSessionPrSpend,
+  buildSubagentIndex,
+  prLinkedTotals,
+  resolveChildFolds,
+} from '../src/sessions-report.js'
+import type { ClassifiedTurn, ParsedApiCall, ProjectSummary, SessionSummary, TokenUsage } from '../src/types.js'
+
+const A = 'https://github.com/o/r/pull/1'
+const B = 'https://github.com/o/r/pull/2'
+
+const ZERO_USAGE: TokenUsage = {
+  inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0,
+  cacheReadInputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0, webSearchRequests: 0,
+}
+
+let seq = 0
+function call(cost: number, model: string, ts: string): ParsedApiCall {
+  return {
+    provider: 'claude', model, usage: ZERO_USAGE, costUSD: cost,
+    tools: [], mcpTools: [], skills: [], subagentTypes: [],
+    hasAgentSpawn: false, hasPlanMode: false, speed: 'standard',
+    timestamp: ts, bashCommands: [], deduplicationKey: `k${seq++}`,
+  }
+}
+
+// A parent turn: one call of `cost` under `model`, at `ts`, optionally carrying
+// `prRefs` and the `spawnToolUseIds` of subagents launched in the turn.
+function turn(opts: {
+  cost: number; model?: string; ts: string; category?: ClassifiedTurn['category']
+  prRefs?: string[]; spawnToolUseIds?: string[]
+}): ClassifiedTurn {
+  return {
+    userMessage: '', timestamp: opts.ts, sessionId: 's',
+    category: opts.category ?? 'coding', retries: 0, hasEdits: false,
+    assistantCalls: [call(opts.cost, opts.model ?? 'claude-sonnet-4-5', opts.ts)],
+    ...(opts.prRefs ? { prRefs: opts.prRefs } : {}),
+    ...(opts.spawnToolUseIds ? { spawnToolUseIds: opts.spawnToolUseIds } : {}),
+  }
+}
+
+function parent(opts: {
+  id: string; prLinks: string[]; turns: ClassifiedTurn[]
+  agentSpawnLinks?: Record<string, string>; project?: string
+}): SessionSummary {
+  return {
+    sessionId: opts.id, project: opts.project ?? 'p',
+    firstTimestamp: '2026-07-01T10:00:00Z', lastTimestamp: '2026-07-01T12:00:00Z',
+    totalCostUSD: 0, totalSavingsUSD: 0, totalEstimatedCostUSD: 0,
+    totalInputTokens: 0, totalOutputTokens: 0, totalReasoningTokens: 0,
+    totalCacheReadTokens: 0, totalCacheWriteTokens: 0,
+    apiCalls: opts.turns.reduce((n, t) => n + t.assistantCalls.length, 0),
+    turns: opts.turns,
+    modelBreakdown: {}, toolBreakdown: {}, mcpBreakdown: {}, bashBreakdown: {},
+    categoryBreakdown: {} as SessionSummary['categoryBreakdown'],
+    skillBreakdown: {} as SessionSummary['skillBreakdown'],
+    subagentBreakdown: {} as SessionSummary['subagentBreakdown'],
+    prLinks: opts.prLinks,
+    ...(opts.agentSpawnLinks ? { agentSpawnLinks: opts.agentSpawnLinks } : {}),
+  }
+}
+
+// A sidechain (subagent) session: one turn of `cost` under `model`/`category`,
+// linked to `parentId` via `agentId`, first active at `firstTs`.
+function child(opts: {
+  agentId: string; parentId: string; cost: number; model?: string
+  category?: ClassifiedTurn['category']; firstTs: string; project?: string; calls?: number
+}): SessionSummary {
+  const n = opts.calls ?? 1
+  const t: ClassifiedTurn = {
+    userMessage: '', timestamp: opts.firstTs, sessionId: `agent-${opts.agentId}`,
+    category: opts.category ?? 'debugging', retries: 0, hasEdits: false,
+    assistantCalls: Array.from({ length: n }, () => call(opts.cost / n, opts.model ?? 'claude-opus-4-8', opts.firstTs)),
+  }
+  return {
+    sessionId: `agent-${opts.agentId}`, project: opts.project ?? 'p',
+    parentSessionId: opts.parentId, agentId: opts.agentId,
+    firstTimestamp: opts.firstTs, lastTimestamp: opts.firstTs,
+    totalCostUSD: opts.cost, totalSavingsUSD: 0, totalEstimatedCostUSD: 0,
+    totalInputTokens: 0, totalOutputTokens: 0, totalReasoningTokens: 0,
+    totalCacheReadTokens: 0, totalCacheWriteTokens: 0,
+    apiCalls: n, turns: [t],
+    modelBreakdown: {}, toolBreakdown: {}, mcpBreakdown: {}, bashBreakdown: {},
+    categoryBreakdown: {} as SessionSummary['categoryBreakdown'],
+    skillBreakdown: {} as SessionSummary['skillBreakdown'],
+    subagentBreakdown: {} as SessionSummary['subagentBreakdown'],
+  }
+}
+
+function project(sessions: SessionSummary[], name = 'p'): ProjectSummary {
+  return { project: name, projectPath: `/${name}`, sessions, totalCostUSD: 0, totalSavingsUSD: 0, totalApiCalls: 0, totalProxiedCostUSD: 0 }
+}
+
+describe('buildSubagentIndex', () => {
+  it('indexes sidechains by project + parentSessionId; skips non-children', () => {
+    const idx = buildSubagentIndex([project([
+      parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })] }),
+      child({ agentId: 'c1', parentId: 'P', cost: 50, firstTs: '2026-07-01T10:05:00Z' }),
+      child({ agentId: 'c2', parentId: 'P', cost: 30, firstTs: '2026-07-01T10:06:00Z' }),
+    ])])
+    expect(idx.size).toBe(1) // one parent key
+    expect([...idx.values()].flat().map(c => c.agentId).sort()).toEqual(['c1', 'c2'])
+  })
+})
+
+describe('resolveChildFolds', () => {
+  const p = parent({
+    id: 'P', prLinks: [A, B],
+    turns: [
+      turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A], spawnToolUseIds: ['toolu_x'] }),
+      turn({ cost: 10, ts: '2026-07-01T10:30:00Z', prRefs: [B] }),
+    ],
+    agentSpawnLinks: { c1: 'toolu_x' },
+  })
+
+  it('resolves via spawn tool_use id (true launch point)', () => {
+    const c = child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:45:00Z' })
+    const folds = resolveChildFolds(p, [buildFold(c)])
+    // firstTs 10:45 sits in turn1's span, but the spawn id lives in turn0 -> turn0 wins.
+    expect(folds.byTurnIndex.get(0)?.[0]?.agentId).toBe('c1')
+    expect(folds.byTurnIndex.has(1)).toBe(false)
+    expect(folds.unlinked).toHaveLength(0)
+  })
+
+  it('falls back to timestamp bucketing when there is no spawn link', () => {
+    const c = child({ agentId: 'unknown', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:45:00Z' })
+    const folds = resolveChildFolds(p, [buildFold(c)])
+    // No agentSpawnLinks entry -> bucket by firstTs 10:45 into the last turn started <= it.
+    expect(folds.byTurnIndex.get(1)?.[0]?.agentId).toBe('unknown')
+    expect(folds.byTurnIndex.has(0)).toBe(false)
+  })
+
+  it('marks a child before the first turn as unlinked', () => {
+    const c = child({ agentId: 'early', parentId: 'P', cost: 100, firstTs: '2026-07-01T09:00:00Z' })
+    const folds = resolveChildFolds(p, [buildFold(c)])
+    expect(folds.byTurnIndex.size).toBe(0)
+    expect(folds.unlinked.map(f => f.agentId)).toEqual(['early'])
+  })
+})
+
+// Round-trip a child SessionSummary through the public index so tests exercise the
+// same ChildFold the report builds (agentId/cost/models/categories derivation).
+function buildFold(c: SessionSummary) {
+  return [...buildSubagentIndex([project([c])]).values()][0]![0]!
+}
+
+describe('attributeSessionPrSpend with folds', () => {
+  it('folds a child into its spawn turn and surfaces its model in that PR', () => {
+    const p = parent({
+      id: 'P', prLinks: [A, B],
+      turns: [
+        turn({ cost: 10, model: 'claude-sonnet-4-5', ts: '2026-07-01T10:00:00Z', prRefs: [A], spawnToolUseIds: ['toolu_x'] }),
+        turn({ cost: 10, model: 'claude-sonnet-4-5', ts: '2026-07-01T10:30:00Z', prRefs: [B] }),
+      ],
+      agentSpawnLinks: { c1: 'toolu_x' },
+    })
+    const c = buildFold(child({ agentId: 'c1', parentId: 'P', cost: 100, model: 'claude-opus-4-8', category: 'debugging', firstTs: '2026-07-01T10:45:00Z' }))
+    const folds = resolveChildFolds(p, [c])
+    const { perUrl } = attributeSessionPrSpend(p, folds)
+    // A owns turn0's own $10 plus the child's $100.
+    expect(perUrl.get(A)!.cost).toBeCloseTo(110, 6)
+    expect(perUrl.get(B)!.cost).toBeCloseTo(10, 6)
+    // The child's opus spend reaches PR A's model + category breakdown.
+    expect(perUrl.get(A)!.models.get('claude-opus-4-8')).toBeCloseTo(100, 6)
+    expect(perUrl.get(A)!.categories.get('debugging')).toBeCloseTo(100, 6)
+    expect(perUrl.get(A)!.categories.get('coding')).toBeCloseTo(10, 6)
+  })
+
+  it('lands a child spawned before any PR reference in unattributed', () => {
+    const p = parent({
+      id: 'P', prLinks: [A],
+      turns: [
+        // turn0 references no PR (current === null); a child folded here is overhead.
+        turn({ cost: 5, ts: '2026-07-01T10:00:00Z', spawnToolUseIds: ['toolu_pre'] }),
+        turn({ cost: 10, ts: '2026-07-01T10:30:00Z', prRefs: [A] }),
+      ],
+      agentSpawnLinks: { c1: 'toolu_pre' },
+    })
+    const c = buildFold(child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }))
+    const { perUrl, unattributed } = attributeSessionPrSpend(p, resolveChildFolds(p, [c]))
+    expect(perUrl.get(A)!.cost).toBeCloseTo(10, 6)
+    expect(unattributed.cost).toBeCloseTo(105, 6) // turn0's $5 + child $100
+  })
+
+  it('folds an unlinked child into unattributed', () => {
+    const p = parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })] })
+    const c = buildFold(child({ agentId: 'orphanTurn', parentId: 'P', cost: 40, firstTs: '2026-07-01T09:00:00Z' }))
+    const { perUrl, unattributed } = attributeSessionPrSpend(p, resolveChildFolds(p, [c]))
+    expect(perUrl.get(A)!.cost).toBeCloseTo(10, 6)
+    expect(unattributed.cost).toBeCloseTo(40, 6)
+  })
+
+  it('is a no-op when no folds are supplied (regression guard)', () => {
+    const p = parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })] })
+    const { perUrl, unattributed } = attributeSessionPrSpend(p)
+    expect(perUrl.get(A)!.cost).toBeCloseTo(10, 6)
+    expect(unattributed.cost).toBe(0)
+  })
+})
+
+describe('aggregateByPr / prLinkedTotals fold subagents end to end', () => {
+  const projects = () => [project([
+    parent({
+      id: 'P', prLinks: [A],
+      turns: [turn({ cost: 20, model: 'claude-sonnet-4-5', ts: '2026-07-01T10:00:00Z', prRefs: [A], spawnToolUseIds: ['toolu_x'] })],
+      agentSpawnLinks: { c1: 'toolu_x' },
+    }),
+    child({ agentId: 'c1', parentId: 'P', cost: 100, model: 'claude-opus-4-8', firstTs: '2026-07-01T10:05:00Z', calls: 5 }),
+  ])]
+
+  it('counts the child cost exactly once in by-PR while it stays a standalone session', () => {
+    const rows = aggregateByPr(projects())
+    const rowA = rows.find(r => r.url === A)!
+    expect(rowA.cost).toBeCloseTo(120, 6) // parent $20 + child $100, once
+    expect(rowA.calls).toBe(6)            // parent 1 + child 5
+    expect(rowA.models).toContain('Opus 4.8') // short name of claude-opus appears beside the parent model
+    // The child is still present as its own session (not removed from projects).
+    expect(projects()[0]!.sessions.some(s => s.sessionId === 'agent-c1')).toBe(true)
+  })
+
+  it('reports subagentSessions alongside PR-linked parent sessions', () => {
+    const totals = prLinkedTotals(projects())
+    expect(totals.sessions).toBe(1)          // one PR-linked parent
+    expect(totals.subagentSessions).toBe(1)  // one folded child
+    expect(totals.attributedCost).toBeCloseTo(120, 6)
+    expect(totals.cost).toBeCloseTo(120, 6)
+  })
+
+  it('ignores an orphan child whose parent is absent from the scan', () => {
+    const rows = aggregateByPr([project([
+      // No parent 'P' here; the child references a parent that is not in the scan.
+      child({ agentId: 'c1', parentId: 'MISSING', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
+    ])])
+    // Nothing PR-linked, so no rows and no folded spend.
+    expect(rows).toHaveLength(0)
+    const totals = prLinkedTotals([project([
+      child({ agentId: 'c1', parentId: 'MISSING', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
+    ])])
+    expect(totals.subagentSessions).toBe(0)
+    expect(totals.cost).toBe(0)
+  })
+
+  it('does not fold children of a parent that referenced no PR', () => {
+    const rows = aggregateByPr([project([
+      // Parent has turns but NO prLinks -> skipped entirely; its child folds nowhere.
+      parent({ id: 'Q', prLinks: [], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z' })] }),
+      child({ agentId: 'c9', parentId: 'Q', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
+    ])])
+    expect(rows).toHaveLength(0)
+  })
+})

--- a/tests/sessions-subagent-fold.test.ts
+++ b/tests/sessions-subagent-fold.test.ts
@@ -48,7 +48,7 @@ const BASE = {
 function parent(opts: {
   id: string; prLinks: string[]; turns: ClassifiedTurn[]; project?: string
   agentSpawnLinks?: Record<string, string>; spawnPrSets?: Record<string, string[]>
-  prRefsAtRangeStart?: string[]; first?: string; last?: string
+  prRefsAtRangeStart?: string[]; first?: string; last?: string; ambiguousSpawnAgentIds?: string[]
 }): SessionSummary {
   return {
     ...BASE,
@@ -60,6 +60,7 @@ function parent(opts: {
     ...(opts.agentSpawnLinks ? { agentSpawnLinks: opts.agentSpawnLinks } : {}),
     ...(opts.spawnPrSets ? { spawnPrSets: opts.spawnPrSets } : {}),
     ...(opts.prRefsAtRangeStart ? { prRefsAtRangeStart: opts.prRefsAtRangeStart } : {}),
+    ...(opts.ambiguousSpawnAgentIds ? { ambiguousSpawnAgentIds: opts.ambiguousSpawnAgentIds } : {}),
   }
 }
 
@@ -365,23 +366,95 @@ describe('MAJOR: id-collision contamination', () => {
     expect(totals.subagentSessions).toBe(0)            // the ambiguous child folds nowhere
     expect(totals.attributedCost).toBeCloseTo(30, 6)   // no child double-charge
   })
+
+  it('folds nowhere when a PR-bearing parent shares its id with a PR-LESS parent', () => {
+    // Only ONE of the two colliding parents has prLinks, but the identity is still
+    // ambiguous: count ALL candidates, not just PR-bearing ones.
+    const projects = [project([
+      parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] } }),
+      // A PR-less session that happens to share id "P" (imported/duplicate data).
+      parent({ id: 'P', prLinks: [], turns: [turn({ cost: 20, ts: '2026-07-01T11:00:00Z' })] }),
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
+    ])]
+    const rows = aggregateByPr(projects)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(10, 6)   // parent own spend; child NOT folded
+    expect(prLinkedTotals(projects).subagentSessions).toBe(0)
+  })
 })
 
-describe('MAJOR: recursion dedup is global (diamond folds once)', () => {
-  it('a grandchild id reachable via two direct children folds exactly once', () => {
-    // Parent P has two direct children c1 and c2; both point (via duplicate data)
-    // at a grandchild with the SAME id "agent-gc". The shared claimed-set folds it
-    // once, not twice.
+describe('MAJOR: ambiguous pairing + late child grace window', () => {
+  const makeProjects = (childFirstTs: string) => [project([
+    // No spawn link for c1, but the parent recorded it as an AMBIGUOUS pairing.
+    parent({
+      id: 'P', prLinks: [A], last: '2026-07-01T11:00:00Z',
+      turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })],
+      ambiguousSpawnAgentIds: ['c1'],
+    }),
+    child({ agentId: 'c1', parentId: 'P', cost: 40, firstTs: childFirstTs }),
+  ])]
+
+  it('folds a within-grace late child to the last turn', () => {
+    // Child starts 20 min after the parent's last timestamp (11:00Z) -> within 30 min.
+    const rows = aggregateByPr(makeProjects('2026-07-01T11:20:00Z'))
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(50, 6) // 10 parent + 40 child, folded to last turn
+    expect(prLinkedTotals(makeProjects('2026-07-01T11:20:00Z')).subagentSessions).toBe(1)
+  })
+
+  it('leaves a beyond-grace late child unlinked', () => {
+    // Child starts 2 hours after the parent's last timestamp -> beyond the window.
+    const totals = prLinkedTotals(makeProjects('2026-07-01T13:00:00Z'))
+    expect(totals.subagentSessions).toBe(0)
+    expect(totals.attributedCost).toBeCloseTo(10, 6) // parent only; child unlinked
+    expect(totals.unattributedCost).toBeCloseTo(0, 6)
+  })
+
+  it('does NOT grace a late child whose pairing was merely ABSENT (not ambiguous)', () => {
+    // Same timing, but the parent never recorded this agent id -> no grace.
     const projects = [project([
+      parent({ id: 'P', prLinks: [A], last: '2026-07-01T11:00:00Z', turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })] }),
+      child({ agentId: 'c1', parentId: 'P', cost: 40, firstTs: '2026-07-01T11:20:00Z' }),
+    ])]
+    expect(prLinkedTotals(projects).subagentSessions).toBe(0)
+  })
+})
+
+describe('MINOR: row session-key delimiter does not collide on names with spaces', () => {
+  it('counts two sessions whose space-joined keys would collide as distinct', () => {
+    // "a b" + "c"  and  "a" + "b c"  both become "a b c" under a space delimiter,
+    // undercounting the PR row's session count. A NUL delimiter keeps them distinct.
+    const s1 = parent({ id: 'c', project: 'a b', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })] })
+    const s2 = parent({ id: 'b c', project: 'a', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })] })
+    const rows = aggregateByPr([project([s1], 'a b'), project([s2], 'a')])
+    expect(rowFor(rows, A)!.sessions).toBe(2)
+  })
+})
+
+describe('MAJOR: recursion dedup and conflicting duplicates', () => {
+  // Parent P > c1, c2; both reach a grandchild id "agent-gc" (duplicate data).
+  const diamond = (gc1Cost: number, gc2Cost: number, order: 'c1first' | 'c2first') => {
+    const base = [
       parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'x1', c2: 'x2' }, spawnPrSets: { x1: [A], x2: [A] } }),
       child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
       child({ agentId: 'c2', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:06:00Z' }),
-      child({ agentId: 'gc', parentId: 'agent-c1', cost: 50, firstTs: '2026-07-01T10:07:00Z' }),
-      { ...child({ agentId: 'gc', parentId: 'agent-c2', cost: 50, firstTs: '2026-07-01T10:08:00Z' }) }, // duplicate gc id under c2
-    ])]
-    const rows = aggregateByPr(projects)
-    // 10 (parent) + 100 (c1) + 100 (c2) + 50 (gc, ONCE, not 100).
-    expect(rowFor(rows, A)!.cost).toBeCloseTo(260, 6)
-    expect(prLinkedTotals(projects).subagentSessions).toBe(3) // c1, c2, gc once
+    ]
+    const gc1 = child({ agentId: 'gc', parentId: 'agent-c1', cost: gc1Cost, firstTs: '2026-07-01T10:07:00Z' })
+    const gc2 = child({ agentId: 'gc', parentId: 'agent-c2', cost: gc2Cost, firstTs: '2026-07-01T10:07:00Z' })
+    return [project([...base, ...(order === 'c1first' ? [gc1, gc2] : [gc2, gc1])])]
+  }
+
+  it('conflicting duplicate ids ($50 vs $500) fold into NEITHER, deterministic across input order', () => {
+    for (const order of ['c1first', 'c2first'] as const) {
+      const rows = aggregateByPr(diamond(50, 500, order))
+      // 10 (parent) + 100 (c1) + 100 (c2); the conflicting grandchild folds nowhere.
+      expect(rowFor(rows, A)!.cost).toBeCloseTo(210, 6)
+      expect(prLinkedTotals(diamond(50, 500, order)).subagentSessions).toBe(2) // c1, c2 only
+    }
+  })
+
+  it('identical duplicate ids fold exactly once', () => {
+    // Same id, same fingerprint (cost/span/links): one logical session, folds once.
+    const rows = aggregateByPr(diamond(50, 50, 'c1first'))
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(260, 6) // 10 + 100 + 100 + 50 (once)
+    expect(prLinkedTotals(diamond(50, 50, 'c1first')).subagentSessions).toBe(3)
   })
 })

--- a/tests/sessions-subagent-fold.test.ts
+++ b/tests/sessions-subagent-fold.test.ts
@@ -398,6 +398,39 @@ describe('MAJOR: id-collision contamination', () => {
     expect(rowFor(rows, A)!.cost).toBeCloseTo(10, 6)   // parent own spend; child NOT folded
     expect(prLinkedTotals(projects).subagentSessions).toBe(0)
   })
+
+  it('distinguishes records whose only difference is a per-turn TIMESTAMP', () => {
+    // Same PR-ref sequence [A then B] and same linkage, but P2 switches to B at a
+    // different time. A fingerprint over the ref SEQUENCE alone would miss this; the
+    // complete per-turn (timestamp/cost/...) fingerprint makes them ambiguous.
+    const mk = (order: 'p1' | 'p2') => {
+      const p1 = parent({ id: 'P', prLinks: [A, B], agentSpawnLinks: { c1: 'x' }, spawnPrSets: { x: [A] }, turns: [turn({ cost: 5, ts: '2026-07-01T10:00:00Z', prRefs: [A] }), turn({ cost: 5, ts: '2026-07-01T10:05:00Z', prRefs: [B] })] })
+      const p2 = parent({ id: 'P', prLinks: [A, B], agentSpawnLinks: { c1: 'x' }, spawnPrSets: { x: [A] }, turns: [turn({ cost: 5, ts: '2026-07-01T10:00:00Z', prRefs: [A] }), turn({ cost: 5, ts: '2026-07-01T10:15:00Z', prRefs: [B] })] })
+      const c = child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:20:00Z' })
+      return [project(order === 'p1' ? [p1, p2, c] : [p2, p1, c])]
+    }
+    for (const order of ['p1', 'p2'] as const) {
+      expect(prLinkedTotals(mk(order)).subagentSessions).toBe(0) // ambiguous -> child folds nowhere
+    }
+  })
+
+  it('does NOT create false ambiguity from set-array ORDER (spawnPrSets / prRefs)', () => {
+    // Two records identical up to array ORDER of set-semantic fields fingerprint EQUAL
+    // (canonical sort), so they are one logical parent and the child folds once (not
+    // dropped as falsely-ambiguous). Cost-0 parent turns isolate the child fold.
+    const mk = (order: 'q1' | 'q2') => {
+      const q1 = parent({ id: 'Q', prLinks: [A, B], agentSpawnLinks: { c1: 'x' }, spawnPrSets: { x: [A, B] }, turns: [turn({ cost: 0, ts: '2026-07-01T10:00:00Z', prRefs: [A, B] })] })
+      const q2 = parent({ id: 'Q', prLinks: [B, A], agentSpawnLinks: { c1: 'x' }, spawnPrSets: { x: [B, A] }, turns: [turn({ cost: 0, ts: '2026-07-01T10:00:00Z', prRefs: [B, A] })] })
+      const c = child({ agentId: 'c1', parentId: 'Q', cost: 100, firstTs: '2026-07-01T10:05:00Z' })
+      return [project(order === 'q1' ? [q1, q2, c] : [q2, q1, c])]
+    }
+    for (const order of ['q1', 'q2'] as const) {
+      expect(prLinkedTotals(mk(order)).subagentSessions).toBe(1) // NOT ambiguous: folds once
+      const rows = aggregateByPr(mk(order))
+      expect(rowFor(rows, A)!.cost).toBeCloseTo(50, 6)           // child $100 split A/B
+      expect(rowFor(rows, B)!.cost).toBeCloseTo(50, 6)
+    }
+  })
 })
 
 describe('MAJOR: ambiguous pairing + late child grace window', () => {
@@ -469,14 +502,70 @@ describe('MAJOR: range-start PR state is recomputed at a filter boundary', () =>
     expect(rowFor(rows, A)).toBeUndefined()
   })
 
-  it('drops an anchor that duplicates a surviving session id (malformed merged input)', () => {
-    // A surviving in-range session and a stray anchor carry the SAME id: the real
-    // session wins, the duplicate anchor is dropped.
-    const surviving = parent({ id: 'dup', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-20T10:00:00Z', prRefs: [A] })], spawnPrSets: { x: [A] } })
-    const strayAnchor = parent({ id: 'dup', prLinks: [A], turns: [], spawnPrSets: { x: [A] } })
-    const proj = { ...project([surviving]), subagentAnchors: [strayAnchor] }
-    const filtered = filterProjectsByDays([proj], new Set(['2026-07-20']))
-    expect(filtered.flatMap(p => p.subagentAnchors ?? []).some(a => a.sessionId === 'dup')).toBe(false)
+  it('breaks an exact-timestamp seed tie deterministically across both turn orders', () => {
+    // Two PR-bearing turns at the SAME pre-slice millisecond (A and B). The seed must
+    // be the same regardless of array order (lexicographically-last ref key wins -> B).
+    const sameMsA = turn({ cost: 5, ts: '2026-07-10T10:00:00Z', prRefs: [A] })
+    const sameMsB = turn({ cost: 5, ts: '2026-07-10T10:00:00Z', prRefs: [B] })
+    const range = { start: new Date('2026-07-20T00:00:00Z'), end: new Date('2026-07-21T23:59:59Z') }
+    for (const turns of [[sameMsA, sameMsB, LATE_TURN()], [sameMsB, sameMsA, LATE_TURN()]]) {
+      const rows = aggregateByPr(filterProjectsByDateRange(build(turns), range))
+      expect(rowFor(rows, B)?.cost ?? 0).toBeCloseTo(10, 6) // ref-less July 20 -> B (stable tie-break)
+      expect(rowFor(rows, A)).toBeUndefined()
+    }
+  })
+
+  it('per-day seeding handles a NON-CONTIGUOUS selection: a switch on an unselected day carries', () => {
+    // July 1 A (selected), July 2 B (UNSELECTED gap), July 3 ref-less (selected). The
+    // July 3 turn must carry B (the switch on the skipped July 2), not the stale A.
+    const jul1 = turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })
+    const jul2 = turn({ cost: 10, ts: '2026-07-02T10:00:00Z', prRefs: [B] })
+    const jul3 = turn({ cost: 10, ts: '2026-07-03T10:00:00Z' }) // ref-less
+    const projects = [project([parent({ id: 'S', prLinks: [A, B], turns: [jul1, jul2, jul3] })])]
+    const rows = aggregateByPr(filterProjectsByDays(projects, new Set(['2026-07-01', '2026-07-03'])))
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(10, 6) // July 1 -> A
+    expect(rowFor(rows, B)!.cost).toBeCloseTo(10, 6) // July 3 -> B (carried across the gap)
+  })
+
+  it('contiguous control: the same three days selected still attribute July 3 to B', () => {
+    const jul1 = turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })
+    const jul2 = turn({ cost: 10, ts: '2026-07-02T10:00:00Z', prRefs: [B] })
+    const jul3 = turn({ cost: 10, ts: '2026-07-03T10:00:00Z' })
+    const projects = [project([parent({ id: 'S', prLinks: [A, B], turns: [jul1, jul2, jul3] })])]
+    const rows = aggregateByPr(filterProjectsByDays(projects, new Set(['2026-07-01', '2026-07-02', '2026-07-03'])))
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(10, 6) // July 1
+    expect(rowFor(rows, B)!.cost).toBeCloseTo(20, 6) // July 2 (B) + July 3 (carried B)
+  })
+
+  it('does NOT drop a same-id anchor of a DIFFERENT provider (fold preserved)', () => {
+    // A surviving Codex session shares the raw id "X" with a Claude fold anchor;
+    // provider-aware identity keeps them distinct, so the anchor and its fold survive.
+    const codexX = parent({ id: 'X', prLinks: [], turns: [turn({ cost: 10, ts: '2026-07-20T10:00:00Z' })] })
+    codexX.turns[0]!.assistantCalls[0]!.provider = 'codex'
+    const anchorX = parent({ id: 'X', prLinks: [A], turns: [], agentSpawnLinks: { c1: 'sx' }, spawnPrSets: { sx: [A] } })
+    const childC1 = child({ agentId: 'c1', parentId: 'X', cost: 100, firstTs: '2026-07-20T10:05:00Z' })
+    const filtered = filterProjectsByDays([project([codexX, childC1], 'p', [anchorX])], new Set(['2026-07-20']))
+    expect(filtered.some(p => (p.subagentAnchors ?? []).some(a => a.sessionId === 'X'))).toBe(true) // Claude anchor kept
+    expect(prLinkedTotals(filtered).subagentSessions).toBe(1)                                       // its child still folds
+  })
+
+  it('drops a genuinely identical same-provider duplicate anchor', () => {
+    // The surviving session and the anchor are the SAME provider AND record (identical
+    // fingerprint): a proven duplicate, so the anchor is dropped.
+    const make = () => parent({ id: 'Y', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-20T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'sx' }, spawnPrSets: { sx: [A] } })
+    const filtered = filterProjectsByDays([project([make()], 'p', [make()])], new Set(['2026-07-20']))
+    expect(filtered.flatMap(p => p.subagentAnchors ?? []).some(a => a.sessionId === 'Y')).toBe(false)
+  })
+
+  it('keeps a same-id/different-record anchor so the ambiguity guard folds neither', () => {
+    // Same provider + id "Z" but a DIFFERENT record: not a proven duplicate, so the
+    // anchor is kept; both records then make the key ambiguous and a child folds nowhere.
+    const surviving = parent({ id: 'Z', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-20T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'sx' }, spawnPrSets: { sx: [A] } })
+    const anchorZ = parent({ id: 'Z', prLinks: [B], turns: [], agentSpawnLinks: { c1: 'sy' }, spawnPrSets: { sy: [B] } }) // different record
+    const childC1 = child({ agentId: 'c1', parentId: 'Z', cost: 100, firstTs: '2026-07-20T10:05:00Z' })
+    const filtered = filterProjectsByDays([project([surviving, childC1], 'p', [anchorZ])], new Set(['2026-07-20']))
+    expect(filtered.flatMap(p => p.subagentAnchors ?? []).some(a => a.sessionId === 'Z')).toBe(true) // anchor NOT dropped
+    expect(prLinkedTotals(filtered).subagentSessions).toBe(0)                                        // ambiguous -> child folds nowhere
   })
 })
 

--- a/tests/sessions-subagent-fold.test.ts
+++ b/tests/sessions-subagent-fold.test.ts
@@ -6,6 +6,7 @@ import {
   prLinkedTotals,
   resolveSubagentAttribution,
 } from '../src/sessions-report.js'
+import { filterProjectsByDateRange, filterProjectsByDays } from '../src/parser.js'
 import type { ClassifiedTurn, ParsedApiCall, ProjectSummary, SessionSummary, TokenUsage } from '../src/types.js'
 
 const A = 'https://github.com/o/r/pull/1'
@@ -367,6 +368,23 @@ describe('MAJOR: id-collision contamination', () => {
     expect(totals.attributedCost).toBeCloseTo(30, 6)   // no child double-charge
   })
 
+  it('folds nowhere when two parents share id + headline stats but map the child to different spawns/PRs', () => {
+    // Same cost/calls/prLinks/turn-refs, but P1 maps c1 -> spawn x (PR A) and P2 maps
+    // c1 -> spawn y (PR B). A fingerprint over headline stats alone would miss this
+    // and first-wins by input order; the full linkage fingerprint makes it ambiguous.
+    const mk = (order: 'p1' | 'p2') => {
+      const p1 = parent({ id: 'P', prLinks: [A, B], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'x' }, spawnPrSets: { x: [A] } })
+      const p2 = parent({ id: 'P', prLinks: [A, B], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'y' }, spawnPrSets: { y: [B] } })
+      const c = child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' })
+      return [project(order === 'p1' ? [p1, p2, c] : [p2, p1, c])]
+    }
+    for (const order of ['p1', 'p2'] as const) {
+      const totals = prLinkedTotals(mk(order))
+      expect(totals.subagentSessions).toBe(0)          // ambiguous identity -> child folds nowhere
+      expect(totals.attributedCost).toBeCloseTo(20, 6) // only the two parents own $10 turns
+    }
+  })
+
   it('folds nowhere when a PR-bearing parent shares its id with a PR-LESS parent', () => {
     // Only ONE of the two colliding parents has prLinks, but the identity is still
     // ambiguous: count ALL candidates, not just PR-bearing ones.
@@ -418,6 +436,50 @@ describe('MAJOR: ambiguous pairing + late child grace window', () => {
   })
 })
 
+describe('MAJOR: range-start PR state is recomputed at a filter boundary', () => {
+  const A_TURN = () => turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })
+  const B_TURN = () => turn({ cost: 10, ts: '2026-07-10T10:00:00Z', prRefs: [B] })
+  const LATE_TURN = () => turn({ cost: 10, ts: '2026-07-20T10:00:00Z' }) // no refs, carries the active PR
+  // The wide parse recorded PR A as active entering the range; a switch to B lands
+  // July 10. A slice starting July 20 must attribute the ref-less July 20 turn to B,
+  // NOT the stale A. Tested under both turn orderings.
+  const build = (turns: ClassifiedTurn[]) => [project([parent({ id: 'S', prLinks: [A, B], prRefsAtRangeStart: [A], turns })])]
+
+  it('recomputes to B (July 1 A -> July 10 B, slice July 20), both turn orders', () => {
+    const range = { start: new Date('2026-07-20T00:00:00Z'), end: new Date('2026-07-21T23:59:59Z') }
+    for (const turns of [[A_TURN(), B_TURN(), LATE_TURN()], [LATE_TURN(), B_TURN(), A_TURN()]]) {
+      const rows = aggregateByPr(filterProjectsByDateRange(build(turns), range))
+      expect(rowFor(rows, B)?.cost ?? 0).toBeCloseTo(10, 6) // ref-less July 20 turn -> B
+      expect(rowFor(rows, A)).toBeUndefined()               // NOT the stale range-start A
+    }
+  })
+
+  it('a slice starting exactly ON the switch turn attributes that turn to the new PR', () => {
+    // Switch to B lands July 10 10:00; slice starts July 10 00:00. The July 10 turn is
+    // inside the slice and applies B; the recomputed seed (from before) is A.
+    const range = { start: new Date('2026-07-10T00:00:00Z'), end: new Date('2026-07-21T23:59:59Z') }
+    const rows = aggregateByPr(filterProjectsByDateRange(build([A_TURN(), B_TURN(), LATE_TURN()]), range))
+    expect(rowFor(rows, B)!.cost).toBeCloseTo(20, 6) // July 10 (B) + July 20 (carried B)
+    expect(rowFor(rows, A)).toBeUndefined()          // July 1 A turn is out of slice
+  })
+
+  it('day filter recomputes the same way (menubar path)', () => {
+    const rows = aggregateByPr(filterProjectsByDays(build([A_TURN(), B_TURN(), LATE_TURN()]), new Set(['2026-07-20'])))
+    expect(rowFor(rows, B)?.cost ?? 0).toBeCloseTo(10, 6)
+    expect(rowFor(rows, A)).toBeUndefined()
+  })
+
+  it('drops an anchor that duplicates a surviving session id (malformed merged input)', () => {
+    // A surviving in-range session and a stray anchor carry the SAME id: the real
+    // session wins, the duplicate anchor is dropped.
+    const surviving = parent({ id: 'dup', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-20T10:00:00Z', prRefs: [A] })], spawnPrSets: { x: [A] } })
+    const strayAnchor = parent({ id: 'dup', prLinks: [A], turns: [], spawnPrSets: { x: [A] } })
+    const proj = { ...project([surviving]), subagentAnchors: [strayAnchor] }
+    const filtered = filterProjectsByDays([proj], new Set(['2026-07-20']))
+    expect(filtered.flatMap(p => p.subagentAnchors ?? []).some(a => a.sessionId === 'dup')).toBe(false)
+  })
+})
+
 describe('MINOR: row session-key delimiter does not collide on names with spaces', () => {
   it('counts two sessions whose space-joined keys would collide as distinct', () => {
     // "a b" + "c"  and  "a" + "b c"  both become "a b c" under a space delimiter,
@@ -451,10 +513,22 @@ describe('MAJOR: recursion dedup and conflicting duplicates', () => {
     }
   })
 
-  it('identical duplicate ids fold exactly once', () => {
-    // Same id, same fingerprint (cost/span/links): one logical session, folds once.
+  it('a truly identical duplicate child (same parent, same record) folds exactly once', () => {
+    // Two copies of the SAME child under the SAME parent, identical in every
+    // fingerprinted field: one logical session, folds once (not doubled).
+    const mk = () => [project([
+      parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'x' }, spawnPrSets: { x: [A] } }),
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }), // exact duplicate
+    ])]
+    expect(rowFor(aggregateByPr(mk()), A)!.cost).toBeCloseTo(110, 6) // 10 + 100 (once, not 210)
+    expect(prLinkedTotals(mk()).subagentSessions).toBe(1)
+  })
+
+  it('the SAME id under DIFFERENT parents is ambiguous even at equal cost (distinct identity)', () => {
+    // Different parentSessionId is part of the fingerprint, so these are NOT the
+    // same logical session: fold neither.
     const rows = aggregateByPr(diamond(50, 50, 'c1first'))
-    expect(rowFor(rows, A)!.cost).toBeCloseTo(260, 6) // 10 + 100 + 100 + 50 (once)
-    expect(prLinkedTotals(diamond(50, 50, 'c1first')).subagentSessions).toBe(3)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(210, 6) // grandchild folds nowhere
   })
 })

--- a/tests/sessions-subagent-fold.test.ts
+++ b/tests/sessions-subagent-fold.test.ts
@@ -85,8 +85,8 @@ function child(opts: {
   }
 }
 
-function project(sessions: SessionSummary[], name = 'p'): ProjectSummary {
-  return { project: name, projectPath: `/${name}`, sessions, totalCostUSD: 0, totalSavingsUSD: 0, totalApiCalls: 0, totalProxiedCostUSD: 0 }
+function project(sessions: SessionSummary[], name = 'p', anchors?: SessionSummary[]): ProjectSummary {
+  return { project: name, projectPath: `/${name}`, sessions, totalCostUSD: 0, totalSavingsUSD: 0, totalApiCalls: 0, totalProxiedCostUSD: 0, ...(anchors ? { subagentAnchors: anchors } : {}) }
 }
 
 function rowFor(rows: ReturnType<typeof aggregateByPr>, url: string) {
@@ -107,7 +107,9 @@ describe('buildSubagentIndex', () => {
       // Child lives in a DIFFERENT project than its parent (worktree cwd resolved elsewhere).
       project([child({ agentId: 'c1', parentId: 'P', cost: 50, firstTs: '2026-07-01T10:05:00Z', project: 'projB' })], 'projB'),
     ])
-    expect(idx.get('P')?.map(s => s.agentId)).toEqual(['c1'])
+    // One key (parentSessionId, provider-prefixed), holding the single child.
+    expect(idx.size).toBe(1)
+    expect([...idx.values()].flat().map(s => s.agentId)).toEqual(['c1'])
   })
 })
 
@@ -248,16 +250,22 @@ describe('MAJOR: date-range correctness', () => {
     expect(rowFor(rows, B)!.cost).toBeCloseTo(10, 6)  // parent's in-range turn only
   })
 
-  it('(a) an in-range child of a parent with no in-range turns still folds', () => {
-    // The parent has zero in-range turns (a 0-cost fold anchor) but carries prLinks
-    // and spawnPrSets; its in-range child must still reach the PR.
+  it('(a) an in-range child of an anchor parent (no in-range turns) folds, anchor uncounted', () => {
+    // The parent is a 0-cost fold ANCHOR: it carries prLinks + spawnPrSets but has
+    // no in-range turns, so it lives in subagentAnchors, NOT sessions. Its in-range
+    // child must still reach the PR, and the anchor must not inflate session counts.
+    const anchor = parent({ id: 'P', prLinks: [A], turns: [], last: '', first: '', agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] } })
     const projects = [project([
-      parent({ id: 'P', prLinks: [A], turns: [], last: '', agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] } }),
-      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-20T10:05:00Z' }),
-    ])]
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-20T10:05:00Z', last: '2026-07-20T10:30:00Z' }),
+    ], 'p', [anchor])]
     const rows = aggregateByPr(projects)
     expect(rowFor(rows, A)!.cost).toBeCloseTo(100, 6)
-    expect(prLinkedTotals(projects).subagentSessions).toBe(1)
+    const totals = prLinkedTotals(projects)
+    expect(totals.subagentSessions).toBe(1)
+    expect(totals.sessions).toBe(0) // the anchor is NOT counted as a PR-linked session
+    // The PR row's date span comes from the CHILD, not the anchor's empty timestamps.
+    expect(rowFor(rows, A)!.firstStarted).toBe('2026-07-20T10:05:00Z')
+    expect(rowFor(rows, A)!.lastEnded).toBe('2026-07-20T10:30:00Z')
   })
 })
 
@@ -278,6 +286,19 @@ describe('MAJOR: timestamp fallback (epoch, end-bounded)', () => {
     const totals = prLinkedTotals(projects)
     expect(totals.attributedCost).toBeCloseTo(10, 6)
     expect(totals.unattributedCost).toBeCloseTo(40, 6) // child fell before the turn -> unattributed
+  })
+
+  it('a child whose spawn link was omitted (ambiguous pairing) still folds via timestamp', () => {
+    // The parent has NO agentSpawnLinks entry for this child (the spawn-result
+    // pairing was ambiguous and omitted). The child must still fold via the
+    // timestamp bucket, not disappear.
+    const projects = [project([
+      parent({ id: 'P', prLinks: [A], last: '2026-07-01T12:00:00Z', turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })] }),
+      child({ agentId: 'noLink', parentId: 'P', cost: 40, firstTs: '2026-07-01T10:30:00Z' }),
+    ])]
+    const rows = aggregateByPr(projects)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(50, 6) // 10 parent + 40 child via timestamp bucket
+    expect(prLinkedTotals(projects).subagentSessions).toBe(1)
   })
 
   it('a child active after the parent last timestamp is UNLINKED (contributes nothing)', () => {
@@ -313,24 +334,54 @@ describe('orphans and non-PR parents contribute nothing', () => {
   })
 })
 
-describe('resolveSubagentAttribution is computed once and shared', () => {
+describe('resolveSubagentAttribution', () => {
   it('resolves each PR-bearing parent to its resolved children', () => {
     const projects = [project([
       parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] } }),
       child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
     ])]
-    const attribution = resolveSubagentAttribution(projects)
-    expect(attribution.get('P')).toHaveLength(1)
-    expect(attribution.get('P')![0]!.prSet).toEqual([A])
-    expect(attribution.get('P')![0]!.fold.cost).toBe(100)
+    const resolved = [...resolveSubagentAttribution(projects).values()]
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0]!).toHaveLength(1)
+    expect(resolved[0]![0]!.prSet).toEqual([A])
+    expect(resolved[0]![0]!.fold.cost).toBe(100)
   })
+})
 
-  it('memoizes by projects identity so the tree is resolved once per render', () => {
+describe('MAJOR: id-collision contamination', () => {
+  it('folds a child into NEITHER of two distinct parents that share a session id', () => {
+    // Two DISTINCT parent sessions both have id "P" (duplicate/imported data). A
+    // child pointing at "P" is ambiguous: it must fold nowhere and stay standalone,
+    // while both parents attribute their OWN spend only.
     const projects = [project([
       parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] } }),
+      parent({ id: 'P', prLinks: [B], turns: [turn({ cost: 20, ts: '2026-07-01T11:00:00Z', prRefs: [B] })], agentSpawnLinks: { c1: 'toolu_y' }, spawnPrSets: { toolu_y: [B] } }),
       child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
     ])]
-    expect(resolveSubagentAttribution(projects)).toBe(resolveSubagentAttribution(projects)) // same array -> same object
-    expect(resolveSubagentAttribution(projects)).not.toBe(resolveSubagentAttribution([...projects])) // different array -> recomputed
+    const rows = aggregateByPr(projects)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(10, 6)   // parent 1 own spend only
+    expect(rowFor(rows, B)!.cost).toBeCloseTo(20, 6)   // parent 2 own spend only
+    const totals = prLinkedTotals(projects)
+    expect(totals.subagentSessions).toBe(0)            // the ambiguous child folds nowhere
+    expect(totals.attributedCost).toBeCloseTo(30, 6)   // no child double-charge
+  })
+})
+
+describe('MAJOR: recursion dedup is global (diamond folds once)', () => {
+  it('a grandchild id reachable via two direct children folds exactly once', () => {
+    // Parent P has two direct children c1 and c2; both point (via duplicate data)
+    // at a grandchild with the SAME id "agent-gc". The shared claimed-set folds it
+    // once, not twice.
+    const projects = [project([
+      parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'x1', c2: 'x2' }, spawnPrSets: { x1: [A], x2: [A] } }),
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
+      child({ agentId: 'c2', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:06:00Z' }),
+      child({ agentId: 'gc', parentId: 'agent-c1', cost: 50, firstTs: '2026-07-01T10:07:00Z' }),
+      { ...child({ agentId: 'gc', parentId: 'agent-c2', cost: 50, firstTs: '2026-07-01T10:08:00Z' }) }, // duplicate gc id under c2
+    ])]
+    const rows = aggregateByPr(projects)
+    // 10 (parent) + 100 (c1) + 100 (c2) + 50 (gc, ONCE, not 100).
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(260, 6)
+    expect(prLinkedTotals(projects).subagentSessions).toBe(3) // c1, c2, gc once
   })
 })

--- a/tests/sessions-subagent-fold.test.ts
+++ b/tests/sessions-subagent-fold.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import {
   aggregateByPr,
-  attributeSessionPrSpend,
   buildSubagentIndex,
   prLinkedTotals,
-  resolveChildFolds,
+  resolveSubagentAttribution,
 } from '../src/sessions-report.js'
 import type { ClassifiedTurn, ParsedApiCall, ProjectSummary, SessionSummary, TokenUsage } from '../src/types.js'
 
@@ -27,66 +26,62 @@ function call(cost: number, model: string, ts: string): ParsedApiCall {
   }
 }
 
-// A parent turn: one call of `cost` under `model`, at `ts`, optionally carrying
-// `prRefs` and the `spawnToolUseIds` of subagents launched in the turn.
-function turn(opts: {
-  cost: number; model?: string; ts: string; category?: ClassifiedTurn['category']
-  prRefs?: string[]; spawnToolUseIds?: string[]
-}): ClassifiedTurn {
+function turn(opts: { cost: number; model?: string; ts: string; prRefs?: string[]; category?: ClassifiedTurn['category'] }): ClassifiedTurn {
   return {
     userMessage: '', timestamp: opts.ts, sessionId: 's',
     category: opts.category ?? 'coding', retries: 0, hasEdits: false,
     assistantCalls: [call(opts.cost, opts.model ?? 'claude-sonnet-4-5', opts.ts)],
     ...(opts.prRefs ? { prRefs: opts.prRefs } : {}),
-    ...(opts.spawnToolUseIds ? { spawnToolUseIds: opts.spawnToolUseIds } : {}),
   }
+}
+
+const BASE = {
+  totalSavingsUSD: 0, totalEstimatedCostUSD: 0,
+  totalInputTokens: 0, totalOutputTokens: 0, totalReasoningTokens: 0,
+  totalCacheReadTokens: 0, totalCacheWriteTokens: 0,
+  modelBreakdown: {}, toolBreakdown: {}, mcpBreakdown: {}, bashBreakdown: {},
+  categoryBreakdown: {} as SessionSummary['categoryBreakdown'],
+  skillBreakdown: {} as SessionSummary['skillBreakdown'],
+  subagentBreakdown: {} as SessionSummary['subagentBreakdown'],
 }
 
 function parent(opts: {
-  id: string; prLinks: string[]; turns: ClassifiedTurn[]
-  agentSpawnLinks?: Record<string, string>; project?: string
+  id: string; prLinks: string[]; turns: ClassifiedTurn[]; project?: string
+  agentSpawnLinks?: Record<string, string>; spawnPrSets?: Record<string, string[]>
+  prRefsAtRangeStart?: string[]; first?: string; last?: string
 }): SessionSummary {
   return {
+    ...BASE,
     sessionId: opts.id, project: opts.project ?? 'p',
-    firstTimestamp: '2026-07-01T10:00:00Z', lastTimestamp: '2026-07-01T12:00:00Z',
-    totalCostUSD: 0, totalSavingsUSD: 0, totalEstimatedCostUSD: 0,
-    totalInputTokens: 0, totalOutputTokens: 0, totalReasoningTokens: 0,
-    totalCacheReadTokens: 0, totalCacheWriteTokens: 0,
+    firstTimestamp: opts.first ?? '2026-07-01T10:00:00Z', lastTimestamp: opts.last ?? '2026-07-01T12:00:00Z',
+    totalCostUSD: opts.turns.reduce((n, t) => n + t.assistantCalls.reduce((s, c) => s + c.costUSD, 0), 0),
     apiCalls: opts.turns.reduce((n, t) => n + t.assistantCalls.length, 0),
-    turns: opts.turns,
-    modelBreakdown: {}, toolBreakdown: {}, mcpBreakdown: {}, bashBreakdown: {},
-    categoryBreakdown: {} as SessionSummary['categoryBreakdown'],
-    skillBreakdown: {} as SessionSummary['skillBreakdown'],
-    subagentBreakdown: {} as SessionSummary['subagentBreakdown'],
-    prLinks: opts.prLinks,
+    turns: opts.turns, prLinks: opts.prLinks,
     ...(opts.agentSpawnLinks ? { agentSpawnLinks: opts.agentSpawnLinks } : {}),
+    ...(opts.spawnPrSets ? { spawnPrSets: opts.spawnPrSets } : {}),
+    ...(opts.prRefsAtRangeStart ? { prRefsAtRangeStart: opts.prRefsAtRangeStart } : {}),
   }
 }
 
-// A sidechain (subagent) session: one turn of `cost` under `model`/`category`,
-// linked to `parentId` via `agentId`, first active at `firstTs`.
 function child(opts: {
   agentId: string; parentId: string; cost: number; model?: string
-  category?: ClassifiedTurn['category']; firstTs: string; project?: string; calls?: number
+  category?: ClassifiedTurn['category']; firstTs: string; last?: string
+  project?: string; calls?: number; prLinks?: string[]
 }): SessionSummary {
   const n = opts.calls ?? 1
   const t: ClassifiedTurn = {
     userMessage: '', timestamp: opts.firstTs, sessionId: `agent-${opts.agentId}`,
     category: opts.category ?? 'debugging', retries: 0, hasEdits: false,
     assistantCalls: Array.from({ length: n }, () => call(opts.cost / n, opts.model ?? 'claude-opus-4-8', opts.firstTs)),
+    ...(opts.prLinks ? { prRefs: opts.prLinks } : {}),
   }
   return {
+    ...BASE,
     sessionId: `agent-${opts.agentId}`, project: opts.project ?? 'p',
     parentSessionId: opts.parentId, agentId: opts.agentId,
-    firstTimestamp: opts.firstTs, lastTimestamp: opts.firstTs,
-    totalCostUSD: opts.cost, totalSavingsUSD: 0, totalEstimatedCostUSD: 0,
-    totalInputTokens: 0, totalOutputTokens: 0, totalReasoningTokens: 0,
-    totalCacheReadTokens: 0, totalCacheWriteTokens: 0,
-    apiCalls: n, turns: [t],
-    modelBreakdown: {}, toolBreakdown: {}, mcpBreakdown: {}, bashBreakdown: {},
-    categoryBreakdown: {} as SessionSummary['categoryBreakdown'],
-    skillBreakdown: {} as SessionSummary['skillBreakdown'],
-    subagentBreakdown: {} as SessionSummary['subagentBreakdown'],
+    firstTimestamp: opts.firstTs, lastTimestamp: opts.last ?? opts.firstTs,
+    totalCostUSD: opts.cost, apiCalls: n, turns: [t],
+    ...(opts.prLinks ? { prLinks: opts.prLinks } : {}),
   }
 }
 
@@ -94,161 +89,248 @@ function project(sessions: SessionSummary[], name = 'p'): ProjectSummary {
   return { project: name, projectPath: `/${name}`, sessions, totalCostUSD: 0, totalSavingsUSD: 0, totalApiCalls: 0, totalProxiedCostUSD: 0 }
 }
 
-describe('buildSubagentIndex', () => {
-  it('indexes sidechains by project + parentSessionId; skips non-children', () => {
-    const idx = buildSubagentIndex([project([
-      parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })] }),
-      child({ agentId: 'c1', parentId: 'P', cost: 50, firstTs: '2026-07-01T10:05:00Z' }),
-      child({ agentId: 'c2', parentId: 'P', cost: 30, firstTs: '2026-07-01T10:06:00Z' }),
-    ])])
-    expect(idx.size).toBe(1) // one parent key
-    expect([...idx.values()].flat().map(c => c.agentId).sort()).toEqual(['c1', 'c2'])
-  })
-})
-
-describe('resolveChildFolds', () => {
-  const p = parent({
-    id: 'P', prLinks: [A, B],
-    turns: [
-      turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A], spawnToolUseIds: ['toolu_x'] }),
-      turn({ cost: 10, ts: '2026-07-01T10:30:00Z', prRefs: [B] }),
-    ],
-    agentSpawnLinks: { c1: 'toolu_x' },
-  })
-
-  it('resolves via spawn tool_use id (true launch point)', () => {
-    const c = child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:45:00Z' })
-    const folds = resolveChildFolds(p, [buildFold(c)])
-    // firstTs 10:45 sits in turn1's span, but the spawn id lives in turn0 -> turn0 wins.
-    expect(folds.byTurnIndex.get(0)?.[0]?.agentId).toBe('c1')
-    expect(folds.byTurnIndex.has(1)).toBe(false)
-    expect(folds.unlinked).toHaveLength(0)
-  })
-
-  it('falls back to timestamp bucketing when there is no spawn link', () => {
-    const c = child({ agentId: 'unknown', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:45:00Z' })
-    const folds = resolveChildFolds(p, [buildFold(c)])
-    // No agentSpawnLinks entry -> bucket by firstTs 10:45 into the last turn started <= it.
-    expect(folds.byTurnIndex.get(1)?.[0]?.agentId).toBe('unknown')
-    expect(folds.byTurnIndex.has(0)).toBe(false)
-  })
-
-  it('marks a child before the first turn as unlinked', () => {
-    const c = child({ agentId: 'early', parentId: 'P', cost: 100, firstTs: '2026-07-01T09:00:00Z' })
-    const folds = resolveChildFolds(p, [buildFold(c)])
-    expect(folds.byTurnIndex.size).toBe(0)
-    expect(folds.unlinked.map(f => f.agentId)).toEqual(['early'])
-  })
-})
-
-// Round-trip a child SessionSummary through the public index so tests exercise the
-// same ChildFold the report builds (agentId/cost/models/categories derivation).
-function buildFold(c: SessionSummary) {
-  return [...buildSubagentIndex([project([c])]).values()][0]![0]!
+function rowFor(rows: ReturnType<typeof aggregateByPr>, url: string) {
+  return rows.find(r => r.url === url)
 }
 
-describe('attributeSessionPrSpend with folds', () => {
-  it('folds a child into its spawn turn and surfaces its model in that PR', () => {
-    const p = parent({
-      id: 'P', prLinks: [A, B],
-      turns: [
-        turn({ cost: 10, model: 'claude-sonnet-4-5', ts: '2026-07-01T10:00:00Z', prRefs: [A], spawnToolUseIds: ['toolu_x'] }),
-        turn({ cost: 10, model: 'claude-sonnet-4-5', ts: '2026-07-01T10:30:00Z', prRefs: [B] }),
-      ],
-      agentSpawnLinks: { c1: 'toolu_x' },
-    })
-    const c = buildFold(child({ agentId: 'c1', parentId: 'P', cost: 100, model: 'claude-opus-4-8', category: 'debugging', firstTs: '2026-07-01T10:45:00Z' }))
-    const folds = resolveChildFolds(p, [c])
-    const { perUrl } = attributeSessionPrSpend(p, folds)
-    // A owns turn0's own $10 plus the child's $100.
-    expect(perUrl.get(A)!.cost).toBeCloseTo(110, 6)
-    expect(perUrl.get(B)!.cost).toBeCloseTo(10, 6)
-    // The child's opus spend reaches PR A's model + category breakdown.
-    expect(perUrl.get(A)!.models.get('claude-opus-4-8')).toBeCloseTo(100, 6)
-    expect(perUrl.get(A)!.categories.get('debugging')).toBeCloseTo(100, 6)
-    expect(perUrl.get(A)!.categories.get('coding')).toBeCloseTo(10, 6)
-  })
+// Sum of the standalone cost of every subagent session, for the double-count check.
+function subagentCostTotal(projects: ProjectSummary[]): number {
+  let t = 0
+  for (const p of projects) for (const s of p.sessions) if (s.parentSessionId) t += s.totalCostUSD
+  return t
+}
 
-  it('lands a child spawned before any PR reference in unattributed', () => {
-    const p = parent({
-      id: 'P', prLinks: [A],
-      turns: [
-        // turn0 references no PR (current === null); a child folded here is overhead.
-        turn({ cost: 5, ts: '2026-07-01T10:00:00Z', spawnToolUseIds: ['toolu_pre'] }),
-        turn({ cost: 10, ts: '2026-07-01T10:30:00Z', prRefs: [A] }),
-      ],
-      agentSpawnLinks: { c1: 'toolu_pre' },
-    })
-    const c = buildFold(child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }))
-    const { perUrl, unattributed } = attributeSessionPrSpend(p, resolveChildFolds(p, [c]))
-    expect(perUrl.get(A)!.cost).toBeCloseTo(10, 6)
-    expect(unattributed.cost).toBeCloseTo(105, 6) // turn0's $5 + child $100
-  })
-
-  it('folds an unlinked child into unattributed', () => {
-    const p = parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })] })
-    const c = buildFold(child({ agentId: 'orphanTurn', parentId: 'P', cost: 40, firstTs: '2026-07-01T09:00:00Z' }))
-    const { perUrl, unattributed } = attributeSessionPrSpend(p, resolveChildFolds(p, [c]))
-    expect(perUrl.get(A)!.cost).toBeCloseTo(10, 6)
-    expect(unattributed.cost).toBeCloseTo(40, 6)
-  })
-
-  it('is a no-op when no folds are supplied (regression guard)', () => {
-    const p = parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })] })
-    const { perUrl, unattributed } = attributeSessionPrSpend(p)
-    expect(perUrl.get(A)!.cost).toBeCloseTo(10, 6)
-    expect(unattributed.cost).toBe(0)
+describe('buildSubagentIndex', () => {
+  it('keys children by parentSessionId alone (global, cross-project)', () => {
+    const idx = buildSubagentIndex([
+      project([parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })] })], 'projA'),
+      // Child lives in a DIFFERENT project than its parent (worktree cwd resolved elsewhere).
+      project([child({ agentId: 'c1', parentId: 'P', cost: 50, firstTs: '2026-07-01T10:05:00Z', project: 'projB' })], 'projB'),
+    ])
+    expect(idx.get('P')?.map(s => s.agentId)).toEqual(['c1'])
   })
 })
 
-describe('aggregateByPr / prLinkedTotals fold subagents end to end', () => {
+describe('spawn-link resolution (async edge: spawn PR wins over first-timestamp)', () => {
   const projects = () => [project([
     parent({
-      id: 'P', prLinks: [A],
-      turns: [turn({ cost: 20, model: 'claude-sonnet-4-5', ts: '2026-07-01T10:00:00Z', prRefs: [A], spawnToolUseIds: ['toolu_x'] })],
+      id: 'P', prLinks: [A, B],
+      // Turn 0 works on A and spawns the child; turn 1 works on B. The child's
+      // first activity lands during turn 1, but the spawn happened under A.
+      turns: [
+        turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] }),
+        turn({ cost: 10, ts: '2026-07-01T10:30:00Z', prRefs: [B] }),
+      ],
       agentSpawnLinks: { c1: 'toolu_x' },
+      spawnPrSets: { toolu_x: [A] },
     }),
-    child({ agentId: 'c1', parentId: 'P', cost: 100, model: 'claude-opus-4-8', firstTs: '2026-07-01T10:05:00Z', calls: 5 }),
+    child({ agentId: 'c1', parentId: 'P', cost: 100, model: 'claude-opus-4-8', firstTs: '2026-07-01T10:45:00Z' }),
   ])]
 
-  it('counts the child cost exactly once in by-PR while it stays a standalone session', () => {
+  it('folds the child under the spawn PR (A), not the first-timestamp PR (B)', () => {
     const rows = aggregateByPr(projects())
-    const rowA = rows.find(r => r.url === A)!
-    expect(rowA.cost).toBeCloseTo(120, 6) // parent $20 + child $100, once
-    expect(rowA.calls).toBe(6)            // parent 1 + child 5
-    expect(rowA.models).toContain('Opus 4.8') // short name of claude-opus appears beside the parent model
-    // The child is still present as its own session (not removed from projects).
-    expect(projects()[0]!.sessions.some(s => s.sessionId === 'agent-c1')).toBe(true)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(110, 6) // turn A ($10) + child ($100)
+    expect(rowFor(rows, B)!.cost).toBeCloseTo(10, 6)
+    expect(rowFor(rows, A)!.models).toContain('Opus 4.8')
   })
 
-  it('reports subagentSessions alongside PR-linked parent sessions', () => {
-    const totals = prLinkedTotals(projects())
-    expect(totals.sessions).toBe(1)          // one PR-linked parent
-    expect(totals.subagentSessions).toBe(1)  // one folded child
+  it('counts the child once and keeps it a standalone session', () => {
+    const p = projects()
+    const totals = prLinkedTotals(p)
+    expect(totals.subagentSessions).toBe(1)
     expect(totals.attributedCost).toBeCloseTo(120, 6)
-    expect(totals.cost).toBeCloseTo(120, 6)
+    // No double-count: folded total minus the child's own cost equals the parents' own spend.
+    expect(totals.cost - subagentCostTotal(p)).toBeCloseTo(20, 6)
+    expect(p[0]!.sessions.some(s => s.sessionId === 'agent-c1')).toBe(true)
+  })
+})
+
+describe('CRITICAL: a self-linking child is NOT folded (mutual exclusion, no double-charge)', () => {
+  it('a child with its own prLinks attributes standalone only', () => {
+    const projects = [project([
+      parent({
+        id: 'P', prLinks: [A],
+        turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })],
+        agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] },
+      }),
+      // The child references its OWN PR (B). It must attribute standalone to B and
+      // NOT also fold into the parent's A -- that would double-charge it.
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z', prLinks: [B] }),
+    ])]
+    const rows = aggregateByPr(projects)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(10, 6)   // parent only, child NOT folded here
+    expect(rowFor(rows, B)!.cost).toBeCloseTo(100, 6)  // child self-attributes to B
+    const totals = prLinkedTotals(projects)
+    expect(totals.subagentSessions).toBe(0)            // nothing was folded
+    // distinctCost / prLinkedTotals consistency: every dollar counted exactly once.
+    const rowsSum = rows.reduce((s, r) => s + r.cost, 0)
+    expect(rowsSum).toBeCloseTo(totals.attributedCost, 6)
+    expect(totals.attributedCost).toBeCloseTo(110, 6)  // 10 + 100, no double
   })
 
-  it('ignores an orphan child whose parent is absent from the scan', () => {
-    const rows = aggregateByPr([project([
-      // No parent 'P' here; the child references a parent that is not in the scan.
-      child({ agentId: 'c1', parentId: 'MISSING', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
-    ])])
-    // Nothing PR-linked, so no rows and no folded spend.
-    expect(rows).toHaveLength(0)
-    const totals = prLinkedTotals([project([
-      child({ agentId: 'c1', parentId: 'MISSING', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
-    ])])
-    expect(totals.subagentSessions).toBe(0)
-    expect(totals.cost).toBe(0)
+  it('a child with NO links folds only (the complementary direction)', () => {
+    const projects = [project([
+      parent({
+        id: 'P', prLinks: [A],
+        turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })],
+        agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] },
+      }),
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
+    ])]
+    const rows = aggregateByPr(projects)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(110, 6)  // folded
+    expect(rowFor(rows, B)).toBeUndefined()
+    expect(prLinkedTotals(projects).subagentSessions).toBe(1)
+  })
+})
+
+describe('MAJOR: nested subagents fold recursively', () => {
+  it('parent > child ($100) > grandchild ($50) lands $150 on the parent PR', () => {
+    const projects = [project([
+      parent({
+        id: 'P', prLinks: [A],
+        turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })],
+        agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] },
+      }),
+      // Middle child (no PR of its own) spawned the grandchild; grandchild's parent
+      // is the middle child, which has no prLinks -> only recursion reaches it.
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
+      child({ agentId: 'gc', parentId: 'agent-c1', cost: 50, firstTs: '2026-07-01T10:06:00Z' }),
+    ])]
+    const rows = aggregateByPr(projects)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(160, 6) // 10 + 100 + 50
+    const totals = prLinkedTotals(projects)
+    expect(totals.subagentSessions).toBe(2)           // child + grandchild
+    expect(totals.attributedCost).toBeCloseTo(160, 6)
   })
 
-  it('does not fold children of a parent that referenced no PR', () => {
-    const rows = aggregateByPr([project([
-      // Parent has turns but NO prLinks -> skipped entirely; its child folds nowhere.
+  it('a self-linking grandchild is excluded from the recursive fold', () => {
+    const projects = [project([
+      parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] } }),
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
+      child({ agentId: 'gc', parentId: 'agent-c1', cost: 50, firstTs: '2026-07-01T10:06:00Z', prLinks: [B] }),
+    ])]
+    const rows = aggregateByPr(projects)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(110, 6)  // 10 + 100 (grandchild NOT folded)
+    expect(rowFor(rows, B)!.cost).toBeCloseTo(50, 6)   // grandchild self-attributes
+  })
+
+  it('a cycle in parent links terminates (visited guard)', () => {
+    // Two sessions each claim the other as parent; the visited set must break it.
+    const a = child({ agentId: 'x', parentId: 'agent-y', cost: 30, firstTs: '2026-07-01T10:06:00Z' })
+    const b = child({ agentId: 'y', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' })
+    // Make x's child be y (cycle: y -> x -> y).
+    const projects = [project([
+      parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { y: 'toolu_x' }, spawnPrSets: { toolu_x: [A] } }),
+      b, a,
+    ])]
+    // y folds into P (100), x folds into y (30); the y<->x cycle must not loop.
+    const rows = aggregateByPr(projects)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(140, 6) // 10 + 100 + 30, counted once
+  })
+})
+
+describe('MAJOR: date-range correctness', () => {
+  it('(b) a spawn in a pre-range turn resolves to the spawn PR, not an in-range one', () => {
+    // The parent's in-range turns only reference B, but the child was spawned in a
+    // pre-range turn working on A (captured in spawnPrSets from the full history).
+    const projects = [project([
+      parent({
+        id: 'P', prLinks: [A, B],
+        turns: [turn({ cost: 10, ts: '2026-07-20T10:00:00Z', prRefs: [B] })], // only in-range turn
+        prRefsAtRangeStart: [B],
+        agentSpawnLinks: { c1: 'toolu_pre' }, spawnPrSets: { toolu_pre: [A] },
+      }),
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-20T10:05:00Z' }),
+    ])]
+    const rows = aggregateByPr(projects)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(100, 6) // child follows the spawn PR
+    expect(rowFor(rows, B)!.cost).toBeCloseTo(10, 6)  // parent's in-range turn only
+  })
+
+  it('(a) an in-range child of a parent with no in-range turns still folds', () => {
+    // The parent has zero in-range turns (a 0-cost fold anchor) but carries prLinks
+    // and spawnPrSets; its in-range child must still reach the PR.
+    const projects = [project([
+      parent({ id: 'P', prLinks: [A], turns: [], last: '', agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] } }),
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-20T10:05:00Z' }),
+    ])]
+    const rows = aggregateByPr(projects)
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(100, 6)
+    expect(prLinkedTotals(projects).subagentSessions).toBe(1)
+  })
+})
+
+describe('MAJOR: timestamp fallback (epoch, end-bounded)', () => {
+  it('compares epoch not lexical: a 12:00Z child does NOT fold into a later 15:00Z (UTC) turn', () => {
+    // Parent turn at 2026-07-01T10:00:00-05:00 == 15:00Z; child at 12:00Z is BEFORE it.
+    const projects = [project([
+      parent({
+        id: 'P', prLinks: [A], last: '2026-07-01T16:00:00Z',
+        turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00-05:00', prRefs: [A] })],
+      }),
+      // No spawn link -> timestamp fallback. 12:00Z < 15:00Z, so it must NOT land on A.
+      child({ agentId: 'early', parentId: 'P', cost: 40, firstTs: '2026-07-01T12:00:00Z' }),
+    ])]
+    const rows = aggregateByPr(projects)
+    // The only turn (A) starts AFTER the child, so nothing carries -> unattributed, no A row from the child.
+    expect(rowFor(rows, A)!.cost).toBeCloseTo(10, 6) // parent turn only
+    const totals = prLinkedTotals(projects)
+    expect(totals.attributedCost).toBeCloseTo(10, 6)
+    expect(totals.unattributedCost).toBeCloseTo(40, 6) // child fell before the turn -> unattributed
+  })
+
+  it('a child active after the parent last timestamp is UNLINKED (contributes nothing)', () => {
+    const projects = [project([
+      parent({
+        id: 'P', prLinks: [A], last: '2026-07-01T11:00:00Z',
+        turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })],
+      }),
+      // No spawn link, and first activity is AFTER the parent's last timestamp.
+      child({ agentId: 'late', parentId: 'P', cost: 40, firstTs: '2026-07-01T23:00:00Z' }),
+    ])]
+    const totals = prLinkedTotals(projects)
+    expect(totals.subagentSessions).toBe(0)             // unlinked -> not counted
+    expect(totals.attributedCost).toBeCloseTo(10, 6)
+    expect(totals.unattributedCost).toBeCloseTo(0, 6)   // contributes nothing at all
+  })
+})
+
+describe('orphans and non-PR parents contribute nothing', () => {
+  it('an orphan child whose parent is absent from the scan is ignored', () => {
+    const projects = [project([child({ agentId: 'c1', parentId: 'MISSING', cost: 100, firstTs: '2026-07-01T10:05:00Z' })])]
+    expect(aggregateByPr(projects)).toHaveLength(0)
+    expect(prLinkedTotals(projects).subagentSessions).toBe(0)
+  })
+
+  it('a child of a parent that referenced no PR is not folded', () => {
+    const projects = [project([
       parent({ id: 'Q', prLinks: [], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z' })] }),
       child({ agentId: 'c9', parentId: 'Q', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
-    ])])
-    expect(rows).toHaveLength(0)
+    ])]
+    expect(aggregateByPr(projects)).toHaveLength(0)
+    expect(prLinkedTotals(projects).subagentSessions).toBe(0)
+  })
+})
+
+describe('resolveSubagentAttribution is computed once and shared', () => {
+  it('resolves each PR-bearing parent to its resolved children', () => {
+    const projects = [project([
+      parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] } }),
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
+    ])]
+    const attribution = resolveSubagentAttribution(projects)
+    expect(attribution.get('P')).toHaveLength(1)
+    expect(attribution.get('P')![0]!.prSet).toEqual([A])
+    expect(attribution.get('P')![0]!.fold.cost).toBe(100)
+  })
+
+  it('memoizes by projects identity so the tree is resolved once per render', () => {
+    const projects = [project([
+      parent({ id: 'P', prLinks: [A], turns: [turn({ cost: 10, ts: '2026-07-01T10:00:00Z', prRefs: [A] })], agentSpawnLinks: { c1: 'toolu_x' }, spawnPrSets: { toolu_x: [A] } }),
+      child({ agentId: 'c1', parentId: 'P', cost: 100, firstTs: '2026-07-01T10:05:00Z' }),
+    ])]
+    expect(resolveSubagentAttribution(projects)).toBe(resolveSubagentAttribution(projects)) // same array -> same object
+    expect(resolveSubagentAttribution(projects)).not.toBe(resolveSubagentAttribution([...projects])) // different array -> recomputed
   })
 })


### PR DESCRIPTION
## Why

Subagent (sidechain) session cost never reaches the by-PR view: each sidechain transcript becomes a standalone session with no `prLinks`, so it is dropped from the by-PR aggregation. A session orchestrated on one model with implementation lanes on another therefore shows only the parent model on every PR row, and the by-PR totals understate real spend.

## What

Fold each sidechain session's cost, calls, per-model cost, and per-category cost into the PR its launching parent turn was working on, so subagent spend inherits that PR under the existing turn-level attribution. Children remain standalone rows in the sessions list; each is counted exactly once.

## Attribution model

`resolveSubagentAttribution` resolves every subagent, once, against its parent's UNFILTERED turn data. `buildPrAttribution` produces PR rows and totals in a single pass (so `aggregateByPr` and `prLinkedTotals` never disagree; the payload builder and CLI call it once), folding each parent key exactly once so duplicate parents cannot double-count shared children.

Resolution of a folded subtree to a PR:
1. Spawn result (`toolUseResult.agentId`) pairs the child's agent id with the `Agent`/`Task` `tool_use` id that launched it; each spawn id maps to the PR active at its emitting turn over the FULL (pre-slice) turn list, so a pre-range spawn still yields the right PR.
2. Otherwise the child's first-activity epoch is bucketed into the parent's turn PR carry.
3. Otherwise unattributed, or unlinked (nothing) after the parent's last turn. An AMBIGUOUSLY-paired child that lands just after the last turn folds within a 30 minute grace window; a truly-absent pairing gets no grace.

Correctness rules:
- Mutual exclusion: a child that referenced its OWN PR attributes standalone and is never folded.
- Global linkage keyed by provider + sessionId (NUL-delimited). A key carried by more than one DISTINCT record is ambiguous, so its child/subtree folds into NEITHER; identical duplicates fold once. The record fingerprint is a recursive canonical serialization of the COMPLETE fold-determining state -- session linkage and, per turn in sequence, timestamp/prRefs/cost/calls/savings/per-model cost -- with object keys sorted and set-semantic arrays sorted (so array order never creates false ambiguity, and a differently-timed switch turn is distinguished). Deterministic across input order.
- Recursion aggregates a child plus its non-self-linking descendants with ONE claimed-set spanning all direct children; a diamond folds once and a cycle terminates.
- Fold anchors (PR-linked parents kept only for attribution) live in `ProjectSummary.subagentAnchors`, never in `sessions`; a folded row takes its span from the child.

## Filters (menubar / dashboard)

The project-rebuilding filters carry `subagentAnchors` through; a date filter CONVERTS a spawn parent whose in-range turns are all filtered out into an anchor. Rebuilt sessions retain their PR + subagent-linkage metadata. `prRefsAtRangeStart` is RECOMPUTED at the new slice boundary by replaying the original full turn sequence (order-independent, with a deterministic same-millisecond tie-break). The day filter additionally seeds EACH selected day's first ref-less turn from the full sequence up to that day's start, so a PR switch on an UNSELECTED day between two selected days carries correctly -- contiguous and non-contiguous selections are both exact. An anchor is dropped only when a surviving session shares its full provider-aware, fingerprint-qualified identity (a proven duplicate), so a different-provider or different-record same-id session does not wrongly drop it.

## Cache

`CACHE_VERSION` 6 -> 7 (v6 never shipped; combined v5 -> v7 bump). Adoption migrates EVERY prior versioned file oldest-to-newest and MERGES per source path (newer wins), so a sparse newer file cannot mask older-only expired-PR orphans; an invariant note requires the list to cover every prior version on disk. New cache fields (`spawnToolUseIds`, `parentSessionId`, `agentSpawnLinks`, `ambiguousSpawnAgentIds`) are threaded through the validator and the append/compact paths like `prRefs`, with an append-vs-cold parity test.

## Footer / payload

Totals include folded subagent spend, so CLI and app footers read "across N PR-linked session(s) + M folded-in subagent runs"; the payload gains an additive `subagentSessions` count (folded subtrees). `distinctCost` covers folded spend, documented in the payload type. `attributedCost + unattributedCost === distinctCost` holds and rows are summable.

## Verification

- tsc (root + app), full root suite, full app suite green. The one deterministic root failure (`cli-durable-totals` provider-parity) is pre-existing on main and unrelated; a couple of CLI integration tests that scan the live environment flake under parallel contention and pass 3/3 in isolation.
- Tests span all five review rounds, including: complete-fingerprint distinctness on a per-turn timestamp difference and non-ambiguity on set-array order (both input orders); the deterministic same-millisecond seed tie-break; per-day seeding across a non-contiguous gap plus a contiguous control; provider-aware fingerprint-qualified anchor dedupe (different-provider kept, identical dropped, different-record kept and folds neither); mutual exclusion, nested recursion, diamond dedup, conflicting-vs-identical duplicates, id-collision ambiguity, the async edge, pre-range spawn resolution, out-of-range anchor parents, the grace window, cache adoption merges, and an end-to-end day-filter fold.
- Every fix in every round was mutation-verified: the test fails on the buggy variant, passes after the fix.
- Fresh real-data drives re-prove, to the cent, that parent-only cost plus folded-children cost equals the folded total (no double-count), that attributed + unattributed reconciles to cost, that rows sum to attributedCost, and that `subagentSessions` equals the folded subtree count -- for a lifetime scan, a single-day slice (anchors created, subagents fold through the filter), and a NON-CONTIGUOUS day selection.