### PR TITLE
refactor(pricing): shared parser modules + codebuff fallback (phase 0 close)

### DIFF
--- a/src/pricing-pass.ts
+++ b/src/pricing-pass.ts
@@ -28,7 +28,7 @@ export function priceProviderCall(call: ParsedProviderCall): ParsedProviderCall 
   // display `model` differs from the model the price table is keyed by, e.g.
   // antigravity's suffix-stripped / aliased id). Falls back to `model` for
   // every provider whose display model is already its pricing model.
-  const costUSD = calculateCost(
+  let costUSD = calculateCost(
     call.pricingModel ?? call.model,
     call.inputTokens,
     outputForCost,
@@ -37,5 +37,12 @@ export function priceProviderCall(call: ParsedProviderCall): ParsedProviderCall 
     call.webSearchRequests,
     call.speed,
   )
+  // Seam extension: some decoders prefer the table price but fall back to a
+  // provider-reported dollar/credit figure when the model is unpriced (cost is
+  // 0). This preserves codebuff's credit fallback and OpenCode/Cline's
+  // session-cost fallback exactly — the inverse of `measured`, which always wins.
+  if (costUSD === 0 && call.fallbackCostUSD !== undefined && call.fallbackCostUSD > 0) {
+    costUSD = call.fallbackCostUSD
+  }
   return { ...call, costUSD }
 }

--- a/src/providers/codebuff.ts
+++ b/src/providers/codebuff.ts
@@ -2,7 +2,6 @@ import { readdir, readFile, stat } from 'fs/promises'
 import { basename, dirname, join } from 'path'
 import { homedir } from 'os'
 
-import { calculateCost } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
 import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
@@ -400,12 +399,9 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
         // Prefer calculated cost from tokens when available (multi-provider
         // models routed through Codebuff still show up in LiteLLM); otherwise
