### PR TITLE
fix(mac): use regular weight for the menubar title text

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -989,7 +989,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSM
         button.image = nil
         button.imagePosition = .noImage
 
-        let font = NSFont.monospacedDigitSystemFont(ofSize: menubarTitleFontSize, weight: .medium)
+        let font = NSFont.monospacedDigitSystemFont(ofSize: menubarTitleFontSize, weight: .regular)
         let baseConfig = NSImage.SymbolConfiguration(pointSize: menubarTitleFontSize, weight: .medium)
         // Tint the flame based on the worst-affected connected provider's quota.
         // Normal (<70%) keeps the template (auto white-on-dark / black-on-light);


### PR DESCRIPTION
Renders the macOS menu-bar title with `.regular` instead of `.medium` weight, matching the visual weight of SwiftBar / MeetingBar. The flame symbol keeps its `.medium` config.

Applies the one-line change from #851 by @timdp (landed directly rather than rebasing that fork branch across the batch; credited as co-author). `swift build` clean.

Closes #851.