### PR TITLE
test(codex): explicit timeout for the every-boundary resume differential

### DIFF
--- a/tests/providers/codex-resume.test.ts
+++ b/tests/providers/codex-resume.test.ts
@@ -279,9 +279,9 @@ describe('codex resume differential', () => {
 
   it('matches a full re-parse at every line boundary of a rich session', async () => {
     await assertEverySplitMatches(RICH_LINES)
-  })
+  }, 60_000)
 
   it('matches a full re-parse at every line boundary of a forked session', async () => {
     await assertEverySplitMatches(FORK_LINES)
-  })
+  }, 60_000)
 })


### PR DESCRIPTION
The 110-split codex resume differential (from #1005) takes ~1.3 s locally but hit vitest's 5 s default on the CI runner after #1008 added the parse-worker tests to the same parallel suite (failed the `test` check on #1008's CI run — pure timeout, not a correctness failure; passed on #1005/#1006/#1007). Sets a 60 s explicit timeout on the two differential tests.