### PR TITLE
chore(gitignore): ignore node_modules symlinks, not only directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-node_modules/
+# No trailing slash: the slash form only ignores directories, so a
+# node_modules SYMLINK (common in linked worktrees) slips into git add -A.
+# One did exactly that in db018f7 and had to be removed again in c642787.
+node_modules
 dist/
 *.tgz
 


### PR DESCRIPTION
Root-cause hardening for the incident #896 cleaned up. `node_modules/` with the trailing slash ignores directories only; a node_modules SYMLINK - which is exactly what linked worktrees sharing one install carry - is not matched, so a `git add -A` in such a worktree committed one in db018f7 (mine, owning that), every later checkout materialized a self-referencing symlink on disk, and #896 had to remove the tracked entry. Dropping the slash makes the pattern cover files, directories and symlinks, so this class of accident is structurally impossible regardless of who runs what in which worktree.