### PR TITLE
fix(mac): use regular menubar text

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -986,7 +986,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSM
         button.image = nil
         button.imagePosition = .noImage
 
-        let font = NSFont.monospacedDigitSystemFont(ofSize: menubarTitleFontSize, weight: .medium)
+        let font = NSFont.monospacedDigitSystemFont(ofSize: menubarTitleFontSize, weight: .regular)
         let baseConfig = NSImage.SymbolConfiguration(pointSize: menubarTitleFontSize, weight: .medium)
         // Tint the flame based on the worst-affected connected provider's quota.
         // Normal (<70%) keeps the template (auto white-on-dark / black-on-light);


### PR DESCRIPTION
## Summary

Render the macOS menu-bar text using regular instead of medium font weight. This matches the visual weight used by apps such as SwiftBar and MeetingBar.

## Testing

- [x] I have tested this locally against real data (not just unit tests)
- [ ] `npm test` passes (ran into issues but they seemed unrelated)
- [x] `npm run build` succeeds
- [x] `swift build -c release` succeeds
- [x] Verified the release build visually with before-and-after screenshots

## Screenshots

| Before | After |
| --- | --- |
| <img width="85" height="30" alt="Screenshot 2026-07-28 at 2 22 35 PM" src="https://github.com/user-attachments/assets/2ea85c57-cce0-4f7f-92ff-bc08b0af7aaa" /> | <img width="88" height="29" alt="Screenshot 2026-07-28 at 2 21 56 PM" src="https://github.com/user-attachments/assets/ca013e1c-e132-4b4d-9a7a-40613de83daa" /> |