### PR TITLE
opencode: sqlite session token fallback column

### DIFF
--- a/src/providers/sqlite-session-parser.ts
+++ b/src/providers/sqlite-session-parser.ts
@@ -43,11 +43,20 @@ function tryQuerySessionTokens(db: SqliteDatabase, sessionId: string): {
   cost: number; input: number; output: number; reasoning: number
   cacheRead: number; cacheWrite: number; model: string | undefined
 } | null {
+  // The real OpenCode session table names this column `model`, not `model_id`
+  // (issue #769). Some forks/older schemas may still use `model_id`, so try
+  // the current name first and fall back rather than assuming one or the other.
+  const select = (modelColumn: string) => db.query<SessionTokenRow>(
+    `SELECT cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write, ${modelColumn} AS model_id FROM session WHERE id = ?`,
+    [sessionId],
+  )
   try {
-    const rows = db.query<SessionTokenRow>(
-      `SELECT cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write, model_id FROM session WHERE id = ?`,
-      [sessionId],
-    )
+    let rows: SessionTokenRow[]
+    try {
+      rows = select('model')
+    } catch {
+      rows = select('model_id')
+    }
     if (rows.length === 0) return null
     const r = rows[0]!
     return {

--- a/tests/providers/kilo-code.test.ts
+++ b/tests/providers/kilo-code.test.ts
@@ -49,6 +49,66 @@ describe('kilo-code provider - discovery path differentiation', () => {
   })
 })
 
+describe('kilo-code provider - sqlite session-level fallback', () => {
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'kilo-code-sqlite-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  // KiloCode's sqlite session table is not confirmed to share OpenCode's
+  // `model` column naming (issue #769 only confirms OpenCode's real schema).
+  // The shared parser's fallback query must keep working here even though
+  // this fixture uses the older/alternate `model_id` name.
+  it('falls back to session-level tokens using a model_id column schema', async () => {
+    const kiloDir = join(tmpDir, 'kilo')
+    await mkdir(kiloDir, { recursive: true })
+    const dbPath = join(kiloDir, 'kilo.db')
+
+    const { DatabaseSync: Database } = require('node:sqlite')
+    const db = new Database(dbPath)
+    db.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT,
+        slug TEXT NOT NULL, directory TEXT NOT NULL, title TEXT NOT NULL,
+        version TEXT NOT NULL, time_created INTEGER, time_updated INTEGER,
+        time_archived INTEGER
+      )
+    `)
+    db.exec(`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL,
+      time_created INTEGER, time_updated INTEGER, data TEXT NOT NULL)`)
+    db.exec(`CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL,
+      session_id TEXT NOT NULL, time_created INTEGER, time_updated INTEGER, data TEXT NOT NULL)`)
+    db.exec(`ALTER TABLE session ADD COLUMN cost REAL`)
+    db.exec(`ALTER TABLE session ADD COLUMN tokens_input INTEGER`)
+    db.exec(`ALTER TABLE session ADD COLUMN tokens_output INTEGER`)
+    db.exec(`ALTER TABLE session ADD COLUMN tokens_reasoning INTEGER`)
+    db.exec(`ALTER TABLE session ADD COLUMN tokens_cache_read INTEGER`)
+    db.exec(`ALTER TABLE session ADD COLUMN tokens_cache_write INTEGER`)
+    db.exec(`ALTER TABLE session ADD COLUMN model_id TEXT`)
+
+    db.prepare(`INSERT INTO session (id, project_id, slug, directory, title, version, time_created)
+      VALUES (?, ?, ?, ?, ?, ?, ?)`).run('sess-1', 'proj-1', 'slug-1', '/home/user/project', 'Project', '1.0', 1700000000000)
+    db.prepare(`UPDATE session SET cost = 0.09, tokens_input = 900, tokens_output = 400, tokens_reasoning = 0, tokens_cache_read = 100, tokens_cache_write = 50, model_id = 'gpt-5' WHERE id = 'sess-1'`).run()
+    db.prepare(`INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)`)
+      .run('msg-1', 'sess-1', 1700000001000, JSON.stringify({ role: 'assistant' }))
+    db.close()
+
+    const provider = createKiloCodeProvider()
+    const source = { path: `${dbPath}:sess-1`, project: 'project', provider: 'kilo-code' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.model).toBe('gpt-5')
+    expect(calls[0]!.inputTokens).toBe(900)
+    expect(calls[0]!.outputTokens).toBe(400)
+    expect(calls[0]!.deduplicationKey).toBe('kilo-code:sess-1:session-level')
+  })
+})
+
 describe('kilo-code provider - metadata', () => {
   it('has correct name and displayName', () => {
     expect(kiloCode.name).toBe('kilo-code')

--- a/tests/providers/opencode.test.ts
+++ b/tests/providers/opencode.test.ts
@@ -823,10 +823,11 @@ skipUnlessSqlite('opencode provider - session parsing', () => {
       db.exec(`ALTER TABLE session ADD COLUMN tokens_reasoning INTEGER`)
       db.exec(`ALTER TABLE session ADD COLUMN tokens_cache_read INTEGER`)
       db.exec(`ALTER TABLE session ADD COLUMN tokens_cache_write INTEGER`)
-      db.exec(`ALTER TABLE session ADD COLUMN model_id TEXT`)
+      // Real OpenCode session schema names this column `model`, not `model_id` (issue #769).
+      db.exec(`ALTER TABLE session ADD COLUMN model TEXT`)
 
       insertSession(db, 'sess-1')
-      db.prepare(`UPDATE session SET cost = 0.15, tokens_input = 5000, tokens_output = 2000, tokens_reasoning = 0, tokens_cache_read = 3000, tokens_cache_write = 1000, model_id = 'claude-sonnet-4-20250514' WHERE id = 'sess-1'`).run()
+      db.prepare(`UPDATE session SET cost = 0.15, tokens_input = 5000, tokens_output = 2000, tokens_reasoning = 0, tokens_cache_read = 3000, tokens_cache_write = 1000, model = 'claude-sonnet-4-20250514' WHERE id = 'sess-1'`).run()
 
       insertMessage(db, 'msg-1', 'sess-1', 1700000001000, {
         role: 'assistant', modelID: 'claude-sonnet-4-20250514',


### PR DESCRIPTION
**Closed in favour of #801, which is the better fix.**

@EuanTop's #801 (open since before this branch) establishes something this branch got wrong: OpenCode's `session.model` column is not a plain string but a JSON blob of the shape `{ id, providerID }`. #801 casts it to a blob and parses it into `providerID/id`.

This branch selected `model AS model_id` and passed the value through as a string, which would have surfaced raw JSON as the model name. It fixes the thrown query but not the value, so it is superseded on the merits rather than merely duplicated.

Nothing here is worth salvaging into #801. The only element it carried that #801 does not is a `model_id` fallback for `kilo-code`, which shares `tryQuerySessionTokens` and whose schema is not established anywhere in this repo. That was defensive guesswork against an unverified schema, not a known requirement, and it is not a reason to hold up the correct fix. If kilo-code's fallback path turns out to need a different column, that is better handled with a real fixture from a real `kilo.db`.

Original description follows for the record.

---

`tryQuerySessionTokens` in `src/providers/sqlite-session-parser.ts` selected `model_id` from the OpenCode session table. The real OpenCode schema names that column `model`, so the query threw, was swallowed by the function's catch-all, and the fallback was dead in practice (#769). The existing session-level fallback fixture in `tests/providers/opencode.test.ts` asserted against a `model_id` schema, so it agreed with the bug.
