### PR TITLE
refactor(pricing): fan-out — zcode, cursor-agent

### DIFF
--- a/src/providers/cursor-agent.ts
+++ b/src/providers/cursor-agent.ts
@@ -4,7 +4,6 @@ import { readdir, readFile, stat } from 'fs/promises'
 import { join, basename } from 'path'
 import { homedir } from 'os'
 
-import { calculateCost } from '../models.js'
 import { openDatabase, type SqliteDatabase } from '../sqlite.js'
 import { normalizeContentBlocks } from '../content-utils.js'
 import { estimateTokensFromChars } from '../token-estimate.js'
@@ -457,15 +456,6 @@ function createParser(
           if (seenKeys.has(deduplicationKey)) continue
           seenKeys.add(deduplicationKey)
 
-          const costUSD = calculateCost(
-            costModel(model),
-            inputTokens,
-            outputTokens + reasoningTokens,
-            0,
-            0,
-            0,
-          )
-
           yield {
             provider: 'cursor-agent',
             model,
@@ -476,7 +466,7 @@ function createParser(
             cachedInputTokens: 0,
             reasoningTokens,
             webSearchRequests: 0,
-            costUSD,
+            costBasis: 'estimated',
             tools: turn.assistant.tools,
             bashCommands: [],
             timestamp,

--- a/src/providers/zcode.ts
+++ b/src/providers/zcode.ts
@@ -1,7 +1,6 @@
 import { join } from 'path'
 import { homedir } from 'os'
 
-import { calculateCost } from '../models.js'
 import { isSqliteAvailable, getSqliteLoadError, openDatabase, type SqliteDatabase } from '../sqlite.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
@@ -169,7 +168,6 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           }
 
           const model = row.model_id
-          const costUSD = calculateCost(model, freshInput, output, cacheCreation, cacheRead, 0)
 
           yield {
             provider: 'zcode',
@@ -181,7 +179,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             cachedInputTokens: 0,
             reasoningTokens: reasoning,
             webSearchRequests: 0,
-            costUSD,
+            costBasis: 'estimated',
             tools,
             bashCommands: [],
             timestamp: epochMsToIso(row.completed_at ?? row.started_at),

--- a/tests/providers/cursor-agent.test.ts
+++ b/tests/providers/cursor-agent.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'os'
 
 import { getAllProviders } from '../../src/providers/index.js'
 import { createCursorAgentProvider } from '../../src/providers/cursor-agent.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import { estimateTokensFromChars } from '../../src/token-estimate.js'
 import type { ParsedProviderCall, Provider, SessionSource } from '../../src/providers/types.js'
 import { isSqliteAvailable } from '../../src/sqlite.js'
@@ -40,7 +41,7 @@ async function makeBaseDir(): Promise<string> {
 async function collectCalls(provider: Provider, source: SessionSource): Promise<ParsedProviderCall[]> {
   const calls: ParsedProviderCall[] = []
   for await (const call of provider.createSessionParser(source, new Set()).parse()) {
-    calls.push(call)
+    calls.push(priceProviderCall(call))
   }
   return calls
 }

--- a/tests/providers/zcode.test.ts
+++ b/tests/providers/zcode.test.ts
@@ -6,6 +6,7 @@ import { createRequire } from 'node:module'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { isSqliteAvailable } from '../../src/sqlite.js'
 import { createZcodeProvider } from '../../src/providers/zcode.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 const requireForTest = createRequire(import.meta.url)
@@ -86,7 +87,7 @@ function seed(dbPath: string): void {
 
 async function collect(parser: { parse(): AsyncGenerator<ParsedProviderCall> }): Promise<ParsedProviderCall[]> {
   const out: ParsedProviderCall[] = []
-  for await (const call of parser.parse()) out.push(call)
+  for await (const call of parser.parse()) out.push(priceProviderCall(call))
   return out
 }
 


### PR DESCRIPTION
Phase 0 fan-out (recipe-driven) for #809, targeting the integration branch. Two Pattern-A conversions. Review note: cursor-agent's local costModel() mapping (cursor-agent-auto -> claude-sonnet-4-5) is redundant with the identical BUILTIN_ALIASES entry in models.ts, so pricing via call.model is exactly equivalent. Full suite 2251 green, tsc clean, grep-clean.