### PR TITLE
fix(tui): coalesce terminal resize frames

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -2,7 +2,7 @@ import { homedir } from 'os'
 import { EventEmitter } from 'node:events'
 
 import React, { useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
-import { render, Box, Text, measureElement, useInput, useApp, useWindowSize, type DOMElement } from 'ink'
+import { render, Box, Text, measureElement, useInput, useApp, useWindowSize, type DOMElement, type Instance, type RenderOptions } from 'ink'
 import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory } from './types.js'
 import { formatCost, formatTokens, markEstimated, carriedCostNote } from './format.js'
 import { aggregateModelEfficiency } from './model-efficiency.js'
@@ -33,7 +33,11 @@ export const DAILY_ACTIVITY_PAGE_SIZE = 10
 export const INTERACTIVE_RENDER_OPTIONS = { alternateScreen: true } as const
 export const RESIZE_DEBOUNCE_MS = 150
 
-export type DebouncedResizeStream = NodeJS.WriteStream & { dispose(): void }
+export type TerminalSize = { columns: number; rows: number }
+export type DebouncedResizeStream = NodeJS.WriteStream & {
+  dispose(): void
+  onSettledResize(listener: (size: TerminalSize) => void): () => void
+}
 
 export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs: number): DebouncedResizeStream {
   let resizeTimer: ReturnType<typeof setTimeout> | undefined
@@ -41,6 +45,7 @@ export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs:
   let columns = source.columns
   let rows = source.rows
   const resizeEvents = new EventEmitter()
+  const settledResizeListeners = new Set<(size: TerminalSize) => void>()
 
   const resize = () => {
     if (resizeTimer) clearTimeout(resizeTimer)
@@ -49,7 +54,8 @@ export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs:
       if (disposed) return
       columns = source.columns
       rows = source.rows
-      resizeEvents.emit('resize')
+      const size = { columns, rows }
+      for (const listener of [...settledResizeListeners]) listener(size)
     }, delayMs)
   }
   source.on('resize', resize)
@@ -61,6 +67,7 @@ export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs:
     if (resizeTimer) clearTimeout(resizeTimer)
     resizeTimer = undefined
     resizeEvents.removeAllListeners()
