### PR TITLE
test: file-level 30s timeout for the three spawn-heavy CLI suites

### DIFF
--- a/tests/cli-emitters.test.ts
+++ b/tests/cli-emitters.test.ts
@@ -3,7 +3,14 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+// These specs spawn the real CLI (tsx compile + full parse) per test, which
+// blows the 5s default under full parallel suite load while passing cleanly
+// in isolation — the exact flake class #948 documented and CI has hit
+// (cli-emitters timed out on a green PR). Same file-level remedy as
+// cli-status-menubar.test.ts: a 30s ceiling for spawn-heavy suites only.
+vi.setConfig({ testTimeout: 30_000 })
 
 function runCli(args: string[], home: string) {
   return spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], {

--- a/tests/cli-json-daily.test.ts
+++ b/tests/cli-json-daily.test.ts
@@ -3,7 +3,14 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+// These specs spawn the real CLI (tsx compile + full parse) per test, which
+// blows the 5s default under full parallel suite load while passing cleanly
+// in isolation — the exact flake class #948 documented and CI has hit
+// (cli-emitters timed out on a green PR). Same file-level remedy as
+// cli-status-menubar.test.ts: a 30s ceiling for spawn-heavy suites only.
+vi.setConfig({ testTimeout: 30_000 })
 
 function runCli(args: string[], home: string) {
   return spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], {

--- a/tests/spend-flow.test.ts
+++ b/tests/spend-flow.test.ts
@@ -7,6 +7,13 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { DateRange, ProjectSummary, SessionSummary, TokenUsage } from '../src/types.js'
 
+// These specs spawn the real CLI (tsx compile + full parse) per test, which
+// blows the 5s default under full parallel suite load while passing cleanly
+// in isolation — the exact flake class #948 documented and CI has hit
+// (cli-emitters timed out on a green PR). Same file-level remedy as
+// cli-status-menubar.test.ts: a 30s ceiling for spawn-heavy suites only.
+vi.setConfig({ testTimeout: 30_000 })
+
 const parserMock = vi.hoisted(() => ({
   parseAllSessions: vi.fn(),
 }))


### PR DESCRIPTION
Retires the known parallel-load timeout flakes (cli-json-daily, spend-flow, cli-emitters - the #948-documented set, reproduced locally and in CI) with the same file-level vi.setConfig ceiling the CLI menubar suite already uses. No global timeout change; each suite passes in isolation before and after. Full suite green with the patch.