### PR TITLE
refactor(pricing): host-side pricing pass, decoders emit tokens + basis (phase 0 exemplar)

### DIFF
--- a/docs/core/phase0-recipe.md
+++ b/docs/core/phase0-recipe.md
@@ -1,0 +1,272 @@
+# Phase 0 fan-out recipe: lift `calculateCost` out of decoders
+
+Phase 0 of the `@codeburn/core` extraction (issue #809) moves cost computation
+out of the provider decoders and into a single host-side pricing pass
+(`src/pricing-pass.ts`). Decoders emit **token counts + a `costBasis` marker**;
+`priceProviderCall` fills in `costUSD` afterwards, byte-identical to today.
+
+The exemplar PR converted three providers (`zerostack`, `qwen`, `quickdesk`) and
+built the seam. This document is the mechanical recipe for the remaining
+providers. **Follow it per-provider; each provider is one small PR.**
+
+---
+
+## The seam (already in place — do not re-add)
+
+- `ParsedProviderCall` gained two optional fields (`src/providers/types.ts`):
+  - `costUSD?: number` — now optional. Converted decoders omit it.
+  - `costBasis?: 'measured' | 'estimated'`.
+- `priceProviderCall` runs in `src/parser.ts` right before
+  `canonicalizeProviderCallProject`, on every parsed call. It is a no-op for
+  calls with no `costBasis` (unconverted providers), so converted and
+  unconverted providers coexist. **You never edit `parser.ts` or `pricing-pass.ts`.**
+
+`priceProviderCall` behaviour:
+
+| `costBasis`   | what the pass does                                              |
+|---------------|----------------------------------------------------------------|
+| `'estimated'` | computes `costUSD = calculateCost(model, input, output+reasoning, cacheCreation, cacheRead, webSearch, speed)` from the call's stored buckets |
+| `'measured'`  | leaves `costUSD` (which the decoder set to a provider-reported dollar figure) untouched |
+| absent        | leaves the call exactly as-is (unconverted)                    |
+
+> **`costBasis` is orthogonal to `costIsEstimated`.** `costIsEstimated` is a
+> display flag meaning "the *tokens* are estimated" (e.g. char-count derived);
+> it is **preserved verbatim** and never derived from `costBasis`. A call can be
+> `costBasis: 'estimated'` with `costIsEstimated: false` (real tokens, priced
+> from the table — this is how `copilot` marks metered-token calls).
+
+---
+
+## Why the estimated path is safe (the confidence lever)
+
+For every **non-whitelisted** provider, the cache-read path
+(`cachedCallToApiCall` in `parser.ts`) **already** recomputes `costUSD` with the
+exact generic formula the pass uses:
+
+```
+outputForCost = provider === 'claude' ? outputTokens : outputTokens + reasoningTokens
+calculateCost(model, inputTokens, outputForCost, cacheCreationInputTokens,
+              cacheReadInputTokens, webSearchRequests, speed, cacheCreationOneHourTokens)
+```
+
+So a non-whitelisted provider's report cost is *already* produced by this
+formula on a warm cache. Converting it to `costBasis: 'estimated'` cannot change
+report output — it just moves the identical computation earlier. **The green
+suite is your proof.**
+
+The "whitelist" is the provider list inside `providerCallToCachedCall`
+(`parser.ts`, ~line 2380) whose `costUSD` **is** persisted to the cache:
+
+```
+mistral-vibe, antigravity, devin, vercel-gateway, hermes, kiro, codewhale, quickdesk
+```
+
+For a whitelisted provider the stored decoder cost is authoritative (not
+recomputed), so its exact number must be preserved — see Pattern B and the
+misfit list. **Do not change the whitelist.**
+
+---
+
+## Before you start (per provider)
+
+```
+grep -n "calculateCost\|calculateLocalModelSavings" src/providers/<name>.ts
+```
+
+Classify **each** call site:
+
+- **Pattern A** — pure token estimate: `calculateCost(model, <buckets>, ...)`
+  with no provider-reported dollar fallback.
+- **Pattern B** — passthrough with fallback: `recorded ?? calculateCost(...)` or
+  `credits > 0 ? credits*rate : calculateCost(...)` (i.e. a real dollar/credit
+  figure when present, token estimate otherwise).
+- **Misfit** — see the flag list. Stop and hand to Opus-tier; do not force it.
+
+Then check whether the provider's test asserts cost on raw `parse()` output:
+
+```
+grep -n "costUSD\|costIsEstimated" tests/providers/<name>.test.ts   # (or wherever it lives)
+```
+
+If yes, you will route that test's collect helper through `priceProviderCall`
+(see "Test wiring" below).
+
+---
+
+## Pattern A — pure token estimate
+
+**Steps**
+
+1. Replace `costUSD: calculateCost(...)` (or `const costUSD = calculateCost(...)`
+   + `costUSD,`) with `costBasis: 'estimated',`.
+2. Delete any now-unused local (`const costUSD = ...`).
+3. Prune the import: drop `calculateCost` from the `../models.js` import; keep
+   other symbols (e.g. `getShortModelName`).
+4. **Verify the buckets match.** The generic formula uses
+   `outputTokens + reasoningTokens`, `cacheCreationInputTokens`,
+   `cacheReadInputTokens`, `webSearchRequests`, `speed`. Confirm the decoder
+   stores into exactly those fields whatever it passed to `calculateCost`. This
+   holds automatically for non-whitelisted providers (see confidence lever), but
+   eyeball it.
+
+**Worked diff — `zerostack` (trivial, all extra buckets zero):**
+
+```diff
+-import { calculateCost, getShortModelName } from '../models.js'
++import { getShortModelName } from '../models.js'
+@@
+         webSearchRequests: 0,
+-        costUSD: calculateCost(model, input, output, 0, 0, 0),
++        costBasis: 'estimated',
+```
+
+**Worked diff — `qwen` (reasoning billed at output rate + cache-read):**
+
+```diff
+-import { calculateCost } from '../models.js'
+@@
+         const cachedTokens = usage.cachedContentTokenCount ?? 0
+-
+-        const costUSD = calculateCost(model, inputTokens, outputTokens + reasoningTokens, 0, cachedTokens, 0)
+@@
+           reasoningTokens,
+           webSearchRequests: 0,
+-          costUSD,
++          costBasis: 'estimated',
+```
+
+`qwen` stores `reasoningTokens` and `cacheReadInputTokens: cachedTokens`, so the
+generic formula reproduces `calculateCost(model, in, out+reasoning, 0, cached, 0)`
+exactly.
+
+**Acceptance:** grep the file clean of `calculateCost`; `npx tsc --noEmit`;
+run the provider's own tests **and** any golden/report test that touches it.
+
+---
+
+## Pattern B — passthrough with fallback
+
+A real dollar/credit figure when the provider reports one, else a token
+estimate. Convert per branch:
+
+- **Measured branch** → set `costUSD: <recordedCost>` **and**
+  `costBasis: 'measured' as const`.
+- **Fallback branch** → `costBasis: 'estimated' as const` (omit `costUSD`).
+- Preserve `costIsEstimated` exactly as before.
+
+Use a conditional spread so the two shapes stay in one `yield`:
+
+**Worked diff — `quickdesk` metrics parser:**
+
+```diff
+-import { calculateCost } from '../models.js'
+@@
+         yield {
+           ...commonCallFields(source, basePath),
+           model,
+           inputTokens,
+           outputTokens,
+-          costUSD: recordedCost ?? calculateCost(model, inputTokens, outputTokens, 0, 0, 0),
++          ...(recordedCost !== undefined
++            ? { costUSD: recordedCost, costBasis: 'measured' as const }
++            : { costBasis: 'estimated' as const }),
+           costIsEstimated,
+```
+
+Its second (database) parser is pure Pattern A:
+
+```diff
+-          costUSD: calculateCost(model, inputTokens, outputTokens, 0, 0, 0),
++          costBasis: 'estimated',
+           costIsEstimated: true,
+```
+
+**Whitelisted vs not:** the conversion is identical either way. If the provider
+is whitelisted, its measured `costUSD` is persisted and used verbatim (correct).
+If not, the measured `costUSD` was already discarded at cache-write and the
+report already used the generic recompute — the conversion preserves that. Either
+way, leave the whitelist alone.
+
+**Credit-based measured branches** (`codebuff`, `kiro`) are Pattern B: the
+`credits * RATE` value is the measured figure — carry it as
+`costUSD: creditsCost, costBasis: 'measured'`; the `calculateCost` fallback
+becomes `costBasis: 'estimated'`.
+
+---
+
+## Test wiring
+
+Only needed when a provider's own test asserts `costUSD`/`costIsEstimated` on the
+raw `parse()` output (unit-level). Route the collect helper through the pass:
+
+```diff
++import { priceProviderCall } from '../../src/pricing-pass.js'
+@@
+-    for await (const call of provider.createSessionParser(source, seen).parse()) calls.push(call)
++    for await (const call of provider.createSessionParser(source, seen).parse()) calls.push(priceProviderCall(call))
+```
+
+All assertions then pass unchanged (the pass reproduces the exact numbers).
+Golden/report tests need **no** change — they run through `parser.ts`, which
+already applies the pass. Providers with no cost assertion on raw output (e.g.
+`qwen`) need no test edit at all.
+
+---
+
+## Per-provider acceptance checklist
+
+1. `grep -n "calculateCost\|calculateLocalModelSavings" src/providers/<name>.ts` → **empty**.
+2. `npx tsc --noEmit` → clean.
+3. `npx vitest run` for the provider's test + any golden/report suite that names it → green, unchanged assertions.
+4. No edit to `parser.ts`, `pricing-pass.ts`, `session-cache.ts`, or the whitelist.
+5. No `PROVIDER_PARSE_VERSIONS` change anywhere (grep the diff).
+6. `git checkout -- src/data/*.json` before committing (build refreshes the pricing snapshot).
+
+---
+
+## Straightforward fan-out targets
+
+Pattern A / B, non-whitelisted unless noted — safe for the cheap fan-out:
+
+`goose, mux, open-design, lingtai-tui, droid, cursor-agent, zcode, pi, forge,
+grok, warp, kimicode, cursor, zed, crush, openclaw, vscode-cline-parser,
+session-message, sqlite-session-parser, codebuff, kimi, hermes (whitelisted, B),
+kiro (whitelisted, B, credits), codewhale (whitelisted, B), quickdesk (done),
+zerostack (done), qwen (done)`
+
+For each whitelisted one, confirm the estimated-branch `calculateCost` args map
+to the stored buckets **with the same model** before trusting Pattern A/B.
+
+---
+
+## Misfits — hand to Opus-tier, do NOT mechanically convert
+
+These break the "generic formula on stored buckets reproduces the cost"
+assumption. They need a seam extension (e.g. an optional `pricingModel` field or
+a session-cost carrier), so they are out of scope for the cheap fan-out:
+
+- **`antigravity`** — prices with a `pricingModel` that differs from the stored
+  `model` (3 sites). The pass uses `call.model`, so `'estimated'` would reprice
+  with the wrong model, and `'measured'` still needs a `calculateCost` on the
+  pricing model inside the decoder. Whitelisted, so the wrong number would ship.
+- **`mistral-vibe`** — computes one session-level cost and **allocates** it
+  across messages (`allocateCost(costUSD, assistantMessages.length)`). Per-call
+  buckets do not map to per-call cost, so the generic formula cannot reproduce
+  it. Whitelisted.
+- **`copilot`** — not a hard misfit, but higher-effort: multiple emit sites
+  (input-only, output-only, full), `durableSources`, and deliberate
+  `costIsEstimated: false` on token-priced calls. Each site is Pattern A, but
+  verify every site's buckets and preserve each `costIsEstimated` literal
+  exactly. Review individually rather than batch.
+- **`gemini`** — Pattern A **if** it stores `reasoningTokens = thoughts` and
+  `cacheReadInputTokens = cached` (it does today; non-whitelisted, so the
+  cache-read path already proves it). Convert, but double-check the buckets.
+
+## Out of scope for this recipe: the `parser.ts` Claude sites
+
+The three `calculateCost` sites in `src/parser.ts` (+ `applyLocalModelSavings`)
+belong to the **native Claude decoder**, which produces `ParsedApiCall` (not
+`ParsedProviderCall`) and does not flow through `priceProviderCall`. Lifting
+those requires a parallel seam on the Claude/`ParsedApiCall` path and is
+Phase 3 (Claude decoder carve-out) work — **do not** attempt it as part of the
+provider fan-out.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,6 +6,7 @@ import { calculateCost, calculateLocalModelSavings, getShortModelName, isProxied
 import { resolveSubagentAttribution, sessionIdentity } from './sessions-report.js'
 import { normalizeContentBlocks } from './content-utils.js'
 import { discoverAllSessions, getProvider } from './providers/index.js'
+import { priceProviderCall } from './pricing-pass.js'
 import { flushCodexCache } from './codex-cache.js'
 import { antigravityCascadeIdFromPath, flushAntigravityCache, shouldReparseAntigravitySource } from './providers/antigravity.js'
 import { getDesktopSessionsDirs } from './providers/claude.js'
@@ -2337,7 +2338,9 @@ function providerCallToTurn(call: ParsedProviderCall): ParsedTurn {
     provider: call.provider,
     model: call.model,
     usage,
-    costUSD: call.costUSD,
+    // costUSD is optional on ParsedProviderCall now (converted decoders defer it
+    // to the pricing pass); the pass has already run by the time turns are built.
+    costUSD: call.costUSD ?? 0,
     tools,
     mcpTools: extractMcpTools(tools),
     skills: call.skills ?? [],
@@ -2885,7 +2888,10 @@ async function parseProviderSources(
         for await (const call of parser.parse()) {
           providerCalls.push(call)
         }
-        const canonicalCalls = await Promise.all(providerCalls.map(canonicalizeProviderCallProject))
+        // Host-side pricing pass: fill costUSD for converted decoders (which
+        // emit tokens + costBasis) before anything is cached or aggregated.
+        const pricedCalls = providerCalls.map(priceProviderCall)
+        const canonicalCalls = await Promise.all(pricedCalls.map(canonicalizeProviderCallProject))
         const turns = providerCallsToCachedTurns(canonicalCalls)
 
         // Store/merge parsed turns into the cache.

--- a/src/pricing-pass.ts
+++ b/src/pricing-pass.ts
@@ -1,0 +1,37 @@
+import { calculateCost } from './models.js'
+import type { ParsedProviderCall } from './providers/types.js'
+
+// Host-side pricing pass (Phase 0 of the @codeburn/core extraction).
+//
+// Converted decoders emit token counts plus a `costBasis` marker instead of
+// pricing calls themselves; this pass turns that into the final `costUSD`,
+// byte-identical to the in-decoder computation it replaces:
+//
+//   'estimated' : cost is computed from the call's token buckets via the
+//                 pricing table — the SAME formula cachedCallToApiCall already
+//                 applies when repricing a cached non-metered call, so a cache
+//                 round-trip is a no-op and the value matches today's decoder.
+//   'measured'  : the decoder already carries a provider-reported dollar figure
+//                 in `costUSD`; the pass passes it through untouched.
+//
+// A call with no `costBasis` comes from a not-yet-converted decoder that still
+// priced itself; the pass leaves it exactly as-is, so converted and unconverted
+// providers coexist during the fan-out.
+export function priceProviderCall(call: ParsedProviderCall): ParsedProviderCall {
+  if (call.costBasis !== 'estimated') return call
+
+  // Mirror cachedCallToApiCall's non-claude branch: reasoning tokens are billed
+  // at the output rate. Provider calls never carry 1-hour cache tokens (the
+  // cache write path hardcodes them to 0), so the default 0 is correct here.
+  const outputForCost = call.outputTokens + call.reasoningTokens
+  const costUSD = calculateCost(
+    call.model,
+    call.inputTokens,
+    outputForCost,
+    call.cacheCreationInputTokens,
+    call.cacheReadInputTokens,
+    call.webSearchRequests,
+    call.speed,
+  )
+  return { ...call, costUSD }
+}

--- a/src/providers/quickdesk.ts
+++ b/src/providers/quickdesk.ts
@@ -2,7 +2,6 @@ import { readdir, readFile, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, isAbsolute, join, resolve } from 'node:path'
 
-import { calculateCost } from '../models.js'
 import { estimateTokensFromChars } from '../token-estimate.js'
 import { blobToText, isSqliteAvailable, openDatabase } from '../sqlite.js'
 import type { SqliteDatabase } from '../sqlite.js'
@@ -468,7 +467,11 @@ function createMetricsParser(source: SessionSource, seenKeys: Set<string>): Sess
           model,
           inputTokens,
           outputTokens,
-          costUSD: recordedCost ?? calculateCost(model, inputTokens, outputTokens, 0, 0, 0),
+          // Provider-reported cost passes through as 'measured'; otherwise the
+          // pricing pass computes it from the token buckets ('estimated').
+          ...(recordedCost !== undefined
+            ? { costUSD: recordedCost, costBasis: 'measured' as const }
+            : { costBasis: 'estimated' as const }),
           costIsEstimated,
           tools,
           timestamp,
@@ -510,7 +513,7 @@ function createDatabaseParser(source: SessionSource, seenKeys: Set<string>): Ses
           model,
           inputTokens,
           outputTokens,
-          costUSD: calculateCost(model, inputTokens, outputTokens, 0, 0, 0),
+          costBasis: 'estimated',
           costIsEstimated: true,
           tools: metadata.tools,
           timestamp,

--- a/src/providers/qwen.ts
+++ b/src/providers/qwen.ts
@@ -3,7 +3,6 @@ import { basename, join } from 'path'
 import { homedir } from 'os'
 
 import { readSessionFile } from '../fs-utils.js'
-import { calculateCost } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
@@ -119,8 +118,6 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         const reasoningTokens = usage.thoughtsTokenCount ?? 0
         const cachedTokens = usage.cachedContentTokenCount ?? 0
 
-        const costUSD = calculateCost(model, inputTokens, outputTokens + reasoningTokens, 0, cachedTokens, 0)
-
         yield {
           provider: 'qwen',
           model,
@@ -131,7 +128,9 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           cachedInputTokens: cachedTokens,
           reasoningTokens,
           webSearchRequests: 0,
-          costUSD,
+          // Priced host-side from these buckets: reasoning tokens are billed at
+          // the output rate and cachedTokens as cache-read (see pricing-pass.ts).
+          costBasis: 'estimated',
           tools: [...new Set(tools)],
           bashCommands: [...new Set(bashCommands)],
           timestamp: entry.timestamp || '',

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -24,7 +24,17 @@ export type ParsedProviderCall = {
   cachedInputTokens: number
   reasoningTokens: number
   webSearchRequests: number
-  costUSD: number
+  // Optional so a decoder converted to the host-side pricing pass (see
+  // src/pricing-pass.ts) can omit it and emit `costBasis: 'estimated'` instead;
+  // the pass fills it in from the token buckets before any consumer reads it.
+  // Unconverted decoders still set it directly.
+  costUSD?: number
+  // Set by decoders that no longer price themselves. 'estimated' => the pricing
+  // pass computes costUSD from the token buckets; 'measured' => the decoder set
+  // costUSD to a provider-reported dollar figure and the pass leaves it alone.
+  // Orthogonal to `costIsEstimated`, which flags estimated *tokens* (e.g. char
+  // counts) regardless of how the dollar amount was derived.
+  costBasis?: 'measured' | 'estimated'
   costIsEstimated?: boolean
   tools: string[]
   bashCommands: string[]

--- a/src/providers/zerostack.ts
+++ b/src/providers/zerostack.ts
@@ -3,7 +3,7 @@ import { basename, join } from 'path'
 import { homedir, platform } from 'os'
 
 import { readSessionFile } from '../fs-utils.js'
-import { calculateCost, getShortModelName } from '../models.js'
+import { getShortModelName } from '../models.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
 // zerostack (https://github.com/gi-dellav/zerostack) is a minimal Rust coding
@@ -100,7 +100,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         cachedInputTokens: 0,
         reasoningTokens: 0,
         webSearchRequests: 0,
-        costUSD: calculateCost(model, input, output, 0, 0, 0),
+        costBasis: 'estimated',
         // zerostack persists only final assistant text, not tool-call records,
         // so there is nothing to extract here.
         tools: [],

--- a/tests/pricing-pass.test.ts
+++ b/tests/pricing-pass.test.ts
@@ -1,0 +1,117 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as models from '../src/models.js'
+import { priceProviderCall } from '../src/pricing-pass.js'
+import { createZerostackProvider } from '../src/providers/zerostack.js'
+import type { ParsedProviderCall } from '../src/providers/types.js'
+
+function baseCall(overrides: Partial<ParsedProviderCall> = {}): ParsedProviderCall {
+  return {
+    provider: 'test',
+    model: 'claude-sonnet-4-5',
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    cachedInputTokens: 0,
+    reasoningTokens: 0,
+    webSearchRequests: 0,
+    tools: [],
+    bashCommands: [],
+    timestamp: '2026-07-17T00:00:00Z',
+    speed: 'standard',
+    deduplicationKey: 'k',
+    userMessage: '',
+    sessionId: 's',
+    ...overrides,
+  }
+}
+
+describe('priceProviderCall', () => {
+  it("computes cost from tokens for costBasis 'estimated'", () => {
+    const call = baseCall({ costBasis: 'estimated', reasoningTokens: 10, cacheReadInputTokens: 20 })
+    const priced = priceProviderCall(call)
+    // Reasoning is billed at the output rate, mirroring the pre-lift decoder call.
+    expect(priced.costUSD).toBe(
+      models.calculateCost('claude-sonnet-4-5', 100, 60, 0, 20, 0, 'standard'),
+    )
+    expect(priced.costUSD!).toBeGreaterThan(0)
+  })
+
+  it("passes a provider-reported cost through untouched for costBasis 'measured'", () => {
+    const call = baseCall({ costBasis: 'measured', costUSD: 0.0042 })
+    expect(priceProviderCall(call).costUSD).toBe(0.0042)
+  })
+
+  it('leaves an unconverted call (no costBasis) exactly as-is', () => {
+    const call = baseCall({ costUSD: 0.99 })
+    expect(priceProviderCall(call)).toBe(call)
+  })
+})
+
+describe('decode determinism: tokens do not depend on pricing', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'pricing-pass-test-'))
+  })
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  const session = JSON.stringify({
+    id: 'sess-det',
+    name: '',
+    messages: [
+      { role: 'user', content: 'hello', estimated_tokens: 7 },
+      { role: 'assistant', content: 'hi', estimated_tokens: 92 },
+    ],
+    compactions: [],
+    created_at: '2026-06-19T11:33:34.022836+00:00',
+    updated_at: '2026-06-19T11:34:14.140631+00:00',
+    total_input_tokens: 34119,
+    total_output_tokens: 961,
+    model: 'deepseek/deepseek-v4-pro',
+    provider: 'openrouter',
+    working_dir: '/Users/test/myproject',
+    permission_allowlist: [],
+  })
+
+  it('decodes tokens with pricing stubbed to throw, then prices separately', async () => {
+    const path = join(tmpDir, 'sess-det.json')
+    await writeFile(path, session)
+
+    // Simulate the pricing table / network being unavailable during decode.
+    const spy = vi.spyOn(models, 'calculateCost').mockImplementation(() => {
+      throw new Error('pricing unavailable (network stubbed)')
+    })
+
+    const provider = createZerostackProvider(tmpDir)
+    const source = { path, project: 'myproject', provider: 'zerostack' }
+    const raw: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) {
+      raw.push(call)
+    }
+
+    // Decoding produced tokens without ever consulting the pricing table.
+    expect(spy).not.toHaveBeenCalled()
+    expect(raw).toHaveLength(1)
+    expect(raw[0]!.inputTokens).toBe(34119)
+    expect(raw[0]!.outputTokens).toBe(961)
+    expect(raw[0]!.costBasis).toBe('estimated')
+    expect(raw[0]!.costUSD).toBeUndefined()
+
+    // Cost is computed only afterwards, by the pass.
+    spy.mockRestore()
+    const priced = priceProviderCall(raw[0]!)
+    expect(priced.costUSD).toBe(
+      models.calculateCost('deepseek/deepseek-v4-pro', 34119, 961, 0, 0, 0, 'standard'),
+    )
+    expect(priced.costUSD!).toBeGreaterThan(0)
+  })
+})

