### PR TITLE
test(dashboard): wait for the Optimize scan on real event-loop turns

### DIFF
--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -665,7 +665,12 @@ describe('InteractiveDashboard refresh', () => {
   })
 
   it('keeps Optimize mounted without a loading frame when auto-refresh fires', async () => {
-    vi.useFakeTimers()
+    // The Optimize scan (`o`) does real fs I/O (readdir/stat) that only
+    // resolves on a real event-loop turn. Leave setImmediate/nextTick/Date
+    // real (Date stays real so the wait loop below can use a genuine
+    // wall-clock deadline) and fake only what the 60s auto-refresh
+    // interval needs.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'] })
     const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream
     const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream
     stdin.isTTY = true
@@ -712,7 +717,15 @@ describe('InteractiveDashboard refresh', () => {
     expect(activityHeader.indexOf('turns') + 'turns'.length).toBe(activityRow.indexOf('12') + '12'.length)
     expect(activityHeader.indexOf('1-shot') + '1-shot'.length).toBe(activityRow.indexOf('50%') + '50%'.length)
     stdin.write('o')
-    for (let i = 0; i < 20 && !frames.some(frame => frame.includes('Token estimates are approximate.')); i++) {
+    // The scan does real fs work, so wait on real event-loop turns
+    // (setImmediate is left un-faked above) rather than counting fake-timer
+    // hops, bounded by a real wall-clock deadline.
+    const realDeadline = Date.now() + 10_000
+    while (!frames.some(frame => frame.includes('Token estimates are approximate.'))) {
+      if (Date.now() > realDeadline) {
+        throw new Error('Timed out waiting for the Optimize scan to render "Token estimates are approximate."')
+      }
+      await new Promise(resolve => setImmediate(resolve))
       await vi.advanceTimersByTimeAsync(50)
     }
     const beforeRefresh = frames.filter(frame => frame.trim()).at(-1) ?? ''
@@ -731,5 +744,5 @@ describe('InteractiveDashboard refresh', () => {
     expect(frame).not.toContain('Loading Today')
     expect(frame).not.toContain('Scanning Today')
 
-  })
+  }, 30_000)
 })


### PR DESCRIPTION
Fixes the intermittent failure of `InteractiveDashboard refresh > keeps Optimize mounted without a loading frame when auto-refresh fires` (seen on #1001's CI and locally): the Optimize scan does real fs I/O (`readdir`/`stat` for agents/skills/commands) that only settles on a real event-loop turn, but `vi.useFakeTimers()` faked `setImmediate` too, so 20 × `advanceTimersByTimeAsync(50)` hops could read a stale "Scanning Today…" frame under load.

- Fake only what the 60 s auto-refresh interval needs (`setTimeout`/`setInterval` + clears); `setImmediate`/`nextTick`/`Date` stay real.
- Wait loop is condition-based, yields a real event-loop turn per iteration, and is bounded by a 10 s wall-clock deadline with a clear error; test timeout 30 s.
- Auto-refresh assertions unchanged and still meaningful (`dashboard.tsx` bails out of background refresh while Optimize is mounted; no `Date.now()` in render paths).

Verified 5/5 plain and 5/5 under CPU pressure (4 busy loops + two heavy suites concurrently). Test-only change.