### PR TITLE
fix(menubar): activate before creating the status item, policy pinned (#868)

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -90,9 +90,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSM
     }
 
     func applicationWillFinishLaunching(_ notification: Notification) {
-        // Set accessory policy before the app's focus chain forms. On macOS Tahoe
-        // (26.x), setting it after didFinishLaunching causes ghost status items
-        // because the policy gets baked into the initial focus chain.
+        // Belt-and-suspenders for dev runs only: packaged builds ship
+        // LSUIElement=true (package-app.sh / build-local.sh), so LaunchServices
+        // starts the process at .accessory before main() runs and this call is
+        // a measured no-op there (returns false, no state change — #868
+        // analysis). What actually matters is that the policy NEVER
+        // transitions while a live NSStatusItem exists: the .regular →
+        // .accessory dance from #147 is what plausibly caused the ghost item
+        // that 85b5728 fixed. Keep the policy pinned; see the activate() call
+        // in applicationDidFinishLaunching for the other half of the story.
         NSApp.setActivationPolicy(.accessory)
     }
 

--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -120,6 +120,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSM
         // interaction (popover open, wake) refreshes immediately.
 
         restorePersistedCurrency()
+        // #868 experiment: restore only the activation half of the #147 fix.
+        // Packaged builds ship LSUIElement=true, so the policy is .accessory
+        // before main() runs and never transitions (the transition is what
+        // plausibly caused the ghost item). Accessory apps can still activate,
+        // which registers the app with the window server before the status
+        // item is created - the effect #147 actually needed for #146.
+        NSApp.activate(ignoringOtherApps: true)
         setupStatusItem()
         setupPopover()
         observeStore()


### PR DESCRIPTION
Ships @ozymandiashh's activate-only fix for #868 (cherry-picked from experiment/868-activate-only, authorship preserved), so the next release carries the best available fix for the never-rendering status item on macOS 26.5.x instead of waiting on the test loop.

The analysis on the issue: 85b5728/db99319's real behavioral change was deleting #147's NSApp.activate call (the policy-setting half was already dead code, since packaged builds ship LSUIElement=true and start at .accessory before main() — measured with a probe bundle). That left the app creating its status item without ever registering with the window server, which is exactly the #146 state. This restores only the activation half, keeping the policy pinned so the .regular -> .accessory transition that plausibly caused the ghost item (the bug 85b5728 fixed) never happens. Second commit corrects the now-disproven comment at the applicationWillFinishLaunching policy call.

Honest framing: neither the analysis author nor this machine reproduces the black icon (renders fine on 26.5.0 and 26.5.2 with 0.9.19), so this is the well-argued middle path that flips neither historical bug, not an evidence-confirmed fix. It is falsifiable by the reporter on the release build either way, and the issue stays open until 25F80 confirms.

Verified: swift build clean, swift test 156/156 green; the healthy-machine case keeps rendering (the activate call is additive for accessory apps, no policy transition occurs).