### PR TITLE
feat(doctor): probeRoots for 12 more providers (#899 Tier 1)

### DIFF
--- a/src/providers/antigravity.ts
+++ b/src/providers/antigravity.ts
@@ -8,7 +8,7 @@ import https from 'https'
 
 import { calculateCost } from '../models.js'
 import { isSqliteAvailable, isSqliteBusyError, openDatabase } from '../sqlite.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { ProbeRoot, Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
 type AntigravityConversationRoot = {
   dir: string
@@ -1426,6 +1426,13 @@ export function createAntigravityProvider(): Provider {
 
     toolDisplayName(rawTool: string): string {
       return rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [
+        ...conversationRoots().map(root => ({ path: root.dir, label: 'conversations' })),
+        { path: getAntigravityStatusLineEventsPath(), label: 'statusline' },
+      ]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/codewhale.ts
+++ b/src/providers/codewhale.ts
@@ -6,7 +6,7 @@ import { extractBashCommands } from '../bash-utils.js'
 import { readSessionFile } from '../fs-utils.js'
 import { calculateCost, getShortModelName } from '../models.js'
 import type { ToolCall } from '../types.js'
-import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
+import type { ProbeRoot, ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
 
 const METADATA_PREFIX_BYTES = 64 * 1024
 
@@ -455,6 +455,10 @@ export function createCodeWhaleProvider(overrideDirs?: string | string[]): Provi
 
     toolDisplayName(rawTool: string): string {
       return mapToolName(rawTool)
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return (configuredDirs ?? defaultSessionDirs()).map(path => ({ path, label: 'sessions' }))
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/crush.ts
+++ b/src/providers/crush.ts
@@ -4,7 +4,7 @@ import { homedir, platform } from 'os'
 
 import { calculateCost } from '../models.js'
 import { isSqliteAvailable, getSqliteLoadError, openDatabase, type SqliteDatabase } from '../sqlite.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { ProbeRoot, Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
 /// Crush stores per-project SQLite databases discovered through a JSON registry.
 /// We only read both. Schema source: charmbracelet/crush
@@ -234,6 +234,10 @@ export function createCrushProvider(): Provider {
 
     toolDisplayName(rawTool: string): string {
       return rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: getRegistryPath(), label: 'registry' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/cursor-agent.ts
+++ b/src/providers/cursor-agent.ts
@@ -13,6 +13,7 @@ import type {
   SessionSource,
   SessionParser,
   ParsedProviderCall,
+  ProbeRoot,
 } from './types.js'
 
 type ConversationSummary = {
@@ -511,6 +512,13 @@ export function createCursorAgentProvider(baseDirOverride?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [
+        { path: projectsDir, label: 'projects' },
+        { path: dbPath, label: 'db' },
+      ]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -8,7 +8,7 @@ import { readCachedResults, writeCachedResults } from '../cursor-cache.js'
 import { isSqliteAvailable, isSqliteBusyError, getSqliteLoadError, openDatabase, blobToText, type SqliteDatabase } from '../sqlite.js'
 import { estimateTokensFromChars } from '../token-estimate.js'
 import type { DateRange } from '../types.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { ProbeRoot, Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
 /** Matches cli-date.ts "all" period cap (6 months). */
 const CURSOR_MAX_LOOKBACK_MONTHS = 6
@@ -1043,6 +1043,10 @@ export function createCursorProvider(dbPathOverride?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: dbPathOverride ?? getCursorDbPath(), label: 'db' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/droid.ts
+++ b/src/providers/droid.ts
@@ -11,6 +11,7 @@ import type {
   SessionSource,
   SessionParser,
   ParsedProviderCall,
+  ProbeRoot,
 } from './types.js'
 
 const toolNameMap: Record<string, string> = {
@@ -389,6 +390,10 @@ export function createDroidProvider(factoryDir?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return toolNameMap[rawTool] ?? rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: sessionsDir, label: 'sessions' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/goose.ts
+++ b/src/providers/goose.ts
@@ -5,7 +5,7 @@ import { calculateCost, getShortModelName } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
 import { isSqliteAvailable, getSqliteLoadError, openDatabase, blobToText, type SqliteDatabase } from '../sqlite.js'
 import type { ToolCall } from '../types.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { ProbeRoot, Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
 type SessionRow = {
   id: string
@@ -273,6 +273,10 @@ export function createGooseProvider(): Provider {
 
     toolDisplayName(rawTool: string): string {
       return toolNameMap[rawTool] ?? rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: getDbPath(), label: 'db' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/hermes.ts
+++ b/src/providers/hermes.ts
@@ -4,7 +4,7 @@ import { homedir } from 'os'
 
 import { calculateCost, getShortModelName } from '../models.js'
 import { isSqliteAvailable, getSqliteLoadError, openDatabase, isSqliteBusyError, type SqliteDatabase } from '../sqlite.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { ProbeRoot, Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 import type { ToolCall } from '../types.js'
 
 type HermesSessionRow = {
@@ -460,6 +460,10 @@ export function createHermesProvider(hermesHomeOverride?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return mapToolName(rawTool)
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: hermesHome, label: 'home' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/ibm-bob.ts
+++ b/src/providers/ibm-bob.ts
@@ -3,7 +3,7 @@ import { homedir } from 'os'
 
 import { getShortModelName } from '../models.js'
 import { discoverClineTasksInBaseDirs, createClineParser } from './vscode-cline-parser.js'
-import type { Provider, SessionSource, SessionParser } from './types.js'
+import type { ProbeRoot, Provider, SessionSource, SessionParser } from './types.js'
 
 const PROVIDER_NAME = 'ibm-bob'
 const DISPLAY_NAME = 'IBM Bob'
@@ -43,6 +43,10 @@ export function createIBMBobProvider(overrideDir?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return (overrideDir ? [overrideDir] : getIBMBobGlobalStorageDirs()).map(path => ({ path, label: 'storage' }))
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/lingtai-tui.ts
+++ b/src/providers/lingtai-tui.ts
@@ -4,7 +4,7 @@ import { homedir } from 'os'
 
 import { readSessionLines } from '../fs-utils.js'
 import { calculateCost, getShortModelName } from '../models.js'
-import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
+import type { ProbeRoot, ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
 
 type JsonObject = Record<string, unknown>
 
@@ -416,6 +416,24 @@ export function createLingTaiTuiProvider(options?: string | LingTaiProviderOptio
 
     toolDisplayName(rawTool: string): string {
       return rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      // Deliberately pre-existence-filter: doctor's job is to show where
+      // discovery looks, so a missing default home reads as "not installed
+      // here" instead of vanishing (getLingTaiHomes drops non-existent
+      // candidates, which is right for discovery and wrong for doctor).
+      const explicit = splitPathList(providerOptions.lingtaiHomeOverride ?? process.env['LINGTAI_HOME'] ?? process.env['LINGTAI_TUI_HOME'])
+      const roots: ProbeRoot[] = explicit.length
+        ? explicit.map(path => ({ path, label: 'sessions' }))
+        : [
+            { path: getDefaultLingTaiHome(providerOptions), label: 'sessions' },
+            { path: getLingTaiGlobalDir(providerOptions), label: 'registry' },
+          ]
+      for (const home of await getLingTaiHomes(providerOptions)) {
+        if (!roots.some(root => root.path === home.path)) roots.push({ path: home.path, label: 'sessions' })
+      }
+      return roots
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/qwen.ts
+++ b/src/providers/qwen.ts
@@ -5,7 +5,7 @@ import { homedir } from 'os'
 import { readSessionFile } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { ProbeRoot, Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
 
 const toolNameMap: Record<string, string> = {
   read_file: 'Read',
@@ -160,6 +160,10 @@ export function createQwenProvider(overrideDir?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return toolNameMap[rawTool] ?? rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: projectsDir, label: 'projects' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/warp.ts
+++ b/src/providers/warp.ts
@@ -5,7 +5,7 @@ import { extractBashCommands } from '../bash-utils.js'
 import { calculateCost, getShortModelName } from '../models.js'
 import { blobToText, getSqliteLoadError, isSqliteAvailable, openDatabase, type SqliteDatabase } from '../sqlite.js'
 import { estimateTokensFromChars } from '../token-estimate.js'
-import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
+import type { ProbeRoot, ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
 import { safeNumber } from '../parser.js'
 
 const WARP_GROUP_CONTAINER = '2BBY89MBSN.dev.warp'
@@ -477,6 +477,10 @@ export function createWarpProvider(dbPathOverride?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return rawTool === 'run_command' ? 'Bash' : rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return getDbCandidates(dbPathOverride).map(path => ({ path, label: 'db' }))
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/tests/provider-probe-roots.test.ts
+++ b/tests/provider-probe-roots.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { isAbsolute, join } from 'path'
+
+import { createCodeWhaleProvider } from '../src/providers/codewhale.js'
+import { createHermesProvider } from '../src/providers/hermes.js'
+import { createLingTaiTuiProvider } from '../src/providers/lingtai-tui.js'
+import { createDroidProvider } from '../src/providers/droid.js'
+import { createCursorProvider } from '../src/providers/cursor.js'
+import { createCursorAgentProvider } from '../src/providers/cursor-agent.js'
+import { createGooseProvider } from '../src/providers/goose.js'
+import { createCrushProvider } from '../src/providers/crush.js'
+import { createWarpProvider } from '../src/providers/warp.js'
+import { createAntigravityProvider } from '../src/providers/antigravity.js'
+import { createQwenProvider } from '../src/providers/qwen.js'
+import { createIBMBobProvider } from '../src/providers/ibm-bob.js'
+
+// probeRoots must mirror the exact resolution each provider's discovery uses
+// (#899 Tier 1). Where a factory takes an override, the assertion is exact:
+// the same override must come back through probeRoots, proving the two paths
+// share one resolution. Providers without an override factory get structural
+// assertions: non-empty, absolute, correctly labeled.
+
+describe('probeRoots mirrors discovery resolution', () => {
+  it('codewhale reports the configured dirs, or both defaults', async () => {
+    expect(await createCodeWhaleProvider('/tmp/cw-root').probeRoots!()).toEqual([
+      { path: '/tmp/cw-root', label: 'sessions' },
+    ])
+    const defaults = await createCodeWhaleProvider().probeRoots!()
+    expect(defaults).toHaveLength(2)
+    for (const root of defaults) expect(isAbsolute(root.path)).toBe(true)
+  })
+
+  it('hermes reports its resolved home', async () => {
+    expect(await createHermesProvider('/tmp/hermes-home').probeRoots!()).toEqual([
+      { path: '/tmp/hermes-home', label: 'home' },
+    ])
+  })
+
+  it('droid reports the sessions dir under the factory root', async () => {
+    expect(await createDroidProvider('/tmp/factory').probeRoots!()).toEqual([
+      { path: join('/tmp/factory', 'sessions'), label: 'sessions' },
+    ])
+  })
+
+  it('cursor reports the state db path', async () => {
+    expect(await createCursorProvider('/tmp/cursor/state.vscdb').probeRoots!()).toEqual([
+      { path: '/tmp/cursor/state.vscdb', label: 'db' },
+    ])
+  })
+
+  it('cursor-agent reports the projects dir and the attribution db', async () => {
+    expect(await createCursorAgentProvider('/tmp/ca').probeRoots!()).toEqual([
+      { path: join('/tmp/ca', 'projects'), label: 'projects' },
+      { path: join('/tmp/ca', 'ai-tracking', 'ai-code-tracking.db'), label: 'db' },
+    ])
+  })
+
+  it('warp reports the override db, or both bundle candidates', async () => {
+    expect(await createWarpProvider('/tmp/warp.db').probeRoots!()).toEqual([
+      { path: '/tmp/warp.db', label: 'db' },
+    ])
+    const defaults = await createWarpProvider().probeRoots!()
+    expect(defaults).toHaveLength(2)
+    for (const root of defaults) {
+      expect(isAbsolute(root.path)).toBe(true)
+      expect(root.label).toBe('db')
+    }
+  })
+
+  it('qwen reports the projects dir', async () => {
+    expect(await createQwenProvider('/tmp/qwen-projects').probeRoots!()).toEqual([
+      { path: '/tmp/qwen-projects', label: 'projects' },
+    ])
+  })
+
+  it('ibm-bob reports the storage dirs', async () => {
+    expect(await createIBMBobProvider('/tmp/bob').probeRoots!()).toEqual([
+      { path: '/tmp/bob', label: 'storage' },
+    ])
+    const defaults = await createIBMBobProvider().probeRoots!()
+    expect(defaults.length).toBeGreaterThan(0)
+    for (const root of defaults) expect(root.label).toBe('storage')
+  })
+
+  it('lingtai-tui reports its candidates even when none exist yet', async () => {
+    // getLingTaiHomes drops non-existent candidates (right for discovery);
+    // probeRoots must keep them visible so doctor can show where it looked.
+    const roots = await createLingTaiTuiProvider().probeRoots!()
+    expect(roots.length).toBeGreaterThanOrEqual(2)
+    for (const root of roots) expect(isAbsolute(root.path)).toBe(true)
+    const labels = new Set(roots.map(r => r.label))
+    expect(labels.has('sessions')).toBe(true)
+    expect(labels.has('registry')).toBe(true)
+  })
+
+  it('goose reports its sessions db', async () => {
+    const roots = await createGooseProvider().probeRoots!()
+    expect(roots).toHaveLength(1)
+    expect(isAbsolute(roots[0]!.path)).toBe(true)
+    expect(roots[0]!.label).toBe('db')
+  })
+
+  it('crush reports its registry file', async () => {
+    const roots = await createCrushProvider().probeRoots!()
+    expect(roots).toHaveLength(1)
+    expect(isAbsolute(roots[0]!.path)).toBe(true)
+    expect(roots[0]!.label).toBe('registry')
+  })
+
+  it('antigravity reports its conversation roots and the statusline file', async () => {
+    const roots = await createAntigravityProvider().probeRoots!()
+    expect(roots.length).toBeGreaterThanOrEqual(2)
+    for (const root of roots) expect(isAbsolute(root.path)).toBe(true)
+    const labels = new Set(roots.map(r => r.label))
+    expect(labels.has('conversations')).toBe(true)
+    expect(labels.has('statusline')).toBe(true)
+  })
+})


### PR DESCRIPTION
Tier 1 of #899: `probeRoots()` for the 12 uncovered providers from the `PROVIDER_ENV_VARS` list - codewhale, hermes, lingtai-tui, droid, cursor, cursor-agent, goose, crush, warp, antigravity, qwen, ibm-bob. Coverage goes 6/42 to 18/42.

Every implementation calls the exact resolution helpers its discovery path uses (same env fallbacks, OS branches, and factory overrides), verified per provider against the discovery code. One deliberate divergence, commented in the code: lingtai-tui reports its candidates BEFORE the existence filter, because `getLingTaiHomes` dropping non-existent dirs is right for discovery and wrong for doctor, whose job is to show where it looked.

Verification:
- `tests/provider-probe-roots.test.ts` (12 cases): wherever a factory takes an override, the SAME override must come back through probeRoots, proving the two paths share one resolution. 12/12 green, `tsc --noEmit` clean.
- Real `codeburn doctor` run on my machine, before/after visible in one table: covered providers now print the exact path checked (`Droid - NOTHING FOUND (~/.factory/sessions does not exist; tool likely not installed)`, `Crush - .../crush/projects.json does not exist`, `Cursor Agent - projects + ai-tracking db, exists`), while the still-uncovered ones keep the generic "tool likely not installed or no history yet" row. That generic row is the remaining Tier 2 target list.

Refs #899 (does not close it; Tier 2 remains).