### PR TITLE
fix(menubar): apply --project/--exclude to the provider list on carried days

### DIFF
--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -634,11 +634,18 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
       providers.push({ name: 'claude', displayName: displayNameByName.get('claude') ?? 'Claude', cost: 0 })
     }
   } else if (isAllProviders) {
-    const unfilteredProviderDays = [
-      ...(rangeStartStr <= historicalRangeEndStr ? getDaysInRange(cache, rangeStartStr, historicalRangeEndStr) : []),
-      ...(await getTodayAllDays()).filter(d => d.date >= rangeStartStr && d.date <= rangeEndStr),
-    ]
-    const allDaysForProviders = daysSelection ? unfilteredProviderDays.filter(d => daysSelection.days.has(d.date)) : unfilteredProviderDays
+    // Reuse the day set the headline was built from instead of rebuilding one
+    // straight out of the cache. The rebuilt version unioned unfiltered historical
+    // days with an already-filtered today, so per-provider costs counted every
+    // carried day whole while today honoured --project/--exclude, and the provider
+    // list could not be reconciled with the By Project panel (#865).
+    //
+    // durable.days is that same union, already narrowed by range, day selection and
+    // the project filter, which is what the comment above the buildDurablePeriod
+    // call already promised this section would use. Non-null here: this branch
+    // implies !isClaudeConfigScoped, which forces the !effectivelyScoped path that
+    // assigns it.
+    const allDaysForProviders = cacheDaysForPeriod ?? []
     const providerTotals: Record<string, number> = {}
     for (const d of allDaysForProviders) {
       for (const [name, p] of Object.entries(d.providers)) {

--- a/tests/project-filter-durable-totals.test.ts
+++ b/tests/project-filter-durable-totals.test.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
-import { DAILY_CACHE_VERSION, currentTzKey, type DailyCache, type DailyEntry } from '../src/daily-cache.js'
+import { DAILY_CACHE_VERSION, currentTzKey, type DailyCache, type DailyEntry, type ProjectDayStats, type ProviderDaySlice } from '../src/daily-cache.js'
 import { loadPricing } from '../src/models.js'
 import { buildDurablePeriod, buildMenubarPayloadForRange, buildPeriodData, getDailyCacheConfigHash } from '../src/usage-aggregator.js'
 import { parseAllSessions, filterProjectsByName, clearSessionCache } from '../src/parser.js'
@@ -80,6 +80,34 @@ function carriedDayWithoutProjects(date: string): DailyEntry {
   const day = carriedDayWithProjects(date)
   delete day.projects
   delete day.providers['claude']!.projects
+  return day
+}
+
+/**
+ * A carried day whose two providers own disjoint projects: claude spent only on
+ * `keep-me`, codex only on `drop-me`. Filtering `drop-me` out must therefore take
+ * codex's whole contribution with it, which is what makes the provider list's
+ * project slicing observable.
+ */
+function carriedDayTwoProviders(date: string): DailyEntry {
+  const day = carriedDayWithProjects(date)
+  const keepProjects = { 'keep-me': { cost: KEEP.cost, calls: KEEP.calls, savingsUSD: 0, sessions: KEEP.sessions, path: '/Users/gone/keep-me' } }
+  const dropProjects = { 'drop-me': { cost: DROP.cost, calls: DROP.calls, savingsUSD: 0, sessions: DROP.sessions, path: '/Users/gone/drop-me' } }
+  const slice = (
+    stats: { cost: number; calls: number; sessions: number },
+    projects: Record<string, ProjectDayStats>,
+  ): ProviderDaySlice => ({
+    calls: stats.calls, cost: stats.cost, savingsUSD: 0, sessions: stats.sessions,
+    inputTokens: 2500, outputTokens: 1000, cacheReadTokens: 0, cacheWriteTokens: 0,
+    editTurns: 2, oneShotTurns: 1,
+    models: { 'Opus 4.8': { calls: stats.calls, cost: stats.cost, savingsUSD: 0, inputTokens: 2500, outputTokens: 1000, cacheReadTokens: 0, cacheWriteTokens: 0 } },
+    categories: { coding: { turns: 5, cost: stats.cost, savingsUSD: 0, editTurns: 2, oneShotTurns: 1 } },
+    projects,
+  })
+  day.providers = {
+    claude: slice(KEEP, keepProjects),
+    codex: slice(DROP, dropProjects),
+  }
   return day
 }
 
@@ -275,6 +303,36 @@ describe('durable headline honours --project / --exclude on carried days', () =>
     expect(menubar.current.cost).toBe(durable.data.cost)
     expect(menubar.current.calls).toBe(durable.data.calls)
     expect(menubar.current.inputTokens).toBe(durable.data.inputTokens)
+  })
+
+  it('slices the provider list by the project filter so it reconciles with the headline', async () => {
+    await seedCache(carriedDayTwoProviders(daysAgoStr(10)))
+    const range = coveringRange()
+
+    clearSessionCache()
+    const menubar = await buildMenubarPayloadForRange({ range, label: 'p' }, { provider: 'all', exclude: ['drop-me'], optimize: false, timeline: false })
+
+    const providers = menubar.current.providers
+    const providerSum = Object.values(providers).reduce((a, b) => a + b, 0)
+
+    // The headline already honours the filter; the provider list used to be built
+    // from unfiltered cache days, so it kept reporting codex's excluded spend.
+    expect(menubar.current.cost).toBeCloseTo(KEEP.cost, 6)
+    expect(providerSum).toBeCloseTo(menubar.current.cost, 6)
+    expect(providers['claude']).toBeCloseTo(KEEP.cost, 6)
+    expect(providers['codex'] ?? 0).toBeCloseTo(0, 6)
+  })
+
+  it('leaves the provider list untouched when no project filter is given', async () => {
+    await seedCache(carriedDayTwoProviders(daysAgoStr(10)))
+    const range = coveringRange()
+
+    clearSessionCache()
+    const menubar = await buildMenubarPayloadForRange({ range, label: 'p' }, { provider: 'all', optimize: false, timeline: false })
+
+    expect(menubar.current.providers['claude']).toBeCloseTo(KEEP.cost, 6)
+    expect(menubar.current.providers['codex']).toBeCloseTo(DROP.cost, 6)
+    expect(menubar.current.cost).toBeCloseTo(DAY_COST, 6)
   })
 
   it('leaves the unfiltered headline exactly as it was', async () => {


### PR DESCRIPTION
Refs #865, which was closed when #864 (2de4d100) fixed the Overview headline via `sliceDayToProject`. This PR closes the adjacent gap that issue documented and #864 deliberately left alone: the menubar provider list still ignores `--project`/`--exclude` on carried days. Verified present on current `main` (44a94f5, `unfilteredProviderDays` at usage-aggregator.ts:637).

## The bug

`buildMenubarPayloadForRange` built the provider list from its own day set rather than the one the headline came from:

```ts
const unfilteredProviderDays = [
  ...(rangeStartStr <= historicalRangeEndStr ? getDaysInRange(cache, rangeStartStr, historicalRangeEndStr) : []),
  ...(await getTodayAllDays()).filter(d => d.date >= rangeStartStr && d.date <= rangeEndStr),
]
```

Historical days came straight out of the cache unfiltered, while `getTodayAllDays()` was already name-filtered. Under `--project` / `--exclude`, per-provider costs therefore counted every carried day whole and could not be reconciled with either the headline or the By Project panel.

On my own data, `status --format menubar-json --period 30days --project codeburn`:

| | before | after |
|---|---|---|
| headline cost | 141.65 | 141.65 |
| sum of provider costs | **12384.12** | **141.65** |
| gap | 12242.47 | 0.00 |

## The fix

Reuse `durable.days`, captured a few lines above as `cacheDaysForPeriod`. It is the same cache-plus-today union the headline is built from, already narrowed by range, day selection and the project filter. The comment above the `buildDurablePeriod` call already stated that this section reuses that slice, so this makes the code match what it claims:

```
// ... The provider list and
// daily-history sections below reuse its cache + today slice.
```

`cacheDaysForPeriod` is non-null in this branch: reaching it implies `!isClaudeConfigScoped`, which forces the `!effectivelyScoped` path that assigns it.

## On the concern that raised this as a policy question

#865 held this back because "narrowing it also changes which providers appear in the list at all". In practice it does not. The installed-but-zero backfill immediately below still adds any provider with discoverable sources at `cost: 0`:

```ts
for (const p of allProviders) {
  if (providers.some(pc => pc.name === p.name)) continue
  const sources = await safeDiscoverSessions(p)
  if (sources.length > 0) providers.push({ name: p.name, displayName: p.displayName, cost: 0 })
}
```

Confirmed on real data: under `--project codeburn`, the providers whose entire spend is excluded still appear, at 0.00.

```
codex=120.09  claude=21.56  copilot=0.00  gemini=0.00  hermes agent=0.00
kimi code=0.00  open design=0.00  antigravity=0.00  cursor=0.00  cursor agent=0.00
```

That is a weaker disappearance than the By Project panel already allows, since `buildTopProjects` drops zero-cost projects outright.

Pre-v15 days with no per-project split keep #864's accepted policy for free, because the slicing happens inside `sliceDayToProject` rather than here.

## Tests

Two cases added to `tests/project-filter-durable-totals.test.ts`, reusing that file's fixture style. A new `carriedDayTwoProviders` helper builds a carried day whose providers own disjoint projects (claude on `keep-me`, codex on `drop-me`), so filtering `drop-me` out must take codex's whole contribution with it.

1. `slices the provider list by the project filter so it reconciles with the headline` asserts the provider costs sum to the headline and that codex drops to zero. Without the fix it fails with `expected 100 to be close to 30, received difference is 70`.
2. `leaves the provider list untouched when no project filter is given` locks the unfiltered path.

Verified unfiltered on real data as well: same provider set, identical costs to the cent, no rows dropped.

`tsc --noEmit` clean. Full suite passes apart from failures that reproduce identically on unmodified `main` in my environment (`tests/cache-refresh-lock.test.ts`, which is flaky under parallel load and passes in isolation, and the two `tests/parser.test.ts` durable-orphan cases that fail on their first parse with `expected +0 to be 200`).
