### PR TITLE
Fix core release coupling, declaration build, and CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Build core
         run: npm run build --workspace=@codeburn/core
 
+      - name: Verify every export target exists
+        run: npm run verify-dist --workspace=@codeburn/core
+
       - name: Verify package contents
         run: npm pack --workspace=@codeburn/core --dry-run
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,38 @@ on:
   pull_request:
 
 jobs:
+  core:
+    name: core (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['22.13.x', '24.x', '26.x']
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install from lockfile
+        run: npm ci
+
+      - name: Check workspace versions
+        run: npm run check:workspace-versions
+
+      - name: Typecheck core
+        run: npm run typecheck --workspace=@codeburn/core
+
+      - name: Test core
+        run: npm test --workspace=@codeburn/core
+
+      - name: Build core
+        run: npm run build --workspace=@codeburn/core
+
+      - name: Verify package contents
+        run: npm pack --workspace=@codeburn/core --dry-run
+
   semgrep:
     runs-on: ubuntu-latest
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codeburn-monorepo",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codeburn-monorepo",
-      "version": "0.9.19",
+      "version": "0.9.20",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -4116,10 +4116,10 @@
     },
     "packages/cli": {
       "name": "codeburn",
-      "version": "0.9.19",
+      "version": "0.9.20",
       "license": "MIT",
       "dependencies": {
-        "@codeburn/core": "*",
+        "@codeburn/core": "0.9.20",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "bonjour-service": "^1.4.1",
         "chalk": "^5.4.1",
@@ -4150,7 +4150,7 @@
     },
     "packages/core": {
       "name": "@codeburn/core",
-      "version": "0.9.19",
+      "version": "0.9.20",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.25.76"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeburn-monorepo",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "CodeBurn monorepo — CLI (packages/cli) + @codeburn/core (packages/core)",
   "private": true,
   "type": "module",
@@ -13,7 +13,8 @@
     "build:cli": "npm run build:cli -w codeburn",
     "build:dash": "npm run build:dash -w codeburn",
     "dev": "npm run dev -w codeburn",
-    "test": "npm run test -w codeburn"
+    "test": "npm run test -w codeburn",
+    "check:workspace-versions": "node scripts/check-workspace-versions.mjs"
   },
   "engines": {
     "node": ">=22.13.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeburn",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "See where your AI spend goes - by task, tool, model, and project",
   "type": "module",
   "main": "./dist/cli.js",
@@ -50,7 +50,7 @@
   },
   "homepage": "https://github.com/getagentseal/codeburn#readme",
   "dependencies": {
-    "@codeburn/core": "*",
+    "@codeburn/core": "0.9.20",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "bonjour-service": "^1.4.1",
     "chalk": "^5.4.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.20",
   "description": "Pure decode/detect engine for CodeBurn: provider session-log decoding, content-minimized observations, and detector contracts. No I/O, no pricing \u2014 hosts supply both.",
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -181,7 +181,9 @@
     "build": "tsup && tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "emit-schemas": "tsx scripts/emit-schemas.mts"
+    "emit-schemas": "tsx scripts/emit-schemas.mts",
+    "verify-dist": "node scripts/verify-dist.mjs",
+    "prepublishOnly": "npm run build && npm run verify-dist"
   },
   "engines": {
     "node": ">=22.13.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -177,7 +177,7 @@
     "schemas"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "emit-schemas": "tsx scripts/emit-schemas.mts"

--- a/packages/core/scripts/verify-dist.mjs
+++ b/packages/core/scripts/verify-dist.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Refuses to let a half-built dist reach npm.
+//
+// `npm run build` is `tsup && tsc`. tsup runs with clean:true, so it wipes dist
+// and writes JavaScript; if tsc then fails, dist holds .js with no declarations.
+// The build exits non-zero, but nothing rebuilds at publish time, so a later
+// `npm publish` would ship a package whose every `types` target 404s. Verified:
+// removing the declarations and running `npm pack --dry-run` succeeds with
+// 41/41 exports subpaths pointing at files that are not in the tarball.
+//
+// This script is the assertion that closes that gap. It runs from
+// `prepublishOnly` (after the build) and in CI, so it is exercised on every
+// push rather than only on the rare publish.
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const pkg = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8'))
+
+const problems = []
+let checked = 0
+
+for (const [subpath, entry] of Object.entries(pkg.exports ?? {})) {
+  for (const condition of ['import', 'types']) {
+    const relative = entry?.[condition]
+    if (!relative) {
+      problems.push(`exports["${subpath}"] declares no "${condition}" target`)
+      continue
+    }
+    checked++
+    if (!existsSync(join(pkgRoot, relative))) {
+      problems.push(`exports["${subpath}"].${condition} -> ${relative} does not exist`)
+    }
+  }
+}
+
+// `files` decides what actually ships; a target outside it is unreachable to a
+// consumer even when it exists on disk here.
+const shipped = pkg.files ?? []
+if (!shipped.includes('dist')) {
+  problems.push('package.json#files does not include "dist", so no export target would ship')
+}
+
+if (problems.length > 0) {
+  console.error(`dist verification failed (${problems.length} problem(s)):`)
+  for (const problem of problems) console.error(`  - ${problem}`)
+  console.error('\nRun `npm run build --workspace=@codeburn/core` and re-check.')
+  process.exit(1)
+}
+
+console.log(
+  `dist verified: ${checked} export targets across ${Object.keys(pkg.exports ?? {}).length} subpaths all present`,
+)

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "sourceMap": false,
+    "noEmit": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["tests/**/*", "scripts/**/*", "dist", "node_modules"]
+}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -2,7 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
+    // No declarationMap: `files` ships dist and schemas but not src, so the
+    // emitted .d.ts.map would point at sources the consumer never receives.
+    // That is 151 files and ~135 kB of maps that resolve to nothing.
+    "declarationMap": false,
     "emitDeclarationOnly": true,
     "rootDir": "src",
     "outDir": "dist",

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -52,5 +52,8 @@ export default defineConfig({
   clean: true,
   splitting: false,
   sourcemap: true,
-  dts: true,
+  // Declarations come from `tsc -p tsconfig.build.json` instead. tsup's dts
+  // worker bundles types for all 41 entries in one pass and exhausts the heap
+  // (ERR_WORKER_OUT_OF_MEMORY) on Node 22 through 26.
+  dts: false,
 })

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Fails when the monorepo root, the CLI, and @codeburn/core drift apart.
+// The CLI must depend on the exact core version it ships with, otherwise a
+// published CLI can resolve a core it was never tested against.
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+const read = (relative) => {
+  const path = join(repoRoot, relative)
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'))
+  } catch (error) {
+    throw new Error(`cannot read ${relative}: ${error.message}`)
+  }
+}
+
+const root = read('package.json')
+const cli = read('packages/cli/package.json')
+const core = read('packages/core/package.json')
+
+const coreDep = cli.dependencies?.['@codeburn/core']
+
+const problems = []
+
+if (root.version !== cli.version) {
+  problems.push(`root version ${root.version} !== cli version ${cli.version}`)
+}
+if (root.version !== core.version) {
+  problems.push(`root version ${root.version} !== core version ${core.version}`)
+}
+if (coreDep !== core.version) {
+  problems.push(
+    `packages/cli depends on "@codeburn/core": ${JSON.stringify(coreDep)}, expected the exact core version "${core.version}"`,
+  )
+}
+
+if (problems.length > 0) {
+  console.error('workspace version check failed:')
+  for (const problem of problems) console.error(`  - ${problem}`)
+  console.error('\nSet root, packages/cli, and packages/core to the same version,')
+  console.error('pin the CLI dependency to that exact version, then run:')
+  console.error('  npm install --package-lock-only --ignore-scripts')
+  process.exit(1)
+}
+
+console.log(`workspace versions agree at ${root.version}`)