-        // fall back to the credit-based approximation.
-        let costUSD = calculateCost(model, usage.input, usage.output, usage.cacheWrite, usage.cacheRead, 0)
-        if (costUSD === 0 && credits > 0) {
-          costUSD = credits * USD_PER_CREDIT
-        }
-
+        // fall back to the credit-based approximation. The pricing pass applies
+        // fallbackCostUSD only when the table price is 0 (unknown model),
+        // reproducing that precedence.
         yield {
           provider: 'codebuff',
           model,
@@ -416,7 +412,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           cachedInputTokens: usage.cacheRead,
           reasoningTokens: 0,
           webSearchRequests: 0,
-          costUSD,
+          costBasis: 'estimated',
+          ...(credits > 0 ? { fallbackCostUSD: credits * USD_PER_CREDIT } : {}),
           tools: acc.tools,
           bashCommands: acc.bash,
           timestamp,

--- a/src/providers/session-message.ts
+++ b/src/providers/session-message.ts
@@ -1,4 +1,3 @@
-import { calculateCost } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
 import type { ParsedProviderCall } from './types.js'
 
@@ -130,18 +129,6 @@ export function buildAssistantCall(opts: {
     .filter(Boolean)
 
   const model = data.modelID ?? data.model ?? 'unknown'
-  let costUSD = calculateCost(
-    model,
-    tokens.input,
-    tokens.output + tokens.reasoning,
-    tokens.cacheWrite,
-    tokens.cacheRead,
-    0,
-  )
-
-  if (costUSD === 0 && typeof data.cost === 'number' && data.cost > 0) {
-    costUSD = data.cost
-  }
 
   return {
     provider: opts.providerName,
@@ -153,7 +140,8 @@ export function buildAssistantCall(opts: {
     cachedInputTokens: tokens.cacheRead,
     reasoningTokens: tokens.reasoning,
     webSearchRequests: 0,
-    costUSD,
+    costBasis: 'estimated',
+    ...(typeof data.cost === 'number' ? { fallbackCostUSD: data.cost } : {}),
     tools,
     bashCommands,
     skills,

--- a/src/providers/sqlite-session-parser.ts
+++ b/src/providers/sqlite-session-parser.ts
@@ -1,7 +1,6 @@
 import { readdir } from 'fs/promises'
 import { join } from 'path'
 
-import { calculateCost } from '../models.js'
 import { isSqliteAvailable, getSqliteLoadError, openDatabase, blobToText, isSqliteBusyError, type SqliteDatabase } from '../sqlite.js'
 import { buildAssistantCall, parseTimestamp, sanitize, type MessageData, type PartData } from './session-message.js'
 import type {
@@ -232,8 +231,6 @@ export function createSqliteSessionParser(
             if (!seenKeys.has(dedupKey)) {
               seenKeys.add(dedupKey)
               const model = sessionTokens.model ?? 'unknown'
-              let costUSD = calculateCost(model, sessionTokens.input, sessionTokens.output, sessionTokens.cacheWrite, sessionTokens.cacheRead, 0)
-              if (costUSD === 0 && sessionTokens.cost > 0) costUSD = sessionTokens.cost
               yield {
                 provider: config.providerName,
                 model,
@@ -244,7 +241,8 @@ export function createSqliteSessionParser(
                 cachedInputTokens: sessionTokens.cacheRead,
                 reasoningTokens: sessionTokens.reasoning,
                 webSearchRequests: 0,
-                costUSD,
+                costBasis: 'estimated',
+                ...(sessionTokens.cost > 0 ? { fallbackCostUSD: sessionTokens.cost } : {}),
                 tools: [],
                 bashCommands: [],
                 timestamp: parseTimestamp(messages[0]!.time_created),

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -41,6 +41,13 @@ export type ParsedProviderCall = {
   // this model instead of `model`, so the decoder no longer needs the price
   // table. Absent for every provider whose display model IS its pricing model.
   pricingModel?: string
+  // Seam extension for the pricing pass: a provider-reported dollar/credit figure
+  // used ONLY as a fallback when the 'estimated' table price computes to 0 (the
+  // model is unpriced). Preserves the "table cost preferred, provider figure only
+  // for unknown models" precedence of codebuff credits and OpenCode/Cline session
+  // cost, which is the inverse of `measured` (a figure that always wins). Ignored
+  // unless costBasis is 'estimated'.
+  fallbackCostUSD?: number
   costIsEstimated?: boolean
   tools: string[]
   bashCommands: string[]

--- a/src/providers/vscode-cline-parser.ts
+++ b/src/providers/vscode-cline-parser.ts
@@ -2,7 +2,6 @@ import { readdir, readFile, stat } from 'fs/promises'
 import { basename, join, posix, win32 } from 'path'
 import { homedir } from 'os'
 
-import { calculateCost } from '../models.js'
 import type { SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
 type UiMessage = {
@@ -193,7 +192,6 @@ export function createClineParser(source: SessionSource, seenKeys: Set<string>, 
         if (tokensIn === 0 && tokensOut === 0) continue
 
         const timestamp = entry.ts ? new Date(entry.ts).toISOString() : ''
-        const costUSD = cost ?? calculateCost(model, tokensIn, tokensOut, cacheWrites, cacheReads, 0)
 
         yield {
           provider: providerName,
@@ -205,7 +203,9 @@ export function createClineParser(source: SessionSource, seenKeys: Set<string>, 
           cachedInputTokens: cacheReads,
           reasoningTokens: 0,
           webSearchRequests: 0,
-          costUSD,
+          ...(cost != null
+            ? { costUSD: cost, costBasis: 'measured' as const }
+            : { costBasis: 'estimated' as const }),
           tools: [],
           bashCommands: [],
           timestamp,

--- a/tests/providers/cline.test.ts
+++ b/tests/providers/cline.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 import { cline, createClineProvider } from '../../src/providers/cline.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 let tmpDir: string
@@ -113,7 +114,7 @@ describe('cline provider - parsing', () => {
 
     const source = { path: taskDir, project: 'Cline', provider: 'cline' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of cline.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of cline.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
 
     expect(calls).toHaveLength(1)
     expect(calls[0]!.provider).toBe('cline')

--- a/tests/providers/codebuff.test.ts
+++ b/tests/providers/codebuff.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 import { createCodebuffProvider } from '../../src/providers/codebuff.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 let tmpDir: string
@@ -175,7 +176,7 @@ describe('codebuff provider - JSONL parsing', () => {
     const source = { path: chatDir, project: 'proj', provider: 'codebuff' }
     const calls: ParsedProviderCall[] = []
     for await (const call of provider.createSessionParser(source, new Set()).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
 
     expect(calls).toHaveLength(1)
@@ -212,7 +213,7 @@ describe('codebuff provider - JSONL parsing', () => {
     const source = { path: chatDir, project: 'proj', provider: 'codebuff' }
     const calls: ParsedProviderCall[] = []
     for await (const call of provider.createSessionParser(source, new Set()).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
 
     expect(calls).toHaveLength(1)
@@ -223,8 +224,10 @@ describe('codebuff provider - JSONL parsing', () => {
     expect(call.cacheCreationInputTokens).toBe(1000)
     expect(call.cacheReadInputTokens).toBe(500)
     expect(call.cachedInputTokens).toBe(500)
-    // With real token counts the calculated cost takes precedence over credits.
-    expect(call.costUSD).toBeGreaterThan(0)
+    // With real token counts the table cost takes precedence over the credit
+    // fallback: claude-haiku-4-5 priced on 5000/2000/1000/500 buckets = $0.0163,
+    // not the credits*$0.01 = $0.10 the fallback would have produced.
+    expect(call.costUSD).toBeCloseTo(0.0163, 6)
   })
 
   it('falls back to providerOptions.codebuff.usage in the stashed RunState history', async () => {
@@ -262,7 +265,7 @@ describe('codebuff provider - JSONL parsing', () => {
     const source = { path: chatDir, project: 'proj', provider: 'codebuff' }
     const calls: ParsedProviderCall[] = []
     for await (const call of provider.createSessionParser(source, new Set()).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
 
     expect(calls).toHaveLength(1)
@@ -281,7 +284,7 @@ describe('codebuff provider - JSONL parsing', () => {
     const source = { path: chatDir, project: 'proj', provider: 'codebuff' }
     const calls: ParsedProviderCall[] = []
     for await (const call of provider.createSessionParser(source, new Set()).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
 
     expect(calls).toHaveLength(0)
@@ -322,7 +325,7 @@ describe('codebuff provider - JSONL parsing', () => {
     const source = { path: chatDir, project: 'proj', provider: 'codebuff' }
     const calls: ParsedProviderCall[] = []
     for await (const call of provider.createSessionParser(source, new Set()).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
 
     expect(calls).toHaveLength(2)
@@ -341,7 +344,7 @@ describe('codebuff provider - JSONL parsing', () => {
     }
     const calls: ParsedProviderCall[] = []
     for await (const call of provider.createSessionParser(source, new Set()).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
     expect(calls).toHaveLength(0)
   })
@@ -355,7 +358,7 @@ describe('codebuff provider - JSONL parsing', () => {
     const source = { path: chatDir, project: 'proj', provider: 'codebuff' }
     const calls: ParsedProviderCall[] = []
     for await (const call of provider.createSessionParser(source, new Set()).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
     expect(calls).toHaveLength(0)
   })
@@ -423,7 +426,7 @@ describe('codebuff provider - sessionId channel scoping', () => {
     const source = { path: chatDir, project: 'proj', provider: 'codebuff' }
     const calls: ParsedProviderCall[] = []
     for await (const call of provider.createSessionParser(source, new Set()).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
 
     expect(calls).toHaveLength(1)
@@ -445,7 +448,7 @@ describe('codebuff provider - sessionId channel scoping', () => {
     const source = { path: chatDir, project: 'proj', provider: 'codebuff' }
     const calls: ParsedProviderCall[] = []
     for await (const call of provider.createSessionParser(source, new Set()).parse()) {
-      calls.push(call)
+      calls.push(priceProviderCall(call))
     }
 
     expect(calls).toHaveLength(1)

--- a/tests/providers/ibm-bob.test.ts
+++ b/tests/providers/ibm-bob.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 import { ibmBob, createIBMBobProvider } from '../../src/providers/ibm-bob.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 let tmpDir: string
@@ -100,7 +101,7 @@ describe('ibm-bob provider - discovery and parsing', () => {
 
     const source = { path: taskDir, project: 'IBM Bob', provider: 'ibm-bob' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of ibmBob.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of ibmBob.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
 
     expect(calls).toHaveLength(1)
     expect(calls[0]!).toMatchObject({
@@ -125,7 +126,7 @@ describe('ibm-bob provider - discovery and parsing', () => {
 
     const source = { path: taskDir, project: 'IBM Bob', provider: 'ibm-bob' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of ibmBob.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of ibmBob.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
 
     expect(calls).toHaveLength(1)
     expect(calls[0]!.model).toBe('ibm-bob-auto')

--- a/tests/providers/opencode-file.test.ts
+++ b/tests/providers/opencode-file.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'os'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 
 import { createOpenCodeProvider } from '../../src/providers/opencode.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 let tmpDir: string
@@ -67,7 +68,7 @@ async function parseAll(seen = new Set<string>()): Promise<ParsedProviderCall[]>
   const sources = await provider.discoverSessions()
   const calls: ParsedProviderCall[] = []
   for (const source of sources) {
-    for await (const call of provider.createSessionParser(source, seen).parse()) calls.push(call)
+    for await (const call of provider.createSessionParser(source, seen).parse()) calls.push(priceProviderCall(call))
   }
   return calls
 }
@@ -275,7 +276,7 @@ describe('opencode file-based provider - env override discovery', () => {
 
     const calls: ParsedProviderCall[] = []
     for (const source of sources) {
-      for await (const call of provider.createSessionParser(source, new Set()).parse()) calls.push(call)
+      for await (const call of provider.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
     }
     expect(calls).toHaveLength(1)
     expect(calls[0]!.sessionId).toBe('ses_mimo')

--- a/tests/providers/opencode.test.ts
+++ b/tests/providers/opencode.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'os'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { isSqliteAvailable } from '../../src/sqlite.js'
 import { createOpenCodeProvider } from '../../src/providers/opencode.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 type TestDb = {
@@ -107,7 +108,7 @@ async function collectCalls(provider: ReturnType<typeof createOpenCodeProvider>,
   const source = { path: `${dbPath}:${sessionId}`, project: 'myproject', provider: 'opencode' }
   const calls: ParsedProviderCall[] = []
   for await (const call of provider.createSessionParser(source, seenKeys ?? new Set()).parse()) {
-    calls.push(call)
+    calls.push(priceProviderCall(call))
   }
   return calls
 }
@@ -654,7 +655,7 @@ skipUnlessSqlite('opencode provider - session parsing', () => {
     const provider = createOpenCodeProvider(tmpDir)
     const source = { path: '/nonexistent/db.db:sess-1', project: 'test', provider: 'opencode' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of provider.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
     expect(calls).toHaveLength(0)
   })
 

--- a/tests/providers/roo-code.test.ts
+++ b/tests/providers/roo-code.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 import { rooCode, createRooCodeProvider } from '../../src/providers/roo-code.js'
+import { priceProviderCall } from '../../src/pricing-pass.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 let tmpDir: string
@@ -74,7 +75,7 @@ describe('roo-code provider - parsing', () => {
 
     const source = { path: taskDir, project: 'task-001', provider: 'roo-code' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
 
     expect(calls).toHaveLength(1)
     const call = calls[0]!
@@ -96,7 +97,7 @@ describe('roo-code provider - parsing', () => {
 
     const source = { path: taskDir, project: 'task-002', provider: 'roo-code' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
 
     expect(calls).toHaveLength(1)
     expect(calls[0]!.model).toBe('claude-sonnet-4-5')
@@ -113,7 +114,7 @@ describe('roo-code provider - parsing', () => {
 
     const source = { path: taskDir, project: 'task-003', provider: 'roo-code' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
 
     expect(calls).toHaveLength(1)
     expect(calls[0]!.model).toBe('cline-auto')
@@ -143,7 +144,7 @@ describe('roo-code provider - parsing', () => {
 
     const source = { path: taskDir, project: 'task-005', provider: 'roo-code' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
 
     expect(calls).toHaveLength(0)
   })
@@ -155,7 +156,7 @@ describe('roo-code provider - parsing', () => {
 
     const source = { path: taskDir, project: 'task-006', provider: 'roo-code' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
 
     expect(calls).toHaveLength(0)
   })
@@ -169,7 +170,7 @@ describe('roo-code provider - parsing', () => {
 
     const source = { path: taskDir, project: 'task-007', provider: 'roo-code' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
 
     expect(calls).toHaveLength(0)
   })
@@ -182,7 +183,7 @@ describe('roo-code provider - parsing', () => {
 
     const source = { path: taskDir, project: 'task-008', provider: 'roo-code' }
     const calls: ParsedProviderCall[] = []
-    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(call)
+    for await (const call of rooCode.createSessionParser(source, new Set()).parse()) calls.push(priceProviderCall(call))
 
     expect(calls).toHaveLength(1)
     expect(calls[0]!.costUSD).toBeGreaterThan(0)


### PR DESCRIPTION
Final Phase 0 wave for #809. Key finding: the reverse-precedence shape (table preferred, provider figure only when table prices $0) lived in THREE files, not just codebuff — so the seam gained a generic add-only fallbackCostUSD?, used by the pass only when the estimated computation returns 0 (exact inverse of measured). Converts vscode-cline-parser (true Pattern B), session-message, sqlite-session-parser, and codebuff with ZERO residual call sites in the four files. The weak >0 codebuff assertion that let the earlier inversion slip is now pinned to exact values on both branches. Consumer matrix: 110/110 green across cline/kilo-code/roo-code/ibm-bob/opencode/codebuff. Full suite 2252 green, tsc clean, no parse-version changes.