+    settledResizeListeners.clear()
   }
 
   const listenerMethods = new Set<PropertyKey>([
@@ -71,11 +78,18 @@ export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs:
   stream = new Proxy(source as DebouncedResizeStream, {
     get(target, property) {
       if (property === 'dispose') return dispose
+      if (property === 'onSettledResize') {
+        return (listener: (size: TerminalSize) => void) => {
+          if (disposed) return () => {}
+          settledResizeListeners.add(listener)
+          return () => settledResizeListeners.delete(listener)
+        }
+      }
       if (property === 'columns') return columns
       if (property === 'rows') return rows
       if (property === 'emit') {
         return (event: string | symbol, ...args: unknown[]) => event === 'resize'
-          ? resizeEvents.emit(event, ...args)
+          ? !disposed && resizeEvents.emit(event, ...args)
           : target.emit(event, ...args)
       }
       if (property === 'setMaxListeners') {
@@ -102,7 +116,7 @@ export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs:
             resizeEvents.removeAllListeners()
             // The source relay is implementation-owned, not part of the
             // facade's public listener set, so preserve it across a global clear.
-            source.on('resize', resize)
+            if (!disposed) source.on('resize', resize)
           } else {
             target.removeAllListeners(event)
           }
@@ -111,6 +125,7 @@ export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs:
       }
       if (listenerMethods.has(property)) {
         return (event: string | symbol, ...args: unknown[]) => {
+          if (event === 'resize' && disposed) return stream
           const emitter = event === 'resize' ? resizeEvents : target
           Reflect.apply(Reflect.get(emitter, property, emitter) as Function, emitter, [event, ...args])
           return stream
@@ -127,6 +142,47 @@ export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs:
     },
   })
   return stream
+}
+
+function DisposeOnUnmount({ dispose, children }: { dispose: () => void; children: React.ReactNode }) {
+  useLayoutEffect(() => dispose, [dispose])
+  return children
+}
+
+export type DebouncedInteractiveInstance = Instance & {
+  dispose(): void
+  stdout: DebouncedResizeStream
+}
+
+export function renderDebouncedInteractive(
+  source: NodeJS.WriteStream,
+  view: (size: TerminalSize) => React.ReactElement,
+  options: Omit<RenderOptions, 'stdout'> = INTERACTIVE_RENDER_OPTIONS,
+): DebouncedInteractiveInstance {
+  const stdout = createDebouncedResizeStream(source, RESIZE_DEBOUNCE_MS)
+  let size = { columns: stdout.columns, rows: stdout.rows }
+  let unsubscribe = () => {}
+  let disposed = false
+  const dispose = () => {
+    if (disposed) return
+    disposed = true
+    unsubscribe()
+    stdout.dispose()
+  }
+  const dashboard = () => <DisposeOnUnmount dispose={dispose}>{view(size)}</DisposeOnUnmount>
+  let app: Instance
+  try {
+    app = render(dashboard(), { ...options, stdout })
+  } catch (error) {
+    dispose()
+    throw error
+  }
+  unsubscribe = stdout.onSettledResize(nextSize => {
+    if (disposed) return
+    size = nextSize
+    app.rerender(dashboard())
+  })
+  return Object.assign(app, { dispose, stdout })
 }
 
 export function getDailyActivityPageSize(columnCount: 1 | 2 | 3, projectRows: number, activityRows: number, dayMode = false): number {
@@ -1325,19 +1381,18 @@ const MOUSE_TRACKING_OFF = '\x1b[?1006l\x1b[?1000l'
 function ScrollableViewport({ children, width, rows, lineScroll = true }: { children: React.ReactNode; width: number; rows: number; lineScroll?: boolean }) {
   const height = Math.max(1, rows - 1)
   const contentRef = useRef<DOMElement>(null)
-  const [maxOffset, setMaxOffset] = useState(0)
   const [offset, setOffset] = useState(0)
   // The stdin listener below outlives renders; it reads the current bound
   // through a ref so scrolling never re-subscribes (and never re-emits the
   // tracking enable sequence).
   const maxOffsetRef = useRef(0)
-  maxOffsetRef.current = maxOffset
-
+  // Re-measure after every commit, but keep the bound outside React state.
+  // A terminal-only resize must preserve the reader's exact anchor and must
+  // not schedule a second correction frame; the next scroll input clamps
+  // against this freshly measured bound instead.
   useLayoutEffect(() => {
     if (!contentRef.current) return
-    const nextMaxOffset = Math.max(0, measureElement(contentRef.current).height - height)
-    setMaxOffset(current => current === nextMaxOffset ? current : nextMaxOffset)
-    setOffset(current => Math.min(current, nextMaxOffset))
+    maxOffsetRef.current = Math.max(0, measureElement(contentRef.current).height - height)
   })
 
   // Mouse-wheel scrolling via SGR mouse reporting. Known tradeoff: while
@@ -1358,24 +1413,24 @@ function ScrollableViewport({ children, width, rows, lineScroll = true }: { chil
   }, [])
 
   useInput((_input, key) => {
-    if (lineScroll && key.downArrow) setOffset(current => Math.min(current + 1, maxOffset))
-    else if (lineScroll && key.upArrow) setOffset(current => Math.max(current - 1, 0))
-    else if (key.pageDown) setOffset(current => Math.min(current + height, maxOffset))
-    else if (key.pageUp) setOffset(current => Math.max(current - height, 0))
+    if (lineScroll && key.downArrow) setOffset(current => Math.min(current + 1, maxOffsetRef.current))
+    else if (lineScroll && key.upArrow) setOffset(current => Math.max(Math.min(current, maxOffsetRef.current) - 1, 0))
+    else if (key.pageDown) setOffset(current => Math.min(current + height, maxOffsetRef.current))
+    else if (key.pageUp) setOffset(current => Math.max(Math.min(current, maxOffsetRef.current) - height, 0))
     else if (key.home) setOffset(0)
-    else if (key.end) setOffset(maxOffset)
+    else if (key.end) setOffset(maxOffsetRef.current)
   })
 
   return (
     <Box width={width} height={height} overflowY="hidden">
-      <Box ref={contentRef} flexDirection="column" position="absolute" top={-Math.min(offset, maxOffset)} left={0}>
+      <Box ref={contentRef} flexDirection="column" position="absolute" top={-offset} left={0}>
         {children}
       </Box>
     </Box>
   )
 }
 
-export function InteractiveDashboard({ initialProjects, initialDailyHistoryProjects, initialPeriod, initialProvider, initialPlanUsages, initialDurable, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel, initialDay }: {
+export function InteractiveDashboard({ initialProjects, initialDailyHistoryProjects, initialPeriod, initialProvider, initialPlanUsages, initialDurable, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel, initialDay, terminalSize }: {
   initialProjects: ProjectSummary[]
   initialDailyHistoryProjects?: ProjectSummary[]
   initialPeriod: Period
@@ -1388,9 +1443,10 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   customRange?: DateRange | null
   customRangeLabel?: string
   initialDay?: string
+  terminalSize: TerminalSize
 }) {
   const { exit } = useApp()
-  const { columns, rows } = useWindowSize()
+  const { columns, rows } = terminalSize
   const [period, setPeriod] = useState<Period>(initialPeriod)
   const [projects, setProjects] = useState<ProjectSummary[]>(initialProjects)
   const [durable, setDurable] = useState<DurableOverview | undefined>(initialDurable)
@@ -1795,18 +1851,13 @@ export async function renderDashboard(period: Period = 'week', provider: string 
   const label = initialDay ? formatDayRangeLabel(initialDay) : customRangeLabel
   patchStdoutForWindows()
   if (isTTY) {
-    const stdout = createDebouncedResizeStream(process.stdout, RESIZE_DEBOUNCE_MS)
-    const dashboard = () => (
-      <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={period} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} />
-    )
-    const app = render(
-      dashboard(),
-      { ...INTERACTIVE_RENDER_OPTIONS, stdout },
-    )
+    const app = renderDebouncedInteractive(process.stdout, terminalSize => (
+      <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={period} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} terminalSize={terminalSize} />
+    ))
     try {
       await app.waitUntilExit()
     } finally {
-      stdout.dispose()
+      app.dispose()
     }
   } else {
     const { unmount } = render(<StaticDashboard projects={filteredProjects} period={period} activeProvider={provider} planUsages={planUsages} label={label} dayMode={initialDay != null} durable={initialDurable} />, { patchConsole: false })

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1,4 +1,5 @@
 import { homedir } from 'os'
+import { EventEmitter } from 'node:events'
 
 import React, { useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { render, Box, Text, measureElement, useInput, useApp, useWindowSize, type DOMElement } from 'ink'
@@ -30,6 +31,103 @@ export type DailyActivityRow = {
 
 export const DAILY_ACTIVITY_PAGE_SIZE = 10
 export const INTERACTIVE_RENDER_OPTIONS = { alternateScreen: true } as const
+export const RESIZE_DEBOUNCE_MS = 150
+
+export type DebouncedResizeStream = NodeJS.WriteStream & { dispose(): void }
+
+export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs: number): DebouncedResizeStream {
+  let resizeTimer: ReturnType<typeof setTimeout> | undefined
+  let disposed = false
+  let columns = source.columns
+  let rows = source.rows
+  const resizeEvents = new EventEmitter()
+
+  const resize = () => {
+    if (resizeTimer) clearTimeout(resizeTimer)
+    resizeTimer = setTimeout(() => {
+      resizeTimer = undefined
+      if (disposed) return
+      columns = source.columns
+      rows = source.rows
+      resizeEvents.emit('resize')
+    }, delayMs)
+  }
+  source.on('resize', resize)
+
+  const dispose = () => {
+    if (disposed) return
+    disposed = true
+    source.off('resize', resize)
+    if (resizeTimer) clearTimeout(resizeTimer)
+    resizeTimer = undefined
+    resizeEvents.removeAllListeners()
+  }
+
+  const listenerMethods = new Set<PropertyKey>([
+    'addListener', 'on', 'once', 'prependListener', 'prependOnceListener', 'off', 'removeListener',
+  ])
+
+  let stream: DebouncedResizeStream
+  stream = new Proxy(source as DebouncedResizeStream, {
+    get(target, property) {
+      if (property === 'dispose') return dispose
+      if (property === 'columns') return columns
+      if (property === 'rows') return rows
+      if (property === 'emit') {
+        return (event: string | symbol, ...args: unknown[]) => event === 'resize'
+          ? resizeEvents.emit(event, ...args)
+          : target.emit(event, ...args)
+      }
+      if (property === 'setMaxListeners') {
+        return (count: number) => {
+          target.setMaxListeners(count)
+          resizeEvents.setMaxListeners(count)
+          return stream
+        }
+      }
+      if (property === 'getMaxListeners') return () => resizeEvents.getMaxListeners()
+      if (property === 'eventNames') {
+        return () => {
+          const names = target.eventNames().filter(event => event !== 'resize')
+          if (resizeEvents.listenerCount('resize') > 0) names.push('resize')
+          return [...new Set(names)]
+        }
+      }
+      if (property === 'removeAllListeners') {
+        return (event?: string | symbol) => {
+          if (event === 'resize') {
+            resizeEvents.removeAllListeners(event)
+          } else if (event === undefined) {
+            target.removeAllListeners()
+            resizeEvents.removeAllListeners()
+            // The source relay is implementation-owned, not part of the
+            // facade's public listener set, so preserve it across a global clear.
+            source.on('resize', resize)
+          } else {
+            target.removeAllListeners(event)
+          }
+          return stream
+        }
+      }
+      if (listenerMethods.has(property)) {
+        return (event: string | symbol, ...args: unknown[]) => {
+          const emitter = event === 'resize' ? resizeEvents : target
+          Reflect.apply(Reflect.get(emitter, property, emitter) as Function, emitter, [event, ...args])
+          return stream
+        }
+      }
+      if (property === 'listenerCount' || property === 'listeners' || property === 'rawListeners') {
+        return (event: string | symbol, ...args: unknown[]) => {
+          const emitter = event === 'resize' ? resizeEvents : target
+          return Reflect.apply(Reflect.get(emitter, property, emitter) as Function, emitter, [event, ...args])
+        }
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  return stream
+}
 
 export function getDailyActivityPageSize(columnCount: 1 | 2 | 3, projectRows: number, activityRows: number, dayMode = false): number {
   if (dayMode) return 1
@@ -1698,23 +1796,25 @@ export async function renderDashboard(period: Period = 'week', provider: string 
   const label = initialDay ? formatDayRangeLabel(initialDay) : customRangeLabel
   patchStdoutForWindows()
   if (isTTY) {
-    let windowColumns = process.stdout.columns
+    const stdout = createDebouncedResizeStream(process.stdout, RESIZE_DEBOUNCE_MS)
+    let windowColumns = stdout.columns
     const dashboard = () => (
       <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={period} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} windowColumns={windowColumns} />
     )
     const app = render(
       dashboard(),
-      INTERACTIVE_RENDER_OPTIONS,
+      { ...INTERACTIVE_RENDER_OPTIONS, stdout },
     )
     const resize = () => {
-      windowColumns = process.stdout.columns
+      windowColumns = stdout.columns
       app.rerender(dashboard())
     }
-    process.stdout.prependListener('resize', resize)
+    stdout.prependListener('resize', resize)
     try {
       await app.waitUntilExit()
     } finally {
-      process.stdout.off('resize', resize)
+      stdout.off('resize', resize)
+      stdout.dispose()
     }
   } else {
     const { unmount } = render(<StaticDashboard projects={filteredProjects} period={period} activeProvider={provider} planUsages={planUsages} label={label} dayMode={initialDay != null} durable={initialDurable} />, { patchConsole: false })

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -19,7 +19,7 @@ import { CompareView } from './compare.js'
 import { getPlanUsages, type PlanUsage } from './plan-usage.js'
 import { planDisplayName } from './plans.js'
 import { formatDayRangeLabel, getDateRange, parseDayFlag, PERIODS, PERIOD_LABELS, shiftDay, type Period } from './cli-date.js'
-import { patchStdoutForWindows } from './ink-win.js'
+import { BSU, ESU, patchStdoutForWindows } from './ink-win.js'
 
 type View = 'dashboard' | 'optimize' | 'compare'
 
@@ -39,23 +39,55 @@ export type DebouncedResizeStream = NodeJS.WriteStream & {
   onSettledResize(listener: (size: TerminalSize) => void): () => void
 }
 
+function normalizeTerminalDimension(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && value! > 0 ? Math.floor(value!) : fallback
+}
+
+function terminalSizeOf(source: NodeJS.WriteStream): TerminalSize {
+  return {
+    columns: normalizeTerminalDimension(source.columns, 80),
+    rows: normalizeTerminalDimension(source.rows, 24),
+  }
+}
+
 export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs: number): DebouncedResizeStream {
   let resizeTimer: ReturnType<typeof setTimeout> | undefined
+  let releaseTimer: ReturnType<typeof setTimeout> | undefined
   let disposed = false
-  let columns = source.columns
-  let rows = source.rows
+  let pendingResize = false
+  let suppressingFrame = false
+  let capturingResizeWrites = false
+  let finalFramePreamble = ''
+  let { columns, rows } = terminalSizeOf(source)
   const resizeEvents = new EventEmitter()
   const settledResizeListeners = new Set<(size: TerminalSize) => void>()
 
   const resize = () => {
+    pendingResize = true
     if (resizeTimer) clearTimeout(resizeTimer)
+    if (releaseTimer) clearTimeout(releaseTimer)
+    releaseTimer = undefined
     resizeTimer = setTimeout(() => {
       resizeTimer = undefined
       if (disposed) return
-      columns = source.columns
-      rows = source.rows
+      ;({ columns, rows } = terminalSizeOf(source))
       const size = { columns, rows }
-      for (const listener of [...settledResizeListeners]) listener(size)
+      // Ink and useWindowSize both observe the same updated facade dimensions.
+      // Their immediate writes remain suppressed until React has applied the
+      // hook update; the wrapper then requests the sole coherent final frame.
+      capturingResizeWrites = true
+      try {
+        resizeEvents.emit('resize')
+      } finally {
+        capturingResizeWrites = false
+      }
+      releaseTimer = setTimeout(() => {
+        releaseTimer = undefined
+        if (disposed) return
+        pendingResize = false
+        suppressingFrame = false
+        for (const listener of [...settledResizeListeners]) listener(size)
+      }, 0)
     }, delayMs)
   }
   source.on('resize', resize)
@@ -65,7 +97,13 @@ export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs:
     disposed = true
     source.off('resize', resize)
     if (resizeTimer) clearTimeout(resizeTimer)
+    if (releaseTimer) clearTimeout(releaseTimer)
     resizeTimer = undefined
+    releaseTimer = undefined
+    pendingResize = false
+    suppressingFrame = false
+    capturingResizeWrites = false
+    finalFramePreamble = ''
     resizeEvents.removeAllListeners()
     settledResizeListeners.clear()
   }
@@ -87,6 +125,53 @@ export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs:
       }
       if (property === 'columns') return columns
       if (property === 'rows') return rows
+      if (property === 'write') {
+        return (chunk: unknown, ...args: unknown[]) => {
+          if (typeof chunk !== 'string') {
+            return Reflect.apply(target.write, target, [chunk, ...args])
+          }
+
+          if (!pendingResize) {
+            if (finalFramePreamble.length === 0) {
+              return Reflect.apply(target.write, target, [chunk, ...args])
+            }
+            const start = chunk.indexOf(BSU)
+            const output = start === -1
+              ? finalFramePreamble + chunk
+              : chunk.slice(0, start + BSU.length) + finalFramePreamble + chunk.slice(start + BSU.length)
+            finalFramePreamble = ''
+            return Reflect.apply(target.write, target, [output, ...args])
+          }
+
+          let visible = ''
+          let rest = chunk
+          while (rest.length > 0) {
+            if (suppressingFrame) {
+              const end = rest.indexOf(ESU)
+              if (end === -1) {
+                rest = ''
+                break
+              }
+              suppressingFrame = false
+              rest = rest.slice(end + ESU.length)
+              continue
+            }
+            const start = rest.indexOf(BSU)
+            if (start === -1) {
+              visible += rest
+              break
+            }
+            visible += rest.slice(0, start)
+            suppressingFrame = true
+            rest = rest.slice(start + BSU.length)
+          }
+
+          if (capturingResizeWrites) finalFramePreamble += visible
+          // An empty native write is a terminal no-op while retaining the
+          // source stream's callback timing and backpressure return value.
+          return Reflect.apply(target.write, target, [capturingResizeWrites ? '' : visible, ...args])
+        }
+      }
       if (property === 'emit') {
         return (event: string | symbol, ...args: unknown[]) => event === 'resize'
           ? !disposed && resizeEvents.emit(event, ...args)

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1322,8 +1322,7 @@ const WHEEL_LINES_PER_TICK = 3
 const MOUSE_TRACKING_ON = '\x1b[?1000h\x1b[?1006h'
 const MOUSE_TRACKING_OFF = '\x1b[?1006l\x1b[?1000l'
 
-function ScrollableViewport({ children, width, lineScroll = true }: { children: React.ReactNode; width: number; lineScroll?: boolean }) {
-  const { rows } = useWindowSize()
+function ScrollableViewport({ children, width, rows, lineScroll = true }: { children: React.ReactNode; width: number; rows: number; lineScroll?: boolean }) {
   const height = Math.max(1, rows - 1)
   const contentRef = useRef<DOMElement>(null)
   const [maxOffset, setMaxOffset] = useState(0)
@@ -1376,7 +1375,7 @@ function ScrollableViewport({ children, width, lineScroll = true }: { children: 
   )
 }
 
-export function InteractiveDashboard({ initialProjects, initialDailyHistoryProjects, initialPeriod, initialProvider, initialPlanUsages, initialDurable, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel, initialDay, windowColumns }: {
+export function InteractiveDashboard({ initialProjects, initialDailyHistoryProjects, initialPeriod, initialProvider, initialPlanUsages, initialDurable, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel, initialDay }: {
   initialProjects: ProjectSummary[]
   initialDailyHistoryProjects?: ProjectSummary[]
   initialPeriod: Period
@@ -1389,9 +1388,9 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   customRange?: DateRange | null
   customRangeLabel?: string
   initialDay?: string
-  windowColumns: number
 }) {
   const { exit } = useApp()
+  const { columns, rows } = useWindowSize()
   const [period, setPeriod] = useState<Period>(initialPeriod)
   const [projects, setProjects] = useState<ProjectSummary[]>(initialProjects)
   const [durable, setDurable] = useState<DurableOverview | undefined>(initialDurable)
@@ -1416,7 +1415,6 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   const isDayMode = dayDate != null
   const isCustomRange = customRange != null && !isDayMode
   const scrollableDailyHistory = !isCustomRange && !isDayMode
-  const columns = windowColumns
   const maxContentWidth = useMemo(
     () => getDashboardMaxWidth(projects, projectBudgets, activeProvider),
     [projects, projectBudgets, activeProvider],
@@ -1739,6 +1737,7 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
     <ScrollableViewport
       key={`${view}:${period}:${activeProvider}:${dayDate ?? ''}:${customRangeLabel ?? ''}`}
       width={dashWidth}
+      rows={rows}
       lineScroll={view !== 'compare'}
     >
       {content}
@@ -1797,23 +1796,16 @@ export async function renderDashboard(period: Period = 'week', provider: string 
   patchStdoutForWindows()
   if (isTTY) {
     const stdout = createDebouncedResizeStream(process.stdout, RESIZE_DEBOUNCE_MS)
-    let windowColumns = stdout.columns
     const dashboard = () => (
-      <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={period} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} windowColumns={windowColumns} />
+      <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={period} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} />
     )
     const app = render(
       dashboard(),
       { ...INTERACTIVE_RENDER_OPTIONS, stdout },
     )
-    const resize = () => {
-      windowColumns = stdout.columns
-      app.rerender(dashboard())
-    }
-    stdout.prependListener('resize', resize)
     try {
       await app.waitUntilExit()
     } finally {
-      stdout.off('resize', resize)
       stdout.dispose()
     }
   } else {

--- a/tests/dashboard-resize.test.ts
+++ b/tests/dashboard-resize.test.ts
@@ -35,6 +35,32 @@ function LifecycleProbe({ onMount, onCleanup }: { onMount: () => void; onCleanup
   return React.createElement(Text, null, 'mounted')
 }
 
+function synchronizedFrames(writes: string[]): string[] {
+  const frames: string[] = []
+  let current: string | undefined
+  for (const write of writes) {
+    let rest = write
+    while (rest.length > 0) {
+      if (current === undefined) {
+        const start = rest.indexOf(BSU)
+        if (start === -1) break
+        current = ''
+        rest = rest.slice(start + BSU.length)
+      }
+      const end = rest.indexOf(ESU)
+      if (end === -1) {
+        current += rest
+        break
+      }
+      current += rest.slice(0, end)
+      frames.push(stripSyncUpdateEscapes(current))
+      current = undefined
+      rest = rest.slice(end + ESU.length)
+    }
+  }
+  return frames
+}
+
 describe('interactive dashboard resize stream', () => {
   afterEach(() => vi.useRealTimers())
 
@@ -75,6 +101,57 @@ describe('interactive dashboard resize stream', () => {
       .map(chunk => chunk.match(/size:\d+x\d+/g) ?? [])
       .flat()
     expect(frames).toEqual(['size:97x30'])
+
+    app.unmount()
+    await vi.runAllTimersAsync()
+    await app.waitUntilExit()
+  })
+
+  it('holds an unrelated state commit until one coherent settled resize frame', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const writes: string[] = []
+    terminal.on('data', chunk => writes.push(String(chunk)))
+    let updateVisibleState = () => {}
+    const windowSizes: Array<{ columns: number; rows: number }> = []
+    const StatefulProbe = ({ size }: { size: { columns: number; rows: number } }) => {
+      const [revision, setRevision] = React.useState(0)
+      updateVisibleState = () => setRevision(value => value + 1)
+      const windowSize = useWindowSize()
+      useEffect(() => {
+        windowSizes.push(windowSize)
+      }, [windowSize])
+      return React.createElement(
+        Text,
+        null,
+        `FRAME:revision=${revision}:prop=${size.columns}x${size.rows}:hook=${windowSize.columns}x${windowSize.rows}`,
+      )
+    }
+    const app = renderDebouncedInteractive(terminal, size => React.createElement(StatefulProbe, { size }), {
+      interactive: true,
+      patchConsole: false,
+      alternateScreen: true,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    writes.length = 0
+    windowSizes.length = 0
+
+    terminal.columns = 80
+    terminal.rows = 20
+    terminal.emit('resize')
+    updateVisibleState()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(writes, 'no stale old-dimension application frame may reach the terminal before resize settlement').toEqual([])
+
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+    await vi.advanceTimersByTimeAsync(100)
+
+    const frames = synchronizedFrames(writes)
+      .filter(frame => frame.includes('FRAME:'))
+      .map(frame => frame.match(/FRAME:[^\r\n]*/)?.[0])
+    expect(frames).toEqual(['FRAME:revision=1:prop=80x20:hook=80x20'])
+    expect(windowSizes).toEqual([{ columns: 80, rows: 20 }])
 
     app.unmount()
     await vi.runAllTimersAsync()
@@ -294,6 +371,29 @@ describe('interactive dashboard resize stream', () => {
     expect(onDrain).toHaveBeenCalledOnce()
 
     stdout.off('drain', onDrain)
+    stdout.dispose()
+  })
+
+  it('passes imperative controls during a pending resize and preserves suppressed-write completion', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const nativeWrites: string[] = []
+    terminal.write = vi.fn((chunk: unknown, ...args: unknown[]) => {
+      nativeWrites.push(String(chunk))
+      const callback = args.find(arg => typeof arg === 'function') as (() => void) | undefined
+      callback?.()
+      return false
+    }) as typeof terminal.write
+    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
+    const frameCallback = vi.fn()
+
+    terminal.columns = 80
+    terminal.emit('resize')
+    expect(stdout.write('\u001B[?1006l\u001B[?1000l')).toBe(false)
+    expect(stdout.write(`${BSU}stale-frame${ESU}`, frameCallback)).toBe(false)
+
+    expect(nativeWrites).toEqual(['\u001B[?1006l\u001B[?1000l', ''])
+    expect(frameCallback).toHaveBeenCalledOnce()
     stdout.dispose()
   })
 

--- a/tests/dashboard-resize.test.ts
+++ b/tests/dashboard-resize.test.ts
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react'
 import { render, Text, useWindowSize } from 'ink'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { RESIZE_DEBOUNCE_MS, createDebouncedResizeStream } from '../src/dashboard.js'
+import { RESIZE_DEBOUNCE_MS, createDebouncedResizeStream, renderDebouncedInteractive } from '../src/dashboard.js'
 import { BSU, ESU, stripSyncUpdateEscapes } from '../src/ink-win.js'
 
 function makeTerminal(): PassThrough & NodeJS.WriteStream {
@@ -26,16 +26,6 @@ function ResizeProbe({ windowColumns, onRender }: {
   return React.createElement(Text, null, `size:${windowColumns}x${size.rows}`)
 }
 
-function ResizeTransitionProbe({ onRender }: {
-  onRender: (size: { windowColumns: number; columns: number; rows: number }) => void
-}) {
-  const size = useWindowSize()
-  useEffect(() => {
-    onRender({ windowColumns: size.columns, ...size })
-  }, [size, onRender])
-  return React.createElement(Text, null, `size:${size.columns}x${size.columns}x${size.rows}`)
-}
-
 function LifecycleProbe({ onMount, onCleanup }: { onMount: () => void; onCleanup: () => void }) {
   useWindowSize()
   useEffect(() => {
@@ -51,14 +41,13 @@ describe('interactive dashboard resize stream', () => {
   it('publishes one coherent dimension transition after a resize burst settles', async () => {
     vi.useFakeTimers()
     const terminal = makeTerminal()
-    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
     const writes: string[] = []
     terminal.on('data', chunk => writes.push(String(chunk)))
-    const transitions: Array<{ windowColumns: number; columns: number; rows: number }> = []
-    const onRender = (size: { windowColumns: number; columns: number; rows: number }) => transitions.push(size)
-    const probe = () => React.createElement(ResizeTransitionProbe, { onRender })
-    const app = render(probe(), {
-      stdout,
+    const transitions: Array<{ columns: number; rows: number }> = []
+    const app = renderDebouncedInteractive(terminal, size => {
+      transitions.push(size)
+      return React.createElement(Text, null, `size:${size.columns}x${size.rows}`)
+    }, {
       interactive: true,
       patchConsole: false,
       alternateScreen: true,
@@ -80,9 +69,84 @@ describe('interactive dashboard resize stream', () => {
     await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
     await vi.advanceTimersByTimeAsync(100)
 
-    expect(transitions).toEqual([{ windowColumns: 97, columns: 97, rows: 30 }])
-    expect(writes.join('')).not.toContain('size:97x100x24')
-    expect(writes.join('').match(/size:97x97x30/g)).toHaveLength(1)
+    expect(transitions).toEqual([{ columns: 97, rows: 30 }])
+    const frames = writes
+      .map(chunk => stripSyncUpdateEscapes(chunk))
+      .map(chunk => chunk.match(/size:\d+x\d+/g) ?? [])
+      .flat()
+    expect(frames).toEqual(['size:97x30'])
+
+    app.unmount()
+    await vi.runAllTimersAsync()
+    await app.waitUntilExit()
+  })
+
+  it.each([
+    { initial: { columns: 135, rows: 24 }, final: { columns: 132, rows: 30 } },
+    { initial: { columns: 80, rows: 24 }, final: { columns: 160, rows: 12 } },
+    { initial: { columns: 20, rows: 2 }, final: { columns: 10, rows: 1 } },
+  ])('writes only the final frame for $initial → $final', async ({ initial, final }) => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    terminal.columns = initial.columns
+    terminal.rows = initial.rows
+    const writes: string[] = []
+    terminal.on('data', chunk => writes.push(String(chunk)))
+    const app = renderDebouncedInteractive(terminal, size => (
+      React.createElement(Text, null, `FRAME:${size.columns}x${size.rows}`)
+    ), {
+      interactive: true,
+      patchConsole: false,
+      alternateScreen: true,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    writes.length = 0
+
+    terminal.columns = Math.max(1, final.columns + 1)
+    terminal.rows = Math.max(1, final.rows - 1)
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(50)
+    terminal.columns = final.columns
+    terminal.rows = final.rows
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS + 100)
+
+    const frames = writes
+      .map(chunk => stripSyncUpdateEscapes(chunk))
+      .flatMap(chunk => chunk.match(/FRAME:\d+x\d+/g) ?? [])
+    expect(frames).toEqual([`FRAME:${final.columns}x${final.rows}`])
+
+    app.unmount()
+    await vi.runAllTimersAsync()
+    await app.waitUntilExit()
+  })
+
+  it('does not require a post-commit layout correction for the settled resize frame', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    terminal.columns = 135
+    terminal.rows = 24
+    const writes: string[] = []
+    terminal.on('data', chunk => writes.push(String(chunk)))
+    const app = renderDebouncedInteractive(terminal, size => (
+      React.createElement(Text, null, `FRAME:${size.columns}x${size.rows}`)
+    ), {
+      interactive: true,
+      patchConsole: false,
+      alternateScreen: true,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    writes.length = 0
+
+    terminal.columns = 132
+    terminal.rows = 30
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS + 100)
+
+    const frames = writes
+      .map(chunk => stripSyncUpdateEscapes(chunk))
+      .flatMap(chunk => chunk.match(/FRAME:\d+x\d+/g) ?? [])
+    expect(frames).toEqual(['FRAME:132x30'])
 
     app.unmount()
     await vi.runAllTimersAsync()
@@ -92,11 +156,11 @@ describe('interactive dashboard resize stream', () => {
   it('does not remount after exit when a source resize is still pending', async () => {
     vi.useFakeTimers()
     const terminal = makeTerminal()
-    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
     const onMount = vi.fn()
     const onCleanup = vi.fn()
-    const app = render(React.createElement(LifecycleProbe, { onMount, onCleanup }), {
-      stdout,
+    const app = renderDebouncedInteractive(terminal, () => (
+      React.createElement(LifecycleProbe, { onMount, onCleanup })
+    ), {
       interactive: true,
       patchConsole: false,
     })
@@ -107,62 +171,78 @@ describe('interactive dashboard resize stream', () => {
     app.unmount()
     await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
     await app.waitUntilExit()
-    stdout.dispose()
+    app.dispose()
 
     expect(onMount).toHaveBeenCalledOnce()
     expect(onCleanup).toHaveBeenCalledOnce()
     expect(terminal.listenerCount('resize')).toBe(0)
   })
 
-  it('lets Ink observe one final resize after a terminal resize burst settles', async () => {
-    vi.useFakeTimers()
+  it('removes the source relay when the initial render throws', () => {
+    const terminal = makeTerminal()
+
+    expect(() => renderDebouncedInteractive(terminal, () => {
+      throw new Error('render failed')
+    }, { interactive: true, patchConsole: false })).toThrow('render failed')
+
+    expect(terminal.listenerCount('resize')).toBe(0)
+  })
+
+  it('keeps disposal terminal across later listener mutation and introspection', () => {
     const terminal = makeTerminal()
     const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
-    const writes: string[] = []
-    terminal.on('data', chunk => writes.push(String(chunk)))
-    const renderedSizes: Array<{ columns: number; rows: number }> = []
-    const onRender = (size: { columns: number; rows: number }) => renderedSizes.push(size)
-    let windowColumns = stdout.columns
-    const probe = () => React.createElement(ResizeProbe, { windowColumns, onRender })
-    const app = render(probe(), {
-      stdout,
+
+    expect(terminal.listenerCount('resize')).toBe(1)
+    stdout.dispose()
+    expect(terminal.listenerCount('resize')).toBe(0)
+
+    stdout.removeAllListeners()
+    stdout.eventNames()
+    stdout.listeners('resize')
+    stdout.rawListeners('resize')
+    stdout.listenerCount('resize')
+    stdout.dispose()
+
+    expect(terminal.listenerCount('resize')).toBe(0)
+
+    const resize = vi.fn()
+    stdout.on('resize', resize)
+    stdout.emit('resize')
+    terminal.emit('resize')
+    expect(resize).not.toHaveBeenCalled()
+    expect(terminal.listenerCount('resize')).toBe(0)
+  })
+
+  it('keeps the mounted component state while applying a settled resize', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const mounts = vi.fn()
+    const cleanups = vi.fn()
+    const Stateful = ({ size }: { size: { columns: number; rows: number } }) => {
+      const [cursor] = React.useState(7)
+      useEffect(() => {
+        mounts()
+        return () => cleanups()
+      }, [])
+      return React.createElement(Text, null, `state:${cursor}:${size.columns}x${size.rows}`)
+    }
+    const app = renderDebouncedInteractive(terminal, size => React.createElement(Stateful, { size }), {
       interactive: true,
       patchConsole: false,
     })
-    const resize = () => {
-      windowColumns = stdout.columns
-      app.rerender(probe())
-    }
-    stdout.prependListener('resize', resize)
     await vi.advanceTimersByTimeAsync(100)
-    writes.length = 0
-    renderedSizes.length = 0
 
-    terminal.columns = 99
+    terminal.columns = 90
+    terminal.rows = 20
     terminal.emit('resize')
-    await vi.advanceTimersByTimeAsync(50)
-    terminal.columns = 98
-    terminal.emit('resize')
-    await vi.advanceTimersByTimeAsync(50)
-    terminal.columns = 97
-    terminal.rows = 30
-    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS + 100)
 
-    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS - 1)
-    expect({ columns: stdout.columns, rows: stdout.rows }).toEqual({ columns: 100, rows: 24 })
-    expect(renderedSizes).toEqual([])
-    expect(writes).toEqual([])
-
-    await vi.advanceTimersByTimeAsync(1)
-    await vi.advanceTimersByTimeAsync(100)
-    expect({ columns: stdout.columns, rows: stdout.rows }).toEqual({ columns: 97, rows: 30 })
-    expect(renderedSizes).toEqual([{ columns: 97, rows: 30 }])
-    expect(writes.join('').match(/size:97x30/g)).toHaveLength(1)
-
-    stdout.off('resize', resize)
+    expect(mounts).toHaveBeenCalledOnce()
+    expect(cleanups).not.toHaveBeenCalled()
     app.unmount()
     await vi.runAllTimersAsync()
     await app.waitUntilExit()
+    expect(cleanups).toHaveBeenCalledOnce()
   })
 
   it('removes the source listener and cancels pending resize delivery on cleanup', async () => {
@@ -235,12 +315,10 @@ describe('interactive dashboard resize stream', () => {
     expect(stdout.listenerCount('resize')).toBe(1)
     expect(terminal.listenerCount('resize')).toBe(1)
 
-    terminal.emit('resize')
-    terminal.emit('resize')
+    stdout.emit('resize')
+    stdout.emit('resize')
     terminal.emit('drain')
-    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
-    terminal.emit('resize')
-    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+    stdout.emit('resize')
 
     expect(resize).toHaveBeenCalledOnce()
     expect(drain).toHaveBeenCalledOnce()
@@ -260,8 +338,7 @@ describe('interactive dashboard resize stream', () => {
     stdout.prependOnceListener('resize', () => order.push('prepended-once'))
     stdout.on('drain', drain)
 
-    terminal.emit('resize')
-    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+    stdout.emit('resize')
     expect(order).toEqual(['prepended-once', 'regular'])
 
     stdout.removeAllListeners()
@@ -275,8 +352,7 @@ describe('interactive dashboard resize stream', () => {
 
     const afterRemoval = vi.fn()
     stdout.once('resize', afterRemoval)
-    terminal.emit('resize')
-    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+    stdout.emit('resize')
     expect(afterRemoval).toHaveBeenCalledOnce()
 
     stdout.dispose()

--- a/tests/dashboard-resize.test.ts
+++ b/tests/dashboard-resize.test.ts
@@ -1,0 +1,214 @@
+import { PassThrough } from 'node:stream'
+
+import React, { useEffect } from 'react'
+import { render, Text, useWindowSize } from 'ink'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { RESIZE_DEBOUNCE_MS, createDebouncedResizeStream } from '../src/dashboard.js'
+import { BSU, ESU, stripSyncUpdateEscapes } from '../src/ink-win.js'
+
+function makeTerminal(): PassThrough & NodeJS.WriteStream {
+  const terminal = new PassThrough() as PassThrough & NodeJS.WriteStream
+  terminal.isTTY = true
+  terminal.columns = 100
+  terminal.rows = 24
+  return terminal
+}
+
+function ResizeProbe({ windowColumns, onRender }: {
+  windowColumns: number
+  onRender: (size: { columns: number; rows: number }) => void
+}) {
+  const size = useWindowSize()
+  useEffect(() => {
+    onRender(size)
+  }, [size, onRender])
+  return React.createElement(Text, null, `size:${windowColumns}x${size.rows}`)
+}
+
+describe('interactive dashboard resize stream', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('lets Ink observe one final resize after a terminal resize burst settles', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
+    const writes: string[] = []
+    terminal.on('data', chunk => writes.push(String(chunk)))
+    const renderedSizes: Array<{ columns: number; rows: number }> = []
+    const onRender = (size: { columns: number; rows: number }) => renderedSizes.push(size)
+    let windowColumns = stdout.columns
+    const probe = () => React.createElement(ResizeProbe, { windowColumns, onRender })
+    const app = render(probe(), {
+      stdout,
+      interactive: true,
+      patchConsole: false,
+    })
+    const resize = () => {
+      windowColumns = stdout.columns
+      app.rerender(probe())
+    }
+    stdout.prependListener('resize', resize)
+    await vi.advanceTimersByTimeAsync(100)
+    writes.length = 0
+    renderedSizes.length = 0
+
+    terminal.columns = 99
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(50)
+    terminal.columns = 98
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(50)
+    terminal.columns = 97
+    terminal.rows = 30
+    terminal.emit('resize')
+
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS - 1)
+    expect({ columns: stdout.columns, rows: stdout.rows }).toEqual({ columns: 100, rows: 24 })
+    expect(renderedSizes).toEqual([])
+    expect(writes).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(100)
+    expect({ columns: stdout.columns, rows: stdout.rows }).toEqual({ columns: 97, rows: 30 })
+    expect(renderedSizes).toEqual([{ columns: 97, rows: 30 }])
+    expect(writes.join('').match(/size:97x30/g)).toHaveLength(1)
+
+    stdout.off('resize', resize)
+    app.unmount()
+    await vi.runAllTimersAsync()
+    await app.waitUntilExit()
+  })
+
+  it('removes the source listener and cancels pending resize delivery on cleanup', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
+    const renderedSizes: Array<{ columns: number; rows: number }> = []
+    const app = render(React.createElement(ResizeProbe, {
+      windowColumns: stdout.columns,
+      onRender: size => renderedSizes.push(size),
+    }), {
+      stdout,
+      interactive: true,
+      patchConsole: false,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    renderedSizes.length = 0
+
+    terminal.columns = 90
+    terminal.emit('resize')
+    app.unmount()
+    await vi.runAllTimersAsync()
+    await app.waitUntilExit()
+    stdout.dispose()
+
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+    expect(renderedSizes).toEqual([])
+    expect(terminal.listenerCount('resize')).toBe(0)
+  })
+
+  it('preserves native write arguments, return values, callbacks, and unrelated events', () => {
+    const terminal = makeTerminal()
+    const callback = vi.fn()
+    const nativeWrite = vi.fn((_chunk: unknown, _encoding?: unknown, done?: () => void) => {
+      done?.()
+      return false
+    })
+    terminal.write = nativeWrite as typeof terminal.write
+    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
+    const onDrain = vi.fn()
+    stdout.on('drain', onDrain)
+
+    const accepted = stdout.write('terminal-frame', 'utf8', callback)
+    terminal.emit('drain')
+
+    expect(accepted).toBe(false)
+    expect(nativeWrite).toHaveBeenCalledWith('terminal-frame', 'utf8', callback)
+    expect(callback).toHaveBeenCalledOnce()
+    expect(onDrain).toHaveBeenCalledOnce()
+
+    stdout.off('drain', onDrain)
+    stdout.dispose()
+  })
+
+  it('keeps listener chaining and inspection scoped to the debounced resize surface', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
+    const resize = vi.fn()
+    const drain = vi.fn()
+
+    const chained = stdout
+      .setMaxListeners(20)
+      .once('resize', resize)
+      .on('drain', drain)
+
+    expect(chained).toBe(stdout)
+    expect(stdout.getMaxListeners()).toBe(20)
+    expect(stdout.eventNames()).toEqual(expect.arrayContaining(['resize', 'drain']))
+    expect(stdout.listenerCount('resize')).toBe(1)
+    expect(terminal.listenerCount('resize')).toBe(1)
+
+    terminal.emit('resize')
+    terminal.emit('resize')
+    terminal.emit('drain')
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+
+    expect(resize).toHaveBeenCalledOnce()
+    expect(drain).toHaveBeenCalledOnce()
+    expect(stdout.listenerCount('resize')).toBe(0)
+
+    stdout.removeAllListeners()
+    stdout.dispose()
+  })
+
+  it('preserves prepended one-shot order and applies global listener removal to both surfaces', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
+    const order: string[] = []
+    const drain = vi.fn()
+    stdout.on('resize', () => order.push('regular'))
+    stdout.prependOnceListener('resize', () => order.push('prepended-once'))
+    stdout.on('drain', drain)
+
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+    expect(order).toEqual(['prepended-once', 'regular'])
+
+    stdout.removeAllListeners()
+    expect(stdout.eventNames()).toEqual([])
+    expect(stdout.listenerCount('resize')).toBe(0)
+    expect(terminal.listenerCount('drain')).toBe(0)
+    expect(terminal.listenerCount('resize')).toBe(1)
+
+    terminal.emit('drain')
+    expect(drain).toHaveBeenCalledTimes(0)
+
+    const afterRemoval = vi.fn()
+    stdout.once('resize', afterRemoval)
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+    expect(afterRemoval).toHaveBeenCalledOnce()
+
+    stdout.dispose()
+  })
+
+  it('passes synchronized-update strings to the patched source without buffer conversion', () => {
+    const terminal = makeTerminal()
+    const filteredWrites: string[] = []
+    terminal.write = vi.fn((chunk: unknown) => {
+      filteredWrites.push(typeof chunk === 'string' ? stripSyncUpdateEscapes(chunk) : 'unexpected-buffer')
+      return true
+    }) as typeof terminal.write
+    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
+
+    stdout.write(`${BSU}terminal-frame${ESU}`)
+
+    expect(filteredWrites).toEqual(['terminal-frame'])
+    stdout.dispose()
+  })
+})

--- a/tests/dashboard-resize.test.ts
+++ b/tests/dashboard-resize.test.ts
@@ -26,8 +26,93 @@ function ResizeProbe({ windowColumns, onRender }: {
   return React.createElement(Text, null, `size:${windowColumns}x${size.rows}`)
 }
 
+function ResizeTransitionProbe({ onRender }: {
+  onRender: (size: { windowColumns: number; columns: number; rows: number }) => void
+}) {
+  const size = useWindowSize()
+  useEffect(() => {
+    onRender({ windowColumns: size.columns, ...size })
+  }, [size, onRender])
+  return React.createElement(Text, null, `size:${size.columns}x${size.columns}x${size.rows}`)
+}
+
+function LifecycleProbe({ onMount, onCleanup }: { onMount: () => void; onCleanup: () => void }) {
+  useWindowSize()
+  useEffect(() => {
+    onMount()
+    return onCleanup
+  }, [onMount, onCleanup])
+  return React.createElement(Text, null, 'mounted')
+}
+
 describe('interactive dashboard resize stream', () => {
   afterEach(() => vi.useRealTimers())
+
+  it('publishes one coherent dimension transition after a resize burst settles', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
+    const writes: string[] = []
+    terminal.on('data', chunk => writes.push(String(chunk)))
+    const transitions: Array<{ windowColumns: number; columns: number; rows: number }> = []
+    const onRender = (size: { windowColumns: number; columns: number; rows: number }) => transitions.push(size)
+    const probe = () => React.createElement(ResizeTransitionProbe, { onRender })
+    const app = render(probe(), {
+      stdout,
+      interactive: true,
+      patchConsole: false,
+      alternateScreen: true,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    writes.length = 0
+    transitions.length = 0
+
+    terminal.columns = 99
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(50)
+    terminal.columns = 98
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(50)
+    terminal.columns = 97
+    terminal.rows = 30
+    terminal.emit('resize')
+
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(transitions).toEqual([{ windowColumns: 97, columns: 97, rows: 30 }])
+    expect(writes.join('')).not.toContain('size:97x100x24')
+    expect(writes.join('').match(/size:97x97x30/g)).toHaveLength(1)
+
+    app.unmount()
+    await vi.runAllTimersAsync()
+    await app.waitUntilExit()
+  })
+
+  it('does not remount after exit when a source resize is still pending', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
+    const onMount = vi.fn()
+    const onCleanup = vi.fn()
+    const app = render(React.createElement(LifecycleProbe, { onMount, onCleanup }), {
+      stdout,
+      interactive: true,
+      patchConsole: false,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+
+    terminal.columns = 90
+    terminal.emit('resize')
+    app.unmount()
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+    await app.waitUntilExit()
+    stdout.dispose()
+
+    expect(onMount).toHaveBeenCalledOnce()
+    expect(onCleanup).toHaveBeenCalledOnce()
+    expect(terminal.listenerCount('resize')).toBe(0)
+  })
 
   it('lets Ink observe one final resize after a terminal resize burst settles', async () => {
     vi.useFakeTimers()

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -467,7 +467,12 @@ describe('interactive terminal rendering', () => {
     chunks.length = 0
     stdout.columns = 134
     stdout.emit('resize')
-    await app.waitUntilRenderFlush()
+    for (let i = 0; i < 100; i++) {
+      await new Promise(resolve => setTimeout(resolve, 5))
+      const latest = chunks.filter(chunk => chunk.trim()).at(-1) ?? ''
+      const title = latest.split('\n').find(line => line.includes('Daily Activity')) ?? ''
+      if (title.includes('By Project') && !title.includes('By Activity')) break
+    }
 
     let panelTitleLine = (chunks.filter(chunk => chunk.trim()).at(-1) ?? '').split('\n').find(line => line.includes('Daily Activity')) ?? ''
     expect(panelTitleLine).toContain('By Project')
@@ -476,7 +481,12 @@ describe('interactive terminal rendering', () => {
     chunks.length = 0
     stdout.columns = 89
     stdout.emit('resize')
-    await app.waitUntilRenderFlush()
+    for (let i = 0; i < 100; i++) {
+      await new Promise(resolve => setTimeout(resolve, 5))
+      const latest = chunks.filter(chunk => chunk.trim()).at(-1) ?? ''
+      const title = latest.split('\n').find(line => line.includes('Daily Activity')) ?? ''
+      if (!title.includes('By Project')) break
+    }
 
     panelTitleLine = (chunks.filter(chunk => chunk.trim()).at(-1) ?? '').split('\n').find(line => line.includes('Daily Activity')) ?? ''
     expect(panelTitleLine).not.toContain('By Project')

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -363,7 +363,6 @@ describe('Daily Activity viewport', () => {
       initialPeriod: 'all',
       initialProvider: 'all',
       refreshSeconds: 0,
-      windowColumns: 100,
     }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
     onTestFinished(() => app.unmount())
     await app.waitUntilRenderFlush()
@@ -428,7 +427,6 @@ describe('interactive terminal rendering', () => {
         initialPeriod: period,
         initialProvider: 'all',
         refreshSeconds: 60,
-        windowColumns: 160,
         initialDay,
       }), { stdin, stdout, interactive: true, patchConsole: false })
       onTestFinished(() => {
@@ -460,14 +458,15 @@ describe('interactive terminal rendering', () => {
       initialProvider: 'all',
       refreshSeconds: 0,
     }
-    const app = render(React.createElement(InteractiveDashboard, { ...props, windowColumns: 135 }), {
+    const app = render(React.createElement(InteractiveDashboard, props), {
       stdin, stdout, interactive: true, patchConsole: false,
     })
     onTestFinished(() => app.unmount())
 
     await new Promise(resolve => setTimeout(resolve, 20))
     chunks.length = 0
-    app.rerender(React.createElement(InteractiveDashboard, { ...props, windowColumns: 134 }))
+    stdout.columns = 134
+    stdout.emit('resize')
     await app.waitUntilRenderFlush()
 
     let panelTitleLine = (chunks.filter(chunk => chunk.trim()).at(-1) ?? '').split('\n').find(line => line.includes('Daily Activity')) ?? ''
@@ -475,7 +474,8 @@ describe('interactive terminal rendering', () => {
     expect(panelTitleLine).not.toContain('By Activity')
 
     chunks.length = 0
-    app.rerender(React.createElement(InteractiveDashboard, { ...props, windowColumns: 89 }))
+    stdout.columns = 89
+    stdout.emit('resize')
     await app.waitUntilRenderFlush()
 
     panelTitleLine = (chunks.filter(chunk => chunk.trim()).at(-1) ?? '').split('\n').find(line => line.includes('Daily Activity')) ?? ''
@@ -503,7 +503,6 @@ describe('interactive terminal rendering', () => {
       initialPeriod: 'today' as const,
       initialProvider: 'all',
       refreshSeconds: 0,
-      windowColumns: columns,
     }
     const app = render(React.createElement(InteractiveDashboard, props), {
       stdin, stdout, debug: true, interactive: true, patchConsole: false,
@@ -520,10 +519,8 @@ describe('interactive terminal rendering', () => {
     frame = frames.filter(chunk => chunk.trim()).at(-1) ?? ''
     expect(frame).not.toContain('[ Today ]')
 
-    app.rerender(React.createElement(InteractiveDashboard, {
-      ...props,
-      windowColumns: columns + 1,
-    }))
+    stdout.columns = columns + 1
+    stdout.emit('resize')
     await app.waitUntilRenderFlush()
     frame = frames.filter(chunk => chunk.trim()).at(-1) ?? ''
     expect(frame).not.toContain('[ Today ]')
@@ -587,7 +584,6 @@ describe('InteractiveDashboard refresh', () => {
       initialPeriod: 'today',
       initialProvider: 'all',
       refreshSeconds: 0,
-      windowColumns: 135,
     }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
     onTestFinished(() => app.unmount())
 
@@ -647,7 +643,6 @@ describe('InteractiveDashboard refresh', () => {
       initialPeriod: 'today',
       initialProvider: 'all',
       refreshSeconds: 0,
-      windowColumns: 80,
     }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
     onTestFinished(() => app.unmount())
 
@@ -686,7 +681,6 @@ describe('InteractiveDashboard refresh', () => {
       initialPeriod: 'today',
       initialProvider: 'all',
       refreshSeconds: 60,
-      windowColumns: 160,
     }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
     onTestFinished(() => {
       app.unmount()

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -561,7 +561,7 @@ describe('interactive terminal rendering', () => {
 
     stdout.columns = columns + 1
     stdout.emit('resize')
-    await app.waitUntilRenderFlush()
+    await new Promise(resolve => setTimeout(resolve, RESIZE_DEBOUNCE_MS + 100))
     frame = frames.filter(chunk => chunk.trim()).at(-1) ?? ''
     expect(frame).not.toContain('[ Today ]')
   })
@@ -598,6 +598,10 @@ describe('interactive terminal rendering', () => {
 
     for (let i = 0; i < 8; i++) stdin.write('\u001B[6~')
     await new Promise(resolve => setTimeout(resolve, 100))
+    const beforeResize = synchronizedUpdates(writes).at(-1) ?? ''
+    const anchor = ['Workflow', 'Delegation', 'Git Ops', 'Build/Deploy', 'Conversation', 'Brainstorming', 'General']
+      .find(label => beforeResize.includes(label))
+    expect(anchor, beforeResize).toBeTruthy()
     writes.length = 0
 
     stdout.columns = 99
@@ -621,6 +625,7 @@ describe('interactive terminal rendering', () => {
     expect(frames[0]).toContain('PgUp/PgDn')
     expect(frames[0].split('\n')).toHaveLength(50)
     expect(frames[0]).not.toContain('[ 6 Months ]')
+    expect(frames[0]).toContain(anchor!)
   })
 })
 

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -7,7 +7,8 @@ import { render } from 'ink'
 import stripAnsi from 'strip-ansi'
 import { describe, it, expect, onTestFinished, vi } from 'vitest'
 
-import { DAILY_ACTIVITY_PAGE_SIZE, INTERACTIVE_RENDER_OPTIONS, dailyActivityFooter, getDailyActivityPageSize, getDailyActivityRows, getDashboardMaxWidth, getDashboardScanRange, getLayout, getRefreshIntervalMs, InteractiveDashboard, pageHistoryCursor, scrollHistoryCursor, selectDashboardPeriodProjects, shortProject, showEmptyState } from '../src/dashboard.js'
+import { DAILY_ACTIVITY_PAGE_SIZE, INTERACTIVE_RENDER_OPTIONS, RESIZE_DEBOUNCE_MS, dailyActivityFooter, getDailyActivityPageSize, getDailyActivityRows, getDashboardMaxWidth, getDashboardScanRange, getLayout, getRefreshIntervalMs, InteractiveDashboard, pageHistoryCursor, renderDebouncedInteractive, scrollHistoryCursor, selectDashboardPeriodProjects, shortProject, showEmptyState } from '../src/dashboard.js'
+import { BSU, ESU } from '../src/ink-win.js'
 import { getDateRange } from '../src/cli-date.js'
 import { formatCost } from '../src/format.js'
 import type { ProjectSummary, SessionSummary } from '../src/types.js'
@@ -87,6 +88,36 @@ function makeTurn(timestamp: string, costs: number[]): SessionSummary['turns'][n
       deduplicationKey: `fixture-${timestamp}-${index}`,
     })),
   }
+}
+
+function synchronizedUpdates(writes: string[]): string[] {
+  const updates: string[] = []
+  let current: string | undefined
+  for (const write of writes) {
+    let rest = write
+    while (rest.length > 0) {
+      if (current === undefined) {
+        const start = rest.indexOf(BSU)
+        if (start === -1) break
+        current = ''
+        rest = rest.slice(start + BSU.length)
+      }
+      const end = rest.indexOf(ESU)
+      if (end === -1) {
+        current += rest
+        break
+      }
+      current += rest.slice(0, end)
+      updates.push(stripAnsi(current))
+      current = undefined
+      rest = rest.slice(end + ESU.length)
+    }
+  }
+  return updates
+}
+
+function writeDelta(writes: string[]): string {
+  return stripAnsi(writes.join(''))
 }
 
 // Logic replicated from TopSessions component
@@ -363,6 +394,7 @@ describe('Daily Activity viewport', () => {
       initialPeriod: 'all',
       initialProvider: 'all',
       refreshSeconds: 0,
+      terminalSize: { columns: stdout.columns, rows: stdout.rows },
     }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
     onTestFinished(() => app.unmount())
     await app.waitUntilRenderFlush()
@@ -428,6 +460,7 @@ describe('interactive terminal rendering', () => {
         initialProvider: 'all',
         refreshSeconds: 60,
         initialDay,
+        terminalSize: { columns: stdout.columns, rows: stdout.rows },
       }), { stdin, stdout, interactive: true, patchConsole: false })
       onTestFinished(() => {
         app.unmount()
@@ -451,44 +484,41 @@ describe('interactive terminal rendering', () => {
     stdout.columns = 135
     stdout.rows = 50
     const chunks: string[] = []
-    stdout.on('data', chunk => chunks.push(stripAnsi(String(chunk))))
+    stdout.on('data', chunk => chunks.push(String(chunk)))
     const props = {
       initialProjects: [makeProject('proj', [makeSession('s1', 1)])],
       initialPeriod: 'today' as const,
       initialProvider: 'all',
       refreshSeconds: 0,
     }
-    const app = render(React.createElement(InteractiveDashboard, props), {
-      stdin, stdout, interactive: true, patchConsole: false,
-    })
+    const app = renderDebouncedInteractive(stdout, terminalSize => (
+      React.createElement(InteractiveDashboard, { ...props, terminalSize })
+    ), { stdin, interactive: true, patchConsole: false })
     onTestFinished(() => app.unmount())
 
     await new Promise(resolve => setTimeout(resolve, 20))
     chunks.length = 0
     stdout.columns = 134
     stdout.emit('resize')
-    for (let i = 0; i < 100; i++) {
-      await new Promise(resolve => setTimeout(resolve, 5))
-      const latest = chunks.filter(chunk => chunk.trim()).at(-1) ?? ''
-      const title = latest.split('\n').find(line => line.includes('Daily Activity')) ?? ''
-      if (title.includes('By Project') && !title.includes('By Activity')) break
-    }
+    await new Promise(resolve => setTimeout(resolve, RESIZE_DEBOUNCE_MS - 1))
+    expect(chunks).toEqual([])
+    await new Promise(resolve => setTimeout(resolve, 100))
 
-    let panelTitleLine = (chunks.filter(chunk => chunk.trim()).at(-1) ?? '').split('\n').find(line => line.includes('Daily Activity')) ?? ''
+    expect(synchronizedUpdates(chunks)).toHaveLength(1)
+    let panelTitleLine = writeDelta(chunks).split('\n').find(line => line.includes('Daily Activity')) ?? ''
     expect(panelTitleLine).toContain('By Project')
     expect(panelTitleLine).not.toContain('By Activity')
 
     chunks.length = 0
     stdout.columns = 89
     stdout.emit('resize')
-    for (let i = 0; i < 100; i++) {
-      await new Promise(resolve => setTimeout(resolve, 5))
-      const latest = chunks.filter(chunk => chunk.trim()).at(-1) ?? ''
-      const title = latest.split('\n').find(line => line.includes('Daily Activity')) ?? ''
-      if (!title.includes('By Project')) break
-    }
+    await new Promise(resolve => setTimeout(resolve, RESIZE_DEBOUNCE_MS - 1))
+    expect(chunks).toEqual([])
+    await new Promise(resolve => setTimeout(resolve, 100))
 
-    panelTitleLine = (chunks.filter(chunk => chunk.trim()).at(-1) ?? '').split('\n').find(line => line.includes('Daily Activity')) ?? ''
+    expect(synchronizedUpdates(chunks)).toHaveLength(1)
+    panelTitleLine = writeDelta(chunks).split('\n').find(line => line.includes('Daily Activity')) ?? ''
+    expect(panelTitleLine).toContain('Daily Activity')
     expect(panelTitleLine).not.toContain('By Project')
   })
 
@@ -514,9 +544,9 @@ describe('interactive terminal rendering', () => {
       initialProvider: 'all',
       refreshSeconds: 0,
     }
-    const app = render(React.createElement(InteractiveDashboard, props), {
-      stdin, stdout, debug: true, interactive: true, patchConsole: false,
-    })
+    const app = renderDebouncedInteractive(stdout, terminalSize => (
+      React.createElement(InteractiveDashboard, { ...props, terminalSize })
+    ), { stdin, debug: true, interactive: true, patchConsole: false })
     onTestFinished(() => app.unmount())
 
     await app.waitUntilRenderFlush()
@@ -534,6 +564,63 @@ describe('interactive terminal rendering', () => {
     await app.waitUntilRenderFlush()
     frame = frames.filter(chunk => chunk.trim()).at(-1) ?? ''
     expect(frame).not.toContain('[ Today ]')
+  })
+
+  it('writes one final dashboard frame while preserving a scrolled viewport', async () => {
+    const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream
+    const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream
+    stdin.isTTY = true
+    stdin.setRawMode = () => stdin
+    stdin.ref = () => stdin
+    stdin.unref = () => stdin
+    stdout.isTTY = true
+    stdout.columns = 100
+    stdout.rows = 12
+    const writes: string[] = []
+    stdout.on('data', chunk => writes.push(String(chunk)))
+    const history = makeSession('history', 20)
+    history.turns = Array.from({ length: 20 }, (_, index) =>
+      makeTurn(`2026-07-${String(index + 1).padStart(2, '0')}T10:00:00Z`, [1]))
+    const projects = [
+      makeProject('project-01', [history]),
+      ...Array.from({ length: 13 }, (_, index) =>
+        makeProject(`project-${String(index + 2).padStart(2, '0')}`, [makeSession(`s-${index}`, 1)])),
+    ]
+    const app = renderDebouncedInteractive(stdout, terminalSize => React.createElement(InteractiveDashboard, {
+      initialProjects: projects,
+      initialPeriod: 'all',
+      initialProvider: 'all',
+      refreshSeconds: 0,
+      terminalSize,
+    }), { stdin, interactive: true, patchConsole: false, alternateScreen: true })
+    onTestFinished(() => app.unmount())
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    for (let i = 0; i < 8; i++) stdin.write('\u001B[6~')
+    await new Promise(resolve => setTimeout(resolve, 100))
+    writes.length = 0
+
+    stdout.columns = 99
+    stdout.rows = 49
+    stdout.emit('resize')
+    await new Promise(resolve => setTimeout(resolve, 50))
+    stdout.columns = 98
+    stdout.rows = 48
+    stdout.emit('resize')
+    await new Promise(resolve => setTimeout(resolve, 50))
+    stdout.columns = 89
+    stdout.rows = 50
+    stdout.emit('resize')
+    await new Promise(resolve => setTimeout(resolve, RESIZE_DEBOUNCE_MS - 1))
+    expect(writes).toEqual([])
+    await new Promise(resolve => setTimeout(resolve, 150))
+
+    const frames = synchronizedUpdates(writes)
+    expect(frames).toHaveLength(1)
+    expect(frames[0]).toContain('By Model')
+    expect(frames[0]).toContain('PgUp/PgDn')
+    expect(frames[0].split('\n')).toHaveLength(50)
+    expect(frames[0]).not.toContain('[ 6 Months ]')
   })
 })
 
@@ -594,6 +681,7 @@ describe('InteractiveDashboard refresh', () => {
       initialPeriod: 'today',
       initialProvider: 'all',
       refreshSeconds: 0,
+      terminalSize: { columns: stdout.columns, rows: stdout.rows },
     }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
     onTestFinished(() => app.unmount())
 
@@ -653,6 +741,7 @@ describe('InteractiveDashboard refresh', () => {
       initialPeriod: 'today',
       initialProvider: 'all',
       refreshSeconds: 0,
+      terminalSize: { columns: stdout.columns, rows: stdout.rows },
     }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
     onTestFinished(() => app.unmount())
 
@@ -691,6 +780,7 @@ describe('InteractiveDashboard refresh', () => {
       initialPeriod: 'today',
       initialProvider: 'all',
       refreshSeconds: 60,
+      terminalSize: { columns: stdout.columns, rows: stdout.rows },
     }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
     onTestFinished(() => {
       app.unmount()


### PR DESCRIPTION
## Problem

Terminal font zoom and window-resize bursts caused the interactive dashboard to repaint repeatedly. Even a simple debounce still allowed unrelated React updates during the quiet window to paint a stale-width frame before the final settled layout.

## Root cause

Ink observed physical terminal dimensions immediately while CodeBurn separately rerendered after resize events. Width and height could therefore advance through different render paths, and state updates or refreshes could write an intermediate frame against dimensions the terminal had already left.

## Change

- Hold interactive terminal dimensions stable during resize bursts.
- Suppress synchronized application frames while a resize is pending while preserving imperative terminal-control writes and write completion semantics.
- Publish one coherent settled resize to Ink, useWindowSize, and the dashboard before requesting the final rerender.
- Preserve mounted period, view, and logical viewport state.
- Cancel pending delivery and remove all resize relays during teardown and render failures.
- Normalize invalid terminal dimensions to safe defaults.

## User impact

Zooming the terminal font or rapidly resizing the window now produces one final reflow after dimensions settle instead of repeated stale or partial dashboard redraws. The user remains at the same logical reading position and terminal modes are restored cleanly on exit.

## Preservation and out of scope

- Static and non-interactive output are unchanged.
- Periodic refresh behavior is unchanged.
- One final synchronized repaint after settlement remains expected.

## Testing

- Credible RED on the prior candidate: a state update during pending resize wrote an old 100×24 frame followed by a mixed 80×20 prop / 100×24 hook frame.
- Focused real-Ink suites: 73/73.
- Full root suite: 2,633 passed, 5 skipped.
- Serial lock suite: 26/26.
- Full desktop suite: 468/468.
- Root, dashboard, and desktop TypeScript checks passed.
- CLI, dashboard, and desktop production builds passed.
- Exact-SHA independent spec and hostile standards reviews approved.
- Real controlling-PTY storm across width/height breakpoints: zero pre-settle bytes, one BSU/ESU transaction, one complete final frame, zero later frames, and clean mouse/alternate-screen teardown.

Fixes #977.