--- a/scripts/check-workspace-versions.mjs
+++ b/scripts/check-workspace-versions.mjs
@@ -2,6 +2,12 @@
 // Fails when the monorepo root, the CLI, and @codeburn/core drift apart.
 // The CLI must depend on the exact core version it ships with, otherwise a
 // published CLI can resolve a core it was never tested against.
+//
+// package-lock.json is checked too. Comparing only the manifests leaves the
+// gate blind to the case it exists for: all three manifests can agree while the
+// lockfile still records a stale workspace version, and `npm ci` does not
+// reject that (verified on npm 10.9.2, 11.12.1, 11.16.0, 11.17.0). A gate that
+// cannot catch its own failure mode is decoration.
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
@@ -20,6 +26,7 @@ const read = (relative) => {
 const root = read('package.json')
 const cli = read('packages/cli/package.json')
 const core = read('packages/core/package.json')
+const lock = read('package-lock.json')
 
 const coreDep = cli.dependencies?.['@codeburn/core']
 
@@ -37,6 +44,39 @@ if (coreDep !== core.version) {
   )
 }
 
+// --- lockfile agreement -----------------------------------------------------
+
+const lockEntry = (key) => lock.packages?.[key]
+
+if (!lock.packages) {
+  problems.push('package-lock.json has no "packages" map; expected lockfileVersion 2 or 3')
+} else {
+  const expected = [
+    ['', root.version, 'root'],
+    ['packages/cli', cli.version, 'packages/cli'],
+    ['packages/core', core.version, 'packages/core'],
+  ]
+  for (const [key, manifestVersion, label] of expected) {
+    const entry = lockEntry(key)
+    if (!entry) {
+      problems.push(`package-lock.json is missing an entry for ${label}`)
+      continue
+    }
+    if (entry.version !== manifestVersion) {
+      problems.push(
+        `package-lock.json records ${label} at ${entry.version}, but its manifest says ${manifestVersion}`,
+      )
+    }
+  }
+
+  const lockedDep = lockEntry('packages/cli')?.dependencies?.['@codeburn/core']
+  if (lockedDep !== undefined && lockedDep !== coreDep) {
+    problems.push(
+      `package-lock.json records the CLI's core dependency as ${JSON.stringify(lockedDep)}, but packages/cli/package.json says ${JSON.stringify(coreDep)}`,
+    )
+  }
+}
+
 if (problems.length > 0) {
   console.error('workspace version check failed:')
   for (const problem of problems) console.error(`  - ${problem}`)
@@ -46,4 +86,4 @@ if (problems.length > 0) {
   process.exit(1)
 }
 
-console.log(`workspace versions agree at ${root.version}`)
+console.log(`workspace versions and package-lock.json agree at ${root.version}`)


### PR DESCRIPTION
Makes `@codeburn/core` buildable and publishable from a clean checkout. Build, release, and CI plumbing only — no `src/` changes, no schema changes, no behavior changes.

Relates to #796 and #809.

## Baseline on `feat/core-extraction` @ `88f298c`

| Gate | Before | After |
|---|---|---|
| `npm ci` | passes, but lockfile records `packages/core@0.9.19` against a manifest saying `0.9.20` | passes, versions agree |
| `npm run check:workspace-versions` | script did not exist | passes at `0.9.20` |
| `npm run typecheck -w @codeburn/core` | passes | passes |
| `npm test -w @codeburn/core` | **1 file fails**, 507 passed / 2 skipped | **36 files pass**, 509 passed |
| `npm run build -w @codeburn/core` | **fails**: `ERR_WORKER_OUT_OF_MEMORY` | passes |
| `npm pack -w @codeburn/core --dry-run` | unreachable (build fails) | 389 files, 376.2 kB |

The build failure:

```
ESM ⚡️ Build success in 48ms
DTS Build start
Error [ERR_WORKER_OUT_OF_MEMORY]: Worker terminated due to reaching memory limit: JS heap out of memory
    at [kOnExit] (node:internal/worker:379:26)
```

`tests/import-smoke.test.ts` shells out to `npm run build` in `beforeAll`, so the DTS crash took the test suite down with it. That is the whole delta between 507 and 509 tests.

## Changes

**1. Couple core and CLI releases** (`c52c567`)

Root, CLI, and core were at `0.9.19` / `0.9.19` / `0.9.20`, and the CLI depended on `"@codeburn/core": "*"`. A published CLI could resolve any core version, including ones it was never tested against.

All three now sit at `0.9.20`, the CLI pins the exact core version, and `scripts/check-workspace-versions.mjs` fails the build if they drift. The gate was tested against fixtures covering `*`, `^0.9.20`, CLI drift, core drift, and the aligned case — it rejects the first four and accepts the last.

**2. Emit declarations with `tsc`** (`0054c9c`)

tsup's DTS worker bundles types for all 41 entries in one pass and exhausts the heap. Reproduced on Node 22.13, 24, 25, and 26 — this is not a local-environment artifact.

`dts: false` in `tsup.config.ts`; declarations now come from `tsc -p tsconfig.build.json` (`emitDeclarationOnly`). tsup still emits the ESM JavaScript. All 398 relative imports in `src/` already carry `.js` extensions, so unbundled `.d.ts` resolve correctly under `node16`/`nodenext`.

Side effect: the core build went from crashing to ~40 ms, and the test suite from 34 s to 4 s.

**3. Gate core in CI** (`7e29455`)

CI ran Semgrep only — never a clean install, core build, typecheck, test, or pack. Adds a `core` job on Node 22.13.x / 24.x / 26.x running `npm ci`, `check:workspace-versions`, `typecheck`, `test`, `build`, and `npm pack --dry-run`. The Semgrep job is unchanged. Also adds `"sideEffects": false` to core so bundlers can tree-shake the 41 subpaths.

## Verification

From a **fresh clone**, not the working tree:

```
npm ci                                        PASS
npm run check:workspace-versions              workspace versions agree at 0.9.20
npm run typecheck --workspace=@codeburn/core  PASS
npm test --workspace=@codeburn/core           36 files / 509 tests passed
npm run build --workspace=@codeburn/core      PASS
npm pack --workspace=@codeburn/core --dry-run 389 files, 376.2 kB
```

The same six gates were run in Docker on `node:22.13` (npm 10.9.2), `node:24` (npm 11.16.0), and `node:26` (npm 11.17.0). All pass on all three.

Consumer smoke — the real tarball installed into an empty project:

- all **41** exports-map subpaths import **by name** under a hook that throws on any `node:fs` / `child_process` / `net` / `http` import
- all **41** subpaths type-resolve under `moduleResolution: node16` with `skipLibCheck: false` — no diagnostics

The existing no-I/O import guard and content-minimization tests are untouched and still pass.

## Notes for review

Three things worth a maintainer's eye, none blocking:

1. **The `npm ci` failure did not reproduce.** The audit behind this work recorded a clean `npm ci` failing on lock/manifest disagreement. It passes on npm 10.9.2, 11.12.1, 11.16.0, and 11.17.0. The underlying drift was real and is fixed; the reported symptom was not reproducible.

2. **`declarationMap: true` ships 151 `.d.ts.map` files (~135 kB unpacked) that point at `src/`, which `files` does not publish.** They resolve to nothing for consumers. Dropping `declarationMap`, or adding `src` to `files`, would both be defensible — happy to do either.

3. **The Node 22.13 leg skips `tests/providers/zed-decode.test.ts`** (6 tests). The suite gates it on `zlib.zstdCompressSync`, which landed in Node 22.15, while `engines.node` is `>=22.13.0`. Testing the declared floor is correct, but zed decoding has no coverage on that leg. Raising the floor to `>=22.15.0` would close the gap.

No publish is included here. npm publication stays a maintainer action.


---

## Update: two defects found in review, both fixed

A multi-model review pass over this branch surfaced two release hazards. Both are now closed by the last two commits, and both were reproduced before being fixed.

**4. Check `package-lock.json` in the version gate** (`6f1f8a4`)

`scripts/check-workspace-versions.mjs` compared only the three manifests, so it passed while the lockfile still recorded a stale workspace version — and `npm ci` does not reject that either (checked on npm 10.9.2, 11.12.1, 11.16.0, 11.17.0). The gate was blind to the exact drift it exists to catch. Reproduced with a fixture whose manifests all read `0.9.20` while the lockfile recorded `packages/core` at `0.9.19` plus a `"*"` CLI dep: the gate exited 0. It now exits 1.

**5. Guard publish against a half-built dist** (`0ec9ea9`)

The build is `tsup && tsc`, and tsup runs with `clean: true`. If tsup succeeds and tsc fails, `dist` holds `.js` with no declarations. The build exits non-zero — but `packages/core` declared no `prepublishOnly`, so nothing rebuilt at publish time.

Reproduced: strip the declarations from a copy of `dist` and `npm pack --dry-run` **still succeeds**, with all 41 exports subpaths pointing at files absent from the tarball. `npm pack` was never the guard.

Adds `prepublishOnly` (build, then verify) and `packages/core/scripts/verify-dist.mjs`, which asserts every exports target exists. CI runs `verify-dist` too, so the guard is exercised on every push rather than only on the rare publish. Negative-tested: it accepts an intact `dist` and rejects the half-built one.

This hazard is **pre-existing**, not introduced here — the old single-`tsup` build had the same window. It is cheap to close, so it is closed.

## Two review claims that did not survive checking

- **Older-TypeScript consumers.** Claim: `TS<4.7` consumers using `moduleResolution: "node"` would lose types now that `dist/index.d.ts` is a thin re-export rather than a tsup bundle. Refuted — a real node10 consumer (`module: commonjs`, `moduleResolution: node`, `skipLibCheck: false`) compiles with no diagnostics. TypeScript maps `./schema.js` to `./schema.d.ts` under node10 as well. Also verified clean under `bundler` and `nodenext` across all 41 subpaths.
- **The Node 22.13 zed skip.** Claim: `engines.node: ">=22.13.0"` is wrong because zed decoding needs zstd from 22.15. Refuted by source — `packages/core/src/providers/zed/decode.ts:6-7` documents that the host only calls the decoder after confirming `zstdDecompressSync` exists. Deliberate, documented degradation. It remains a CI visibility nit: those 6 tests skip silently on the 22.13 leg while CI reports green.

**`declarationMap` is now dropped** (`ed4f84d`). It was emitting 151 `.d.ts.map` files pointing at `src/`, which `files` does not ship, so they resolved to nothing for consumers. The tarball goes from 389 files / 376.2 kB to 238 files / 354.4 kB. Declarations are unchanged: 151 `.d.ts`, all 41 export targets still verified present.
