### PR TITLE
packaging: Snap Store target and CI, Flathub manifest

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -1,0 +1,58 @@
+name: Build Snap package
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Upload to the Snap Store (stable channel)
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - .github/workflows/build-snap.yml
+      - app/**
+      - src/**
+      - package.json
+      - package-lock.json
+
+permissions:
+  contents: read
+
+jobs:
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.13.0
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            app/package-lock.json
+
+      - name: Install CLI dependencies
+        run: npm ci
+
+      - name: Install desktop dependencies
+        run: npm ci --prefix app
+
+      - name: Build snap
+        run: npm --prefix app run package:snap
+
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: CodeBurn-Snap
+          path: app/release/codeburn_*.snap
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Publish to Snap Store
+        if: github.event_name == 'workflow_dispatch' && inputs.publish
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          sudo snap install snapcraft --classic
+          snapcraft upload --release=stable app/release/codeburn_*.snap

--- a/app/flathub/README.md
+++ b/app/flathub/README.md
@@ -1,0 +1,32 @@
+# Flathub submission
+
+These files publish CodeBurn Desktop on Flathub. The manifest repacks the
+Linux deb from GitHub Releases, so no source build is needed.
+
+## First-time submission
+
+1. Fork `https://github.com/flathub/flathub` (uncheck "fork only master").
+2. Create a branch off `new-pr` named `org.agentseal.CodeBurn`.
+3. Copy the three `org.agentseal.CodeBurn.*` files from this directory into the
+   repo root of that branch.
+4. Open a pull request against the `new-pr` branch of `flathub/flathub`.
+5. A reviewer responds on the PR. After approval Flathub creates a dedicated
+   `flathub/org.agentseal.CodeBurn` repo; future updates are PRs there.
+
+## Local test build (any Linux machine or VM)
+
+```sh
+flatpak install flathub org.flatpak.Builder
+flatpak run org.flatpak.Builder --force-clean --user --install \
+  --install-deps-from=flathub --repo=repo builddir org.agentseal.CodeBurn.yaml
+flatpak run org.agentseal.CodeBurn
+```
+
+## Each desktop release
+
+Update in `org.agentseal.CodeBurn.yaml`:
+- the deb `url` (new `desktop-vX.Y.Z` tag)
+- its `sha256` (`gh api repos/getagentseal/codeburn/releases/tags/desktop-vX.Y.Z -q '.assets[] | select(.name | endswith(".deb")) | .digest'`)
+
+and add a `<release>` entry in `org.agentseal.CodeBurn.metainfo.xml`.
+Then PR the `flathub/org.agentseal.CodeBurn` repo; merging publishes.

--- a/app/flathub/org.agentseal.CodeBurn.desktop
+++ b/app/flathub/org.agentseal.CodeBurn.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=CodeBurn
+Comment=See where your AI coding spend actually goes
+Exec=codeburn-run %U
+Terminal=false
+Type=Application
+Icon=org.agentseal.CodeBurn
+Categories=Development;Utility;
+Keywords=AI;tokens;cost;usage;Claude;Codex;Cursor;Copilot;
+StartupWMClass=CodeBurn

--- a/app/flathub/org.agentseal.CodeBurn.metainfo.xml
+++ b/app/flathub/org.agentseal.CodeBurn.metainfo.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.agentseal.CodeBurn</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>CodeBurn</name>
+  <summary>See where your AI coding spend actually goes</summary>
+  <developer id="org.agentseal">
+    <name>AgentSeal</name>
+  </developer>
+  <description>
+    <p>
+      AI coding assistants have become a real cost, but the invoice is one line.
+      CodeBurn reads the session logs your AI coding tools already write on your
+      machine and turns them into itemized cost analytics: by project, model,
+      session, day, and pull request.
+    </p>
+    <p>
+      Everything runs locally. No API keys, no account, no data leaving your
+      machine.
+    </p>
+    <ul>
+      <li>Works with 14+ tools: Claude Code, Codex, Cursor, Copilot, Gemini, Kimi Code, Qwen, and more</li>
+      <li>Overview with spend, streaks, activity heatmap, and an efficiency score</li>
+      <li>Every session listed with its cost, models, turns, and tokens</li>
+      <li>Pull request attribution: what each PR cost to build</li>
+      <li>Spend flow from model to project, plus an hour-by-weekday punchcard</li>
+      <li>Optimize: findings that show where money is being wasted</li>
+      <li>Model comparison: head-to-head cost and efficiency</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">org.agentseal.CodeBurn.desktop</launchable>
+  <url type="homepage">https://codeburn.app</url>
+  <url type="bugtracker">https://github.com/getagentseal/codeburn/issues</url>
+  <url type="vcs-browser">https://github.com/getagentseal/codeburn</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/getagentseal/codeburn/main/assets/desktop.jpg</image>
+      <caption>Overview: spend, activity, and efficiency at a glance</caption>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1"/>
+  <categories>
+    <category>Development</category>
+    <category>Utility</category>
+  </categories>
+  <releases>
+    <release version="0.9.20" date="2026-08-10"/>
+  </releases>
+</component>

--- a/app/flathub/org.agentseal.CodeBurn.yaml
+++ b/app/flathub/org.agentseal.CodeBurn.yaml
@@ -1,0 +1,56 @@
+# Flathub manifest for CodeBurn Desktop. Repacks the published Linux deb from
+# GitHub Releases (the same artifact shipped everywhere else) with the Electron
+# baseapp + zypak. Update the url/sha256 pair on each desktop release.
+app-id: org.agentseal.CodeBurn
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '24.08'
+command: codeburn-run
+separate-locales: false
+
+finish-args:
+  # CodeBurn reads local session logs written by AI coding tools into
+  # dot-directories across the home dir (~/.claude, ~/.codex, ~/.cursor, ...).
+  # Everything is parsed locally; nothing is uploaded.
+  - --filesystem=home
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+  # Release check against GitHub and opening PR/session links in the browser.
+  - --share=network
+  - --talk-name=org.freedesktop.portal.Desktop
+
+modules:
+  - name: codeburn
+    buildsystem: simple
+    build-commands:
+      - ar x codeburn-desktop.deb
+      - tar -xf data.tar.*
+      - cp -r opt/CodeBurn /app/codeburn
+      - install -Dm755 codeburn-run /app/bin/codeburn-run
+      - install -Dm644 org.agentseal.CodeBurn.desktop /app/share/applications/org.agentseal.CodeBurn.desktop
+      - install -Dm644 org.agentseal.CodeBurn.metainfo.xml /app/share/metainfo/org.agentseal.CodeBurn.metainfo.xml
+      - |
+        for size in 16 32 48 64 128 256 512; do
+          icon=usr/share/icons/hicolor/${size}x${size}/apps/codeburn.png
+          if [ -f "$icon" ]; then
+            install -Dm644 "$icon" /app/share/icons/hicolor/${size}x${size}/apps/org.agentseal.CodeBurn.png
+          fi
+        done
+    sources:
+      - type: file
+        url: https://github.com/getagentseal/codeburn/releases/download/desktop-v0.9.20/codeburn-desktop_0.9.20_amd64.deb
+        sha256: bf875a11aef90853bee3891ece965b98a7ddcc5331d98dfd113b72c80e8598ca
+        dest-filename: codeburn-desktop.deb
+        only-arches: [x86_64]
+      - type: script
+        dest-filename: codeburn-run
+        commands:
+          - exec zypak-wrapper /app/codeburn/codeburn "$@"
+      - type: file
+        path: org.agentseal.CodeBurn.desktop
+      - type: file
+        path: org.agentseal.CodeBurn.metainfo.xml

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "codeburn-desktop",
   "private": true,
   "version": "0.9.20",
-  "description": "CodeBurn Desktop — Electron app fed by the codeburn CLI",
+  "description": "CodeBurn Desktop \u2014 Electron app fed by the codeburn CLI",
   "main": "dist/electron/main.js",
   "scripts": {
     "build:electron": "tsc -p tsconfig.electron.json",
@@ -17,7 +17,8 @@
     "package:x64": "npm run stage-cli && npm run build && electron-builder --mac --x64",
     "package:win": "npm run stage-cli && npm run build && electron-builder --win",
     "package:store": "npm run stage-cli && npm run build && electron-builder --win appx --x64",
-    "package:linux": "npm run stage-cli && npm run build && electron-builder --linux"
+    "package:linux": "npm run stage-cli && npm run build && electron-builder --linux",
+    "package:snap": "npm run stage-cli && npm run build && electron-builder --linux snap --x64"
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",
@@ -140,6 +141,12 @@
       "icon": "build/icon.png",
       "maintainer": "AgentSeal <hello@agentseal.org>",
       "executableName": "codeburn"
+    },
+    "snap": {
+      "confinement": "classic",
+      "grade": "stable",
+      "summary": "See where your AI coding spend actually goes",
+      "artifactName": "codeburn_${version}_${arch}.${ext}"
     }
   },
   "homepage": "https://github.com/getagentseal/codeburn",


### PR DESCRIPTION
## What

Two Linux store paths for the desktop app.

**Snap Store**
- `package:snap` script and electron-builder snap config, classic confinement (strict confinement hides dot-directories, which is where every provider writes its session logs)
- `build-snap.yml` workflow: builds the snap on ubuntu, always uploads it as an artifact, and only publishes to the store when dispatched with `publish: true` and the `SNAPCRAFT_STORE_CREDENTIALS` secret is set

**Flathub**
- `app/flathub/`: manifest that repacks the released Linux deb (Electron baseapp + zypak), desktop entry, AppStream metainfo, and a README with the submission and per-release update steps
- Submission itself happens as a PR to `flathub/flathub` from a personal account; these files are the source of truth kept in-repo

## Notes

- Snap name `codeburn` is registered on snapcraft.io; classic confinement needs a one-time approval request on the Snapcraft forum before first publish
- Flathub home filesystem access is declared in the manifest with a comment explaining why (local session-log parsing)
- No release artifacts change; `package:linux` still builds AppImage/deb/rpm as before