### PR TITLE
Scope the root test script to tests/ so npm test runs from a clean install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,16 +24,23 @@ There is no separate build step required to run the dev CLI. `npm run dev` runs 
 
 | Command | What it does |
 |---|---|
-| `npm test` | Runs the vitest suite (42 test files, 568 tests). |
+| `npm test` | Runs the vitest suite under `tests/` (189 of the 192 files, 2,494 tests). |
+| `npm run test:locks` | Runs the three parallelism-sensitive `cache-refresh-lock` suites serially. |
+| `npm run test:watch` | Same scope as `npm test`, in watch mode. |
 | `npm run dev -- status` | Runs the CLI in dev mode against your real data. |
 | `npm run build` | Bundles the litellm pricing snapshot, then runs `tsup` to produce `dist/cli.js`. |
 | `npm run bundle-litellm` | Refreshes `src/data/litellm-snapshot.json` from the upstream litellm repo. |
 
-To test a specific suite, pass a path:
+To test a specific suite, run vitest directly with a path:
 
 ```bash
-npm test -- tests/providers/codex.test.ts
+npx vitest run tests/providers/codex.test.ts
 ```
+
+`npm test` is scoped to `tests/` on purpose. The Electron app under `app/` carries its
+own vitest config and its own `jsdom` dependency in `app/node_modules`; letting vitest's
+default glob reach those specs from a root install fails with
+`ERR_MODULE_NOT_FOUND: jsdom`. To run the app's tests, install and run them from `app/`.
 
 ## What to Read Before Editing
 
@@ -65,9 +72,14 @@ See `docs/architecture.md` for a fuller map.
 
 ## Tests
 
-- Each new provider should ship with a fixture-based test under `tests/providers/`. The five providers without test files today (claude, gemini, goose, qwen, antigravity) are a known gap; new code should not add to that list.
+- Each new provider should ship with a fixture-based test under `tests/providers/`. The three providers without test files today (claude, goose, qwen) are a known gap; new code should not add to that list.
 - Each new optimize detector in `src/optimize.ts` needs at least one positive and one negative case in `tests/optimize.test.ts`.
 - If your change affects the menubar JSON contract, update `tests/menubar-json.test.ts`.
+- A new test that exercises the cross-process refresh lock must be named
+  `tests/cache-refresh-lock-<what>.test.ts` **and** added to the `test:locks` script in
+  `package.json`. `npm test` excludes that prefix, so a lock test placed anywhere else
+  runs under the full worker pool and fails intermittently; one that matches the prefix
+  but is missing from `test:locks` never runs at all.
 
 ## Commit Message Format
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,12 @@ Run the test suite to catch any regressions:
 
 ```bash
 npm test
+npm run test:locks
 ```
+
+`npm test` covers `tests/`. `npm run test:locks` runs the three parallelism-sensitive
+`cache-refresh-lock` suites serially; CI treats them as reporting-only, so check them by
+hand here.
 
 Verify that the build completes without errors:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -177,13 +177,21 @@ The `prepublishOnly` hook in `package.json` runs `npm run build` so `npm publish
 
 ## Tests
 
-`npm test` runs vitest. Forty-two test files live under `tests/`:
+`npm test` runs vitest, scoped to `tests/`. 192 test files live there:
 
-- `tests/` root (27 files) covers CLI, parser, optimize, cache, format, models, plans.
+- `tests/` root (141 files) covers CLI, parser, optimize, cache, format, models, plans.
 - `tests/security/` (1 file) covers prototype-pollution guards.
-- `tests/providers/` (15 files) covers per-provider parsing.
+- `tests/providers/` (44 files) covers per-provider parsing.
+- `tests/sharing/` (6 files) covers the share/export surface.
+- `tests/setup/` holds the env-isolation setup file, not specs.
 - `tests/fixtures/` holds redacted real-world session data.
 
-Five providers ship without dedicated test files today: `antigravity`, `claude`, `gemini`, `goose`, `qwen`. Closing this gap is a standing good-first-issue.
+The scope is deliberate: the Electron app under `app/` has its own vitest config and its
+own `jsdom` dependency, so vitest's default glob must not reach it from a root install.
+The three `cache-refresh-lock` suites are excluded from `npm test` and run serially via
+`npm run test:locks`, because they exercise a cross-process file lock and fail under full
+worker pressure.
 
-CI runs Semgrep against `.semgrep/rules/no-bracket-assign-hot-paths.yml` over `src/providers/` and `src/parser.ts` (`.github/workflows/ci.yml`). It does not run vitest in CI today; tests run locally before publish.
+Three providers ship without dedicated test files today: `claude`, `goose`, `qwen`. Closing this gap is a standing good-first-issue.
+
+CI runs Semgrep against `.semgrep/rules/no-bracket-assign-hot-paths.yml` over `src/providers/` and `src/parser.ts` (`.github/workflows/ci.yml`). The vitest suite runs in CI too, via `.github/workflows/tests.yml`, on every pull request and every push to `main`.

--- a/docs/design/codeburn-mcp-plan.md
+++ b/docs/design/codeburn-mcp-plan.md
@@ -184,7 +184,7 @@ Keep `main.ts:477–484` (the `daysSelection`/`customRange`/`daySelection`/`peri
 
 - [ ] **Step 4: Typecheck + parity test**
 
