### PR TITLE
chore(sync): HTML-escape callback page inputs

### DIFF
--- a/src/sync/auth.ts
+++ b/src/sync/auth.ts
@@ -149,7 +149,14 @@ export interface CallbackResult {
  * is served once from a throwaway localhost server, so it must not depend
  * on network fonts, external CSS, or dashboard assets.
  */
-export function renderCallbackPage(ok: boolean, title: string, message: string): string {
+export function renderCallbackPage(ok: boolean, rawTitle: string, rawMessage: string): string {
+  // Current call sites pass literals, but escape anyway so a future caller
+  // interpolating IdP-influenced text (e.g. the callback `error` param) cannot
+  // turn this localhost page into an XSS sink.
+  const escapeHtml = (s: string) => s.replace(/[&<>"']/g, c =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]!)
+  const title = escapeHtml(rawTitle)
+  const message = escapeHtml(rawMessage)
   const accent = ok ? '#1f8a5b' : '#c8541f' // --primary / --chart-5 (terracotta)
   const mark = ok ? '&#10003;' : '&#10005;' // ✓ / ✕
   return `<!doctype html>

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -10,6 +10,7 @@ import {
   buildAuthUrl,
   resolveScopes,
   startCallbackServer,
+  renderCallbackPage,
   CALLBACK_PORTS,
 } from '../src/sync/auth.js'
 
@@ -256,5 +257,22 @@ describe('syncConfig', () => {
     expect(raw).not.toContain('token')
     expect(raw).not.toContain('secret')
     expect(raw).not.toContain('password')
+  })
+})
+
+// ── Callback Page Escaping ────────────────────────────────────────────
+
+describe('renderCallbackPage', () => {
+  it('escapes HTML metacharacters in title and message', () => {
+    const html = renderCallbackPage(false, '<script>alert(1)</script>', 'a & b "c" \'d\'')
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(html).toContain('a &amp; b &quot;c&quot; &#39;d&#39;')
+  })
+
+  it('leaves literal copy intact', () => {
+    const html = renderCallbackPage(true, 'Login successful', 'You can close this tab.')
+    expect(html).toContain('Login successful')
+    expect(html).toContain('You can close this tab.')
   })
 })


### PR DESCRIPTION
Follow-up to #804: renderCallbackPage now escapes its title/message inputs. Both call sites pass literals today, so no behavior change — this inoculates future callers against interpolating IdP-influenced text (e.g. the callback error param) into the localhost page. Two tests added.