### PR TITLE
refactor(pricing): misfit conversions — antigravity, mistral-vibe, copilot

### DIFF
--- a/src/pricing-pass.ts
+++ b/src/pricing-pass.ts
@@ -24,8 +24,12 @@ export function priceProviderCall(call: ParsedProviderCall): ParsedProviderCall 
   // at the output rate. Provider calls never carry 1-hour cache tokens (the
   // cache write path hardcodes them to 0), so the default 0 is correct here.
   const outputForCost = call.outputTokens + call.reasoningTokens
+  // Seam extension: price `pricingModel` when the decoder supplied one (its
+  // display `model` differs from the model the price table is keyed by, e.g.
+  // antigravity's suffix-stripped / aliased id). Falls back to `model` for
+  // every provider whose display model is already its pricing model.
   const costUSD = calculateCost(
-    call.model,
+    call.pricingModel ?? call.model,
     call.inputTokens,
     outputForCost,
     call.cacheCreationInputTokens,

--- a/src/providers/antigravity.ts
+++ b/src/providers/antigravity.ts
@@ -6,7 +6,6 @@ import { homedir } from 'os'
 import { fileURLToPath } from 'url'
 import https from 'https'
 
-import { calculateCost } from '../models.js'
 import { isSqliteAvailable, isSqliteBusyError, openDatabase } from '../sqlite.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
@@ -765,7 +764,6 @@ function buildCallFromSqliteGenMetadataRow(cascadeId: string, row: AntigravityGe
   const responseId = antigravitySqliteResponseId(usageFields, String(row.idx))
   const model = antigravitySqliteModel(chatFields)
   const pricingModel = normalizePricingModel(model)
-  const costUSD = calculateCost(pricingModel, inputTokens, responseTokens + thinkingTokens, 0, 0, 0)
 
   return {
     provider: 'antigravity',
@@ -777,7 +775,12 @@ function buildCallFromSqliteGenMetadataRow(cascadeId: string, row: AntigravityGe
     cachedInputTokens: 0,
     reasoningTokens: thinkingTokens,
     webSearchRequests: 0,
-    costUSD,
+    // Whitelisted for cost persistence: the pass prices `pricingModel` (which
+    // strips suffixes / applies aliases) and the result is stored verbatim, so
+    // the display `model` never reaches the price table. reasoning is billed at
+    // the output rate (outputTokens + reasoningTokens), matching the lift.
+    costBasis: 'estimated',
+    pricingModel,
     tools: [],
     bashCommands: [],
     timestamp: antigravitySqliteCreatedAt(chatFields),
@@ -895,7 +898,6 @@ function buildCallsFromGeneratorMetadata(
     const model = dropPlaceholderModelId(modelMap[usage.model] ?? usage.model)
     const pricingModel = normalizePricingModel(model)
     const timestamp = entry.chatModel?.chatStartMetadata?.createdAt ?? ''
-    const costUSD = calculateCost(pricingModel, inputTokens, responseTokens + thinkingTokens, 0, 0, 0)
 
     results.push({
       provider: 'antigravity',
@@ -907,7 +909,10 @@ function buildCallsFromGeneratorMetadata(
       cachedInputTokens: 0,
       reasoningTokens: thinkingTokens,
       webSearchRequests: 0,
-      costUSD,
+      // See buildCallFromSqliteGenMetadataRow: pricing pass prices `pricingModel`
+      // and the whitelist persists the result verbatim.
+      costBasis: 'estimated',
+      pricingModel,
       tools: [],
       bashCommands: [],
       timestamp,
@@ -1110,14 +1115,6 @@ async function parseStatusLineCalls(source: SessionSource, seenKeys: Set<string>
       if (seenKeys.has(dedupKey)) continue
 
       const u = billableUsage
-      const costUSD = calculateCost(
-        normalizePricingModel(event.model),
-        u.inputTokens,
-        u.outputTokens,
-        u.cacheCreationInputTokens,
-        u.cacheReadInputTokens,
-        0,
-      )
 
       results.push({
         provider: 'antigravity',
@@ -1132,7 +1129,10 @@ async function parseStatusLineCalls(source: SessionSource, seenKeys: Set<string>
         // of inventing a breakdown.
         reasoningTokens: 0,
         webSearchRequests: 0,
-        costUSD,
+        // Pass prices `pricingModel` (reasoningTokens is 0 here, so the output
+        // basis is exactly u.outputTokens); whitelist persists the result.
+        costBasis: 'estimated',
+        pricingModel: normalizePricingModel(event.model),
         tools: [],
         bashCommands: [],
         timestamp: event.at,

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -823,6 +823,17 @@ function createJsonlParser(
 
             // Tokens are real counts written by the CLI, so this cost is
             // measured, not char-estimated: costIsEstimated is false.
+            //
+            // NOT lifted to the pricing pass (Phase 0 residual; revisit Phase 8):
+            // this call carries reasoningTokens for reporting but deliberately
+            // prices output as 0 (the per-turn assistant.message events own the
+            // output cost; billing it here would double-count). The generic
+            // 'estimated' path bills outputTokens + reasoningTokens, so it cannot
+            // reproduce this reasoning-excluded figure when reasoningTokens > 0.
+            // Keep the in-decoder price call; the pass leaves it untouched (no
+            // costBasis). copilot is non-whitelisted, so the cache-read recompute
+            // already bills reasoning here — a pre-existing cold/warm divergence
+            // left exactly as-is.
             const costUSD = calculateCost(model, inputTokens, 0, cacheWriteTokens, cacheReadTokens, 0)
 
             yield {
@@ -897,7 +908,6 @@ function createJsonlParser(
           // Copilot JSONL only logs outputTokens; inputTokens are NOT available.
           // Cost will be lower than actual API cost. This is the original
           // behaviour — OTel data (below) replaces it when available.
-          const costUSD = calculateCost(currentModel, 0, outputTokens, 0, 0, 0)
 
           yield {
             provider: 'copilot',
@@ -910,7 +920,7 @@ function createJsonlParser(
             cachedInputTokens: 0,
             reasoningTokens: 0,
             webSearchRequests: 0,
-            costUSD,
+            costBasis: 'estimated' as const,
             tools,
             bashCommands,
             skills: skills.length > 0 ? skills : undefined,
@@ -964,7 +974,6 @@ function createChatSessionParser(
         seenKeys.add(dedupKey)
 
         const model = modelFromChatSessionRequest(rawReq, metadata)
-        const costUSD = calculateCost(model, inputTokens, outputTokens, 0, 0, 0)
         const timestamp = timestampToISO(rawReq['timestamp']) || sessionCreatedAt
 
         yield {
@@ -979,7 +988,7 @@ function createChatSessionParser(
           cachedInputTokens: 0,
           reasoningTokens: 0,
           webSearchRequests: 0,
-          costUSD,
+          costBasis: 'estimated' as const,
           tools: extractChatSessionTools(metadata),
           bashCommands: [],
           timestamp,
@@ -1545,7 +1554,6 @@ function createJetBrainsParser(
             const model = turn.model || storeModel || 'copilot-anthropic-auto'
             // Errored turns (failed generation) contribute no billable output.
             const outputTokens = turn.errored ? 0 : estimateTokens(turn.replyText)
-            const costUSD = outputTokens > 0 ? calculateCost(model, 0, outputTokens, 0, 0, 0) : 0
             // Project resolution precedence:
             //   1. projectName — the plugin's own recorded label (1.12+),
             //      joined across kind dirs by store id. Authoritative.
@@ -1569,7 +1577,10 @@ function createJetBrainsParser(
               cachedInputTokens: 0,
               reasoningTokens: 0,
               webSearchRequests: 0,
-              costUSD,
+              // Tokens are char-estimated (costIsEstimated) but the dollar
+              // amount is still table-priced from those tokens: costBasis
+              // 'estimated'. Errored turns have outputTokens 0 → priced to $0.
+              costBasis: 'estimated' as const,
               costIsEstimated: true,
               tools: [],
               bashCommands: [],
@@ -1784,15 +1795,9 @@ function createOtelParser(
             const subagentTypes = subagentsByTrace.get(spanMetadata.trace_id)
             const timestamp = epochToISO(spanMetadata.start_time_ms)
 
-            // calculateCost with FULL token data — this is the key improvement.
-            const costUSD = calculateCost(
-              model,
-              inputTokens,
-              outputTokens,
-              cacheCreationTokens,
-              cacheReadTokens,
-              0 // reasoningTokens — not exposed in current OTel schema
-            )
+            // FULL token data (input + cache) — the key improvement — priced by
+            // the pass. reasoningTokens is 0 (not in the OTel schema), so the
+            // output basis is exactly outputTokens.
 
             yield {
               provider: 'copilot',
@@ -1806,7 +1811,7 @@ function createOtelParser(
               cachedInputTokens: 0,
               reasoningTokens: 0,
               webSearchRequests: 0,
-              costUSD,
+              costBasis: 'estimated' as const,
               tools,
               bashCommands,
               subagentTypes: subagentTypes && subagentTypes.length > 0 ? subagentTypes : undefined,

--- a/src/providers/mistral-vibe.ts
+++ b/src/providers/mistral-vibe.ts
@@ -177,6 +177,16 @@ function resolveModel(metadata: VibeMetadata): string {
   return configured?.alias ?? configured?.name ?? DEFAULT_MODEL
 }
 
+// Residual pricing-table dependency (Phase 0 misfit; revisit in Phase 8): this
+// decoder computes ONE session cost — a provider-reported `session_cost`, else
+// Vibe's own per-million prices, else the generic price table — and ALLOCATES it
+// evenly across the session's assistant messages (allocateCost). Per-call token
+// buckets therefore do not each reproduce their per-call dollar figure, so the
+// generic 'estimated' pass cannot recreate the number. The decoder's allocated
+// dollar figure is authoritative, so emitted calls are marked costBasis
+// 'measured' and the pass passes costUSD through untouched. Only the last of the
+// three branches consults the price table; lifting it out would require moving
+// allocation host-side, which is a Core-extraction concern beyond Phase 0.
 function calculateSessionCost(metadata: VibeMetadata, model: string, inputTokens: number, outputTokens: number): number {
   const stats = metadata.stats ?? {}
   const sessionCost = safeNumber(stats.session_cost)
@@ -333,6 +343,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           reasoningTokens: 0,
           webSearchRequests: 0,
           costUSD,
+          costBasis: 'measured',
           tools,
           bashCommands,
           timestamp: fallbackTimestamp,
@@ -380,6 +391,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           reasoningTokens: 0,
           webSearchRequests: 0,
           costUSD: allocateCost(costUSD, assistantMessages.length),
+          costBasis: 'measured',
           tools,
           bashCommands,
           timestamp: message.timestamp ?? fallbackTimestamp,

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -35,6 +35,12 @@ export type ParsedProviderCall = {
   // Orthogonal to `costIsEstimated`, which flags estimated *tokens* (e.g. char
   // counts) regardless of how the dollar amount was derived.
   costBasis?: 'measured' | 'estimated'
+  // Model to price with when it differs from the display `model` (antigravity
+  // strips agent/effort suffixes and applies pricing aliases before pricing).
+  // Seam extension for the pricing pass: when set, the 'estimated' path prices
+  // this model instead of `model`, so the decoder no longer needs the price
+  // table. Absent for every provider whose display model IS its pricing model.
+  pricingModel?: string
   costIsEstimated?: boolean
   tools: string[]
   bashCommands: string[]

--- a/tests/pricing-pass.test.ts
+++ b/tests/pricing-pass.test.ts
@@ -47,6 +47,19 @@ describe('priceProviderCall', () => {
     expect(priceProviderCall(call).costUSD).toBe(0.0042)
   })
 
+  it("prices `pricingModel` instead of `model` when supplied (antigravity misfit)", () => {
+    const call = baseCall({
+      costBasis: 'estimated',
+      model: 'gemini-3.1-pro-high',
+      pricingModel: 'gemini-3.1-pro',
+    })
+    // The suffix-stripped pricing model is what reaches the price table; the
+    // display model is not.
+    expect(priceProviderCall(call).costUSD).toBe(
+      models.calculateCost('gemini-3.1-pro', 100, 50, 0, 0, 0, 'standard'),
+    )
+  })
+
   it('leaves an unconverted call (no costBasis) exactly as-is', () => {
     const call = baseCall({ costUSD: 0.99 })
     expect(priceProviderCall(call)).toBe(call)

--- a/tests/providers/antigravity.test.ts
+++ b/tests/providers/antigravity.test.ts
@@ -19,6 +19,7 @@ import {
   recordAntigravityStatusLinePayload,
   shouldReparseAntigravitySource,
 } from '../../src/providers/antigravity.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 const requireForTest = createRequire(import.meta.url)
@@ -56,7 +57,9 @@ function createCurrentAntigravityCliDb(dbPath: string, fixture: CurrentCliFixtur
 async function collectAntigravityCalls(source: { path: string; project: string; provider: string }): Promise<ParsedProviderCall[]> {
   const parser = createAntigravityProvider().createSessionParser(source, new Set())
   const calls: ParsedProviderCall[] = []
-  for await (const call of parser.parse()) calls.push(call)
+  // Route through the pricing pass so cost assertions see the report-path
+  // costUSD (converted sites emit costBasis + pricingModel, not costUSD).
+  for await (const call of parser.parse()) calls.push(priceProviderCall(call))
   return calls
 }
 
@@ -349,7 +352,7 @@ describe('antigravity provider helpers', () => {
 
       const parser = createAntigravityProvider().createSessionParser(source, new Set())
       const calls = []
-      for await (const call of parser.parse()) calls.push(call)
+      for await (const call of parser.parse()) calls.push(priceProviderCall(call))
 
       expect(calls).toHaveLength(1)
       expect(calls[0]).toMatchObject({

--- a/tests/providers/copilot.test.ts
+++ b/tests/providers/copilot.test.ts
@@ -7,6 +7,7 @@ import { createRequire } from 'node:module'
 import { copilot, createCopilotProvider, getVSCodeGlobalStorageDirs, getVSCodeWorkspaceStorageDirs } from '../../src/providers/copilot.js'
 import { isSqliteAvailable } from '../../src/sqlite.js'
 import { calculateCost } from '../../src/models.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 let tmpDir: string
@@ -120,7 +121,9 @@ async function createChatSessionFile(filePath: string, entries: unknown[]) {
 
 async function collectCalls(source: { path: string; project: string; provider: string; sourceType?: string }, seenKeys = new Set<string>()) {
   const calls: ParsedProviderCall[] = []
-  for await (const call of copilot.createSessionParser(source, seenKeys).parse()) calls.push(call)
+  // Route through the host-side pricing pass so cost assertions see the same
+  // costUSD the report path produces (converted sites emit costBasis, not costUSD).
+  for await (const call of copilot.createSessionParser(source, seenKeys).parse()) calls.push(priceProviderCall(call))
   return calls
 }
 
@@ -142,7 +145,7 @@ describe('copilot provider - JSONL parsing', () => {
 
     const source = { path: eventsPath, project: 'myproject', provider: 'copilot' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of copilot.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
 
     expect(calls).toHaveLength(1)
     const call = calls[0]!
@@ -1043,7 +1046,7 @@ describe('copilot provider - OTel cache token parsing', () => {
 
     const calls: ParsedProviderCall[] = []
     for await (const call of provider.createSessionParser(otelSources[0]!, new Set()).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
 
     expect(calls).toHaveLength(1)


### PR DESCRIPTION
Phase 0 misfits for #809 (the three providers the mechanical recipe could not handle), targeting the integration branch.

- antigravity: full lift via a minimal seam extension — optional pricingModel? on ParsedProviderCall; the pass prices pricingModel ?? model. Whitelisted, so the persisted cost is pass-computed and the display model never reaches the table.
- mistral-vibe: measured passthrough; session-cost allocation stays a decode concern. Residual documented: one calculateCost branch inside calculateSessionCost, deferred to Phase 8.
- copilot: 4 of 5 sites lifted; the session.shutdown site deliberately keeps in-decoder pricing (it prices output=0 by design to avoid double-count; the generic formula would change cold-parse numbers when reasoning>0). Documented residual + a noted pre-existing cold/warm divergence left untouched.

Suite 2252 green (new pricingModel pass test), tsc clean, build ok, no parse-version changes, whitelist untouched.