### PR TITLE
refactor(core): codex decoder with explicit serializable state, cost leaves the decoder (phase 4)

### DIFF
--- a/packages/cli/src/codex-cache.ts
+++ b/packages/cli/src/codex-cache.ts
@@ -4,16 +4,29 @@ import { randomBytes } from 'crypto'
 import { join } from 'path'
 import { homedir } from 'os'
 
+import type { CodexDecodeState } from '@codeburn/core/providers/codex'
+
 import type { ParsedProviderCall } from './providers/types.js'
 
 // v4: attribute MCP calls emitted as event_msg/mcp_tool_call_end (issue #478).
-// Recent Codex sessions cached under v3 dropped these, so force a re-parse.
-// v5: also attribute CLI-wrapped MCP calls (`mcp-cli call server tool`) that
-// Codex logs as a plain exec_command (issue #478 follow-up). Force a re-parse
-// so sessions cached under v4 pick up the CLI-MCP attribution.
-// v6: rich-session-capture — per-call locAdded/locRemoved/editFailed from
-// patch_apply_end. Sessions cached under v5 lack these fields; re-parse to add.
-const CODEX_CACHE_VERSION = 7
+// v5: also attribute CLI-wrapped MCP calls (`mcp-cli call server tool`).
+// v6: rich-session-capture — per-call locAdded/locRemoved/editFailed.
+// v7: (interim) unchanged decoder output shape.
+// v8 (phase 4, issue #809): the decoder moved to @codeburn/core as a pure
+// function over EXPLICIT serializable state, and cost now leaves the decoder.
+// The persisted format changes accordingly and is bumped once, deliberately:
+//   - `calls` are HOST-PRICED ParsedProviderCall (costBasis:'estimated',
+//     costUSD filled by the pricing pass) instead of self-priced decoder output.
+//   - `state` is the decoder's end-of-file CodexDecodeState (its per-session
+//     streaming locals — running token counters, mid-turn accumulators, id/turn
+//     bookkeeping). `seenKeys` is stripped: cross-file dedup is reconstructed
+//     each run from the session cache, exactly as the pre-phase-4 shared set was.
+//   - `byteOffset` is the byte position after the last complete line consumed,
+//     so a grown (appended-to) rollout resumes from `state`+`byteOffset` and
+//     decodes only the new bytes instead of re-streaming the whole file.
+// This is lossless: Codex rollout files are durable (never auto-deleted), so the
+// one-time re-derive on first run under v8 rebuilds byte-identical data.
+const CODEX_CACHE_VERSION = 8
 const CACHE_FILE = 'codex-results.json'
 
 type FileFingerprint = { mtimeMs: number; sizeBytes: number }
@@ -22,6 +35,8 @@ type FileEntry = {
   mtimeMs: number
   sizeBytes: number
   project: string
+  byteOffset: number
+  state: CodexDecodeState
   calls: ParsedProviderCall[]
 }
 
@@ -54,35 +69,32 @@ async function loadCache(): Promise<ResultCache> {
   return memCache
 }
 
-function getEntry(cache: ResultCache, filePath: string, fp: FileFingerprint): FileEntry | null {
-  if (!Object.hasOwn(cache.files, filePath)) return null
-  const entry = cache.files[filePath]
-  if (entry && entry.mtimeMs === fp.mtimeMs && entry.sizeBytes === fp.sizeBytes) {
-    return entry
-  }
-  return null
-}
-
-export async function readCachedCodexResults(
-  filePath: string,
-): Promise<ParsedProviderCall[] | null> {
-  try {
-    const s = await stat(filePath)
-    const cache = await loadCache()
-    const entry = getEntry(cache, filePath, { mtimeMs: s.mtimeMs, sizeBytes: s.size })
-    return entry?.calls ?? null
-  } catch {}
-  return null
-}
-
 export async function getCachedCodexProject(
   filePath: string,
 ): Promise<string | null> {
   try {
     const s = await stat(filePath)
     const cache = await loadCache()
-    const entry = getEntry(cache, filePath, { mtimeMs: s.mtimeMs, sizeBytes: s.size })
-    return entry?.project ?? null
+    if (!Object.hasOwn(cache.files, filePath)) return null
+    const entry = cache.files[filePath]
+    if (entry && entry.mtimeMs === s.mtimeMs && entry.sizeBytes === s.size) {
+      return entry.project
+    }
+  } catch {}
+  return null
+}
+
+// The stored decode for a file, WITHOUT fingerprint gating: the caller compares
+// the current fingerprint against `mtimeMs`/`sizeBytes` to decide exact-hit
+// (serve `calls`), append-resume (file grew — decode from `byteOffset`+`state`),
+// or cold re-decode.
+export async function readCodexCacheEntry(
+  filePath: string,
+): Promise<FileEntry | null> {
+  try {
+    const cache = await loadCache()
+    if (!Object.hasOwn(cache.files, filePath)) return null
+    return cache.files[filePath] ?? null
   } catch {}
   return null
 }
@@ -98,20 +110,13 @@ export async function fingerprintFile(
   }
 }
 
-export async function writeCachedCodexResults(
+export async function writeCodexCacheEntry(
   filePath: string,
-  project: string,
-  calls: ParsedProviderCall[],
-  fingerprint: FileFingerprint,
+  entry: FileEntry,
 ): Promise<void> {
   try {
     const cache = await loadCache()
-    cache.files[filePath] = {
-      mtimeMs: fingerprint.mtimeMs,
-      sizeBytes: fingerprint.sizeBytes,
-      project,
-      calls,
-    }
+    cache.files[filePath] = entry
   } catch {}
 }
 
@@ -148,3 +153,5 @@ export async function flushCodexCache(): Promise<void> {
     }
   } catch {}
 }
+
+export type { FileEntry as CodexCacheEntry, FileFingerprint as CodexFileFingerprint }

--- a/packages/cli/src/providers/codex.ts
+++ b/packages/cli/src/providers/codex.ts
@@ -4,13 +4,22 @@ import { createInterface } from 'readline'
 import { basename, join } from 'path'
 import { homedir } from 'os'
 
+import { decodeCodex, codexToolNameMap, countUnifiedDiffLoc } from '@codeburn/core/providers/codex'
+import type { CodexDecodedCall, CodexDecodeState, CodexEntry } from '@codeburn/core/providers/codex'
+
 import { readSessionLines } from '../fs-utils.js'
