### PR TITLE
ci: call the npm test scripts instead of duplicating their vitest strings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,16 +23,14 @@ jobs:
       # parallelism-sensitive (they fail under full worker pressure and pass serially -
       # reproduced repeatedly on unmodified main), so they run in their own serial step
       # below instead of making every PR roll dice.
-      # Scoped to tests/: the Electron app's renderer tests under app/ carry
-      # their own vitest config and jsdom dependency (app/node_modules) and
-      # cannot run from the root install - the root default glob picking them
-      # up is exactly what failed run #2 with ERR_MODULE_NOT_FOUND: jsdom.
+      # Scoping (tests/ only, app/ excluded) lives in the package.json test
+      # script since #948, so CI and a contributor's `npm test` can never drift.
       - name: Test suite (parallel)
-        run: npx vitest run tests --exclude "tests/cache-refresh-lock*"
+        run: npm test
       # Single forked worker, so lock contention comes only from the child processes the
       # tests spawn deliberately. Quarantined (reports, never gates): the process
       # suite still races its own takeover window even serially on slow runners -
       # tracked in #904; drop continue-on-error once that race is settled.
       - name: Cache-lock suite (serial, quarantined)
         continue-on-error: true
-        run: npx vitest run tests/cache-refresh-lock.test.ts tests/cache-refresh-lock-corrupt-body.test.ts tests/cache-refresh-lock-process.test.ts --poolOptions.forks.singleFork=true
+        run: npm run test:locks


### PR DESCRIPTION
The one-line follow-up #948 proposed: now that the test scoping lives in package.json (test and test:locks are byte-identical to what this workflow spelled out), the workflow calls the scripts so the two invocations cannot drift apart again. The quarantine comment and continue-on-error on the lock step are unchanged.