### PR TITLE
chore(core): publish-ready manifest — real description, public access

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codeburn/core",
   "version": "0.9.19",
-  "description": "Shared, provider-agnostic core for CodeBurn (parsing, pricing, models). Skeleton — populated in later phases of the core extraction.",
+  "description": "Pure decode/detect engine for CodeBurn: provider session-log decoding, content-minimized observations, and detector contracts. No I/O, no pricing \u2014 hosts supply both.",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -198,6 +198,9 @@
     "zod-to-json-schema": "^3.24.1"
   },
   "author": "AgentSeal <hello@agentseal.org>",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Phase 9 prep (tracking #809): replaces the Phase 1 skeleton description (which wrongly named pricing as core content — pricing is host-side by design) with an accurate one, and adds `publishConfig.access: public` required for the scoped package's first npm publish. No code changes.