### PR TITLE
fix(models): keep claude-4-sonnet-thinking in the Sonnet 4 family

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -311,7 +311,7 @@ const BUILTIN_ALIASES: Record<string, string> = {
   // reports that quote literal slugs (e.g. forum.cursor.com/t/154933).
   'claude-4-sonnet':                'claude-sonnet-4',
   'claude-4-sonnet-1m':             'claude-sonnet-4',
-  'claude-4-sonnet-thinking':       'claude-sonnet-4-5',
+  'claude-4-sonnet-thinking':       'claude-sonnet-4',
   'claude-4.5-sonnet':              'claude-sonnet-4-5',
   'claude-4.5-sonnet-thinking':     'claude-sonnet-4-5',
   'claude-4.6-sonnet':              'claude-sonnet-4-6',

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -505,7 +505,7 @@ describe('Cursor model variants resolve to pricing', () => {
     // Sonnet family
     ['claude-4-sonnet', 'claude-sonnet-4'],
     ['claude-4-sonnet-1m', 'claude-sonnet-4'],
-    ['claude-4-sonnet-thinking', 'claude-sonnet-4-5'],
+    ['claude-4-sonnet-thinking', 'claude-sonnet-4'],
     ['claude-4.5-sonnet', 'claude-sonnet-4-5'],
     ['claude-4.5-sonnet-thinking', 'claude-sonnet-4-5'],
     ['claude-4.6-sonnet', 'claude-sonnet-4-6'],
@@ -558,6 +558,14 @@ describe('Cursor model variants resolve to pricing', () => {
       expect(costs!.outputCostPerToken).toBe(expected!.outputCostPerToken)
     })
   }
+
+  // Regression for #912: Cursor's unversioned `claude-4-sonnet-thinking`
+  // slug is the thinking variant of Sonnet 4, not Sonnet 4.5. The two models
+  // currently share a price, so the display name pins the canonical identity
+  // independently of today's pricing coincidence.
+  it('keeps claude-4-sonnet-thinking in the Sonnet 4 model family', () => {
+    expect(getShortModelName('claude-4-sonnet-thinking')).toBe('Sonnet 4')
+  })
 })
 
 describe('Cursor house model pricing', () => {


### PR DESCRIPTION
## Problem

Cursor's unversioned `claude-4-sonnet-thinking` slug was aliased to `claude-sonnet-4-5`, even though it identifies the thinking variant of Sonnet 4.

This is easy to miss today because Sonnet 4 and Sonnet 4.5 currently have identical rates. The incorrect identity nevertheless surfaces the wrong model name and could become a pricing error if those rates diverge.

## Change

- map `claude-4-sonnet-thinking` to `claude-sonnet-4`
- update the Cursor alias regression table
- add an independent display-name assertion that pins the model identity even while the two models share pricing

## User impact

Cursor sessions using this slug now appear under Sonnet 4 rather than Sonnet 4.5 and remain attached to the correct pricing family.

## Validation

- `npx vitest run tests/models.test.ts` — 154 passed
- `npm test` — 2,617 passed, 5 skipped
- `npm run test:locks` — 26 passed
- `npx tsc --noEmit`
- `npm run build:cli`
- `npm --prefix dash run build`
- runtime probe resolves the slug to `Sonnet 4`

Addresses the confirmed model-alias finding in #912.
