### PR TITLE
flathub: correct supported tool count to 40

### DIFF
--- a/app/flathub/org.agentseal.CodeBurn.metainfo.xml
+++ b/app/flathub/org.agentseal.CodeBurn.metainfo.xml
@@ -20,7 +20,7 @@
       machine.
     </p>
     <ul>
-      <li>Works with 14+ tools: Claude Code, Codex, Cursor, Copilot, Gemini, Kimi Code, Qwen, and more</li>
+      <li>Works with 40 tools: Claude Code, Codex, Cursor, Copilot, Gemini, Kimi Code, Qwen, and more</li>
       <li>Overview with spend, streaks, activity heatmap, and an efficiency score</li>
       <li>Every session listed with its cost, models, turns, and tokens</li>
       <li>Pull request attribution: what each PR cost to build</li>


### PR DESCRIPTION
The metainfo understated the supported tool count as 14+; the real number is 40.