### PR TITLE
fix(insights): stop counting prose 'wrong answer' as a user correction

### DIFF
--- a/src/workflow-insights.ts
+++ b/src/workflow-insights.ts
@@ -20,7 +20,12 @@ export const USER_CORRECTION_PATTERNS: RegExp[] = [
   /\byou (?:missed|forgot|misunderstood|broke)\b/i,
   /\brevert (?:that|it|this|your|the last|the change)\b/i,
   /\bundo (?:that|it|this|your|the last|the change)\b/i,
-  /\bwrong (?:file|approach|place|method|function|answer|way|direction)\b/i,
+  // "answer" is deliberately absent from the noun list: injected skill/system
+  // prose lands in the user-message slot and reads as ordinary writing where
+  // "the wrong answer" is an idiom ("a well-composed page is never the wrong
+  // answer" counted 4 phantom corrections on real data). The other nouns are
+  // concrete work artifacts that prose rarely uses with "wrong".
+  /\bwrong (?:file|approach|place|method|function|way|direction)\b/i,
   /\bstill (?:wrong|broken|failing|not working)\b/i,
 ]
 

--- a/tests/workflow-insights.test.ts
+++ b/tests/workflow-insights.test.ts
@@ -119,10 +119,23 @@ describe('scanUserCorrections', () => {
       'undo the migration when done',
       'the build is failing, can you fix it',
       'what went wrong here',
+      // Verbatim from an injected skill prompt that counted 4 phantom
+      // corrections on real data: "wrong answer" is prose idiom, not a
+      // correction, which is why "answer" is not in the wrong-<noun> list.
+      'When unsure: a well-composed page is never the wrong answer; an over-designed visual identity sometimes is.',
     ]
     const p = project([session('s1', phrases.map(m => turn({ userMessage: m })))])
     const r = scanUserCorrections([p])
     expect(r.corrections).toBe(0)
+  })
+
+  it('still flags concrete wrong-<artifact> follow-ups', () => {
+    const p = project([session('s1', [
+      turn({ userMessage: 'rename the helper' }),
+      turn({ userMessage: 'you edited the wrong file' }),
+      turn({ userMessage: "that's the wrong approach, use the cache" }),
+    ])])
+    expect(scanUserCorrections([p]).corrections).toBe(2)
   })
 
   it('ignores continuation turns with no fresh prompt', () => {


### PR DESCRIPTION
Real-data validation of the workflow metrics found the week's entire correction count (4) was one injected skill prompt matched four times: the artifact-design prompt contains "a well-composed page is never the wrong answer", and the wrong-<noun> correction pattern fired on it. The true correction count for the window was 0.

Injected skill and system prose lands in the user-message slot, where "the wrong answer" is an ordinary idiom. The fix removes "answer" from the wrong-<noun> alternation; the remaining nouns (file, approach, place, method, function, way, direction) are concrete work artifacts that prose rarely pairs with "wrong". Regression test carries the verbatim sentence; a companion test pins that concrete wrong-file / wrong-approach follow-ups still count.