### PR TITLE
fix(models): price codex Kimi rollouts recorded as kimi/k3[1m]

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -593,6 +593,7 @@ function getCanonicalName(model: string): string {
     .replace(/@.*$/, '')       // strip pin: claude-sonnet-4-6@20250929 -> claude-sonnet-4-6
     .replace(/-\d{8}$/, '')   // strip date: claude-sonnet-4-20250514 -> claude-sonnet-4
     .replace(/^[^/]+\//, '') // strip provider prefix: anthropic/foo -> foo
+    .replace(/\[[^\]]*\]$/, '') // strip context tag: Codex records Kimi as k3[1m], so kimi/k3[1m] -> k3
 }
 
 function stripKnownPricingVariantSuffix(model: string): string | null {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -215,6 +215,32 @@ describe('builtin aliases - getShortModelName', () => {
   })
 })
 
+// Codex driving a Kimi backend records the model as `kimi/k3[1m]` (provider
+// prefix + context-length tag). getCanonicalName strips the prefix but the
+// `[1m]` tag used to survive, so it matched no alias and priced to $0 - the
+// Kimi-via-codex spend was silently reported as free.
+describe('codex Kimi context-tag normalization (kimi/k3[1m])', () => {
+  it('prices kimi/k3[1m] the same as canonical kimi-k3 instead of $0', () => {
+    expect(getModelCosts('kimi/k3[1m]')).not.toBeNull()
+    expect(getModelCosts('kimi/k3[1m]')).toEqual(getModelCosts('kimi-k3'))
+    expect(calculateCost('kimi/k3[1m]', 1_000_000, 100_000, 0, 0, 0)).toBeGreaterThan(0)
+  })
+
+  it('resolves the bare k3[1m] tag too', () => {
+    expect(getModelCosts('k3[1m]')).toEqual(getModelCosts('kimi-k3'))
+  })
+
+  it('names kimi/k3[1m] as Kimi K3', () => {
+    expect(getShortModelName('kimi/k3[1m]')).toBe('Kimi K3')
+  })
+
+  it('does not strip a non-bracket suffix from an ordinary model id', () => {
+    expect(getShortModelName('gpt-5.5')).toBe('GPT-5.5')
+    expect(getModelCosts('gpt-5.5')).toEqual(getModelCosts('gpt-5.5'))
+    expect(calculateCost('gpt-5.5', 1_000_000, 100_000, 0, 0, 0)).toBeCloseTo(8, 5)
+  })
+})
+
 describe('Antigravity Gemini 3.5 Flash variants resolve to pricing', () => {
   const variants = [
     'gemini-3.5-flash',


### PR DESCRIPTION
## The bug

Codex driving a Kimi backend records the model as `kimi/k3[1m]` (a `kimi/` provider prefix plus a `[1m]` context-length tag). `getCanonicalName` strips the provider prefix but the `[1m]` tag survived, so the id reached alias resolution as `k3[1m]`, matched no alias or pricing key, and priced to **$0**.

The bare `k3` and `k3-agent` ids are already mapped to `kimi-k3` ($4.50 / 1M in + 100k out), so the tagged variant was the lone gap. Effect: a user running codex on Kimi K3 saw their entire codex spend reported as free, and because the menubar only surfaces a provider segment with nonzero cost, no Codex segment appeared at all.

## The fix

Strip a trailing `[...]` context tag in `getCanonicalName`, alongside the existing pin/date/provider-prefix strips, so `kimi/k3[1m]` -> `k3` -> `kimi-k3`. This repairs both cost (`getModelCosts`/`calculateCost`) and the display name (`getShortModelName`), which share that canonicalizer. The strip is anchored to the end and only removes a bracketed group, so ordinary model ids are untouched.

## Verification

- Four unit tests: `kimi/k3[1m]` and the bare `k3[1m]` now price identically to canonical `kimi-k3`, name as "Kimi K3", and an ordinary id (`gpt-5.5`, $8) is a regression guard proving the strip does not over-match. Mutation-checked: removing the strip fails the three Kimi cases and leaves the guard passing.
- tsc clean; full suite green apart from the two standing parser.test.ts failures that reproduce on main.
- Live-verified against a real `~/.codex` corpus (isolated cache): codex month cost went from **$0.00** to **$5.01**, today from **$0.00** to **$1.43** - previously-invisible Kimi-via-codex usage now priced.