--- a/tests/providers/quickdesk.test.ts
+++ b/tests/providers/quickdesk.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { calculateCost, getShortModelName } from '../../src/models.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import { providers } from '../../src/providers/index.js'
 import { quickdesk } from '../../src/providers/quickdesk.js'
 import { isSqliteAvailable } from '../../src/sqlite.js'
@@ -99,7 +100,7 @@ async function collectCalls(sources: SessionSource[]): Promise<ParsedProviderCal
   const calls: ParsedProviderCall[] = []
   const seenKeys = new Set<string>()
   for (const source of sources) {
-    for await (const call of quickdesk.createSessionParser(source, seenKeys).parse()) calls.push(call)
+    for await (const call of quickdesk.createSessionParser(source, seenKeys).parse()) calls.push(priceProviderCall(call))
   }
   return calls
 }

--- a/tests/providers/zerostack.test.ts
+++ b/tests/providers/zerostack.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 import { createZerostackProvider } from '../../src/providers/zerostack.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 let tmpDir: string
@@ -82,7 +83,7 @@ describe('zerostack provider - parsing', () => {
     const source = { path, project: 'myproject', provider: 'zerostack' }
     const calls: ParsedProviderCall[] = []
     for await (const call of provider.createSessionParser(source, seen).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
     return calls
   }


### PR DESCRIPTION
Phase 0 exemplar for #809, targeting the integration branch (not main).

- New src/pricing-pass.ts: 'estimated' basis computes cost via the exact formula cachedCallToApiCall already uses on warm-cache reads; 'measured' passes provider-reported dollars through; absent basis = unconverted provider, untouched — both kinds coexist during the fan-out.
- ParsedProviderCall: add-only optional costUSD?/costBasis?. Pass runs before any cache write: CachedCall values byte-identical, zero parse-version bumps.
- 3 exemplars converted (zerostack trivial, qwen standard incl. reasoning+cache buckets, quickdesk real-cost passthrough), chosen from a full 33-file call-site survey.
- docs/core/phase0-recipe.md: per-pattern mechanical recipe for the ~27-provider fan-out, incl. the cache-formula safety theorem, whitelist, worked diffs, per-provider acceptance. Misfits flagged for stronger-model handling: antigravity, mistral-vibe, copilot; parser.ts Claude sites deferred to Phase 3 by design.
- Determinism test: network/pricing stubbed to throw — decoders never price; tokens identical; cost computed separately.

Verified independently: full suite 2251 passed, tsc clean, exemplars grep-clean of calculateCost, no PROVIDER_PARSE_VERSIONS changes.