### PR TITLE
ci: make the bracket-assign guard actually match its targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,12 @@ jobs:
           set -e
           semgrep --config .semgrep/rules/no-bracket-assign-hot-paths.yml \
             --strict --json \
-            packages/cli/src/providers/ packages/cli/src/parser.ts > semgrep-out.json
+            packages/cli/src/providers/ packages/cli/src/parser.ts packages/core/src/providers/ > semgrep-out.json
+          SCANNED=$(jq '.paths.scanned | length' semgrep-out.json)
+          if [ "$SCANNED" -eq 0 ]; then
+            echo "::error::semgrep scanned no files — the rule's paths.include no longer matches any scan target; check .semgrep/rules/no-bracket-assign-hot-paths.yml"
+            exit 1
+          fi
           FINDINGS=$(jq '.results | length' semgrep-out.json)
           if [ "$FINDINGS" -gt 0 ]; then
             jq -r '.results[] | "::error file=\(.path),line=\(.start.line)::\(.extra.message)"' semgrep-out.json

--- a/.semgrep/rules/no-bracket-assign-hot-paths.yml
+++ b/.semgrep/rules/no-bracket-assign-hot-paths.yml
@@ -18,5 +18,6 @@ rules:
           ...
     paths:
       include:
-        - '/src/providers/*.ts'
-        - '/src/parser.ts'
+        - '/packages/cli/src/providers/**/*.ts'
+        - '/packages/cli/src/parser.ts'
+        - '/packages/core/src/providers/**/*.ts'


### PR DESCRIPTION
The prototype-pollution guard has never fired.

Its `paths.include` named the pre-workspace layout (`/src/providers/*.ts`, `/src/parser.ts`) while the job scans `packages/cli/src/…`. Semgrep intersects the scan targets with `paths.include`, so the rule selected no files and the step passed green unconditionally — including on the old layout, where the same mismatch applied. It is a standing hole, not something the workspace move broke.

Verified rather than reasoned about: with the old rule and the old targets, a planted bracket-assign under `packages/cli/src/providers/` reports **0 findings**. With this change the same violation is reported at the right file and line, and the real tree scans 184 files clean.

## What changed

**The include list now matches.** It also brings `packages/core/src/providers/**` into scope: provider decoding moved there in the extraction, so that is where records from untrusted session logs are turned into maps — precisely what the rule exists to guard. The CLI entry is recursive too; the directory is flat today, but a nested provider directory would otherwise be scanned by CI and then silently excluded by the rule.

**The step now fails when it scans nothing.** This is the part that matters. The gate only counted findings, so if the includes ever drift out of sync again, `.results` is `[]` and the job goes green — the exact failure this PR is fixing, waiting to recur on the next rename. `--strict` does not assert that anything was selected. The new check reads `.paths.scanned`, which reflects what the rule actually selected rather than the raw targets.

A low-water mark was considered and rejected as brittle: the provider count moves by design and CI installs semgrep unpinned, so a magic number would need constant bumping and would itself decay back into vacuity. Greater-than-zero is the honest assertion.

## Verification

The `run:` block was extracted from the committed workflow and executed verbatim, twice:

- clean tree → exit 0, `scanned=184`, `results=0`
- include paths deliberately broken, scan targets intact → semgrep reports `Targets scanned: 0`, the new check fires, **exit 1**

Plus: a planted violation in the flat providers directory is reported; a planted violation under a nested directory is reported (it would not have been before); both removed afterwards and the tree re-verified clean.

The narrow whitelist is deliberate and unchanged in spirit — broadening it would produce false positives on unrelated maps elsewhere in the tree, so the non-vacuity check is what protects it instead.