### PR TITLE
refactor(pricing): fan-out — forge, grok, warp

### DIFF
--- a/src/providers/forge.ts
+++ b/src/providers/forge.ts
@@ -3,7 +3,6 @@ import { homedir } from 'os'
 import { join } from 'path'
 
 import { extractBashCommands } from '../bash-utils.js'
-import { calculateCost } from '../models.js'
 import { getSqliteLoadError, isSqliteAvailable, openDatabase, type SqliteDatabase } from '../sqlite.js'
 import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
 
@@ -211,7 +210,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             cachedInputTokens,
             reasoningTokens: 0,
             webSearchRequests: 0,
-            costUSD: calculateCost(model, inputTokens, outputTokens, 0, cachedInputTokens, 0),
+            costBasis: 'estimated',
             tools,
             bashCommands,
             timestamp: sqliteTimestampToIso(row.updated_at ?? row.created_at),

--- a/src/providers/grok.ts
+++ b/src/providers/grok.ts
@@ -3,7 +3,7 @@ import { basename, dirname, join } from 'path'
 import { homedir } from 'os'
 
 import { readSessionFile } from '../fs-utils.js'
-import { calculateCost, getShortModelName } from '../models.js'
+import { getShortModelName } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
@@ -195,7 +195,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         cachedInputTokens: cacheRead,
         reasoningTokens: 0,
         webSearchRequests: 0,
-        costUSD: calculateCost(model, input, output, 0, cacheRead, 0),
+        costBasis: 'estimated',
         costIsEstimated: true,
         tools,
         bashCommands,

--- a/src/providers/warp.ts
+++ b/src/providers/warp.ts
@@ -2,7 +2,7 @@ import { join } from 'path'
 import { homedir } from 'os'
 
 import { extractBashCommands } from '../bash-utils.js'
-import { calculateCost, getShortModelName } from '../models.js'
+import { getShortModelName } from '../models.js'
 import { blobToText, getSqliteLoadError, isSqliteAvailable, openDatabase, type SqliteDatabase } from '../sqlite.js'
 import { estimateTokensFromChars } from '../token-estimate.js'
 import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
@@ -402,7 +402,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             cachedInputTokens: 0,
             reasoningTokens: 0,
             webSearchRequests: 0,
-            costUSD: calculateCost(model, inputTokens, 0, 0, 0, 0),
+            costBasis: 'estimated',
             costIsEstimated: true,
             tools: exchangeTools.tools,
             bashCommands: exchangeTools.bashCommands,

--- a/tests/providers/grok.test.ts
+++ b/tests/providers/grok.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 import { createGrokProvider } from '../../src/providers/grok.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 let tmpDir: string
@@ -118,7 +119,7 @@ describe('grok provider - parsing', () => {
     const calls: ParsedProviderCall[] = []
     if (!source) return calls
     for await (const call of provider.createSessionParser(source, seen).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
     return calls
   }


### PR DESCRIPTION
Phase 0 fan-out for #809, targeting the integration branch. Three Pattern-A conversions per docs/core/phase0-recipe.md. Review-verified field mappings: warp's zero-output pricing site matches its yielded outputTokens: 0; forge's cacheRead=cached_tokens mapping exact. Full suite 2251 green, tsc clean, grep-clean, no parse-version changes.