### PR TITLE
fix(sync): setup error handling, Windows browser open, themed callback pages

### DIFF
--- a/src/sync/auth.ts
+++ b/src/sync/auth.ts
@@ -141,6 +141,35 @@ export interface CallbackResult {
   port: number
 }
 
+/**
+ * Themed HTML for the OAuth callback landing page.
+ *
+ * Matches the CodeBurn dashboard theme (dash/src/index.css): warm paper
+ * surfaces, ink text, forest-green accent. Everything is inline — this page
+ * is served once from a throwaway localhost server, so it must not depend
+ * on network fonts, external CSS, or dashboard assets.
+ */
+export function renderCallbackPage(ok: boolean, title: string, message: string): string {
+  const accent = ok ? '#1f8a5b' : '#c8541f' // --primary / --chart-5 (terracotta)
+  const mark = ok ? '&#10003;' : '&#10005;' // ✓ / ✕
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CodeBurn — ${title}</title>
+</head>
+<body style="margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#e9e6de;color:#16181d;font-family:'Geist',system-ui,-apple-system,'Segoe UI',sans-serif;letter-spacing:-0.006em;">
+  <main style="background:#ffffff;border:1px solid rgba(23,27,32,0.08);border-radius:8px;padding:48px 56px;max-width:420px;text-align:center;box-shadow:0 1px 3px rgba(23,27,32,0.06);">
+    <div style="width:56px;height:56px;margin:0 auto 20px;border-radius:50%;background:${accent};color:#ffffff;font-size:28px;line-height:56px;font-weight:700;">${mark}</div>
+    <h1 style="margin:0 0 8px;font-size:20px;font-weight:600;color:#2c5242;">${title}</h1>
+    <p style="margin:0;font-size:15px;color:#5d626b;line-height:1.5;">${message}</p>
+    <p style="margin:28px 0 0;font-size:12px;color:#8a857c;">CodeBurn <span style="color:${accent};">&bull;</span> local sync login</p>
+  </main>
+</body>
+</html>`
+}
+
 export function startCallbackServer(
   expectedState: string,
   timeoutMs: number = 300_000, // 5 minutes
@@ -179,8 +208,8 @@ export function startCallbackServer(
       // Connection: close on every response — the callback server is
       // single-purpose and must never leave pooled keep-alive sockets behind.
       if (error) {
-        res.writeHead(400, { 'Content-Type': 'text/html', 'Connection': 'close' })
-        res.end('<html><body><h1>Login failed</h1><p>You can close this tab.</p></body></html>')
+        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8', 'Connection': 'close' })
+        res.end(renderCallbackPage(false, 'Login failed', 'The identity provider rejected the login. You can close this tab and retry from the terminal.'))
         clearTimeout(timer)
         shutdown()
         reject(new AuthError(`IdP returned error: ${error}`))
@@ -199,8 +228,8 @@ export function startCallbackServer(
         return
       }
 
-      res.writeHead(200, { 'Content-Type': 'text/html', 'Connection': 'close' })
-      res.end('<html><body><h1>✓ Login successful</h1><p>You can close this tab.</p></body></html>')
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Connection': 'close' })
+      res.end(renderCallbackPage(true, 'Login successful', 'CodeBurn sync is now authenticated. You can close this tab and return to the terminal.'))
       clearTimeout(timer)
       shutdown()
       resolve({ code, port: resolvedPort })

--- a/src/sync/cli.ts
+++ b/src/sync/cli.ts
@@ -7,8 +7,9 @@
 import type { Command } from 'commander'
 import { randomBytes } from 'crypto'
 
-import { fetchDiscoveryDoc } from './discovery.js'
+import { fetchDiscoveryDoc, DiscoveryError } from './discovery.js'
 import {
+  AuthError,
   fetchOidcConfig,
   generatePkce,
   buildAuthUrl,
@@ -33,100 +34,120 @@ export function registerSyncCommands(program: Command): void {
     .command('setup <url>')
     .description('Configure sync with a remote endpoint (one-time)')
     .action(async (url: string) => {
-      const baseUrl = url.replace(/\/$/, '')
-      process.stderr.write(`Fetching discovery doc from ${baseUrl}...\n`)
-
-      // 1. Fetch codeburn discovery doc
-      const discovery = await fetchDiscoveryDoc(baseUrl)
-      process.stderr.write(`  Issuer: ${discovery.issuer}\n`)
-      process.stderr.write(`  Client: ${discovery.client_id}\n`)
-
-      // 2. Fetch OIDC configuration from the issuer
-      const oidc = await fetchOidcConfig(discovery.issuer)
-      process.stderr.write(`  Auth endpoint: ${oidc.authorization_endpoint}\n`)
-
-      // 3. Resolve scopes
-      const scopes = resolveScopes(discovery.scopes, oidc.scopes_supported)
-
-      // 4. Generate PKCE
-      const pkce = generatePkce()
-      const state = randomBytes(16).toString('hex')
-
-      // 5. Start callback server — await the actually-bound port (port
-      // fallback means it may not be the first in CALLBACK_PORTS)
-      const { promise: callbackPromise, ready } = startCallbackServer(state)
-      const port = await ready
-      const redirectUri = `http://127.0.0.1:${port}/callback`
-
-      // 6. Build auth URL and open browser
-      const authUrl = buildAuthUrl({
-        authorization_endpoint: oidc.authorization_endpoint,
-        client_id: discovery.client_id,
-        redirect_uri: redirectUri,
-        scopes,
-        state,
-        pkce,
-      })
-
-      process.stderr.write(`\nOpening browser for login...\n`)
-      process.stderr.write(`If the browser doesn't open, visit:\n  ${authUrl}\n\n`)
-
-      // Open browser (best-effort, platform-specific).
-      // execFileSync with args array — authUrl comes from the remote discovery
-      // doc so it must never be shell-interpolated. Scheme is also validated.
       try {
-        if (!/^https:\/\//.test(authUrl)) {
-          throw new Error('auth URL must be https')
+        const baseUrl = url.replace(/\/$/, '')
+        process.stderr.write(`Fetching discovery doc from ${baseUrl}...\n`)
+
+        // 1. Fetch codeburn discovery doc
+        const discovery = await fetchDiscoveryDoc(baseUrl)
+        process.stderr.write(`  Issuer: ${discovery.issuer}\n`)
+        process.stderr.write(`  Client: ${discovery.client_id}\n`)
+
+        // 2. Fetch OIDC configuration from the issuer
+        const oidc = await fetchOidcConfig(discovery.issuer)
+        process.stderr.write(`  Auth endpoint: ${oidc.authorization_endpoint}\n`)
+
+        // 3. Resolve scopes
+        const scopes = resolveScopes(discovery.scopes, oidc.scopes_supported)
+
+        // 4. Generate PKCE
+        const pkce = generatePkce()
+        const state = randomBytes(16).toString('hex')
+
+        // 5. Start callback server — await the actually-bound port (port
+        // fallback means it may not be the first in CALLBACK_PORTS)
+        const { promise: callbackPromise, ready } = startCallbackServer(state)
+        // If all ports are in use, BOTH `ready` and `callbackPromise` reject.
+        // Mark callbackPromise as handled so the second rejection can't crash
+        // the process as an unhandled rejection while we're throwing from
+        // `await ready`. The later `await callbackPromise` still throws.
+        callbackPromise.catch(() => {})
+        const port = await ready
+        const redirectUri = `http://127.0.0.1:${port}/callback`
+
+        // 6. Build auth URL and open browser
+        const authUrl = buildAuthUrl({
+          authorization_endpoint: oidc.authorization_endpoint,
+          client_id: discovery.client_id,
+          redirect_uri: redirectUri,
+          scopes,
+          state,
+          pkce,
+        })
+
+        process.stderr.write(`\nOpening browser for login...\n`)
+        process.stderr.write(`If the browser doesn't open, visit:\n  ${authUrl}\n\n`)
+
+        // Open browser (best-effort, platform-specific).
+        // execFileSync with args array — authUrl comes from the remote discovery
+        // doc so it must never be shell-interpolated. Scheme is also validated.
+        try {
+          if (!/^https:\/\//.test(authUrl)) {
+            throw new Error('auth URL must be https')
+          }
+          const { execFileSync } = await import('child_process')
+          if (process.platform === 'darwin') {
+            execFileSync('open', [authUrl], { stdio: 'ignore' })
+          } else if (process.platform === 'win32') {
+            // Do NOT use `cmd /c start` here: cmd.exe treats `&` as a command
+            // separator, so the auth URL's query string gets truncated at the
+            // first parameter and the IdP sees a bare /authorize request.
+            // rundll32's FileProtocolHandler receives the URL as a plain
+            // process argument with no shell parsing, so `&` survives intact.
+            execFileSync('rundll32', ['url.dll,FileProtocolHandler', authUrl], { stdio: 'ignore' })
+          } else {
+            execFileSync('xdg-open', [authUrl], { stdio: 'ignore' })
+          }
+        } catch {
+          // Browser open failed — user sees the URL above
         }
-        const { execFileSync } = await import('child_process')
-        if (process.platform === 'darwin') {
-          execFileSync('open', [authUrl], { stdio: 'ignore' })
-        } else if (process.platform === 'win32') {
-          // `start` is a cmd builtin; empty first arg is the window title
-          execFileSync('cmd', ['/c', 'start', '', authUrl], { stdio: 'ignore' })
+
+        // 7. Wait for callback
+        process.stderr.write(`Waiting for login (5 min timeout)...\n`)
+        const callback = await callbackPromise
+
+        // 8. Exchange code for tokens
+        const tokenRedirectUri = `http://127.0.0.1:${callback.port}/callback`
+        const tokens = await exchangeCode(
+          oidc.token_endpoint,
+          callback.code,
+          pkce.code_verifier,
+          tokenRedirectUri,
+          discovery.client_id,
+        )
+
+        if (!tokens.refresh_token) {
+          process.stderr.write(`Warning: IdP did not return a refresh token. You may need to re-authenticate frequently.\n`)
+        }
+
+        // 9. Store credentials
+        const store = createCredentialStore()
+        if (tokens.refresh_token) {
+          store.store(tokens.refresh_token)
+        }
+
+        // 10. Write config
+        writeSyncConfig({
+          baseUrl,
+          clientId: discovery.client_id,
+          tracesPath: discovery.traces_path,
+          issuer: discovery.issuer,
+        })
+
+        process.stderr.write(`\n✓ Sync configured successfully.\n`)
+        process.stderr.write(`  Endpoint: ${baseUrl}\n`)
+        process.stderr.write(`  Token stored in: ${store.method()}\n`)
+        process.stderr.write(`\nRun \`codeburn sync push\` to send telemetry data.\n`)
+      } catch (err) {
+        // Known errors (login timeout, port exhaustion, discovery failures)
+        // get a clean one-line message instead of a raw Node crash dump.
+        if (err instanceof AuthError || err instanceof DiscoveryError) {
+          process.stderr.write(`\nError: ${err.message}\n`)
         } else {
-          execFileSync('xdg-open', [authUrl], { stdio: 'ignore' })
+          process.stderr.write(`\nError: ${(err as Error).stack ?? (err as Error).message}\n`)
         }
-      } catch {
-        // Browser open failed — user sees the URL above
+        process.exit(1)
       }
-
-      // 7. Wait for callback
-      process.stderr.write(`Waiting for login (5 min timeout)...\n`)
-      const callback = await callbackPromise
-
-      // 8. Exchange code for tokens
-      const tokenRedirectUri = `http://127.0.0.1:${callback.port}/callback`
-      const tokens = await exchangeCode(
-        oidc.token_endpoint,
-        callback.code,
-        pkce.code_verifier,
-        tokenRedirectUri,
-        discovery.client_id,
-      )
-
-      if (!tokens.refresh_token) {
-        process.stderr.write(`Warning: IdP did not return a refresh token. You may need to re-authenticate frequently.\n`)
-      }
-
-      // 9. Store credentials
-      const store = createCredentialStore()
-      if (tokens.refresh_token) {
-        store.store(tokens.refresh_token)
-      }
-
-      // 10. Write config
-      writeSyncConfig({
-        baseUrl,
-        clientId: discovery.client_id,
-        tracesPath: discovery.traces_path,
-        issuer: discovery.issuer,
-      })
-
-      process.stderr.write(`\n✓ Sync configured successfully.\n`)
-      process.stderr.write(`  Endpoint: ${baseUrl}\n`)
-      process.stderr.write(`  Token stored in: ${store.method()}\n`)
-      process.stderr.write(`\nRun \`codeburn sync push\` to send telemetry data.\n`)
     })
 
   // --- status ---


### PR DESCRIPTION
Three fixes to the `codeburn sync setup` login flow based on user feedback.

## 1. Login timeout crashed Node with a raw stack trace

When the 5-minute login window expired, `sync setup` died like this:

```
Waiting for login (5 min timeout)...
file:///.../codeburn/dist/main.js:32406
      reject(new AuthError("Login timed out after 5 minutes. Please try again."));
             ^
AuthError: Login timed out after 5 minutes. Please try again.
    at Timeout._onTimeout (...)
```

The `setup` action had no error handling (unlike `push`), so the rejection
escaped as an unhandled promise rejection. Now:

- Known errors (`AuthError`, `DiscoveryError` — login timeout, callback port
  exhaustion, discovery/OIDC failures) print a clean one-line
  `Error: <message>` and exit 1.
- Unexpected errors still print a stack for debuggability.
- Fixed a latent double-rejection: when all callback ports are in use, both
  the `ready` promise and the callback promise reject; the second one could
  crash the process as a separate unhandled rejection. The callback promise
  is now marked handled while `await` semantics are preserved.

## 2. Windows: browser opened the auth URL with no query parameters

On Windows the browser opened, but the IdP showed a "no parameters" error.

Cause: the URL was launched via `cmd /c start "" <url>`. `cmd.exe` splits its
command line on `&`, so the OAuth query string was truncated at the first
parameter — the IdP received a bare `/authorize` with no `client_id`,
`redirect_uri`, or PKCE challenge, and cmd tried to execute the leftover
fragments as commands.

Fix: launch via `rundll32 url.dll,FileProtocolHandler <url>`, which receives
the URL as a plain process argument with no shell parsing, putting Windows on
the same footing as macOS (`open`) and Linux (`xdg-open`).

Verified on Windows 11: `rundll32 url.dll,FileProtocolHandler
"https://example.com/?a=1&b=2&c=3"` opens the browser with all parameters
intact, and the equivalent `execFileSync` call (the exact code path) does too.

## 3. Themed callback landing pages

The success/failure pages were unstyled `<h1>` markup. They now match the
dashboard theme (`dash/src/index.css` — warm paper surfaces, ink text,
forest-green success / terracotta failure), via a new `renderCallbackPage()`
in `src/sync/auth.ts`. Everything is inline: the page is served once from a
throwaway localhost server, so it has no network font, external CSS, or asset
dependencies.

## Testing

All three fixes were manually verified end-to-end, and the full test suite was run.

**Manual verification:**

- Timeout path: let the 5-minute login window expire — clean one-line error
  and exit 1, no stack trace (previously crashed Node).
- Windows browser open: confirmed on Windows 11 that
  `rundll32 url.dll,FileProtocolHandler "https://example.com/?a=1&b=2&c=3"`
  opens the browser with all query parameters intact, and the exact
  `execFileSync` call used by the fix behaves the same. The old
  `cmd /c start` path reproduces the truncation.
- Themed callback pages: verified rendering of both the success and failure
  states.
- macOS flow re-tested end-to-end: unaffected (`open` already passed the URL
  as a direct argument).

**Automated:**

- `npx tsc --noEmit` clean
- Full suite (`npx vitest run`, 217 files / 2456 tests): 2440 passed,
  11 failed, 5 skipped. All failures are pre-existing on `main` or
  load-order flakes — verified by running the same failing files on `main`
  (identical failures: `cursor-real-tokens`, `parser-proxy-pricing`) and in
  isolation on this branch (the CLI/menubar files pass). None touch sync.
- All 48 sync tests pass (`tests/sync.test.ts`, `tests/sync-e2e.test.ts`,
  `tests/sync-push.test.ts`), including the callback-server timeout test.