-Run: `npx tsc --noEmit && npm test -- cli-status-menubar`
+Run: `npx tsc --noEmit && npx vitest run cli-status-menubar`
 Expected: clean typecheck; `tests/cli-status-menubar.test.ts` passes — i.e. `status --format menubar-json` output is unchanged (parity).
 
 - [ ] **Step 5: Add a direct unit test for the aggregator**
@@ -207,7 +207,7 @@ describe('buildMenubarPayloadForRange', () => {
 })
 ```
 
-Run: `npm test -- usage-aggregator`
+Run: `npx vitest run usage-aggregator`
 Expected: PASS (uses the empty real environment; `scanAndDetect` not called because `optimize:false`).
 
 - [ ] **Step 6: Commit**
@@ -272,7 +272,7 @@ describe('redact', () => {
 
 - [ ] **Step 2: Run to verify failure**
 
-Run: `npm test -- mcp-redact`
+Run: `npx vitest run mcp-redact`
 Expected: FAIL ("Cannot find module '../src/mcp/redact.js'").
 
 - [ ] **Step 3: Implement**
@@ -302,7 +302,7 @@ export function redactProjectNames(payload: MenubarPayload, includeNames: boolea
 
 - [ ] **Step 4: Run to verify pass**
 
-Run: `npm test -- mcp-redact`
+Run: `npx vitest run mcp-redact`
 Expected: PASS (3 tests).
 
 - [ ] **Step 5: Commit**
@@ -370,7 +370,7 @@ describe('tables', () => {
 
 - [ ] **Step 2: Run to verify failure**
 
-Run: `npm test -- mcp-tables`
+Run: `npx vitest run mcp-tables`
 Expected: FAIL ("Cannot find module '../src/mcp/tables.js'").
 
 - [ ] **Step 3: Implement**
@@ -434,7 +434,7 @@ export function renderSavingsTable(p: MenubarPayload): string {
 
 - [ ] **Step 4: Run to verify pass**
 
-Run: `npm test -- mcp-tables`
+Run: `npx vitest run mcp-tables`
 Expected: PASS (4 tests).
 
 - [ ] **Step 5: Commit**
@@ -521,7 +521,7 @@ describe('mcp server', () => {
 
 - [ ] **Step 2: Run to verify failure**
 
-Run: `npm test -- mcp-server`
+Run: `npx vitest run mcp-server`
 Expected: FAIL ("Cannot find module '../src/mcp/server.js'").
 
 - [ ] **Step 3: Implement the server**
@@ -660,7 +660,7 @@ export async function startStdioServer(version: string): Promise<void> {
 
 - [ ] **Step 4: Run to verify pass**
 
-Run: `npm test -- mcp-server`
+Run: `npx vitest run mcp-server`
 Expected: PASS (5 tests).
 
 - [ ] **Step 5: Commit**

--- a/docs/providers/codewhale.md
+++ b/docs/providers/codewhale.md
@@ -104,5 +104,5 @@ parser key is `codewhale:<session-id>`.
 1. Reproduce with a minimal real-shape saved-session JSON fixture.
 2. Verify aggregate tokens and parent-plus-subagent cost before checking UI
    totals; do not infer an input/output split CodeWhale does not store.
-3. Run `npm test -- tests/providers/codewhale.test.ts --run` and
-   `npm test -- tests/provider-registry.test.ts tests/session-cache.test.ts --run`.
+3. Run `npx vitest run tests/providers/codewhale.test.ts` and
+   `npx vitest run tests/provider-registry.test.ts tests/session-cache.test.ts`.

--- a/docs/providers/hermes.md
+++ b/docs/providers/hermes.md
@@ -62,6 +62,6 @@ The shared session cache fingerprints Hermes state DB files. `HERMES_HOME` is in
 ## When fixing a bug here
 
 1. Reproduce against a real Hermes `state.db` or a minimal SQLite fixture.
-2. Run `npm test -- tests/providers/hermes.test.ts --run`.
+2. Run `npx vitest run tests/providers/hermes.test.ts`.
 3. For local smoke testing, use an isolated cache directory, for example:
    `CODEBURN_CACHE_DIR=/tmp/codeburn-hermes-cache node --import tsx -e "import { parseAllSessions } from './src/parser.ts'; console.log(await parseAllSessions(undefined, 'hermes'))"`.

--- a/docs/providers/lingtai-tui.md
+++ b/docs/providers/lingtai-tui.md
@@ -85,4 +85,4 @@ The ledger is append-only, so line number is stable for normal operation.
 
 1. Prefer a minimal redacted `token_ledger.jsonl` fixture over full `chat_history.jsonl`.
 2. Check whether a daemon entry is already mirrored into the parent ledger before adding new discovery paths.
-3. Run `npm test -- tests/providers/lingtai-tui.test.ts --run`.
+3. Run `npx vitest run tests/providers/lingtai-tui.test.ts`.

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -57,6 +57,6 @@ Per `<sessionId>:<messageId>`.
 
 ## When fixing a bug here
 
-1. The 558-line test suite catches a lot. Run `npm test -- tests/providers/opencode.test.ts` before and after any change.
+1. The 558-line test suite catches a lot. Run `npx vitest run tests/providers/opencode.test.ts` before and after any change.
 2. If the bug is "missing table" warning, do not catch and silence it. Either upgrade the version expectation in the parser or document the breaking schema change.
 3. If the bug is "reasoning tokens off by one", check the parts index ordering.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "build:cli": "tsup && node -e \"const fs=require('fs'); fs.copyFileSync('src/cli.ts','dist/cli.js'); fs.chmodSync('dist/cli.js',0o755)\"",
     "build:dash": "cd dash && npm install --no-audit --no-fund --silent && npm run build",
     "dev": "NODE_OPTIONS=--no-deprecation tsx src/cli.ts",
-    "test": "vitest",
+    "test": "vitest run tests --exclude \"tests/cache-refresh-lock*\"",
+    "test:locks": "vitest run tests/cache-refresh-lock.test.ts tests/cache-refresh-lock-corrupt-body.test.ts tests/cache-refresh-lock-process.test.ts --poolOptions.forks.singleFork=true",
+    "test:watch": "vitest tests --exclude \"tests/cache-refresh-lock*\"",
     "prepublishOnly": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Problem

`npm test` does not work from a clean root install.

`"test": "vitest"` is unscoped, so vitest's default glob reaches the Electron app's specs under `app/`. Those carry their own `app/vitest.config.ts` and their own `jsdom` in `app/package.json`, installed into `app/node_modules` — which a root `npm ci` does not create. The run dies before it gets anywhere:

```
$ git clone … && npm ci && npm test
Error: Cannot find package 'jsdom' imported from …/node_modules/vitest/dist/chunks/index.CmSc2RE5.js
Serialized Error: { code: 'ERR_MODULE_NOT_FOUND' }
…
 Test Files  3 failed | 199 passed | 2 skipped (230)
     Errors  26 errors
