### PR TITLE
fix(dash): one-shot rate showed 10000% in Model efficiency

### DIFF
--- a/dash/src/App.tsx
+++ b/dash/src/App.tsx
@@ -172,7 +172,10 @@ function DeviceView({ payload, isRemote, unit }: { payload?: Payload; isRemote: 
             rows={(c?.modelEfficiency ?? []).slice(0, 10).map((m) => ({
               name: m.name,
               costPerEdit: usd(m.costPerEdit),
-              oneShot: `${Math.round(m.oneShotRate * 100)}%`,
+              // modelEfficiency.oneShotRate arrives as a PERCENT (0-100),
+              // unlike current.oneShotRate which is a fraction - the TUI and
+              // menubar render it verbatim; multiplying again showed 10000%.
+              oneShot: `${Math.round(m.oneShotRate)}%`,
             }))}
           />
         </Panel>


### PR DESCRIPTION
Caught during the v0.9.20 browser surface sweep: the payload's modelEfficiency[].oneShotRate is already a percent (0-100) - the TUI and menubar render it verbatim - but the dash multiplied by 100 again, showing 10000% / 8570% / 9380% in the Model efficiency table. current.oneShotRate (a fraction) keeps its existing correct handling in the overview card. One line plus the unit comment; dash typecheck and vite build clean; verified fixed in the live browser.