### PR TITLE
models: name GPT-5.6, Grok 4.5 and ClinePass slugs instead of showing raw ids

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -922,6 +922,27 @@ const SHORT_NAMES: Record<string, string> = {
   'glm-5p2': 'GLM-5.2',
   'qwen3p7-plus': 'Qwen 3.7 Plus',
   'kimi-k2p7-code': 'Kimi K2.7 Code',
+  // Ids that price correctly but had no display entry, so reports showed the
+  // raw slug. All display-only. The GPT-5.6 variants are listed individually
+  // rather than as a bare `gpt-5.6`: a base entry would swallow every future
+  // `gpt-5.6-*` via the prefix match and hide the variant, which is exactly
+  // what getShortModelName's version-boundary rule is there to prevent.
+  'gpt-5.6-sol': 'GPT-5.6 Sol',
+  'gpt-5.6-terra': 'GPT-5.6 Terra',
+  'gpt-5.6-luna': 'GPT-5.6 Luna',
+  // The Grok Build harness reports the model it runs (`grok-4.5`), so this is
+  // the model's own name; `grok-build*` ids still resolve to "Grok Build".
+  'grok-4.5': 'Grok 4.5',
+  // ClinePass routes models as `cline-pass/<slug>`; getShortModelName's path
+  // fallback strips the prefix and re-resolves the bare slug through this
+  // table, the same way it handles `accounts/fireworks/models/<slug>`.
+  'qwen3.7-max': 'Qwen 3.7 Max',
+  'mimo-v2.5-pro': 'MiMo v2.5 Pro',
+  // Both spellings occur in the wild: OpenRouter gap-filled keys are lowercase
+  // slugs while sessions report the capitalized name (see the case-insensitive
+  // pricing index above). SHORT_NAMES matching is case-sensitive, so map both.
+  'minimax-m3': 'MiniMax M3',
+  'MiniMax-M3': 'MiniMax M3',
 }
 
 // Sorted longest-first so more-specific prefixes match before shorter ones.

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -123,6 +123,36 @@ describe('getShortModelName', () => {
     expect(getShortModelName('accounts/fireworks/models/some-unlisted-slug')).toBe('some-unlisted-slug')
   })
 
+  it('names GPT-5.6 variants individually rather than collapsing them', () => {
+    expect(getShortModelName('gpt-5.6-sol')).toBe('GPT-5.6 Sol')
+    expect(getShortModelName('gpt-5.6-terra')).toBe('GPT-5.6 Terra')
+    expect(getShortModelName('gpt-5.6-luna')).toBe('GPT-5.6 Luna')
+    // No bare `gpt-5.6` entry exists, so an unlisted future variant must still
+    // fall through to its raw id rather than borrow a sibling's label.
+    expect(getShortModelName('gpt-5.6-unlisted')).toBe('gpt-5.6-unlisted')
+  })
+
+  it('names grok-4.5 without disturbing the Grok Build harness label', () => {
+    // The Grok Build CLI reports the model it runs, so the model id gets the
+    // model's name; ids that really are grok-build keep the harness label.
+    expect(getShortModelName('grok-4.5')).toBe('Grok 4.5')
+    expect(getShortModelName('grok-build-0.1')).toBe('Grok Build')
+  })
+
+  it('names ClinePass-routed slugs through the path fallback', () => {
+    // ClinePass ids arrive as `cline-pass/<slug>`; the path fallback strips the
+    // prefix and re-resolves the bare slug, as it does for Fireworks ids.
+    expect(getShortModelName('cline-pass/qwen3.7-max')).toBe('Qwen 3.7 Max')
+    expect(getShortModelName('cline-pass/minimax-m3')).toBe('MiniMax M3')
+    expect(getShortModelName('cline-pass/mimo-v2.5-pro')).toBe('MiMo v2.5 Pro')
+    expect(getShortModelName('cline-pass/kimi-k3')).toBe('Kimi K3')
+  })
+
+  it('names MiniMax M3 in both the lowercase-slug and capitalized spellings', () => {
+    expect(getShortModelName('minimax-m3')).toBe('MiniMax M3')
+    expect(getShortModelName('MiniMax-M3')).toBe('MiniMax M3')
+  })
+
   it('resolves Fireworks-hosted fleet models to friendly names via the path fallback', () => {
     // Real ids are the full Fireworks path `accounts/fireworks/models/<slug>`.
     expect(getShortModelName('accounts/fireworks/models/glm-5p2')).toBe('GLM-5.2')


### PR DESCRIPTION
## Summary

- Adds `SHORT_NAMES` entries for model ids that **price correctly but had no display entry**, so the By Model panel rendered a raw slug next to properly named siblings: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `grok-4.5`, `qwen3.7-max`, `minimax-m3`, `mimo-v2.5-pro`.
- Display-only. No dollar amounts move — pricing already resolved for all of these (`mimo-v2.5-pro` is unpriced upstream both before and after; this only gives it a name).

Before / after, from a real local report:

```
qwen3.7-max      $0.562      ->  Qwen 3.7 Max     $0.562
minimax-m3       $0.154      ->  MiniMax M3       $0.154
mimo-v2.5-pro    $0.0090     ->  MiMo v2.5 Pro    $0.0090
grok-4.5        ~$10.82      ->  Grok 4.5        ~$10.82
gpt-5.6-sol      $280.56     ->  GPT-5.6 Sol      $280.56
gpt-5.6-terra    $122.98     ->  GPT-5.6 Terra    $122.98
```

## Notes on the non-obvious ones

**GPT-5.6 variants are listed individually, not as a bare `gpt-5.6`.** A base entry would swallow every future `gpt-5.6-*` via the prefix match and hide the variant behind a sibling's label — precisely what `getShortModelName`'s version-boundary rule exists to prevent. An unlisted variant still falls through to its raw id, and a test pins that.

**`grok-4.5` is the model, not the harness.** The Grok Build CLI reports the model it runs as `current_model_id`, so the id takes the model's own name. Ids that really are `grok-build*` keep the "Grok Build" label — also covered by a test, since that distinction is easy to regress.

**ClinePass needed no new prefix handling.** Its ids arrive as `cline-pass/<slug>`; `getShortModelName`'s path fallback already strips the prefix and re-resolves the bare slug, exactly as it does for `accounts/fireworks/models/<slug>`. Adding a dedicated prefix rule would have been dead code. Tests cover the `cline-pass/` path so the behavior stays intentional rather than incidental.

**MiniMax M3 is mapped under both spellings.** The gap-filled OpenRouter key is the lowercase slug while sessions report the capitalized name; `SHORT_NAMES` matching is case-sensitive, and the case-insensitive index covers pricing only.

## Testing

- [x] I have tested this locally against real data (not just unit tests)
- [x] `npm test` passes
- [x] `npm run build` succeeds

Every id above was taken from real local sessions, not from documentation — `gpt-5.6-luna` in particular only surfaced by grepping actual Codex transcripts (7 records), which is why it is included alongside the two obvious variants.

`npm test`: 20 failed / 2619 passed against a `main` baseline of 23 failed / 2612 passed on the same machine and commit base. No file fails here that does not also fail on `main`; the failures are the pre-existing `cache-refresh-lock` / `parser` durable-orphan / `app/electron/cli` set plus CLI-subprocess tests that flake under parallel load and pass in isolation. The 26 errors in both runs are `app/renderer` tests needing `jsdom` from `app/`'s own dependency tree.

Five new assertions in `tests/models.test.ts` cover the variant-collapse guard, the Grok Build distinction, the `cline-pass/` path fallback, and both MiniMax spellings.