-import { calculateCost } from '../models.js'
-import { readCachedCodexResults, writeCachedCodexResults, getCachedCodexProject, fingerprintFile } from '../codex-cache.js'
-import { normalizeContentBlocks } from '../content-utils.js'
-import { estimateTokensFromChars } from '../token-estimate.js'
-import type { ToolCall } from '../types.js'
+import { priceProviderCall } from '../pricing-pass.js'
+import {
+  readCodexCacheEntry,
+  writeCodexCacheEntry,
+  getCachedCodexProject,
+  fingerprintFile,
+} from '../codex-cache.js'
 import type { Provider, ProbeRoot, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+
+// The unified-diff LOC counter now lives in @codeburn/core (the decoder uses it).
+// Re-exported so existing importers keep resolving it from this module.
+export { countUnifiedDiffLoc }
 
 const modelDisplayNames: Record<string, string> = {
   'codex-auto-review': 'Codex Auto Review',
@@ -29,101 +38,6 @@ const modelDisplayNames: Record<string, string> = {
 // Longest-first + version-boundary match so an unlisted future minor (gpt-5.6)
 // falls through to its raw id instead of collapsing into the base "GPT-5" entry.
 const modelDisplayEntries = Object.entries(modelDisplayNames).sort((a, b) => b[0].length - a[0].length)
-
-const toolNameMap: Record<string, string> = {
-  exec_command: 'Bash',
-  read_file: 'Read',
-  write_file: 'Edit',
-  apply_diff: 'Edit',
-  apply_patch: 'Edit',
-  spawn_agent: 'Agent',
-  close_agent: 'Agent',
-  wait_agent: 'Agent',
-  read_dir: 'Glob',
-}
-
-// CLI-based MCP wrappers (e.g. philschmid/mcp-cli) let Codex call an MCP tool
-// through a shell command instead of registering the server natively. Codex
-// then logs a plain exec_command with no `mcp_tool_call_end` event, so the MCP
-// usage would only appear as a shell command and be absent from the MCP
-// breakdown (issue #478). Recognize the `mcp-cli [options] call <server>
-// <tool>` form and return the canonical mcp__<server>__<tool> so the call is
-// also attributed to MCP. Only the `call` subcommand (an actual tool execution)
-// is matched; info / grep / bare listing are lookups. The exec_command still
-// counts as Bash since it genuinely is a shell exec. Scoped to the mcp-cli
-// binary; other wrappers would need their own pattern.
-//
-// The negative lookbehind keeps `mcp-cli` a standalone binary (a leading
-// quote/space/slash from a `bash -lc "..."` wrapper or absolute path is fine,
-// but `foo-mcp-cli` is not). `(?:\s+(?!call\b)[^\s;|&]+)*` skips any options and
-// their values between the binary and the subcommand (e.g.
-// `mcp-cli -c ./mcp.json call ...`) without crossing a shell separator, and
-// stops at the `call` token. This is substring matching, so a command that
-// merely mentions the phrase (a comment, an echo, a commit message) can
-// false-positive, an accepted tradeoff for the common case. \s+ and the token
-// class don't overlap, so there is no catastrophic backtracking.
-const MCP_CLI_CALL = /(?<![\w.-])mcp-cli(?:\s+(?!call\b)[^\s;|&]+)*\s+call\s+(\S+)\s+(\S+)/
-function mcpToolFromShellCommand(command: unknown): string | null {
-  const text = typeof command === 'string'
-    ? command
-    : Array.isArray(command) ? command.filter(x => typeof x === 'string').join(' ') : ''
-  if (!text) return null
-  const m = MCP_CLI_CALL.exec(text)
-  if (!m) return null
-  const server = m[1]!.replace(/['"]/g, '')
-  const tool = m[2]!.replace(/['"]/g, '')
-  if (!server || !tool) return null
-  return `mcp__${server}__${tool}`
-}
-
-// Count added/removed lines from a Codex `patch_apply_end` change's
-// `unified_diff`. A leading '+' is an added line and '-' a removed line; the
-// '+++'/'---' file headers and '@@' hunk headers are excluded. Numbers only —
-// the diff text is never stored. Rich-session-capture (capture-only).
-export function countUnifiedDiffLoc(diff: unknown): { added: number; removed: number } {
-  let added = 0
-  let removed = 0
-  if (typeof diff !== 'string') return { added, removed }
-  for (const line of diff.split('\n')) {
-    if (line.startsWith('+') && !line.startsWith('+++')) added++
-    else if (line.startsWith('-') && !line.startsWith('---')) removed++
-  }
-  return { added, removed }
-}
-
-type CodexEntry = {
-  type: string
-  timestamp?: string
-  payload?: {
-    type?: string
-    role?: string
-    cwd?: string
-    model_provider?: string
-    originator?: string
-    session_id?: string
-    forked_from_id?: string
-    model?: string
-    name?: string
-    content?: Array<{ type?: string; text?: string }>
-    info?: {
-      model?: string
-      model_name?: string
-      last_token_usage?: CodexTokenUsage
-      total_token_usage?: CodexTokenUsage
-    }
-  }
-}
-
-type CodexTokenUsage = {
-  input_tokens?: number
-  cached_input_tokens?: number
-  output_tokens?: number
-  reasoning_output_tokens?: number
-  total_tokens?: number
-}
-
-const RAW_HEAD_BYTES = 64 * 1024
-const LARGE_TEXT_CAP = 2000
 
 function getCodexDir(override?: string): string {
   return override ?? process.env['CODEX_HOME'] ?? join(homedir(), '.codex')
@@ -151,9 +65,6 @@ async function readFirstLine(filePath: string): Promise<CodexEntry | null> {
   })
   // Silence stream errors so a late read-ahead error after we've already
   // returned the first line cannot escape as an unhandled 'error' event.
-  // readline's async iterator re-throws underlying stream errors (ENOENT,
-  // EACCES, etc.) on Node 16+, which the catch below handles for the cases
-  // that matter for validation.
   stream.on('error', () => {})
   const rl = createInterface({ input: stream, crlfDelay: Infinity })
   let firstLine: string | undefined
@@ -183,117 +94,6 @@ async function isValidCodexSession(filePath: string): Promise<{ valid: boolean; 
     typeof entry.payload?.originator === 'string' &&
     entry.payload.originator.toLowerCase().startsWith('codex')
   return { valid, meta: valid ? entry : undefined }
-}
-
-function getRawJsonStringField(head: string, field: string): string | undefined {
-  const re = new RegExp(`"${field}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`)
-  const match = re.exec(head)
-  if (!match) return undefined
-  try {
-    return JSON.parse(`"${match[1]}"`) as string
-  } catch {
-    return match[1]
-  }
-}
-
-function payloadHead(head: string): string {
-  const idx = head.indexOf('"payload"')
-  return idx === -1 ? head : head.slice(idx)
-}
-
-function countJsonStringBytes(source: Buffer, valueStart: number): number {
-  let count = 0
-  for (let i = valueStart; i < source.length; i++) {
-    const ch = source[i]
-    if (ch === 0x5c) {
-      i++
-      count++
-      continue
-    }
-    if (ch === 0x22) return count
-    count++
-  }
-  return count
-}
-
-function extractFirstJsonText(source: Buffer, cap = LARGE_TEXT_CAP): string {
-  const key = Buffer.from('"text"')
-  const idx = source.indexOf(key)
-  if (idx === -1) return ''
-  const colon = source.indexOf(0x3a, idx + key.length)
-  if (colon === -1) return ''
-  const qStart = source.indexOf(0x22, colon + 1)
-  if (qStart === -1) return ''
-  const chunks: number[] = []
-  for (let i = qStart + 1; i < source.length && chunks.length < cap; i++) {
-    const ch = source[i]
-    if (ch === 0x5c) {
-      const next = source[++i]
-      if (next === 0x6e) chunks.push(0x0a)
-      else if (next === 0x72) chunks.push(0x0d)
-      else if (next === 0x74) chunks.push(0x09)
-      else if (next !== undefined) chunks.push(next)
-      continue
-    }
-    if (ch === 0x22) break
-    chunks.push(ch)
-  }
-  return Buffer.from(chunks).toString('utf-8')
-}
-
-function countFirstJsonText(source: Buffer): number {
-  const key = Buffer.from('"text"')
-  const idx = source.indexOf(key)
-  if (idx === -1) return 0
-  const colon = source.indexOf(0x3a, idx + key.length)
-  if (colon === -1) return 0
-  const qStart = source.indexOf(0x22, colon + 1)
-  if (qStart === -1) return 0
-  return countJsonStringBytes(source, qStart + 1)
-}
-
-function parseCodexLine(line: string | Buffer): CodexEntry | null {
-  if (typeof line === 'string') {
-    const trimmed = line.trim()
-    if (!trimmed) return null
-    try {
-      return JSON.parse(trimmed) as CodexEntry
-    } catch {
-      return null
-    }
-  }
-
-  if (line.length === 0) return null
-  const head = line.subarray(0, RAW_HEAD_BYTES).toString('utf-8')
-  const type = getRawJsonStringField(head, 'type')
-  if (!type) return null
-  const pHead = payloadHead(head)
-  const payloadType = getRawJsonStringField(pHead, 'type')
-  const role = getRawJsonStringField(pHead, 'role')
-
-  const entry: CodexEntry = {
-    type,
-    timestamp: getRawJsonStringField(head, 'timestamp'),
-    payload: {
-      type: payloadType,
-      role,
-      cwd: getRawJsonStringField(pHead, 'cwd'),
-      model_provider: getRawJsonStringField(pHead, 'model_provider'),
-      originator: getRawJsonStringField(pHead, 'originator'),
-      session_id: getRawJsonStringField(pHead, 'session_id'),
-      forked_from_id: getRawJsonStringField(pHead, 'forked_from_id'),
-      model: getRawJsonStringField(pHead, 'model'),
-      name: getRawJsonStringField(pHead, 'name'),
-    },
-  }
-
-  if (type === 'response_item' && payloadType === 'message' && role === 'user') {
-    entry.payload!.content = [{ type: 'input_text', text: extractFirstJsonText(line) }]
-  } else if (type === 'response_item' && payloadType === 'message' && role === 'assistant') {
-    entry.payload!.content = [{ type: 'output_text', text: 'x'.repeat(Math.min(countFirstJsonText(line), LARGE_TEXT_CAP)) }]
-  }
-
-  return entry
 }
 
 async function discoverSessionFile(filePath: string): Promise<SessionSource | null> {
@@ -356,20 +156,53 @@ async function discoverSessionsInDir(codexDir: string): Promise<SessionSource[]>
   return sources
 }
 
-function resolveModel(info: CodexEntry['payload'], sessionModel?: string): string {
-  return info?.model
-    ?? info?.info?.model
-    ?? info?.info?.model_name
-    ?? sessionModel
-    ?? 'gpt-5'
+// Map a rich, cost-free decoder call into the host's ParsedProviderCall, then
+// price it via the estimated-cost seam. Cost leaves the decoder: `costBasis`
+// marks the call so the pricing pass fills `costUSD` from the token buckets,
+// byte-identical to the two in-decoder pricing calls this retires (issue #809).
+function toPricedProviderCall(rich: CodexDecodedCall): ParsedProviderCall {
+  const call: ParsedProviderCall = {
+    provider: 'codex',
+    model: rich.model,
+    inputTokens: rich.inputTokens,
+    outputTokens: rich.outputTokens,
+    cacheCreationInputTokens: rich.cacheCreationInputTokens,
+    cacheReadInputTokens: rich.cacheReadInputTokens,
+    cachedInputTokens: rich.cachedInputTokens,
+    reasoningTokens: rich.reasoningTokens,
+    webSearchRequests: rich.webSearchRequests,
+    costBasis: 'estimated',
+    tools: rich.tools,
+    bashCommands: [],
+    timestamp: rich.timestamp,
+    speed: rich.speed,
+    deduplicationKey: rich.deduplicationKey,
+    turnId: rich.turnId,
+    userMessage: rich.userMessage,
+    sessionId: rich.sessionId,
+    ...(rich.toolSequence ? { toolSequence: rich.toolSequence } : {}),
+    ...(rich.projectPath ? { projectPath: rich.projectPath } : {}),
+    ...(rich.workingDirectory ? { workingDirectory: rich.workingDirectory } : {}),
+    ...(rich.locAdded !== undefined ? { locAdded: rich.locAdded } : {}),
+    ...(rich.locRemoved !== undefined ? { locRemoved: rich.locRemoved } : {}),
+    ...(rich.editFailed !== undefined ? { editFailed: rich.editFailed } : {}),
+    ...(rich.costIsEstimated ? { costIsEstimated: rich.costIsEstimated } : {}),
+  }
+  return priceProviderCall(call)
 }
 
 function createParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
   return {
     async *parse(): AsyncGenerator<ParsedProviderCall> {
-      const cached = await readCachedCodexResults(source.path)
-      if (cached) {
-        for (const call of cached) {
+      const currentFp = await fingerprintFile(source.path)
+      if (!currentFp) return
+
+      const cached = await readCodexCacheEntry(source.path)
+
+      // Exact hit: the file is unchanged. Serve the cached host-priced calls,
+      // deduped against the shared cross-file set (a fork may already own a key).
+      if (cached && cached.mtimeMs === currentFp.mtimeMs && cached.sizeBytes === currentFp.sizeBytes) {
+        for (const call of cached.calls) {
           if (seenKeys.has(call.deduplicationKey)) continue
           seenKeys.add(call.deduplicationKey)
           yield call
@@ -377,342 +210,67 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         return
       }
 
-      const fp = await fingerprintFile(source.path)
-      if (!fp) return
-
-      let sessionModel: string | undefined
-      let sessionId = ''
-      let sessionCwd: string | undefined
-      let forkedFromId = ''
-      let forkCutoff = ''
-      // Null sentinel rather than `0` so the FIRST event is never confused
-      // with a duplicate. A session that only emits last_token_usage (no
-      // total_token_usage) reports cumulativeTotal=0 on every event; with a
-      // 0-initialized prev, the first event would have matched and been
-      // dropped. Once we've observed any event, we record its cumulative
-      // total and dedup on equality regardless of whether it is zero.
-      let prevCumulativeTotal: number | null = null
-      let prevInput = 0
-      let prevCached = 0
-      let prevOutput = 0
-      let prevReasoning = 0
-      let pendingTools: string[] = []
-      let pendingToolSequence: ToolCall[][] = []
-      let pendingUserMessage = ''
-      let pendingOutputChars = 0
-      // Rich-session-capture: edit LOC deltas and failed-patch count accumulated
-      // across a turn's patch_apply_end events, flushed onto the turn's call.
-      let pendingLocAdded = 0
-      let pendingLocRemoved = 0
-      let pendingEditFailed = 0
-      let estCounter = 0
-      let turnCounter = 0
-      let currentTurnId = `${sessionId}:t0`
-      let sawAnyLine = false
-      const results: ParsedProviderCall[] = []
-
-      // Stream the session file line by line. Heavy Codex sessions can exceed
-      // 250 MB on disk; reading the entire file into a string would either hit
-      // the readSessionFile cap or push V8 toward its 512 MB string limit
-      // after split('\n'). readSessionLines streams raw buffers and hands
-      // huge lines to the compact parser without full string conversion.
-      for await (const rawLine of readSessionLines(source.path, undefined, { largeLineAsBuffer: true })) {
-        sawAnyLine = true
-        const entry = parseCodexLine(rawLine)
-        if (!entry) continue
-
-        if (entry.type === 'session_meta') {
-          sessionId = entry.payload?.session_id ?? basename(source.path, '.jsonl')
-          sessionCwd = entry.payload?.cwd ?? sessionCwd
-          forkedFromId = entry.payload?.forked_from_id ?? ''
-          if (forkedFromId && entry.timestamp) {
-            forkCutoff = new Date(new Date(entry.timestamp).getTime() + 5000).toISOString()
-          }
-          sessionModel = entry.payload?.model ?? sessionModel
-          continue
-        }
-
-        if (entry.type === 'turn_context' && entry.payload?.model) {
-          sessionModel = entry.payload.model
-          continue
-        }
-
-        if (entry.type === 'response_item' && entry.payload?.type === 'function_call') {
-          const rawName = entry.payload.name ?? ''
-          const mapped = toolNameMap[rawName] ?? rawName
-          pendingTools.push(mapped)
-          const call: ToolCall = { tool: mapped }
-          const rawArgs = (entry.payload as Record<string, unknown>)['arguments']
-          const args = typeof rawArgs === 'string'
-            ? (() => { try { return JSON.parse(rawArgs) as Record<string, unknown> } catch { return null } })()
-            : typeof rawArgs === 'object' && rawArgs ? rawArgs as Record<string, unknown> : null
-          if (args) {
-            const fp = args['file_path'] ?? args['path']
-            if (typeof fp === 'string') call.file = fp
-            const cmd = args['command'] ?? args['cmd']
-            if (typeof cmd === 'string') call.command = cmd
-            // Attribute a CLI-wrapped MCP call (e.g. `mcp-cli call server tool`)
-            // to the MCP breakdown too; the exec still counts as Bash above.
-            const mcpTool = mcpToolFromShellCommand(cmd)
-            if (mcpTool) {
-              pendingTools.push(mcpTool)
-              pendingToolSequence.push([{ tool: mcpTool }])
-            }
-          }
-          pendingToolSequence.push([call])
-          continue
-        }
-
-        if (entry.type === 'event_msg' && entry.payload?.type === 'patch_apply_end') {
-          pendingTools.push('Edit')
-          const p = entry.payload as Record<string, unknown>
-          const changes = p['changes']
-          const changesObj = typeof changes === 'object' && changes ? changes as Record<string, unknown> : {}
-          const filePaths = Object.keys(changesObj)
-          if (filePaths.length > 0) {
-            for (const fp of filePaths) {
-              pendingToolSequence.push([{ tool: 'Edit', file: fp }])
-              const diff = (changesObj[fp] as Record<string, unknown> | undefined)?.['unified_diff']
-              const loc = countUnifiedDiffLoc(diff)
-              pendingLocAdded += loc.added
-              pendingLocRemoved += loc.removed
-            }
-          } else {
-            pendingToolSequence.push([{ tool: 'Edit' }])
-          }
-          // Only an explicit failure counts; a missing `success` is treated as ok.
-          if (p['success'] === false) pendingEditFailed++
-          continue
-        }
-
-        // Recent Codex emits MCP calls as `event_msg`/`mcp_tool_call_end`
-        // instead of a `function_call` response_item, so the call was never
-        // attributed. Rebuild the canonical `mcp__<server>__<tool>` name the
-        // classifier recognizes.
-        if (entry.type === 'event_msg' && entry.payload?.type === 'mcp_tool_call_end') {
-          const inv = (entry.payload as Record<string, unknown>)['invocation'] as Record<string, unknown> | undefined
-          const server = typeof inv?.['server'] === 'string' ? inv['server'] as string : ''
-          const tool = typeof inv?.['tool'] === 'string' ? inv['tool'] as string : ''
-          if (server && tool) {
-            const name = `mcp__${server}__${tool}`
-            pendingTools.push(name)
-            pendingToolSequence.push([{ tool: name }])
-          }
-          continue
-        }
-
-        if (entry.type === 'response_item' && entry.payload?.type === 'message' && entry.payload?.role === 'user') {
-          const texts = normalizeContentBlocks(entry.payload.content)
-            .filter(c => c.type === 'input_text')
-            .map(c => c.text ?? '')
-            .filter(Boolean)
-          if (texts.length > 0) {
-            pendingUserMessage = texts.join(' ').slice(0, 500)
-            currentTurnId = `${sessionId}:t${++turnCounter}`
-          }
-          continue
-        }
-
-        if (entry.type === 'response_item' && entry.payload?.type === 'message' && entry.payload?.role === 'assistant') {
-          const texts = normalizeContentBlocks(entry.payload.content)
-            .filter(c => c.type === 'output_text' || c.type === 'text')
-            .map(c => c.text ?? '')
-          pendingOutputChars += texts.join('').length
-          continue
-        }
-
-        if (entry.type === 'event_msg' && entry.payload?.type === 'token_count') {
-          // Forked sessions replay the parent's entire event history with
-          // timestamps clustered at the fork creation time. Skip replayed
-          // events (within 5s of fork) to avoid double-counting.
-          if (forkCutoff && entry.timestamp && entry.timestamp < forkCutoff) continue
-          const info = entry.payload.info
-          if (!info) {
-            if (pendingOutputChars === 0 && pendingUserMessage.length === 0) continue
-            const estInput = estimateTokensFromChars(pendingUserMessage.length)
-            const estOutput = estimateTokensFromChars(pendingOutputChars)
-            if (estInput === 0 && estOutput === 0) continue
-
-            const model = sessionModel ?? 'gpt-5'
-            const timestamp = entry.timestamp ?? ''
-            const dedupKey = `codex:${sessionId}:${timestamp}:est${estCounter++}`
-
-            if (seenKeys.has(dedupKey)) { pendingTools = []; pendingToolSequence = []; pendingUserMessage = ''; pendingOutputChars = 0; pendingLocAdded = 0; pendingLocRemoved = 0; pendingEditFailed = 0; continue }
-            seenKeys.add(dedupKey)
-
-            // Phase-0 residual (issue #809): NOT converted to costBasis:'estimated'.
-            // codex-cache.ts persists the whole ParsedProviderCall (costUSD included);
-            // dropping costUSD here changes every newly-written cache entry without a
-            // CODEX_CACHE_VERSION bump, yielding a mixed-format v7 cache. Deferred to
-            // Phase 4 (codex decoder carve-out owns its result-cache state).
-            const costUSD = calculateCost(model, estInput, estOutput, 0, 0, 0)
-
-            results.push({
-              provider: 'codex',
-              model,
-              inputTokens: estInput,
-              outputTokens: estOutput,
-              cacheCreationInputTokens: 0,
-              cacheReadInputTokens: 0,
-              cachedInputTokens: 0,
-              reasoningTokens: 0,
-              webSearchRequests: 0,
-              costUSD,
-              costIsEstimated: true,
-              tools: pendingTools,
-              bashCommands: [],
-              timestamp,
-              speed: 'standard',
-              deduplicationKey: dedupKey,
-              turnId: currentTurnId,
-              toolSequence: pendingToolSequence.length > 0 ? pendingToolSequence : undefined,
-              userMessage: pendingUserMessage,
-              sessionId,
-              ...(sessionCwd ? { projectPath: sessionCwd, workingDirectory: sessionCwd } : {}),
-              ...(pendingLocAdded ? { locAdded: pendingLocAdded } : {}),
-              ...(pendingLocRemoved ? { locRemoved: pendingLocRemoved } : {}),
-              ...(pendingEditFailed ? { editFailed: pendingEditFailed } : {}),
-            })
-
-            pendingTools = []
-            pendingToolSequence = []
-            pendingUserMessage = ''
-            pendingOutputChars = 0
-            pendingLocAdded = 0
-            pendingLocRemoved = 0
-            pendingEditFailed = 0
-            continue
-          }
-
-          const cumulativeTotal = info.total_token_usage?.total_tokens ?? 0
-          // Dedup guard. Two consecutive events with cumulativeTotal=0 but
-          // non-empty last_token_usage would have been double-counted with
-          // the previous `> 0` clause. The null sentinel ensures the FIRST
-          // event always passes (so a session that never reports cumulative
-          // doesn't lose its opening turn).
-          if (prevCumulativeTotal !== null && cumulativeTotal === prevCumulativeTotal) continue
-          prevCumulativeTotal = cumulativeTotal
-
-          const last = info.last_token_usage
-          let inputTokens = 0
-          let cachedInputTokens = 0
-          let outputTokens = 0
-          let reasoningTokens = 0
-
-          if (last) {
-            inputTokens = last.input_tokens ?? 0
-            cachedInputTokens = last.cached_input_tokens ?? 0
-            outputTokens = last.output_tokens ?? 0
-            reasoningTokens = last.reasoning_output_tokens ?? 0
-          } else if (cumulativeTotal > 0) {
-            const total = info.total_token_usage
-            if (!total) continue
-            inputTokens = (total.input_tokens ?? 0) - prevInput
-            cachedInputTokens = (total.cached_input_tokens ?? 0) - prevCached
-            outputTokens = (total.output_tokens ?? 0) - prevOutput
-            reasoningTokens = (total.reasoning_output_tokens ?? 0) - prevReasoning
-          }
-
-          // Always advance the prev counters to track the cumulative state.
-          // Previously prev was only updated on the fallback branch, so a
-          // session with mixed last_token_usage / no-last events would
-          // compute the next fallback delta against a stale prev=0 baseline,
-          // double-counting the entire cumulative window. The prev value
-          // must mirror what cumulative reports regardless of whether this
-          // event used `last` or fell back to deltas.
-          const total = info.total_token_usage
-          if (total) {
-            prevInput = total.input_tokens ?? 0
-            prevCached = total.cached_input_tokens ?? 0
-            prevOutput = total.output_tokens ?? 0
-            prevReasoning = total.reasoning_output_tokens ?? 0
-          }
-
-          const totalTokens = inputTokens + cachedInputTokens + outputTokens + reasoningTokens
-          if (totalTokens === 0) continue
-
-          // OpenAI includes cached tokens inside input_tokens; Anthropic does not.
-          // Normalize to Anthropic semantics: inputTokens = non-cached only.
-          const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens)
-
-          const model = resolveModel(entry.payload, sessionModel)
-          const timestamp = entry.timestamp ?? ''
-          // Forked sessions copy the parent's entire token_count history
-          // (re-timestamped), so replays must collide with the parent's events
-          // and drop to avoid double-counting -- hence the parent namespace
-          // (forkedFromId) and the deliberate omission of the per-session id.
-          // But cumulativeTotal alone is too coarse a discriminator: a genuine
-          // post-divergence fork event whose running total coincidentally equals
-          // some parent total would also collide and be lost (undercount). So we
-          // also key on the cumulative token breakdown, which a fork replays
-          // verbatim from the parent -- a true replay collides exactly, while
-          // genuinely different work at the same total stays distinct. We use the
-          // CUMULATIVE figures (not the per-event deltas) on purpose: the deltas
-          // are computed against a running `prev` that the fork advances
-          // differently once the 5s cutoff skips some replays, so a delta-based
-          // key would spuriously diverge on a replay and double-count it.
-          const dedupKey = `codex:${forkedFromId || sessionId}:${cumulativeTotal}:${total?.input_tokens ?? 0}:${total?.cached_input_tokens ?? 0}:${total?.output_tokens ?? 0}:${total?.reasoning_output_tokens ?? 0}`
-
-          if (seenKeys.has(dedupKey)) continue
-          seenKeys.add(dedupKey)
-
-          // Phase-0 residual (issue #809): left on the in-decoder pricing path for
-          // the same reason as the estimate branch above — codex-cache.ts persists
-          // costUSD, so converting would change cached bytes without a version bump.
-          // Deferred to Phase 4.
-          const costUSD = calculateCost(
-            model,
-            uncachedInputTokens,
-            outputTokens + reasoningTokens,
-            0,
-            cachedInputTokens,
-            0,
-          )
-
-          results.push({
-            provider: 'codex',
-            model,
-            inputTokens: uncachedInputTokens,
-            outputTokens,
-            cacheCreationInputTokens: 0,
-            cacheReadInputTokens: cachedInputTokens,
-            cachedInputTokens,
-            reasoningTokens,
-            webSearchRequests: 0,
-            costUSD,
-            tools: pendingTools,
-            bashCommands: [],
-            timestamp,
-            speed: 'standard',
-            deduplicationKey: dedupKey,
-            turnId: currentTurnId,
-            toolSequence: pendingToolSequence.length > 0 ? pendingToolSequence : undefined,
-            userMessage: pendingUserMessage,
-            sessionId,
-            ...(sessionCwd ? { projectPath: sessionCwd, workingDirectory: sessionCwd } : {}),
-            ...(pendingLocAdded ? { locAdded: pendingLocAdded } : {}),
-            ...(pendingLocRemoved ? { locRemoved: pendingLocRemoved } : {}),
-            ...(pendingEditFailed ? { editFailed: pendingEditFailed } : {}),
-          })
-
-          pendingTools = []
-          pendingToolSequence = []
-          pendingUserMessage = ''
-          pendingOutputChars = 0
-          pendingLocAdded = 0
-          pendingLocRemoved = 0
-          pendingEditFailed = 0
-        }
+      // Append-resume: the file grew (Codex only appends to a rollout). Reuse the
+      // cached end-state + priced calls and decode ONLY the new bytes from the
+      // stored byte offset. Prior calls' dedup keys must be visible before the
+      // appended records decode so the resumed stream dedups against them.
+      let startByteOffset = 0
+      let initialState: CodexDecodeState | undefined
+      let priorCalls: ParsedProviderCall[] = []
+      const resume = !!(cached && cached.byteOffset > 0 && currentFp.sizeBytes > cached.sizeBytes)
+      if (resume && cached) {
+        startByteOffset = cached.byteOffset
+        initialState = cached.state
+        priorCalls = cached.calls
+        for (const c of priorCalls) seenKeys.add(c.deduplicationKey)
       }
 
-      // If the stream yielded nothing the file was unreadable, oversized, or
-      // empty. Skip cache write so a transient failure can't pin an empty
-      // result set against a fingerprint that would otherwise be re-parsed.
-      if (!sawAnyLine) return
+      // Stream raw lines (only the appended tail when resuming). Buffers for huge
+      // lines pass straight into the decoder without a full string conversion.
+      const records: (string | Buffer)[] = []
+      const tracker = { lastCompleteLineOffset: startByteOffset }
+      let sawAnyLine = false
+      for await (const rawLine of readSessionLines(source.path, undefined, {
+        largeLineAsBuffer: true,
+        startByteOffset,
+        byteOffsetTracker: tracker,
+      })) {
+        sawAnyLine = true
+        records.push(rawLine)
+      }
 
-      await writeCachedCodexResults(source.path, source.project, results, fp)
+      // A cold decode that streamed nothing means the file was unreadable,
+      // oversized, or empty — skip the cache write so a transient failure can't
+      // pin an empty result set (mirrors the pre-phase-4 sawAnyLine guard).
+      if (!sawAnyLine && !resume) return
 
-      for (const call of results) {
+      const { calls: richCalls, state: newState } = decodeCodex({
+        records,
+        context: { privacyKey: '', providerId: 'codex', sourceRef: source.path },
+        state: initialState,
+        // Live shared dedup set (mutated in place); the decoder leaves
+        // state.seenKeys empty when a live set is supplied.
+        seenKeys,
+        sessionIdFallback: basename(source.path, '.jsonl'),
+      })
+
+      const newPriced = richCalls.map(toPricedProviderCall)
+      const allCalls = resume ? [...priorCalls, ...newPriced] : newPriced
+
+      // Persist the state blob + host-priced calls + resume offset. seenKeys is
+      // stripped from the stored state (cross-file dedup is reconstructed each
+      // run from the session cache, as the pre-phase-4 shared set was).
+      const storedState: CodexDecodeState = { ...newState, seenKeys: [] }
+      await writeCodexCacheEntry(source.path, {
+        mtimeMs: currentFp.mtimeMs,
+        sizeBytes: currentFp.sizeBytes,
+        project: source.project,
+        byteOffset: tracker.lastCompleteLineOffset,
+        state: storedState,
+        calls: allCalls,
+      })
+
+      for (const call of allCalls) {
         yield call
       }
     },
@@ -734,7 +292,7 @@ export function createCodexProvider(codexDir?: string): Provider {
     },
 
     toolDisplayName(rawTool: string): string {
-      return toolNameMap[rawTool] ?? rawTool
+      return codexToolNameMap[rawTool] ?? rawTool
     },
 
     // Same `dir` discoverSessionsInDir walks: <codexDir>/sessions (dated

--- a/packages/cli/tests/codex-resume.test.ts
+++ b/packages/cli/tests/codex-resume.test.ts
@@ -1,0 +1,119 @@
+// Phase-4 signature test at the CLI layer: the codex-results cache persists the
+// decoder's serializable end-state + byte offset, so a rollout that GREW (Codex
+// only appends) resumes from that state and decodes ONLY the appended bytes. The
+// resumed output must equal a cold decode of the full grown file.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, mkdir, writeFile, appendFile, rm } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+import { createCodexProvider } from '../src/providers/codex.js'
+import { readCodexCacheEntry } from '../src/codex-cache.js'
+import type { ParsedProviderCall } from '../src/providers/types.js'
+
+let tmpDir: string
+let cacheDir: string
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'codex-resume-'))
+  cacheDir = await mkdtemp(join(tmpdir(), 'codex-resume-cache-'))
+  process.env['CODEBURN_CACHE_DIR'] = cacheDir
+})
+
+afterEach(async () => {
+  delete process.env['CODEBURN_CACHE_DIR']
+  await rm(tmpDir, { recursive: true, force: true })
+  await rm(cacheDir, { recursive: true, force: true })
+})
+
+function sessionMeta() {
+  return JSON.stringify({ type: 'session_meta', timestamp: '2026-04-14T10:00:00Z', payload: { cwd: '/Users/t/p', originator: 'codex-cli', session_id: 'sess-resume', model: 'gpt-5.3-codex' } })
+}
+function userMessage(text: string, ts: string) {
+  return JSON.stringify({ type: 'response_item', timestamp: ts, payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text }] } })
+}
+function tokenCount(ts: string, lastInput: number, cumulative: number) {
+  return JSON.stringify({ type: 'event_msg', timestamp: ts, payload: { type: 'token_count', info: { last_token_usage: { input_tokens: lastInput, output_tokens: 0, total_tokens: lastInput }, total_token_usage: { input_tokens: cumulative, total_tokens: cumulative } } } })
+}
+
+const PREFIX = [
+  sessionMeta(),
+  userMessage('first turn', '2026-04-14T10:00:01Z'),
+  tokenCount('2026-04-14T10:00:02Z', 700, 700),
+  userMessage('second turn', '2026-04-14T10:00:03Z'),
+  tokenCount('2026-04-14T10:00:04Z', 400, 1100),
+]
+const APPENDED = [
+  userMessage('third turn', '2026-04-14T10:00:05Z'),
+  tokenCount('2026-04-14T10:00:06Z', 300, 1400),
+]
+
+async function writeAt(dir: string, filename: string, lines: string[]): Promise<string> {
+  const sessionDir = join(dir, 'sessions', '2026', '04', '14')
+  await mkdir(sessionDir, { recursive: true })
+  const filePath = join(sessionDir, filename)
+  await writeFile(filePath, lines.join('\n') + '\n')
+  return filePath
+}
+
+async function parseFile(filePath: string): Promise<ParsedProviderCall[]> {
+  const provider = createCodexProvider(tmpDir)
+  const source = { path: filePath, project: 'Users-t-p', provider: 'codex' }
+  const calls: ParsedProviderCall[] = []
+  for await (const c of provider.createSessionParser(source, new Set<string>()).parse()) calls.push(c)
+  return calls
+}
+
+describe('codex append-resume through the CLI cache', () => {
+  it('resumes from the persisted state + byte offset and matches a cold decode of the grown file', async () => {
+    const filePath = await writeAt(tmpDir, 'rollout-grow.jsonl', PREFIX)
+
+    // Run 1: cold decode of the prefix. Writes the state blob + priced calls +
+    // byte offset into the codex-results cache.
+    const v1 = await parseFile(filePath)
+    expect(v1).toHaveLength(2)
+
+    const entry = await readCodexCacheEntry(filePath)
+    expect(entry).not.toBeNull()
+    expect(entry!.byteOffset).toBeGreaterThan(0)
+    expect(entry!.calls).toHaveLength(2)
+    // The persisted state is plain JSON and carries the running cumulative
+    // counter (1100 after the prefix) so the appended delta computes correctly.
+    expect(entry!.state.prevInput).toBe(1100)
+    expect(Array.isArray(entry!.state.seenKeys)).toBe(true)
+
+    // The file grows: Codex appends a third turn.
+    await appendFile(filePath, APPENDED.join('\n') + '\n')
+
+    // Run 2: same process, cache entry still in memory with the pre-append
+    // fingerprint -> the grown file takes the append-resume branch.
+    const v2 = await parseFile(filePath)
+    expect(v2).toHaveLength(3)
+
+    // Cold decode of the full grown file via a fresh, never-cached path.
+    const coldPath = await writeAt(tmpDir, 'rollout-cold.jsonl', [...PREFIX, ...APPENDED])
+    const cold = await parseFile(coldPath)
+    expect(cold).toHaveLength(3)
+
+    // The resumed output must equal the cold decode (session_id is path-
+    // independent, so dedup keys and every field line up).
+    expect(v2).toEqual(cold)
+  })
+
+  it('reuses the cached prior calls on resume rather than re-decoding the prefix', async () => {
+    const filePath = await writeAt(tmpDir, 'rollout-proof.jsonl', PREFIX)
+    await parseFile(filePath)
+
+    // Plant a sentinel on the cached prior calls. If run 2 re-decoded the prefix
+    // cold, the sentinel would be gone; if it resumed (reusing cached priorCalls),
+    // the sentinel survives onto the emitted prior calls.
+    const entry = await readCodexCacheEntry(filePath)
+    entry!.calls[0]!.model = 'SENTINEL-MODEL'
+
+    await appendFile(filePath, APPENDED.join('\n') + '\n')
+    const v2 = await parseFile(filePath)
+
+    expect(v2.map(c => c.model)).toContain('SENTINEL-MODEL')
+  })
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,10 @@
     "./providers/claude": {
       "types": "./dist/providers/claude/index.d.ts",
       "import": "./dist/providers/claude/index.js"
+    },
+    "./providers/codex": {
+      "types": "./dist/providers/codex/index.d.ts",
+      "import": "./dist/providers/codex/index.js"
     }
   },
   "files": [

--- a/packages/core/src/providers/codex/decode.ts
+++ b/packages/core/src/providers/codex/decode.ts
@@ -1,0 +1,525 @@
+// @codeburn/core Codex decoder: pure decode over supplied rollout records with
+// EXPLICIT serializable state. No fs / env / clock — the host streams the file
+// and hands lines (string OR Buffer) straight through; a Buffer passes through
+// un-re-buffered so a >250 MB session never materializes as a string. The rich
+// output carries token buckets but NO pricing (cost leaves the decoder; the host
+// prices via its estimated-cost seam).
+
+import type { DecodeContext } from '../../contracts.js'
+import type { RecordDiagnostic } from '../../diagnostics.js'
+import type {
+  CodexDecodedCall,
+  CodexDecodeState,
+  CodexEntry,
+  CodexToolCall,
+  CodexTokenUsage,
+} from './types.js'
+
+// ── Pure helpers (self-contained copies; core must not import from the CLI) ──
+
+const CHARS_PER_TOKEN = 4
+function estimateTokensFromChars(chars: number): number {
+  return Math.ceil(chars / CHARS_PER_TOKEN)
+}
+
+// Coerce a message `content` into an array of blocks. Some turns write `content`
+// as a bare string; a raw string reaching `.filter` would throw mid-decode.
+function normalizeContentBlocks<T extends { type?: string; text?: string }>(
+  content: T[] | string | null | undefined,
+): T[] {
+  if (Array.isArray(content)) {
+    const isBlock = (b: T): boolean => b != null && typeof b === 'object'
+    return content.every(isBlock) ? content : content.filter(isBlock)
+  }
+  if (typeof content === 'string') return [{ type: 'text', text: content } as T]
+  return []
+}
+
+export const codexToolNameMap: Record<string, string> = {
+  exec_command: 'Bash',
+  read_file: 'Read',
+  write_file: 'Edit',
+  apply_diff: 'Edit',
+  apply_patch: 'Edit',
+  spawn_agent: 'Agent',
+  close_agent: 'Agent',
+  wait_agent: 'Agent',
+  read_dir: 'Glob',
+}
+
+// CLI-based MCP wrappers (e.g. philschmid/mcp-cli) let Codex call an MCP tool
+// through a shell command instead of registering the server natively. Codex logs
+// a plain exec_command with no `mcp_tool_call_end` event, so the MCP usage would
+// only appear as a shell command (issue #478). Recognize the `mcp-cli [options]
+// call <server> <tool>` form and return the canonical mcp__<server>__<tool>. The
+// negative lookbehind keeps `mcp-cli` a standalone binary; the option-skip group
+// stops at the `call` token without crossing a shell separator.
+const MCP_CLI_CALL = /(?<![\w.-])mcp-cli(?:\s+(?!call\b)[^\s;|&]+)*\s+call\s+(\S+)\s+(\S+)/
+export function mcpToolFromShellCommand(command: unknown): string | null {
+  const text = typeof command === 'string'
+    ? command
+    : Array.isArray(command) ? command.filter(x => typeof x === 'string').join(' ') : ''
+  if (!text) return null
+  const m = MCP_CLI_CALL.exec(text)
+  if (!m) return null
+  const server = m[1]!.replace(/['"]/g, '')
+  const tool = m[2]!.replace(/['"]/g, '')
+  if (!server || !tool) return null
+  return `mcp__${server}__${tool}`
+}
+
+// Count added/removed lines from a Codex `patch_apply_end` change's
+// `unified_diff`. Numbers only — the diff text is never stored.
+export function countUnifiedDiffLoc(diff: unknown): { added: number; removed: number } {
+  let added = 0
+  let removed = 0
+  if (typeof diff !== 'string') return { added, removed }
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+') && !line.startsWith('+++')) added++
+    else if (line.startsWith('-') && !line.startsWith('---')) removed++
+  }
+  return { added, removed }
+}
+
+const RAW_HEAD_BYTES = 64 * 1024
+const LARGE_TEXT_CAP = 2000
+
+function getRawJsonStringField(head: string, field: string): string | undefined {
+  const re = new RegExp(`"${field}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`)
+  const match = re.exec(head)
+  if (!match) return undefined
+  try {
+    return JSON.parse(`"${match[1]}"`) as string
+  } catch {
+    return match[1]
+  }
+}
+
+function payloadHead(head: string): string {
+  const idx = head.indexOf('"payload"')
+  return idx === -1 ? head : head.slice(idx)
+}
+
+function countJsonStringBytes(source: Buffer, valueStart: number): number {
+  let count = 0
+  for (let i = valueStart; i < source.length; i++) {
+    const ch = source[i]
+    if (ch === 0x5c) {
+      i++
+      count++
+      continue
+    }
+    if (ch === 0x22) return count
+    count++
+  }
+  return count
+}
+
+function extractFirstJsonText(source: Buffer, cap = LARGE_TEXT_CAP): string {
+  const key = Buffer.from('"text"')
+  const idx = source.indexOf(key)
+  if (idx === -1) return ''
+  const colon = source.indexOf(0x3a, idx + key.length)
+  if (colon === -1) return ''
+  const qStart = source.indexOf(0x22, colon + 1)
+  if (qStart === -1) return ''
+  const chunks: number[] = []
+  for (let i = qStart + 1; i < source.length && chunks.length < cap; i++) {
+    const ch = source[i]
+    if (ch === 0x5c) {
+      const next = source[++i]
+      if (next === 0x6e) chunks.push(0x0a)
+      else if (next === 0x72) chunks.push(0x0d)
+      else if (next === 0x74) chunks.push(0x09)
+      else if (next !== undefined) chunks.push(next)
+      continue
+    }
+    if (ch === 0x22) break
+    chunks.push(ch)
+  }
+  return Buffer.from(chunks).toString('utf-8')
+}
+
+function countFirstJsonText(source: Buffer): number {
+  const key = Buffer.from('"text"')
+  const idx = source.indexOf(key)
+  if (idx === -1) return 0
+  const colon = source.indexOf(0x3a, idx + key.length)
+  if (colon === -1) return 0
+  const qStart = source.indexOf(0x22, colon + 1)
+  if (qStart === -1) return 0
+  return countJsonStringBytes(source, qStart + 1)
+}
+
+// Parse one rollout line. A small line arrives as a string (plain JSON.parse); a
+// huge line arrives as a Buffer and is scanned for just the fields the decoder
+// needs, so a 250 MB assistant message never becomes a V8 string.
+export function parseCodexLine(line: string | Buffer): CodexEntry | null {
+  if (typeof line === 'string') {
+    const trimmed = line.trim()
+    if (!trimmed) return null
+    try {
+      return JSON.parse(trimmed) as CodexEntry
+    } catch {
+      return null
+    }
+  }
+
+  if (line.length === 0) return null
+  const head = line.subarray(0, RAW_HEAD_BYTES).toString('utf-8')
+  const type = getRawJsonStringField(head, 'type')
+  if (!type) return null
+  const pHead = payloadHead(head)
+  const payloadType = getRawJsonStringField(pHead, 'type')
+  const role = getRawJsonStringField(pHead, 'role')
+
+  const entry: CodexEntry = {
+    type,
+    timestamp: getRawJsonStringField(head, 'timestamp'),
+    payload: {
+      type: payloadType,
+      role,
+      cwd: getRawJsonStringField(pHead, 'cwd'),
+      model_provider: getRawJsonStringField(pHead, 'model_provider'),
+      originator: getRawJsonStringField(pHead, 'originator'),
+      session_id: getRawJsonStringField(pHead, 'session_id'),
+      forked_from_id: getRawJsonStringField(pHead, 'forked_from_id'),
+      model: getRawJsonStringField(pHead, 'model'),
+      name: getRawJsonStringField(pHead, 'name'),
+    },
+  }
+
+  if (type === 'response_item' && payloadType === 'message' && role === 'user') {
+    entry.payload!.content = [{ type: 'input_text', text: extractFirstJsonText(line) }]
+  } else if (type === 'response_item' && payloadType === 'message' && role === 'assistant') {
+    entry.payload!.content = [{ type: 'output_text', text: 'x'.repeat(Math.min(countFirstJsonText(line), LARGE_TEXT_CAP)) }]
+  }
+
+  return entry
+}
+
+function resolveModel(info: CodexEntry['payload'], sessionModel?: string): string {
+  return info?.model
+    ?? info?.info?.model
+    ?? info?.info?.model_name
+    ?? sessionModel
+    ?? 'gpt-5'
+}
+
+// ── Explicit state ──────────────────────────────────────────────────────
+
+export function freshCodexState(): CodexDecodeState {
+  return {
+    sessionModel: undefined,
+    sessionId: '',
+    sessionCwd: undefined,
+    forkedFromId: '',
+    forkCutoff: '',
+    prevCumulativeTotal: null,
+    prevInput: 0,
+    prevCached: 0,
+    prevOutput: 0,
+    prevReasoning: 0,
+    pendingTools: [],
+    pendingToolSequence: [],
+    pendingUserMessage: '',
+    pendingOutputChars: 0,
+    pendingLocAdded: 0,
+    pendingLocRemoved: 0,
+    pendingEditFailed: 0,
+    estCounter: 0,
+    turnCounter: 0,
+    // The pre-phase-4 decoder computed this as `${sessionId}:t0` at init time,
+    // when sessionId was still '' — session_meta sets the id later but never
+    // recomputes this, so a call before the first user message keeps ':t0'.
+    currentTurnId: ':t0',
+    seenKeys: [],
+  }
+}
+
+function cloneState(prev: CodexDecodeState): CodexDecodeState {
+  return {
+    ...prev,
+    pendingTools: [...prev.pendingTools],
+    pendingToolSequence: prev.pendingToolSequence.map(step => step.map(c => ({ ...c }))),
+    seenKeys: [...prev.seenKeys],
+  }
+}
+
+function clearPending(s: CodexDecodeState): void {
+  s.pendingTools = []
+  s.pendingToolSequence = []
+  s.pendingUserMessage = ''
+  s.pendingOutputChars = 0
+  s.pendingLocAdded = 0
+  s.pendingLocRemoved = 0
+  s.pendingEditFailed = 0
+}
+
+export type CodexDecodeInput = {
+  records: unknown[]
+  context: DecodeContext
+  state?: CodexDecodeState
+  // Optional live dedup set the host mutates in place (its shared cross-file
+  // seenKeys). When provided it is canonical and `state.seenKeys` is left empty;
+  // when absent the decoder threads dedup memory through `state.seenKeys`.
+  seenKeys?: Set<string>
+  // Session id to fall back to when a session_meta omits `session_id` (the CLI
+  // passes the rollout file's basename; core never touches the path).
+  sessionIdFallback?: string
+}
+
+export type CodexDecodeResult = {
+  calls: CodexDecodedCall[]
+  diagnostics: RecordDiagnostic[]
+  state: CodexDecodeState
+}
+
+/**
+ * Decode a batch of Codex rollout records into rich, cost-free calls, threading
+ * explicit serializable state. Concatenating the calls from decoding a corpus in
+ * one pass equals concatenating the calls from any split of it, as long as the
+ * state (and dedup memory) threads between passes — the resume invariant.
+ */
+// `context` is part of the Decoder contract but the rich layer never consumes it:
+// minimization / fingerprinting happens in toObservations, which takes the
+// privacy key directly. It stays in the input type for contract conformance.
+export function decodeCodex({ records, state: prevState, seenKeys: liveSeen, sessionIdFallback = '' }: CodexDecodeInput): CodexDecodeResult {
+  const s = prevState ? cloneState(prevState) : freshCodexState()
+  const seen = liveSeen ?? new Set(s.seenKeys)
+  const calls: CodexDecodedCall[] = []
+  const diagnostics: RecordDiagnostic[] = []
+
+  for (const rawLine of records) {
+    const entry = parseCodexLine(rawLine as string | Buffer)
+    if (!entry) continue
+
+    if (entry.type === 'session_meta') {
+      // Update in place — do NOT reset the running counters. A single rollout
+      // file can carry more than one session_meta (Codex re-emits it on resume /
+      // fork within the same file); the pre-phase-4 decoder treated the whole
+      // file as one continuous session and only re-assigned these fields, keeping
+      // the cumulative-dedup and delta counters intact. Per-file freshness comes
+      // from the host starting a new decode (state: undefined) per file, not from
+      // resetting here.
+      s.sessionId = entry.payload?.session_id ?? sessionIdFallback
+      s.sessionCwd = entry.payload?.cwd ?? s.sessionCwd
+      s.forkedFromId = entry.payload?.forked_from_id ?? ''
+      if (s.forkedFromId && entry.timestamp) {
+        s.forkCutoff = new Date(new Date(entry.timestamp).getTime() + 5000).toISOString()
+      }
+      s.sessionModel = entry.payload?.model ?? s.sessionModel
+      continue
+    }
+
+    if (entry.type === 'turn_context' && entry.payload?.model) {
+      s.sessionModel = entry.payload.model
+      continue
+    }
+
+    if (entry.type === 'response_item' && entry.payload?.type === 'function_call') {
+      const rawName = entry.payload.name ?? ''
+      const mapped = codexToolNameMap[rawName] ?? rawName
+      s.pendingTools.push(mapped)
+      const call: CodexToolCall = { tool: mapped }
+      const rawArgs = (entry.payload as Record<string, unknown>)['arguments']
+      const args = typeof rawArgs === 'string'
+        ? (() => { try { return JSON.parse(rawArgs) as Record<string, unknown> } catch { return null } })()
+        : typeof rawArgs === 'object' && rawArgs ? rawArgs as Record<string, unknown> : null
+      if (args) {
+        const fp = args['file_path'] ?? args['path']
+        if (typeof fp === 'string') call.file = fp
+        const cmd = args['command'] ?? args['cmd']
+        if (typeof cmd === 'string') call.command = cmd
+        const mcpTool = mcpToolFromShellCommand(cmd)
+        if (mcpTool) {
+          s.pendingTools.push(mcpTool)
+          s.pendingToolSequence.push([{ tool: mcpTool }])
+        }
+      }
+      s.pendingToolSequence.push([call])
+      continue
+    }
+
+    if (entry.type === 'event_msg' && entry.payload?.type === 'patch_apply_end') {
+      s.pendingTools.push('Edit')
+      const p = entry.payload as Record<string, unknown>
+      const changes = p['changes']
+      const changesObj = typeof changes === 'object' && changes ? changes as Record<string, unknown> : {}
+      const filePaths = Object.keys(changesObj)
+      if (filePaths.length > 0) {
+        for (const fp of filePaths) {
+          s.pendingToolSequence.push([{ tool: 'Edit', file: fp }])
+          const diff = (changesObj[fp] as Record<string, unknown> | undefined)?.['unified_diff']
+          const loc = countUnifiedDiffLoc(diff)
+          s.pendingLocAdded += loc.added
+          s.pendingLocRemoved += loc.removed
+        }
+      } else {
+        s.pendingToolSequence.push([{ tool: 'Edit' }])
+      }
+      if (p['success'] === false) s.pendingEditFailed++
+      continue
+    }
+
+    if (entry.type === 'event_msg' && entry.payload?.type === 'mcp_tool_call_end') {
+      const inv = (entry.payload as Record<string, unknown>)['invocation'] as Record<string, unknown> | undefined
+      const server = typeof inv?.['server'] === 'string' ? inv['server'] as string : ''
+      const tool = typeof inv?.['tool'] === 'string' ? inv['tool'] as string : ''
+      if (server && tool) {
+        const name = `mcp__${server}__${tool}`
+        s.pendingTools.push(name)
+        s.pendingToolSequence.push([{ tool: name }])
+      }
+      continue
+    }
+
+    if (entry.type === 'response_item' && entry.payload?.type === 'message' && entry.payload?.role === 'user') {
+      const texts = normalizeContentBlocks(entry.payload.content)
+        .filter(c => c.type === 'input_text')
+        .map(c => c.text ?? '')
+        .filter(Boolean)
+      if (texts.length > 0) {
+        s.pendingUserMessage = texts.join(' ').slice(0, 500)
+        s.currentTurnId = `${s.sessionId}:t${++s.turnCounter}`
+      }
+      continue
+    }
+
+    if (entry.type === 'response_item' && entry.payload?.type === 'message' && entry.payload?.role === 'assistant') {
+      const texts = normalizeContentBlocks(entry.payload.content)
+        .filter(c => c.type === 'output_text' || c.type === 'text')
+        .map(c => c.text ?? '')
+      s.pendingOutputChars += texts.join('').length
+      continue
+    }
+
+    if (entry.type === 'event_msg' && entry.payload?.type === 'token_count') {
+      // Forked sessions replay the parent's event history clustered at the fork
+      // creation time. Skip replays within 5s of the fork to avoid double-count.
+      if (s.forkCutoff && entry.timestamp && entry.timestamp < s.forkCutoff) continue
+      const info = entry.payload.info
+      if (!info) {
+        if (s.pendingOutputChars === 0 && s.pendingUserMessage.length === 0) continue
+        const estInput = estimateTokensFromChars(s.pendingUserMessage.length)
+        const estOutput = estimateTokensFromChars(s.pendingOutputChars)
+        if (estInput === 0 && estOutput === 0) continue
+
+        const model = s.sessionModel ?? 'gpt-5'
+        const timestamp = entry.timestamp ?? ''
+        const dedupKey = `codex:${s.sessionId}:${timestamp}:est${s.estCounter++}`
+
+        if (seen.has(dedupKey)) { clearPending(s); continue }
+        seen.add(dedupKey)
+
+        calls.push({
+          provider: 'codex',
+          model,
+          inputTokens: estInput,
+          outputTokens: estOutput,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          cachedInputTokens: 0,
+          reasoningTokens: 0,
+          webSearchRequests: 0,
+          costIsEstimated: true,
+          tools: s.pendingTools,
+          timestamp,
+          speed: 'standard',
+          deduplicationKey: dedupKey,
+          turnId: s.currentTurnId,
+          toolSequence: s.pendingToolSequence.length > 0 ? s.pendingToolSequence : undefined,
+          userMessage: s.pendingUserMessage,
+          sessionId: s.sessionId,
+          ...(s.sessionCwd ? { projectPath: s.sessionCwd, workingDirectory: s.sessionCwd } : {}),
+          ...(s.pendingLocAdded ? { locAdded: s.pendingLocAdded } : {}),
+          ...(s.pendingLocRemoved ? { locRemoved: s.pendingLocRemoved } : {}),
+          ...(s.pendingEditFailed ? { editFailed: s.pendingEditFailed } : {}),
+        })
+
+        clearPending(s)
+        continue
+      }
+
+      const cumulativeTotal = info.total_token_usage?.total_tokens ?? 0
+      if (s.prevCumulativeTotal !== null && cumulativeTotal === s.prevCumulativeTotal) continue
+      s.prevCumulativeTotal = cumulativeTotal
+
+      const last = info.last_token_usage
+      let inputTokens = 0
+      let cachedInputTokens = 0
+      let outputTokens = 0
+      let reasoningTokens = 0
+
+      if (last) {
+        inputTokens = last.input_tokens ?? 0
+        cachedInputTokens = last.cached_input_tokens ?? 0
+        outputTokens = last.output_tokens ?? 0
+        reasoningTokens = last.reasoning_output_tokens ?? 0
+      } else if (cumulativeTotal > 0) {
+        const total = info.total_token_usage
+        if (!total) continue
+        inputTokens = (total.input_tokens ?? 0) - s.prevInput
+        cachedInputTokens = (total.cached_input_tokens ?? 0) - s.prevCached
+        outputTokens = (total.output_tokens ?? 0) - s.prevOutput
+        reasoningTokens = (total.reasoning_output_tokens ?? 0) - s.prevReasoning
+      }
+
+      // Always advance the prev counters to mirror the cumulative state, whether
+      // this event used `last` or the delta fallback.
+      const total: CodexTokenUsage | undefined = info.total_token_usage
+      if (total) {
+        s.prevInput = total.input_tokens ?? 0
+        s.prevCached = total.cached_input_tokens ?? 0
+        s.prevOutput = total.output_tokens ?? 0
+        s.prevReasoning = total.reasoning_output_tokens ?? 0
+      }
+
+      const totalTokens = inputTokens + cachedInputTokens + outputTokens + reasoningTokens
+      if (totalTokens === 0) continue
+
+      // OpenAI includes cached tokens inside input_tokens; normalize to Anthropic
+      // semantics: inputTokens = non-cached only.
+      const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens)
+
+      const model = resolveModel(entry.payload, s.sessionModel)
+      const timestamp = entry.timestamp ?? ''
+      // Fork replays copy the parent's token_count history verbatim, so key on
+      // the parent namespace plus the cumulative breakdown: a true replay collides
+      // exactly, genuinely different work at the same total stays distinct.
+      const dedupKey = `codex:${s.forkedFromId || s.sessionId}:${cumulativeTotal}:${total?.input_tokens ?? 0}:${total?.cached_input_tokens ?? 0}:${total?.output_tokens ?? 0}:${total?.reasoning_output_tokens ?? 0}`
+
+      if (seen.has(dedupKey)) continue
+      seen.add(dedupKey)
+
+      calls.push({
+        provider: 'codex',
+        model,
+        inputTokens: uncachedInputTokens,
+        outputTokens,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: cachedInputTokens,
+        cachedInputTokens,
+        reasoningTokens,
+        webSearchRequests: 0,
+        tools: s.pendingTools,
+        timestamp,
+        speed: 'standard',
+        deduplicationKey: dedupKey,
+        turnId: s.currentTurnId,
+        toolSequence: s.pendingToolSequence.length > 0 ? s.pendingToolSequence : undefined,
+        userMessage: s.pendingUserMessage,
+        sessionId: s.sessionId,
+        ...(s.sessionCwd ? { projectPath: s.sessionCwd, workingDirectory: s.sessionCwd } : {}),
+        ...(s.pendingLocAdded ? { locAdded: s.pendingLocAdded } : {}),
+        ...(s.pendingLocRemoved ? { locRemoved: s.pendingLocRemoved } : {}),
+        ...(s.pendingEditFailed ? { editFailed: s.pendingEditFailed } : {}),
+      })
+
+      clearPending(s)
+    }
+  }
+
+  s.seenKeys = liveSeen ? [] : [...seen]
+  return { calls, diagnostics, state: s }
+}

--- a/packages/core/src/providers/codex/index.ts
+++ b/packages/core/src/providers/codex/index.ts
@@ -1,0 +1,33 @@
+// @codeburn/core Codex provider.
+//
+// Two layers:
+//  - Rich pure decode (`decodeCodex`): host-facing, NOT part of the stable
+//    minimized surface. Pure over supplied records with EXPLICIT serializable
+//    state; carries content in-memory but no pricing (cost leaves the decoder).
+//  - Minimizing transform (`toObservations`): maps the rich decode into the
+//    strict observation envelope; the content-smuggling guarantees bind here.
+
+export {
+  decodeCodex,
+  freshCodexState,
+  parseCodexLine,
+  countUnifiedDiffLoc,
+  mcpToolFromShellCommand,
+  codexToolNameMap,
+  type CodexDecodeInput,
+  type CodexDecodeResult,
+} from './decode.js'
+
+export {
+  toObservations,
+  type RichCodexSessionDecode,
+  type CodexToObservationsContext,
+} from './observations.js'
+
+export type {
+  CodexDecodedCall,
+  CodexDecodeState,
+  CodexEntry,
+  CodexToolCall,
+  CodexTokenUsage,
+} from './types.js'

--- a/packages/core/src/providers/codex/observations.ts
+++ b/packages/core/src/providers/codex/observations.ts
@@ -1,0 +1,109 @@
+// Minimizing transform: rich Codex decode -> the strict observation envelope.
+// This is where the content-smuggling guarantees bind. Only opaque ids,
+// fingerprints, enums, numbers, timestamps, and CANONICAL tool names cross into
+// the output — never the user message, the cwd/project path, a shell command, an
+// edited file path, or a tool argument. `.strict()` on the schemas rejects any
+// extra field; this transform simply never emits one.
+
+import { projectRef, sessionRef } from '../../fingerprint.js'
+import type { RecordDiagnostic } from '../../diagnostics.js'
+import type { CallObservation, SessionObservation } from '../../observations.js'
+import type { CodexDecodedCall } from './types.js'
+
+/** One Codex session's rich decode, as the host holds it before minimization. */
+export interface RichCodexSessionDecode {
+  sessionId: string
+  /** Absolute project path (the session cwd); fingerprinted, never emitted raw. */
+  projectPath: string
+  /** Rich, cost-free calls in decode order (as decodeCodex emits them). */
+  calls: CodexDecodedCall[]
+}
+
+export interface CodexToObservationsContext {
+  /** HMAC key that scopes every fingerprint. */
+  privacyKey: string
+  /** Provider id stamped onto sessions/calls and folded into sessionRef. */
+  provider?: string
+}
+
+// Canonical tool-name charset, mirroring core's CanonicalToolName schema. A name
+// that does not match (a smuggled command with spaces/slashes, an argument blob)
+// is dropped rather than emitted.
+const CANONICAL_TOOL_NAME = /^[A-Za-z0-9_.-]{1,64}$/
+
+function toCallObservation(call: CodexDecodedCall, turnIndex: number): CallObservation {
+  return {
+    provider: call.provider,
+    model: call.model,
+    tokens: {
+      input: call.inputTokens,
+      output: call.outputTokens,
+      reasoning: call.reasoningTokens,
+      cacheRead: call.cacheReadInputTokens,
+      cacheCreate: call.cacheCreationInputTokens,
+    },
+    webSearchRequests: call.webSearchRequests,
+    speed: call.speed,
+    // Codex calls are priced from token buckets by the host's pricing table;
+    // they carry no provider-reported dollar figure.
+    costBasis: 'estimated',
+    timestamp: call.timestamp,
+    dedupKey: call.deduplicationKey,
+    toolNames: call.tools.filter(t => CANONICAL_TOOL_NAME.test(t)),
+    turnIndex,
+    ...(call.locAdded !== undefined ? { locAdded: call.locAdded } : {}),
+    ...(call.locRemoved !== undefined ? { locRemoved: call.locRemoved } : {}),
+    ...(call.editFailed !== undefined ? { editFailed: call.editFailed } : {}),
+  }
+}
+
+function toSessionObservation(decode: RichCodexSessionDecode, ctx: CodexToObservationsContext): SessionObservation {
+  const provider = ctx.provider ?? 'codex'
+  const calls: CallObservation[] = []
+  // Assign a turnIndex by grouping consecutive calls that share a turnId, so the
+  // raw turnId string (which embeds the session id) never crosses the boundary.
+  let turnIndex = -1
+  let lastTurnId: string | undefined
+  let turnCount = 0
+  for (const call of decode.calls) {
+    if (call.turnId !== lastTurnId) {
+      turnIndex++
+      turnCount++
+      lastTurnId = call.turnId
+    }
+    calls.push(toCallObservation(call, turnIndex))
+  }
+
+  const timestamps = calls.map(c => c.timestamp).filter(t => t.length > 0).sort()
+  const startedAt = timestamps[0] ?? ''
+  const endedAt = timestamps.length > 0 ? timestamps[timestamps.length - 1]! : ''
+
+  const session: SessionObservation = {
+    sessionRef: sessionRef(ctx.privacyKey, provider, decode.sessionId),
+    projectRef: projectRef(ctx.privacyKey, decode.projectPath),
+    providerId: provider,
+    startedAt,
+    ...(endedAt ? { endedAt } : {}),
+    calls,
+    turnCount,
+  }
+  return session
+}
+
+/**
+ * Map a rich Codex decode (one or many sessions) into the minimized observation
+ * layer. Returns the `sessions` array plus any per-record `diagnostics`.
+ *
+ * Content-smuggling guarantee: no free text (user message, cwd, project path,
+ * command, edited file path, tool argument) is ever copied into the result. Only
+ * fingerprints, enums, numbers, timestamps, dedup keys, and canonical tool names
+ * cross the boundary.
+ */
+export function toObservations(
+  decode: RichCodexSessionDecode | RichCodexSessionDecode[],
+  ctx: CodexToObservationsContext,
+): { sessions: SessionObservation[]; diagnostics: RecordDiagnostic[] } {
+  const decodes = Array.isArray(decode) ? decode : [decode]
+  const sessions = decodes.map(d => toSessionObservation(d, ctx))
+  return { sessions, diagnostics: [] }
+}

--- a/packages/core/src/providers/codex/types.ts
+++ b/packages/core/src/providers/codex/types.ts
@@ -1,0 +1,134 @@
+// Raw record + rich-decode types for the Codex provider.
+//
+// The record types (CodexEntry, CodexTokenUsage) describe the shape of a Codex
+// CLI rollout JSONL line. The Decoded* types are the rich decode layer's output:
+// pure over supplied records, carrying content in-memory but NO pricing (the
+// host prices them). The CLI adapter maps CodexDecodedCall into its own
+// ParsedProviderCall by adding `costBasis: 'estimated'` and running the pricing
+// pass.
+
+export type CodexTokenUsage = {
+  input_tokens?: number
+  cached_input_tokens?: number
+  output_tokens?: number
+  reasoning_output_tokens?: number
+  total_tokens?: number
+}
+
+export type CodexEntry = {
+  type: string
+  timestamp?: string
+  payload?: {
+    type?: string
+    role?: string
+    cwd?: string
+    model_provider?: string
+    originator?: string
+    session_id?: string
+    forked_from_id?: string
+    model?: string
+    name?: string
+    content?: Array<{ type?: string; text?: string }>
+    info?: {
+      model?: string
+      model_name?: string
+      last_token_usage?: CodexTokenUsage
+      total_token_usage?: CodexTokenUsage
+    }
+  }
+}
+
+// A single tool invocation captured in a turn's tool sequence. Mirrors the
+// CLI's ToolCall so the host can consume it without a shape conversion.
+export type CodexToolCall = {
+  tool: string
+  file?: string
+  command?: string
+}
+
+// The rich decode of one Codex call (one flushed turn), pre-pricing. Mirrors the
+// host's ParsedProviderCall minus `costUSD`/`costBasis`/`bashCommands` (the host
+// adds those): cost leaves the decoder. `costIsEstimated` flags a call whose
+// TOKENS were estimated from character counts (a turn with no token_count.info),
+// orthogonal to pricing.
+export type CodexDecodedCall = {
+  provider: 'codex'
+  model: string
+  inputTokens: number
+  outputTokens: number
+  cacheCreationInputTokens: number
+  cacheReadInputTokens: number
+  cachedInputTokens: number
+  reasoningTokens: number
+  webSearchRequests: number
+  tools: string[]
+  timestamp: string
+  speed: 'standard' | 'fast'
+  deduplicationKey: string
+  turnId: string
+  toolSequence?: CodexToolCall[][]
+  userMessage: string
+  sessionId: string
+  projectPath?: string
+  workingDirectory?: string
+  locAdded?: number
+  locRemoved?: number
+  editFailed?: number
+  costIsEstimated?: boolean
+}
+
+/**
+ * All cross-record memory the Codex decoder keeps, as a plain JSON-serializable
+ * object so a decode can be paused, persisted, and resumed byte-identically.
+ *
+ * Two kinds of memory live here:
+ *
+ *  - Per-session streaming locals (everything except `seenKeys`): the running
+ *    token counters used to turn cumulative totals into per-event deltas, the
+ *    fork-replay cutoff, the mid-turn accumulators (pending tools / user message
+ *    / output chars / edit LOC), and the id/counter bookkeeping. These are what
+ *    a mid-session resume needs. A `session_meta` record updates the id / cwd /
+ *    fork / model fields IN PLACE without resetting the counters — a single
+ *    rollout file can carry more than one session_meta and the pre-phase-4
+ *    decoder treated the whole file as one continuous session. Per-file
+ *    freshness comes from the host starting a new decode (state: undefined) per
+ *    file, one file being one logical session.
+ *
+ *  - `seenKeys`: the cross-file/cross-run dedup memory. A forked session (a
+ *    separate rollout file) replays its parent's token history; those replays are
+ *    dropped by colliding with the parent's already-emitted keys, so the dedup
+ *    memory must thread across files — which is why a split across a forked
+ *    session round-trips only when it threads through the serialized state.
+ *
+ * When the host supplies a live `seenKeys` Set on the decode input (a
+ * performance fast-path so the CLI's shared dedup set is mutated in place rather
+ * than snapshotted per file), `state.seenKeys` is left empty and the live Set is
+ * canonical; the round-trip contract instead threads `seenKeys` through this
+ * serialized array.
+ */
+export type CodexDecodeState = {
+  sessionModel?: string
+  sessionId: string
+  sessionCwd?: string
+  forkedFromId: string
+  forkCutoff: string
+  // Null sentinel (not 0) so the FIRST event is never mistaken for a duplicate:
+  // a session that only emits last_token_usage reports cumulativeTotal=0 on every
+  // event, and a 0-initialized prev would drop its opening turn.
+  prevCumulativeTotal: number | null
+  prevInput: number
+  prevCached: number
+  prevOutput: number
+  prevReasoning: number
+  pendingTools: string[]
+  pendingToolSequence: CodexToolCall[][]
+  pendingUserMessage: string
+  pendingOutputChars: number
+  pendingLocAdded: number
+  pendingLocRemoved: number
+  pendingEditFailed: number
+  estCounter: number
+  turnCounter: number
+  currentTurnId: string
+  seenKeys: string[]
+}

--- a/packages/core/tests/content-smuggling.test.ts
+++ b/packages/core/tests/content-smuggling.test.ts
@@ -18,6 +18,8 @@ import {
   toObservations,
 } from '../src/providers/claude/index.js'
 import type { JournalEntry, ToolResultMeta } from '../src/providers/claude/index.js'
+import { decodeCodex, toObservations as toCodexObservations } from '../src/providers/codex/index.js'
+import type { DecodeContext } from '../src/contracts.js'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const goldenEnvelope = JSON.parse(
@@ -193,6 +195,66 @@ describe('content-smuggling guardrail: real claude decode -> toObservations is s
 
   it('drops non-canonical (argument-carrying) tool names instead of emitting them', () => {
     const env = buildEnvelope()
+    const allToolNames = env.sessions.flatMap(s => s.calls.flatMap(c => c.toolNames))
+    expect(allToolNames).toContain('Bash')
+    expect(allToolNames).toContain('Read')
+    expect(allToolNames).not.toContain(SECRETS.commandLine)
+  })
+})
+
+describe('content-smuggling guardrail: real codex decode -> toObservations is secret-free', () => {
+  // A hostile Codex rollout planting every secret in the free-text fields a real
+  // decode captures: the cwd (project path), the user prompt, an exec command,
+  // and an edited file path — plus a tool NAME carrying a command line. Decoding
+  // it fully and minimizing MUST surface none of them.
+  const codexContext: DecodeContext = { privacyKey: 'test-privacy-key', providerId: 'codex', sourceRef: 'ref' }
+
+  function decodeAndMinimize() {
+    const records = [
+      JSON.stringify({
+        type: 'session_meta',
+        timestamp: '2026-07-17T10:00:00.000Z',
+        payload: { cwd: SECRETS.absPath, originator: 'codex-cli', session_id: 'sess-hostile', model: 'gpt-5.3-codex' },
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-07-17T10:00:01.000Z',
+        payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: `${SECRETS.prompt} ${SECRETS.apiKey} ${SECRETS.fileContent}` }] },
+      }),
+      // A shell exec whose command carries a secret, plus a read whose path is the
+      // secret absolute path — both land in the toolSequence a real decode keeps.
+      JSON.stringify({ type: 'response_item', timestamp: '2026-07-17T10:00:02.000Z', payload: { type: 'function_call', name: 'exec_command', arguments: JSON.stringify({ command: SECRETS.commandLine }) } }),
+      JSON.stringify({ type: 'response_item', timestamp: '2026-07-17T10:00:03.000Z', payload: { type: 'function_call', name: 'read_file', arguments: JSON.stringify({ file_path: SECRETS.absPath }) } }),
+      // A hostile tool NAME carrying a command line (spaces + slashes): it fails
+      // the canonical charset and must be dropped, not emitted.
+      JSON.stringify({ type: 'response_item', timestamp: '2026-07-17T10:00:04.000Z', payload: { type: 'function_call', name: SECRETS.commandLine } }),
+      JSON.stringify({ type: 'event_msg', timestamp: '2026-07-17T10:00:05.000Z', payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 500, output_tokens: 200, total_tokens: 700 }, total_token_usage: { total_tokens: 700 } } } }),
+    ]
+    const { calls } = decodeCodex({ records, context: codexContext })
+    const { sessions } = toCodexObservations(
+      { sessionId: 'sess-hostile', projectPath: SECRETS.absPath, calls },
+      { privacyKey: 'test-privacy-key', provider: 'codex' },
+    )
+    return {
+      schemaVersion: OBSERVATION_SCHEMA_VERSION,
+      generator: { name: '@codeburn/core', version: '0.0.0-test' },
+      sessions,
+    }
+  }
+
+  it('produces a schema-valid envelope from the hostile rollout', () => {
+    expect(ObservationEnvelope.safeParse(decodeAndMinimize()).success).toBe(true)
+  })
+
+  it('the serialized envelope contains none of the planted secrets', () => {
+    const serialized = JSON.stringify(decodeAndMinimize())
+    for (const secret of ALL_SECRETS) {
+      expect(serialized).not.toContain(secret)
+    }
+  })
+
+  it('keeps canonical tool names (Bash/Read) and drops the argument-carrying name', () => {
+    const env = decodeAndMinimize()
     const allToolNames = env.sessions.flatMap(s => s.calls.flatMap(c => c.toolNames))
     expect(allToolNames).toContain('Bash')
     expect(allToolNames).toContain('Read')

--- a/packages/core/tests/providers/codex-decode.test.ts
+++ b/packages/core/tests/providers/codex-decode.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+
+import { decodeCodex } from '../../src/providers/codex/index.js'
+import type { CodexDecodeState } from '../../src/providers/codex/index.js'
+import type { DecodeContext } from '../../src/contracts.js'
+
+const context: DecodeContext = { privacyKey: 'k', providerId: 'codex', sourceRef: 'ref' }
+
+function sessionMeta(opts: { session_id: string; model?: string; forked_from_id?: string; timestamp?: string; cwd?: string }) {
+  return JSON.stringify({
+    type: 'session_meta',
+    timestamp: opts.timestamp ?? '2026-04-14T10:00:00Z',
+    payload: {
+      cwd: opts.cwd ?? '/Users/t/p',
+      originator: 'codex-cli',
+      session_id: opts.session_id,
+      model: opts.model ?? 'gpt-5.3-codex',
+      ...(opts.forked_from_id ? { forked_from_id: opts.forked_from_id } : {}),
+    },
+  })
+}
+function userMessage(text: string, timestamp: string) {
+  return JSON.stringify({ type: 'response_item', timestamp, payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text }] } })
+}
+function assistantMessage(text: string, timestamp: string) {
+  return JSON.stringify({ type: 'response_item', timestamp, payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text }] } })
+}
+function functionCall(name: string, timestamp: string) {
+  return JSON.stringify({ type: 'response_item', timestamp, payload: { type: 'function_call', name } })
+}
+function tokenCount(opts: { timestamp: string; last?: { input?: number; cached?: number; output?: number; reasoning?: number }; total?: { input?: number; cached?: number; output?: number; reasoning?: number; total?: number }; noInfo?: boolean }) {
+  const info = opts.noInfo ? undefined : {
+    last_token_usage: opts.last ? { input_tokens: opts.last.input ?? 0, cached_input_tokens: opts.last.cached ?? 0, output_tokens: opts.last.output ?? 0, reasoning_output_tokens: opts.last.reasoning ?? 0, total_tokens: (opts.last.input ?? 0) + (opts.last.output ?? 0) } : undefined,
+    total_token_usage: opts.total ? { input_tokens: opts.total.input ?? 0, cached_input_tokens: opts.total.cached ?? 0, output_tokens: opts.total.output ?? 0, reasoning_output_tokens: opts.total.reasoning ?? 0, total_tokens: opts.total.total ?? 0 } : undefined,
+  }
+  return JSON.stringify({ type: 'event_msg', timestamp: opts.timestamp, payload: { type: 'token_count', ...(opts.noInfo ? {} : { info }) } })
+}
+
+// A corpus spanning THREE sessions, including a forked session that replays the
+// parent's history and a session whose token_count carries no info (char-estimate
+// branch). Session boundaries (session_meta) exercise the per-session reset while
+// the fork boundary exercises cross-session dedup memory in the threaded state.
+const CORPUS: string[] = [
+  // Session A (parent): 1100 tokens of real work across two turns.
+  sessionMeta({ session_id: 'sess-parent', timestamp: '2026-04-14T10:00:00Z' }),
+  userMessage('fix the parser', '2026-04-14T10:00:01Z'),
+  functionCall('exec_command', '2026-04-14T10:00:02Z'),
+  tokenCount({ timestamp: '2026-04-14T10:00:03Z', last: { input: 700 }, total: { input: 700, total: 700 } }),
+  userMessage('now the tests', '2026-04-14T10:00:04Z'),
+  functionCall('read_file', '2026-04-14T10:00:05Z'),
+  tokenCount({ timestamp: '2026-04-14T10:00:06Z', last: { input: 400 }, total: { input: 1100, total: 1100 } }),
+  // Session B (fork of A): replays A's two events past the 5s cutoff, then +400.
+  sessionMeta({ session_id: 'sess-fork', forked_from_id: 'sess-parent', timestamp: '2026-04-14T10:05:00Z' }),
+  tokenCount({ timestamp: '2026-04-14T10:05:20Z', last: { input: 700 }, total: { input: 700, total: 700 } }),
+  tokenCount({ timestamp: '2026-04-14T10:05:21Z', last: { input: 400 }, total: { input: 1100, total: 1100 } }),
+  functionCall('spawn_agent', '2026-04-14T10:05:22Z'),
+  tokenCount({ timestamp: '2026-04-14T10:05:23Z', last: { input: 400 }, total: { input: 1500, total: 1500 } }),
+  // Session C: char-estimate branch (token_count with no info).
+  sessionMeta({ session_id: 'sess-est', model: 'gpt-5.5', timestamp: '2026-04-14T11:00:00Z' }),
+  userMessage('hello there estimate branch', '2026-04-14T11:00:01Z'),
+  assistantMessage('a fairly long assistant reply that should estimate some output tokens here', '2026-04-14T11:00:02Z'),
+  tokenCount({ timestamp: '2026-04-14T11:00:03Z', noInfo: true }),
+]
+
+const FORK_BOUNDARY_INDEX = 7 // the fork's session_meta
+const MID_PARENT_INDEX = 4    // between A's two turns
+
+function decodeCold(records: string[]) {
+  return decodeCodex({ records, context }).calls
+}
+
+function decodeTwoPass(records: string[], split: number) {
+  const first = decodeCodex({ records: records.slice(0, split), context })
+  // Serialize state to JSON and back between passes (the resume invariant).
+  const serialized: CodexDecodeState = JSON.parse(JSON.stringify(first.state))
+  const second = decodeCodex({ records: records.slice(split), context, state: serialized })
+  return [...first.calls, ...second.calls]
+}
+
+describe('codex decoder — round-trip resume invariant', () => {
+  it('cold single pass produces the expected number of calls', () => {
+    const cold = decodeCold(CORPUS)
+    // A: 2 real turns; fork: replays dropped, 1 genuine; C: 1 estimate = 4.
+    expect(cold).toHaveLength(4)
+    // The fork's genuine event survives (input 400 at cumulative 1500).
+    const tokensTotal = cold.reduce((n, c) => n + c.inputTokens + c.outputTokens + c.cachedInputTokens + c.reasoningTokens, 0)
+    // A: 700 + 400; fork: +400; C: estimate input+output.
+    expect(tokensTotal).toBeGreaterThan(1500)
+  })
+
+  it('two-pass split at EVERY index deep-equals the cold pass', () => {
+    const cold = decodeCold(CORPUS)
+    for (let split = 0; split <= CORPUS.length; split++) {
+      const twoPass = decodeTwoPass(CORPUS, split)
+      expect(twoPass, `split at index ${split}`).toEqual(cold)
+    }
+  })
+
+  it('mid-session split (between two turns of the same session) matches cold', () => {
+    expect(decodeTwoPass(CORPUS, MID_PARENT_INDEX)).toEqual(decodeCold(CORPUS))
+  })
+
+  it('split across the forked-session boundary matches cold (dedup memory threads)', () => {
+    expect(decodeTwoPass(CORPUS, FORK_BOUNDARY_INDEX)).toEqual(decodeCold(CORPUS))
+  })
+
+  it('serialized state is plain JSON (no Map/Set/undefined-only loss)', () => {
+    const { state } = decodeCodex({ records: CORPUS.slice(0, FORK_BOUNDARY_INDEX), context })
+    const round = JSON.parse(JSON.stringify(state)) as CodexDecodeState
+    // seenKeys survives as an array carrying the parent's dedup fingerprints.
+    expect(Array.isArray(round.seenKeys)).toBe(true)
+    expect(round.seenKeys.length).toBeGreaterThan(0)
+    // prevCumulativeTotal is a JSON-safe null|number.
+    expect(round.prevCumulativeTotal === null || typeof round.prevCumulativeTotal === 'number').toBe(true)
+  })
+
+  it('a fork replay is dropped only because seenKeys threaded across the split', () => {
+    // Splitting exactly at the fork boundary, WITHOUT threading state, would let
+    // the fork replay its parent's events (double count). With threaded state the
+    // replay collides and drops — proving the dedup memory is in the state.
+    const threaded = decodeTwoPass(CORPUS, FORK_BOUNDARY_INDEX)
+    const parentAndForkFresh = [
+      ...decodeCodex({ records: CORPUS.slice(0, FORK_BOUNDARY_INDEX), context }).calls,
+      // second pass with NO state: the fork can't see the parent's keys.
+      ...decodeCodex({ records: CORPUS.slice(FORK_BOUNDARY_INDEX), context }).calls,
+    ]
+    expect(parentAndForkFresh.length).toBeGreaterThan(threaded.length)
+  })
+})

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     'src/fingerprint.ts',
     'src/contracts.ts',
     'src/providers/claude/index.ts',
+    'src/providers/codex/index.ts',
   ],
   format: ['esm'],
   target: 'node20',


### PR DESCRIPTION
Phase 4 of #809. Codex decode moves to packages/core/src/providers/codex with EXPLICIT plain-JSON state (every piece of implicit memory enumerated: cumulative/delta counters, fork cutoff + lineage, mid-turn accumulators, dedup keys). Signature invariant proven: two-pass decode with JSON-serialized state at EVERY split index deep-equals the cold pass, incl. mid-session and across forked-session boundaries; end-to-end CLI resume test writes the blob, appends, resumes from byteOffset+state. Bonus capability: codex now has incremental append parsing.

Cost leaves the decoder — both Phase-0 residual calculateCost sites retired (grep: zero call sites). CODEX_CACHE_VERSION 7→8, the one sanctioned bump: lossless (rollout files are durable), one-time re-derive == one normal cold run (~14s on a 4.2GB corpus).

Gates, independently re-verified in review: frozen-corpus parity (PRE self-consistent, then PRE≡POST at rel_tol 1e-9 for codex-only AND full payload, separate cache dirs, 51k calls/812 sessions); perf cold +1.4% / warm +0.4% (within ±5%); root suite green (the isolated 'failures' in review were a wrong-cwd invocation post-workspace-move — 5/5 green from packages/cli; residual full-suite timeouts are the documented tsx-spawn flake class); core 108 tests incl. codex smuggling cases; import-smoke covers the codex subpath; tsc clean.

Development note: the frozen-corpus parity gate caught a real bug mid-phase (session_meta in-place update vs reset — multi-meta rollout files would have double-counted) — fixed before commit.

Flag for Phase 9: packages/cli/dist does a bare runtime import of @codeburn/core (workspace-resolved). npm publish will require core published first or bundled via noExternal — tracked for the publish phase.