### PR TITLE
test: fix time-of-day flake in the durable-headline project-filter tests

### DIFF
--- a/tests/project-filter-durable-totals.test.ts
+++ b/tests/project-filter-durable-totals.test.ts
@@ -83,13 +83,13 @@ function carriedDayWithoutProjects(date: string): DailyEntry {
   return day
 }
 
-async function seedCache(day: DailyEntry): Promise<void> {
+async function seedCache(...days: DailyEntry[]): Promise<void> {
   const cache: DailyCache = {
     version: DAILY_CACHE_VERSION,
     savingsConfigHash: getDailyCacheConfigHash(),
     tzKey: currentTzKey(),
     lastComputedDate: daysAgoStr(1),
-    days: [day],
+    days,
     complete: true,
   }
   await writeFile(join(ROOT, 'cache', `daily-cache.v${DAILY_CACHE_VERSION}.json`), JSON.stringify(cache), 'utf-8')
@@ -100,7 +100,13 @@ async function seedLiveTodaySession(): Promise<void> {
   const projectDir = join(ROOT, 'home', '.claude', 'projects', 'live-proj')
   await mkdir(projectDir, { recursive: true })
   const now = new Date()
-  const at = (h: number, m: number): string => new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, m, 0).toISOString()
+  // Timestamps a few minutes OLD, clamped into today: a wall-clock hour (12:00)
+  // is in the future whenever the suite runs before noon, and the periods here
+  // end at `new Date()`, so a fixed hour made the live half of the union vanish
+  // for a morning run. Relative-and-clamped keeps the session inside today and
+  // in the past at every hour.
+  const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
+  const minutesAgo = (m: number): string => new Date(Math.max(midnight, now.getTime() - m * 60_000)).toISOString()
   const line = (id: string, t: string): string => JSON.stringify({
     type: 'assistant',
     timestamp: t,
@@ -111,7 +117,7 @@ async function seedLiveTodaySession(): Promise<void> {
       usage: { input_tokens: 90000, output_tokens: 12000, cache_creation_input_tokens: 0, cache_read_input_tokens: 300000 },
     },
   })
-  await writeFile(join(projectDir, 's-today.jsonl'), [line('m1', at(12, 0)), line('m2', at(12, 30))].join('\n') + '\n', 'utf-8')
+  await writeFile(join(projectDir, 's-today.jsonl'), [line('m1', minutesAgo(10)), line('m2', minutesAgo(5))].join('\n') + '\n', 'utf-8')
 }
 
 /** What the name-filtered live parse alone reports — the By Project panel's source. */
@@ -320,13 +326,18 @@ describe('carried days with no per-project split (pre-v15)', () => {
   })
 
   it('says so in the overview instead of just showing a short total', async () => {
-    await seedCache(carriedDayWithoutProjects(daysAgoStr(10)))
+    // Two cached days: one that cannot be attributed (the footnote's subject) and
+    // one that can. The attributable day keeps the headline non-zero from the
+    // CACHE alone, so the assertion tests the footnote rather than depending on
+    // the live parse to keep renderOverview off its "No usage found" path.
+    await seedCache(carriedDayWithoutProjects(daysAgoStr(10)), carriedDayWithProjects(daysAgoStr(5)))
     await seedLiveTodaySession()
     const range = coveringRange()
 
     clearSessionCache()
     const durable = await buildDurablePeriod({ range, label: 'This month' }, { provider: 'all', exclude: ['drop-me'] })
     expect(durable.unattributedCostUSD).toBeGreaterThan(0)
+    expect(durable.data.cost).toBeGreaterThan(0)
 
     const rendered = renderOverview(durable.liveProjects, {
       label: 'This month',


### PR DESCRIPTION
## Summary

- The tests I added in #864 fail for **half of every day**. They seed today's live session at a fixed wall-clock hour (`12:00` local) while the periods they build end at `new Date()`, and the suite runs under `TZ=UTC` — so on any run before **12:00 UTC** that timestamp is in the future, the range filter correctly drops it, and the live half of the cache/live union contributes nothing.
- With the headline then at `$0`, the one assertion that needs a non-zero total — the `unattributedCostUSD` footnote — hits `renderOverview`'s `No usage found` early return and goes red. a769b50 fixed the start-of-month flake in the same file; this one survived it.
- Fixes the fixture (seed a few minutes **before** now, clamped into today) and removes the footnote test's dependence on the live parse entirely.

## Testing

- [x] I have tested this locally against real data (not just unit tests)
- [x] `npm test` passes
- [x] `npm run build` succeeds

`npm test`: **2,537 passed, 5 failed** — none in this file; the 12 tests here are green. The 5 are `parser.test.ts` ×2 (the pre-existing pair you already noted), `cli-durable-totals.test.ts` "resolves provider filters identically" (fails on `main`, unrelated — `parseAllSessions` returns nothing for a today-only range once the on-disk session cache is warm), and `cache-refresh-lock.test.ts` ×2 (lock/timing, flaky here run-to-run). `npx tsc --noEmit` clean.

### Evidence

Bisected the fixture on the **unpatched** test file, at a 03:38 UTC run:

| seeded hour | relative to `now` | result |
|---|---|---|
| `12:00` (as merged) | future | `1 failed \| 11 passed` |
| `01:00` | past | `12 passed` |

Nothing else changed, so the timestamp's position relative to `now` is the entire cause. A direct probe of `parseAllSessions` confirms the mechanism — same fixture, same run:

```
wall-clock 12:00 fixture, range end = new Date()  -> 0 projects, $0.00
relative "10 minutes ago" fixture, same range     -> 1 project,  $1.08
```

I also tried to demonstrate this across timezones and got misled: `TZ=...` has no effect because the vitest config pins `TZ=UTC`, so every "timezone" run was the same 03:37 UTC morning. The bisect above is the reliable evidence.

## Fix

1. **Fixture timestamps are now relative and clamped**: `max(today's midnight, now − 10min)`, so the session is always inside today *and* already in the past, at every hour.
2. **The footnote test no longer needs the live parse.** It seeds a second, *attributable* cached day alongside the unattributable one, so the headline is non-zero from the cache alone. The assertion now exercises the footnote rather than the fixture's timing — which is what it was meant to test.

Sorry for the follow-up on my own tests; this was mine to catch, not yours.
