### PR TITLE
fix(kiro): estimate input tokens from the full prompt, not a 500-char slice

### DIFF
--- a/src/providers/kiro.ts
+++ b/src/providers/kiro.ts
@@ -203,12 +203,20 @@ function parseChatFile(data: KiroChatFile, sessionId: string, project: string, s
   if (modelId === 'auto' || !modelId) modelId = 'kiro-auto'
 
   let pendingUserMessage = ''
+  // Accumulate every human turn's full length for the input-token estimate,
+  // mirroring the modern-execution path (which sums inputChars). The prior
+  // code estimated input tokens from pendingUserMessage.length alone - the
+  // LAST human turn truncated to 500 chars - so a multi-turn session, or any
+  // final prompt over 500 chars, undercounted input tokens (and therefore
+  // costUSD) severalfold, while output correctly summed all bot chars.
+  let inputChars = 0
   const allTools: string[] = []
   const toolSequence: ToolCall[][] = []
 
   for (const msg of chat) {
     if (msg.role === 'human') {
       if (msg.content.startsWith('<identity>')) continue
+      inputChars += msg.content.length
       pendingUserMessage = msg.content.slice(0, 500)
     }
     if (msg.role === 'bot') {
@@ -226,7 +234,7 @@ function parseChatFile(data: KiroChatFile, sessionId: string, project: string, s
   if (seenKeys.has(dedupKey)) return results
 
   const outputTokens = estimateTokensFromChars(totalOutputChars)
-  const inputTokens = estimateTokensFromChars(pendingUserMessage.length)
+  const inputTokens = estimateTokensFromChars(inputChars)
   const costUSD = calculateCost(modelId, inputTokens, outputTokens, 0, 0, 0)
   const tsDate = parseKiroTimestamp(metadata.startTime)
   if (!tsDate) return results

--- a/tests/providers/kiro.test.ts
+++ b/tests/providers/kiro.test.ts
@@ -111,6 +111,26 @@ describe('kiro provider - chat file parsing', () => {
     expect(call.costUSD).toBeGreaterThan(0)
   })
 
+  it('estimates input tokens from the full prompt, not a 500-char slice (money-path)', async () => {
+    // Regression: parseChatFile estimated input tokens from pendingUserMessage
+    // (the last human turn sliced to 500 chars) while output summed every bot
+    // char, so a long prompt undercounted input tokens - and cost - severalfold.
+    const wsHash = 'f'.repeat(32)
+    const wsDir = join(tmpDir, wsHash)
+    await mkdir(wsDir, { recursive: true })
+    const chatPath = join(wsDir, 'long.chat')
+    const prompt = 'x'.repeat(2400) // 2400 chars / 4 = 600 tokens; a 500-slice would give 125
+    await writeFile(chatPath, makeChatFile({ userPrompt: prompt, botResponses: ['ok'] }))
+
+    const calls: ParsedProviderCall[] = []
+    for await (const call of kiro.createSessionParser({ path: chatPath, project: 'p', provider: 'kiro' }, new Set()).parse()) calls.push(call)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.inputTokens).toBe(600)
+    // userMessage stays capped for display; only the token estimate uses the full length.
+    expect(calls[0]!.userMessage.length).toBe(500)
+  })
+
   it('stores kiro-auto when model is auto', async () => {
     const wsHash = 'b'.repeat(32)
     const wsDir = join(tmpDir, wsHash)


### PR DESCRIPTION
Money-path accuracy fix from the systematic audit (find -> verify -> adversarial -> manual confirmation + mutation check).

`kiro.ts` `parseChatFile` estimated input tokens from `pendingUserMessage` - the last human turn sliced to 500 chars - while output correctly summed every bot char. So a multi-turn Kiro session, or any final prompt over 500 chars, undercounted input tokens and therefore `costUSD` severalfold. The asymmetry was the tell: output used a full accumulator, input used one truncated turn. The sibling modern-execution path in the same file already does the right thing with an `inputChars` accumulator; this makes `parseChatFile` match it, keeping the 500-char slice for the display `userMessage` only.

Mutation-checked: a 2400-char prompt reports 125 input tokens before the fix, 600 after (the real full-length estimate). `tsc --noEmit` clean, kiro suite green.
