### PR TITLE
fix(menubar): retry mid-stream download drops and harden the retry budget

### DIFF
--- a/src/menubar-installer.ts
+++ b/src/menubar-installer.ts
@@ -239,19 +239,49 @@ function formatAssetHttpError(label: string, url: string, response: FetchLikeRes
   return `${base}. ${hint}`
 }
 
-/// Fetch a release asset, retrying only transient failures. Returns the successful response;
-/// the caller consumes the body. Every thrown message carries the requested URL so the user can
-/// retry it by hand.
-async function fetchReleaseAsset(url: string, label: string, options: AssetFetchOptions): Promise<FetchLikeResponse> {
+/// Clamp a caller-supplied attempt budget to a finite positive integer. `AssetFetchOptions` is
+/// exported, so a NaN/Infinity/0 slipping through must never turn the loop below into an unbounded
+/// (and, once `2 ** attempt` overflows to a ~1ms setTimeout, tight) retry against the same host.
+function normalizeMaxAttempts(value: number | undefined): number {
+  if (value === undefined) return ASSET_MAX_ATTEMPTS
+  if (!Number.isFinite(value) || value < 1) return 1
+  return Math.floor(value)
+}
+
+/// Release a response's body so undici can return the socket to the pool instead of holding it
+/// open until GC across a run of retries. Best effort: a missing or already-consumed body is fine.
+async function drainBody(response: FetchLikeResponse): Promise<void> {
+  const body = response.body as { cancel?: () => Promise<unknown> } | null
+  try {
+    await body?.cancel?.()
+  } catch {
+    // ignore
+  }
+}
+
+/// Fetch a release asset and hand the successful response to `consume`, retrying only transient
+/// failures: a 5xx, a network-level rejection, or a failure while consuming the body (a socket
+/// dropped mid-download). 4xx is never retried - 404/410 keep routing to the release-API fallback
+/// with their status intact, and a 403/429 rate limit cannot clear inside the backoff window.
+/// `consume` runs inside the retry, so it must clean up after itself on failure (see downloadToFile,
+/// which removes any partial file before re-throwing) and must not fold in an integrity check that
+/// has to fail closed (see verifyChecksum, which compares the digest only after this returns).
+async function fetchReleaseAsset<T>(
+  url: string,
+  label: string,
+  consume: (response: FetchLikeResponse) => Promise<T>,
+  options: AssetFetchOptions,
+): Promise<T> {
   const doFetch = options.fetchImpl ?? fetchWithProxy
   const sleep = options.sleep ?? ((ms: number) => new Promise<void>(r => setTimeout(r, ms)))
   const log = options.log ?? console.log
-  const maxAttempts = options.maxAttempts ?? ASSET_MAX_ATTEMPTS
+  const maxAttempts = normalizeMaxAttempts(options.maxAttempts)
   const baseDelayMs = options.baseDelayMs ?? ASSET_BASE_DELAY_MS
 
   for (let attempt = 1; ; attempt++) {
     const isLastAttempt = attempt >= maxAttempts
     const delayMs = baseDelayMs * 2 ** (attempt - 1)
+
     let response: FetchLikeResponse
     try {
       response = await doFetch(url, {
@@ -262,18 +292,32 @@ async function fetchReleaseAsset(url: string, label: string, options: AssetFetch
       // Network-level failure (ECONNRESET / ETIMEDOUT / socket hang up): no status to inspect,
       // and always transient enough to be worth one more try.
       const reason = err instanceof Error ? err.message : String(err)
-      if (isLastAttempt) throw new Error(`${label} failed after ${maxAttempts} attempts: ${reason} (${url})`)
+      if (isLastAttempt) throw new Error(`${label} failed after ${maxAttempts} attempts: ${reason} (${url})`, { cause: err })
       log(`${label} hit a network error (${reason}), retrying in ${delayMs}ms (attempt ${attempt + 1} of ${maxAttempts})...`)
       await sleep(delayMs)
       continue
     }
 
-    if (response.ok) return response
-    if (!isTransientStatus(response.status) || isLastAttempt) {
-      throw new HttpStatusError(formatAssetHttpError(label, url, response), response.status)
+    if (!response.ok) {
+      const retryable = isTransientStatus(response.status) && !isLastAttempt
+      await drainBody(response)
+      if (!retryable) throw new HttpStatusError(formatAssetHttpError(label, url, response), response.status)
+      log(`${label} failed with HTTP ${response.status}, retrying in ${delayMs}ms (attempt ${attempt + 1} of ${maxAttempts})...`)
+      await sleep(delayMs)
+      continue
     }
-    log(`${label} failed with HTTP ${response.status}, retrying in ${delayMs}ms (attempt ${attempt + 1} of ${maxAttempts})...`)
-    await sleep(delayMs)
+
+    try {
+      return await consume(response)
+    } catch (err) {
+      // The body did not arrive in full (a dropped socket mid-stream, or a 2xx with no body).
+      // consume has cleaned up any partial artifact, so this is safe to treat as transient.
+      const reason = err instanceof Error ? err.message : String(err)
+      if (isLastAttempt) throw new Error(`${label} failed after ${maxAttempts} attempts: ${reason} (${url})`, { cause: err })
+      log(`${label} stream failed (${reason}), retrying in ${delayMs}ms (attempt ${attempt + 1} of ${maxAttempts})...`)
+      await sleep(delayMs)
+      continue
+    }
   }
 }
 
@@ -282,14 +326,13 @@ export async function verifyChecksum(
   checksumUrl: string,
   options: AssetFetchOptions = {},
 ): Promise<void> {
-  const response = await fetchReleaseAsset(checksumUrl, 'Checksum download', options)
-  const text = await response.text()
+  // Only the transport is retried. The digest comparison below is deliberately outside the retry:
+  // an integrity failure must abort on the first look and never re-download.
+  const text = await fetchReleaseAsset(checksumUrl, 'Checksum download', response => response.text(), options)
   const expected = text.trim().split(/\s+/)[0]!.toLowerCase()
   const fileBytes = await readFile(archivePath)
   const actual = createHash('sha256').update(fileBytes).digest('hex')
   if (actual !== expected) {
-    // Deliberately outside the retry loop: retries cover transport failures only. A digest
-    // mismatch is an integrity failure and must abort immediately, never re-download.
     throw new Error(
       `Checksum mismatch for ${archivePath}.\n` +
       `  Expected: ${expected}\n` +
@@ -304,13 +347,21 @@ export async function downloadToFile(
   destPath: string,
   options: AssetFetchOptions = {},
 ): Promise<void> {
-  const response = await fetchReleaseAsset(url, 'Download', options)
-  if (response.body === null) {
-    throw new HttpStatusError(`Download failed: HTTP ${response.status} with an empty body (${url})`, response.status)
-  }
-  // fetch's ReadableStream needs to be wrapped for Node streams.
-  const nodeStream = Readable.fromWeb(response.body as never)
-  await pipeline(nodeStream, createWriteStream(destPath))
+  await fetchReleaseAsset(url, 'Download', async response => {
+    // A 2xx with no body is the most retryable response there is; throw so the retry picks it up
+    // rather than writing a zero-byte file that verifyChecksum would later reject as a mismatch.
+    if (response.body === null) throw new Error('response had no body')
+    // fetch's ReadableStream needs to be wrapped for Node streams.
+    const nodeStream = Readable.fromWeb(response.body as never)
+    try {
+      await pipeline(nodeStream, createWriteStream(destPath))
+    } catch (err) {
+      // A mid-stream drop leaves a truncated file. Remove it before re-throwing so the retry
+      // starts clean and a genuine failure never leaves a partial artifact behind.
+      await rm(destPath, { force: true }).catch(() => {})
+      throw err
+    }
+  }, options)
 }
 
 async function stageMenubarApp(assets: ResolvedAssets, stagingDir: string): Promise<string> {

--- a/tests/menubar-installer.test.ts
+++ b/tests/menubar-installer.test.ts
@@ -187,6 +187,19 @@ function sha256(text: string): string {
   return createHash('sha256').update(Buffer.from(text)).digest('hex')
 }
 
+/** A 200 whose body delivers `chunk`, then errors - a socket dropped mid-download. */
+function droppedStreamResponse(chunk: string, err: Error) {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) { controller.enqueue(new TextEncoder().encode(chunk)) },
+    pull(controller) { controller.error(err) },
+  })
+  return { ok: true, status: 200, headers: { get: () => null }, body, text: async () => chunk }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try { await readFile(path); return true } catch { return false }
+}
+
 describe('release asset download retry', () => {
   let sandbox: string
   let sleeps: number[]
@@ -350,5 +363,77 @@ describe('release asset download retry', () => {
 
     expect(calls).toBe(2)
     expect(sleeps).toEqual([10])
+  })
+
+  it('retries a socket dropped mid-download and completes on the next attempt', async () => {
+    const dest = join(sandbox, 'CodeBurnMenubar-v0.9.19.zip')
+    let calls = 0
+
+    await downloadToFile(ZIP_URL, dest, {
+      ...recorder,
+      fetchImpl: async () => {
+        calls++
+        return calls === 1
+          ? droppedStreamResponse('partial', Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }))
+          : httpResponse(200, 'zip-bytes')
+      },
+    })
+
+    expect(calls).toBe(2)
+    expect(await readFile(dest, 'utf8')).toBe('zip-bytes')
+    expect(sleeps).toEqual([500])
+    expect(logs.some(l => l.includes('stream failed'))).toBe(true)
+  })
+
+  it('gives up on a persistent mid-download failure and leaves no partial file behind', async () => {
+    const dest = join(sandbox, 'CodeBurnMenubar-v0.9.19.zip')
+    let calls = 0
+
+    await expect(downloadToFile(ZIP_URL, dest, {
+      ...recorder,
+      fetchImpl: async () => { calls++; return droppedStreamResponse('partial', new Error('socket hang up')) },
+    })).rejects.toThrow(/socket hang up/)
+
+    expect(calls).toBe(3)
+    expect(sleeps).toEqual([500, 1000])
+    expect(await fileExists(dest)).toBe(false)
+  })
+
+  it('retries a 2xx response that arrives with no body', async () => {
+    const dest = join(sandbox, 'CodeBurnMenubar-v0.9.19.zip')
+    let calls = 0
+
+    await downloadToFile(ZIP_URL, dest, {
+      ...recorder,
+      fetchImpl: async () => { calls++; return calls === 1 ? httpResponse(200) : httpResponse(200, 'zip-bytes') },
+    })
+
+    expect(calls).toBe(2)
+    expect(await readFile(dest, 'utf8')).toBe('zip-bytes')
+  })
+
+  it('clamps a non-finite attempt budget to a single attempt instead of looping', async () => {
+    let calls = 0
+
+    await expect(downloadToFile(ZIP_URL, join(sandbox, 'out.zip'), {
+      ...recorder,
+      maxAttempts: Number.POSITIVE_INFINITY,
+      fetchImpl: async () => { calls++; return httpResponse(500) },
+    })).rejects.toThrow(/HTTP 500/)
+
+    expect(calls).toBe(1)
+    expect(sleeps).toEqual([])
+  })
+
+  it('preserves the underlying error as the cause when retries are exhausted', async () => {
+    const original = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })
+    let captured: unknown
+
+    await downloadToFile(ZIP_URL, join(sandbox, 'out.zip'), {
+      ...recorder,
+      fetchImpl: async () => { throw original },
+    }).catch((err: unknown) => { captured = err })
+
+    expect((captured as Error).cause).toBe(original)
   })
 })


### PR DESCRIPTION
Follow-up hardening for the release-asset download retry landed in #880. A post-merge review flagged edge cases that #880 correctly left as follow-ups; this applies them without changing the happy path.

## What

`fetchReleaseAsset` is now generic over a `consume(response)` callback that runs inside the retry loop, so a body/stream failure mid-download is retryable rather than fatal:

- Retries a socket dropped mid-stream. `downloadToFile` streams to `destPath` inside `consume`; on any failure it removes the partial file before re-throwing, so a persistent failure leaves no truncated artifact and a mid-stream drop retries cleanly (previously a dropped socket after a 200 aborted the install and left a partial zip that verifyChecksum then reported as a checksum mismatch).
- A 2xx with no body now retries instead of aborting with an HTTP-status error stamped with status 200.
- `normalizeMaxAttempts` clamps a caller-supplied budget to a finite positive integer, so a NaN/Infinity slipping through the exported option can never turn the loop into an unbounded retry.
- Non-ok response bodies are drained before the retry sleep so undici returns the socket to the pool.
- Exhausted retries now carry the original error as `cause`.

## Security invariant preserved

The SHA-256 comparison stays outside the retry: `verifyChecksum`'s `consume` is only `response.text()`, and the digest mismatch is thrown after `fetchReleaseAsset` returns. A tampered or corrupt artifact still aborts on the first look and is never re-downloaded. Mutation-checked: injecting a re-download on mismatch fails the "checksum mismatch immediately" test.

## Verification

- tsc clean; menubar-installer suite 27 tests (22 existing unchanged + 5 new), all passing.
- Mutation-checked the new guards: removing the partial-file cleanup fails the "leaves no partial file behind" test; removing the finite-attempt guard sends an Infinity budget into an OOM loop while the guarded code passes instantly; dropping `cause` fails the cause test.
- Full suite green apart from the two standing parser.test.ts failures (proven to reproduce on main) and known parallel-load flakes that pass in isolation.

## Known limitations (deliberately not addressed here)

- Re-throwing a status-bearing error from the fetch layer: skipped because `fetchWithProxy` wraps undici's fetch, which returns non-ok responses and never throws an HttpStatusError, so guarding it would handle a scenario the current code cannot reach.
- A persistent local filesystem error while writing (ENOSPC, EACCES) is now retried within the budget and reported as a stream failure. It is not reachable on the real install path (the destination always lives inside a fresh mkdtemp dir), the original error reason and `cause` are preserved verbatim, and it costs at most the ~1.5s backoff, so it is left as-is rather than adding filesystem-errno classification.
