### PR TITLE
test: raise vitest testTimeout to 30s

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,8 @@ export default defineConfig({
     // session-discovery env vars (CLAUDE_CONFIG_DIRS, HOME, XDG_*, every
     // provider-specific *_HOME) don't bleed real local data into fixtures.
     setupFiles: ['./tests/setup/env-isolation.ts'],
+    // Real-I/O tests (session parses, sqlite fixtures, worker pools) exceed the
+    // 5s default under CI runner load; a hung test still fails at 30s.
+    testTimeout: 30_000,
   },
 })


### PR DESCRIPTION
Three unrelated real-I/O tests (dashboard optimize scan #1018, codex resume differential #1009, and now the OTel DB-prune test on #1024's run) hit vitest's 5 s default purely from CI runner load on the Node-22 line. A single global 30 s cap: hung tests still fail, load-induced flakes stop. Config-only change.