### PR TITLE
ci: run the CLI suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,33 @@ jobs:
       - name: Verify package contents
         run: npm pack --workspace=@codeburn/core --dry-run
 
+  cli:
+    name: cli (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['22.13.x', '24.x']
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Check workspace versions
+        run: npm run check:workspace-versions
+
+      - name: Install from lockfile
+        run: npm ci
+
+      - name: Build core
+        run: npm run build --workspace=@codeburn/core
+
+      - name: Test cli
+        run: npm test --workspace=codeburn
+
   semgrep:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:cli": "npm run build:cli -w codeburn",
     "build:dash": "npm run build:dash -w codeburn",
     "dev": "npm run dev -w codeburn",
-    "test": "npm run test -w codeburn",
+    "test": "npm run build -w @codeburn/core && npm run test -w @codeburn/core && npm run test -w codeburn",
     "check:workspace-versions": "node scripts/check-workspace-versions.mjs"
   },
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
     "build:cli": "tsup && node -e \"const fs=require('fs'); fs.copyFileSync('src/cli.ts','dist/cli.js'); fs.chmodSync('dist/cli.js',0o755)\"",
     "build:dash": "cd ../../dash && npm install --no-audit --no-fund --silent && npm run build",
     "dev": "NODE_OPTIONS=--no-deprecation tsx src/cli.ts",
-    "test": "vitest",
+    "test": "vitest run",
     "prepublishOnly": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
> **Merge after #921.** That PR fixes the aged fixture and adds the retry that keeps this job stable; landing this first would put a red, flaky gate in front of every subsequent PR.

CI followed the core package through the workspace move: there is a job for typecheck, test, build, verify-dist and pack across three node versions. Nothing runs the CLI's suite — roughly 2470 tests, **including the 29 provider bridge suites that byte-compare against goldens captured before the extraction**.

That matters more than a missing job usually would. #809 states that every phase PR passes a byte-identical parity gate. The gate exists and is real — `packages/cli/tests/providers/*-bridge.test.ts` are genuine byte-compare tests — but nothing has been running it, so "parity holds" has been an assertion rather than a check for the whole extraction.

## Two things stood in the way

**`"test": "vitest"` is watch mode.** In CI that hangs the runner instead of failing. Now `vitest run`.

**The root `test` script only forwarded to the CLI workspace**, so core's guardrail suite — architecture-gate, content-smuggling, import-smoke, schema-drift — never ran from the command a contributor actually types. Worse, the CLI half could not run from a clean checkout at all: core's exports resolve to `dist`, which is gitignored, so a fresh clone died on `Cannot find module '@codeburn/core'`.

The root script now builds core first. That costs a build on every local run, which is a genuine annoyance; the alternative is a script that only works if you happened to build core earlier.

## Two node legs, and why that is not sprawl

A review caught something that would have made this job worse than useless: `zed-bridge.test.ts` seeds its fixture with zlib's **zstd**, which only landed in Node 22.15, so it self-skips below that. Pinning the job to the engines floor of 22.13 would have **silently skipped a byte-compare parity suite and reported green** — precisely the failure mode this PR exists to eliminate.

So the job runs two legs. The floor leg keeps the `>=22.13` promise honest; the 24.x leg makes the parity gate actually execute. Worth flagging separately: the engines floor and that test's real requirement disagree, which is a question for you rather than something to paper over here.

## Other review fixes

- **15-minute timeout.** Actions defaults to 360; measured wall time for the suite is about 2 minutes. A hung run cannot burn a runner for six hours.
- **Workspace-versions check moved before `npm ci`.** It only reads the manifests and the lockfile, so drift now fails in a second rather than after a full install.

## Verification

`actionlint` clean on the workflow. Verified that building core is sufficient: no CLI test spawns the built CLI, and none depend on the dash build or the litellm bundle. The Playwright sync E2E self-skips without three env vars, so it stays inert in CI — noted rather than fixed.