### PR TITLE
test(core+cli): act/apply stays host-derived — advisory findings gated (phase 7)

### DIFF
--- a/packages/cli/src/optimize.ts
+++ b/packages/cli/src/optimize.ts
@@ -668,6 +668,17 @@ export function loadMcpConfigs(projectCwds: Iterable<string>, homeDir = homedir(
 // existing WasteFinding display shape. Display strings, fix payloads and trend
 // stay host-derived from the CLI's own path data (D5-A); the core Finding
 // supplies the decision and the authoritative counts.
+//
+// Reverse-map contract (D5-A): the resourceId fingerprints this bridge produces
+// are one-way (HMAC) and are NEVER inverted. The "reverse map" that turns a
+// finding back into a concrete path/basename is simply the raw ToolCall[] the
+// host already holds — re-iterated in each detector below to build the display,
+// fix and trend. That array lives in memory for the process only; the envelope
+// built here is a transient local, passed straight to the pure detector and
+// discarded — it is never assigned to a field, cached, serialized, or written to
+// any payload. No structure ever stores resourceId alongside its path, so the
+// fingerprint->path mapping cannot leak. Anything a payload needs must come from
+// this raw array, not from the core Finding.
 
 const READ_RESOURCE_TOOLS = new Set(['Read', 'FileReadTool'])
 const SESSION_KEY_SEP = ''

--- a/packages/cli/tests/act-apply-host-derived.test.ts
+++ b/packages/cli/tests/act-apply-host-derived.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  detectJunkReads,
+  detectDuplicateReads,
+  detectLowReadEditRatio,
+  type ToolCall,
+} from '../src/optimize.js'
+import { resourceFingerprint } from '@codeburn/core/fingerprint'
+import { getHostPrivacyKey } from '../src/privacy-key.js'
+
+// Decision D5-A (phase 7): the three fingerprint-migrated detectors
+// (junk-reads -> build-folder-reads, duplicate-reads -> redundant-rereads,
+// context-bloat -> read-edit-ratio) delegate the DECISION and the counts to the
+// pure @codeburn/core detector, which sees only fingerprinted resource refs. But
+// every concrete `fix` payload and every displayed path/basename is re-derived
+// HOST-SIDE from the CLI's own ToolCall[] — the reverse of the fingerprint,
+// which the host holds because it never discarded its raw paths. This test locks
+// two properties:
+//   (1) the fix payloads stay byte-identical to their goldens, and
+//   (2) the display path is produced from the host's raw calls (the "reverse
+//       map"), NOT by inverting a fingerprint — proven by a case where the exact
+//       basename can only come from raw data, while the core-visible fingerprint
+//       never surfaces in the finding.
+
+const rd = (fp: string): ToolCall => ({ name: 'Read', input: { file_path: fp }, sessionId: 's1', project: 'p1' })
+const ed = (fp: string): ToolCall => ({ name: 'Edit', input: { file_path: fp }, sessionId: 's1', project: 'p1' })
+
+describe('migrated detectors: fix payloads are byte-identical goldens', () => {
+  it('build-folder-reads (junk-reads) fix payload', () => {
+    const calls = Array.from({ length: 6 }, (_, i) => rd(`/home/u/proj/node_modules/pkg/f${i}.js`))
+    const finding = detectJunkReads(calls)
+    expect(finding).not.toBeNull()
+    expect(finding!.fix).toEqual({
+      type: 'paste',
+      destination: 'claude-md',
+      label: 'Append to your project CLAUDE.md:',
+      text: 'Do not read or search files under these directories unless I explicitly ask: node_modules, .git, dist, __pycache__.',
+    })
+  })
+
+  it('redundant-rereads (duplicate-reads) fix payload', () => {
+    const calls = Array.from({ length: 7 }, () => rd('/home/u/proj/src/Zebra_9xQ.ts'))
+    const finding = detectDuplicateReads(calls)
+    expect(finding).not.toBeNull()
+    expect(finding!.fix).toEqual({
+      type: 'paste',
+      destination: 'prompt',
+      label: 'Point Claude at exact locations in your prompt, for example:',
+      text: 'In <file> lines <start>-<end>, look at the <function> function.',
+    })
+  })
+
+  it('read-edit-ratio (context-bloat) fix payload', () => {
+    const calls = [
+      ...Array.from({ length: 12 }, (_, i) => ed(`/home/u/proj/src/e${i}.ts`)),
+      rd('/home/u/proj/src/a.ts'),
+      rd('/home/u/proj/src/b.ts'),
+    ]
+    const finding = detectLowReadEditRatio(calls)
+    expect(finding).not.toBeNull()
+    expect(finding!.fix).toEqual({
+      type: 'paste',
+      destination: 'claude-md',
+      label: 'Add to your CLAUDE.md:',
+      text: 'Before editing any file, read it first. Before modifying a function, grep for all callers. Research before you edit.',
+    })
+  })
+})
+
+describe('displayed paths are host-derived (reverse map), never un-fingerprinted', () => {
+  // The core Finding for duplicate-reads carries only a 16-hex resourceId + counts
+  // (see packages/core/src/detectors/duplicate-reads.ts). The displayed per-file
+  // breakdown names the actual basename, which the one-way HMAC fingerprint can
+  // never yield. So its presence proves the host recovered the path from the raw
+  // ToolCall[] it holds — the reverse map is REQUIRED to render this string.
+  const RAW_PATH = '/home/u/proj/src/Zebra_9xQ_UNIQUE.ts'
+  const BASENAME = 'Zebra_9xQ_UNIQUE.ts'
+
+  it('the distinct basename is rendered, and its fingerprint never leaks', () => {
+    const calls = Array.from({ length: 7 }, () => rd(RAW_PATH))
+    const finding = detectDuplicateReads(calls)!
+    const fp = resourceFingerprint(getHostPrivacyKey(), RAW_PATH)
+
+    // A well-formed one-way fingerprint (what the core detector actually sees).
+    expect(fp.resourceId).toMatch(/^[0-9a-f]{16}$/)
+    expect(fp.resourceId).not.toBe(RAW_PATH)
+
+    // Host-derived display: the real basename appears...
+    expect(finding.explanation).toContain(BASENAME)
+    // ...while the core-visible fingerprint appears nowhere in the finding.
+    const serialized = JSON.stringify(finding)
+    expect(serialized).not.toContain(fp.resourceId)
+    expect(serialized).not.toContain(RAW_PATH) // full path is never emitted either
+  })
+
+  it('changing only the basename changes the display but not the core count', () => {
+    // Same read structure (7 reads of one file) -> identical core decision/count;
+    // only the host-held raw path differs, so only the displayed basename moves.
+    const a = detectDuplicateReads(Array.from({ length: 7 }, () => rd('/home/u/proj/src/Alpha.ts')))!
+    const b = detectDuplicateReads(Array.from({ length: 7 }, () => rd('/home/u/proj/src/Bravo.ts')))!
+
+    expect(a.tokensSaved).toBe(b.tokensSaved) // count comes from core, path-agnostic
+    expect(a.explanation).toContain('Alpha.ts')
+    expect(a.explanation).not.toContain('Bravo.ts')
+    expect(b.explanation).toContain('Bravo.ts')
+    expect(b.explanation).not.toContain('Alpha.ts')
+  })
+
+  it('junk-reads names the directory from the raw path, not from any fingerprint', () => {
+    // A junk dir buried in a distinctive path: the fix text must name the dir,
+    // which is only knowable from the raw path the host retained.
+    const calls = Array.from({ length: 6 }, (_, i) => rd(`/home/u/wsX/coverage/report-${i}.html`))
+    const finding = detectJunkReads(calls)!
+    expect(finding.fix.type).toBe('paste')
+    if (finding.fix.type === 'paste') {
+      expect(finding.fix.text).toContain('coverage')
+    }
+    // The fingerprint of that raw path must not surface in the finding.
+    const fp = resourceFingerprint(getHostPrivacyKey(), '/home/u/wsX/coverage/report-0.html')
+    expect(JSON.stringify(finding)).not.toContain(fp.resourceId)
+  })
+})

--- a/packages/core/tests/finding-no-fix-payload.test.ts
+++ b/packages/core/tests/finding-no-fix-payload.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+
+import { Confidence, Evidence, Finding } from '../src/contracts.js'
+
+// Advisory-findings gate (decision D5-A, phase 7). The phase-6 architecture gate
+// (architecture-gate.test.ts) proves, by scanning the compiled JSON schema, that
+// no free-text string FIELD exists on the Finding. This complements it from the
+// other direction: it exercises the zod schema at runtime to prove the Finding
+// contract is structurally incapable of carrying a concrete fix payload — a
+// file path, file content, a command, or paste text. Every concrete fix payload
+// is re-derived host-side (optimize.ts) from the CLI's own ToolCall[]; a core
+// Finding may only carry counts, confidence and 16-hex fingerprint refs, so a
+// migrated detector can never become a channel for host-executable content.
+
+// Names a WasteAction / apply payload would use if one ever leaked into the wire
+// Finding. None of these may exist on the Finding, its Evidence, or Confidence.
+const FORBIDDEN_KEYS = [
+  'fix',
+  'command',
+  'content',
+  'path',
+  'text',
+  'file_path',
+  'filePath',
+  'cmd',
+  'apply',
+  'destination',
+  'label',
+] as const
+
+const baseFinding = () => ({
+  detectorId: 'duplicate-reads',
+  algorithmVersion: '1.0.0',
+  confidence: { score: 0.5, basis: 'demo' },
+  evidence: [
+    { kind: 'duplicate-reads', count: 7, refs: ['deadbeefcafe0011'], sessionRefs: ['a1b2c3d4e5f60718'] },
+    { kind: 'tokens-saved', count: 3500 },
+  ],
+})
+
+describe('Finding contract cannot carry a fix payload (D5-A advisory gate)', () => {
+  it('the golden-shaped Finding parses', () => {
+    expect(Finding.safeParse(baseFinding()).success).toBe(true)
+  })
+
+  it('the Finding schema declares none of the fix-payload keys', () => {
+    const declared = Object.keys(Finding.shape)
+    for (const key of FORBIDDEN_KEYS) {
+      expect(declared, `Finding must not declare "${key}"`).not.toContain(key)
+    }
+    // Positive lock on the entire allowed surface: if a new top-level key is
+    // added it must be reviewed here, not silently accepted.
+    expect(declared.sort()).toEqual(
+      ['algorithmVersion', 'confidence', 'detectorId', 'evidence', 'impactUSD'].sort(),
+    )
+  })
+
+  it('.strict() rejects a fix-payload key smuggled at the top level', () => {
+    for (const key of FORBIDDEN_KEYS) {
+      const smuggled = { ...baseFinding(), [key]: 'rm -rf / || cat /etc/passwd' }
+      expect(Finding.safeParse(smuggled).success, `top-level "${key}" must be rejected`).toBe(false)
+    }
+  })
+
+  it('.strict() rejects a fix-payload key smuggled onto an Evidence item', () => {
+    for (const key of FORBIDDEN_KEYS) {
+      const evil = { kind: 'duplicate-reads', count: 1, [key]: '/Users/victim/.ssh/id_rsa' }
+      expect(Evidence.safeParse(evil).success, `evidence "${key}" must be rejected`).toBe(false)
+      const finding = { ...baseFinding(), evidence: [evil] }
+      expect(Finding.safeParse(finding).success, `nested evidence "${key}" must be rejected`).toBe(false)
+    }
+  })
+
+  it('.strict() rejects a fix-payload key smuggled onto Confidence', () => {
+    for (const key of FORBIDDEN_KEYS) {
+      const evil = { score: 0.5, basis: 'demo', [key]: 'echo pwned' }
+      expect(Confidence.safeParse(evil).success, `confidence "${key}" must be rejected`).toBe(false)
+    }
+  })
+
+  it('evidence refs and sessionRefs accept only 16-char lowercase-hex fingerprints', () => {
+    const notFingerprints = [
+      '/Users/torukmakto/project/src/secret.ts', // a raw path
+      'deadbeefcafe0011deadbeef', // 24 hex (too long)
+      'deadbeefcafe001', // 15 hex (too short)
+      'DEADBEEFCAFE0011', // uppercase
+      'deadbeefcafeg011', // non-hex char
+      'src/index.ts', // arbitrary text
+    ]
+    for (const bad of notFingerprints) {
+      const finding = { ...baseFinding(), evidence: [{ kind: 'k', refs: [bad] }] }
+      expect(Finding.safeParse(finding).success, `ref "${bad}" must be rejected`).toBe(false)
+      const finding2 = { ...baseFinding(), evidence: [{ kind: 'k', sessionRefs: [bad] }] }
+      expect(Finding.safeParse(finding2).success, `sessionRef "${bad}" must be rejected`).toBe(false)
+    }
+    const ok = { ...baseFinding(), evidence: [{ kind: 'k', refs: ['0f1e2d3c4b5a6978'] }] }
+    expect(Finding.safeParse(ok).success).toBe(true)
+  })
+
+  it('a parsed Finding recursively contains no fix-payload key', () => {
+    const parsed = Finding.parse(baseFinding())
+    const seen: string[] = []
+    const walk = (node: unknown) => {
+      if (Array.isArray(node)) return node.forEach(walk)
+      if (node && typeof node === 'object') {
+        for (const [k, v] of Object.entries(node)) {
+          seen.push(k)
+          walk(v)
+        }
+      }
+    }
+    walk(parsed)
+    for (const key of FORBIDDEN_KEYS) {
+      expect(seen, `parsed Finding must not surface "${key}"`).not.toContain(key)
+    }
+  })
+})


### PR DESCRIPTION
Phase 7 of #809, executing D5-A. Audit conclusion: no gap existed — the three migrated detectors' fix payloads (CLAUDE.md pastes, dir lists, per-file breakdowns) are all re-derived host-side from raw ToolCall data; the core Finding contributes only decisions and authoritative counts; the observation envelope is a transient local (grep-proven never assigned/cached/serialized) and fingerprints are never inverted. Deliverables: (1) core gate — Finding/Evidence/Confidence zod schemas reject fix/command/content/path/text keys at parse time at every nesting level (complements the Phase-6 compiled-schema gate); (2) CLI gate — migrated detectors' fix payloads byte-identical to frozen goldens, with proof display paths come from host data (fingerprint never leaks, basename moves display without touching core counts); (3) reverse-map contract documented at the fingerprint-envelope bridge. Core 151, root 2260, all act/apply suites green, tsc clean.