```

This is already a known trap — `.github/workflows/tests.yml` documents it in a comment ("the root default glob picking them up is exactly what failed run #2 with `ERR_MODULE_NOT_FOUND: jsdom`") and works around it by spelling out a scoped vitest invocation in the workflow. But the workaround lives only in CI, so:

- `CONTRIBUTING.md` tells a new contributor to run `npm test`, which fails on their first try.
- `RELEASING.md` names `npm test` as the **pre-release gate** ("Before Every Release → Run the test suite"). That command currently errors out.

## Change

Move the scoping CI already applies into `package.json`, and have CI call the scripts so the two cannot drift again:

| script | what it runs |
|---|---|
| `test` | `tests/`, minus the parallelism-sensitive `cache-refresh-lock` suites |
| `test:locks` | those three suites, serially (`--poolOptions.forks.singleFork=true`) |
| `test:watch` | same scope as `test`, watch mode — preserves the old `vitest` behaviour |

`test` (189 files) and `test:locks` (3) together cover all 192 files under `tests/`, so nothing is orphaned by the split.

**CI behaviour is unchanged** — this PR does not touch `.github/workflows/`. The `test` and `test:locks` strings are byte-identical to the invocations `tests.yml` already spells out (verified by string equality, not by eye), so if you want the two to stop drifting apart, those two `run:` lines can become `npm test` and `npm run test:locks` in a one-line follow-up. I left that edit out deliberately so this PR needs no workflow permissions — happy to add it if you would rather have it here.

### One consequence worth calling out

Scoping the script changes what a **trailing path argument** means. vitest ORs positional filters, so `npm test -- tests/providers/hermes.test.ts` now resolves to `vitest run tests --exclude "…" tests/providers/hermes.test.ts` — which does not narrow to that file, it runs everything. Measured:

```
npx vitest list tests --exclude "tests/cache-refresh-lock*"                                 → 189 files
npx vitest list tests --exclude "tests/cache-refresh-lock*" tests/providers/codex.test.ts  → 189 files   (narrows nothing)
npx vitest list tests/providers/codex.test.ts                                              → 1 file
```

So every documented use of that idiom is rewritten to `npx vitest run <path>` — 13 lines across the four provider guides (`opencode`, `hermes`, `codewhale`, `lingtai-tui`) and `docs/design/codeburn-mcp-plan.md`. Without that, a contributor following `docs/providers/hermes.md` would expect a ten-second single-file run and get the full suite instead.

Docs refreshed alongside, because they had drifted:

- `CONTRIBUTING.md`: "42 test files, 568 tests" → 189 of 192 files / 2,494 tests.
- The provider test-gap list — `CONTRIBUTING.md` and `docs/architecture.md` both still name five providers without test files, but `tests/providers/antigravity.test.ts` and `tests/providers/gemini.test.ts` exist on `main` today. Corrected to the three that are genuinely missing (claude, goose, qwen). Pre-existing, but it sits in the sections this PR rewrites.
- `docs/architecture.md`: per-directory counts (27/1/15 → 141/1/44, plus `tests/sharing/`), and the line "It does not run vitest in CI today", which stopped being true when `tests.yml` landed.
- `RELEASING.md`: the pre-release gate now names `npm run test:locks` too, since CI treats those suites as reporting-only and a maintainer should eyeball them by hand before publishing.
- `CONTRIBUTING.md` also gains a line making the lock-test convention explicit: a new cross-process-lock test must both match the `tests/cache-refresh-lock-*` prefix and be added to `test:locks`. Nothing recorded that before, and the split makes it load-bearing — a lock test named anything else runs under the full worker pool and flakes, while one that matches the prefix but is missing from `test:locks` silently never runs.

## Verification

Run on a clean `npm ci` in a fresh worktree at `3536a1d`:

- **Before:** `npx vitest run app/renderer/App.test.tsx` → `ERR_MODULE_NOT_FOUND: jsdom`. Reproduced.
- **After:** `npm test` → no jsdom error, 189 files / 2,494 tests collected.
- **Green:** `npx vitest run tests --exclude "tests/cache-refresh-lock*" --testTimeout=30000` → **187 passed | 2 skipped (189 files), 2,489 passed | 5 skipped (2,494 tests), 0 failures.**
- `npx tsc --noEmit` → clean.

One caveat worth flagging rather than burying: at the default 5s `testTimeout` I could not get a green run on my machine — I saw 17, then 12, then 1 failure across runs, all timeouts, and the same flakiness on **unmodified** `main` at the same SHA (so it is not introduced here; upstream CI is green on `3536a1d`). Raising only `--testTimeout` makes it uniformly green, which suggests the 5s default is tight for the suites that spawn CLI subprocesses on slower or loaded hardware. I have deliberately **not** touched the timeout in this PR — happy to open a separate one if you think it is worth doing.

`npm run test:locks` fails on my hardware, as `#904` describes; it also fails there on unmodified `main`, and CI keeps it `continue-on-error`, so this PR does not change its status.

## Notes

Related to #947 (release cadence) only in passing: the pre-release gate in `RELEASING.md` being a command that errors out seemed worth fixing regardless of when the next release lands.
