### PR TITLE
fix(tui): coalesce resize bursts without dropping updates

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1,7 +1,8 @@
 import { homedir } from 'os'
+import { EventEmitter } from 'node:events'
 
 import React, { Fragment, useState, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
-import { render, Box, Text, measureElement, useInput, useApp, useWindowSize, type DOMElement } from 'ink'
+import { render, Box, Text, measureElement, useInput, useApp, useWindowSize, type DOMElement, type Instance, type RenderOptions } from 'ink'
 import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory } from './types.js'
 import { formatCost, formatTokens, markEstimated, carriedCostNote } from './format.js'
 import { aggregateModelEfficiency } from './model-efficiency.js'
@@ -31,6 +32,138 @@ export type DailyActivityRow = {
 
 export const DAILY_ACTIVITY_PAGE_SIZE = 10
 export const INTERACTIVE_RENDER_OPTIONS = { alternateScreen: true } as const
+export const RESIZE_DEBOUNCE_MS = 150
+
+export type TerminalSize = { columns: number; rows: number }
+export type DebouncedResizeStream = NodeJS.WriteStream & {
+  dispose(): void
+  onSettledResize(listener: (size: TerminalSize) => void): () => void
+}
+
+function normalizeTerminalDimension(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && value! > 0 ? Math.floor(value!) : fallback
+}
+
+function terminalSizeOf(source: NodeJS.WriteStream): TerminalSize {
+  return {
+    columns: normalizeTerminalDimension(source.columns, 80),
+    rows: normalizeTerminalDimension(source.rows, 24),
+  }
+}
+
+const RESIZE_LISTENER_METHODS = new Set<PropertyKey>([
+  'addListener', 'on', 'once', 'prependListener', 'prependOnceListener', 'off', 'removeListener',
+])
+
+export function createDebouncedResizeStream(source: NodeJS.WriteStream, delayMs: number): DebouncedResizeStream {
+  let resizeTimer: ReturnType<typeof setTimeout> | undefined
+  let disposed = false
+  let { columns, rows } = terminalSizeOf(source)
+  const resizeEvents = new EventEmitter()
+  const settledResizeListeners = new Set<(size: TerminalSize) => void>()
+
+  const resize = () => {
+    if (disposed) return
+    if (resizeTimer) clearTimeout(resizeTimer)
+    resizeTimer = setTimeout(() => {
+      resizeTimer = undefined
+      if (disposed) return
+      const next = terminalSizeOf(source)
+      const changed = next.columns !== columns || next.rows !== rows
+      columns = next.columns
+      rows = next.rows
+      if (!changed) return
+      // Rerender first so the settled view owns the first paint at the new
+      // size; then notify Ink/useWindowSize. Writes are never intercepted, so
+      // a mid-burst state update still reaches the terminal even when net
+      // size is unchanged.
+      for (const listener of [...settledResizeListeners]) listener(next)
+      resizeEvents.emit('resize')
+    }, delayMs)
+  }
+  source.on('resize', resize)
+
+  const dispose = () => {
+    if (disposed) return
+    disposed = true
+    source.off('resize', resize)
+    if (resizeTimer) clearTimeout(resizeTimer)
+    resizeTimer = undefined
+    resizeEvents.removeAllListeners()
+    settledResizeListeners.clear()
+  }
+
+  const stream = new Proxy(source as DebouncedResizeStream, {
+    get(target, property) {
+      if (property === 'dispose') return dispose
+      if (property === 'onSettledResize') {
+        return (listener: (size: TerminalSize) => void) => {
+          if (disposed) return () => {}
+          settledResizeListeners.add(listener)
+          return () => settledResizeListeners.delete(listener)
+        }
+      }
+      if (property === 'columns') return columns
+      if (property === 'rows') return rows
+      if (RESIZE_LISTENER_METHODS.has(property)) {
+        return (event: string | symbol, ...args: unknown[]) => {
+          if (event === 'resize') {
+            if (!disposed) {
+              Reflect.apply(Reflect.get(resizeEvents, property) as (...args: unknown[]) => unknown, resizeEvents, [event, ...args])
+            }
+            return stream
+          }
+          Reflect.apply(Reflect.get(target, property, target) as (...args: unknown[]) => unknown, target, [event, ...args])
+          return stream
+        }
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+  return stream
+}
+
+function DisposeOnUnmount({ dispose, children }: { dispose: () => void; children: React.ReactNode }) {
+  useLayoutEffect(() => dispose, [dispose])
+  return children
+}
+
+export type DebouncedInteractiveInstance = Instance & {
+  dispose(): void
+  stdout: DebouncedResizeStream
+}
+
+export function renderDebouncedInteractive(
+  source: NodeJS.WriteStream,
+  view: (size: TerminalSize) => React.ReactElement,
+  options: Omit<RenderOptions, 'stdout'> = INTERACTIVE_RENDER_OPTIONS,
+): DebouncedInteractiveInstance {
+  const stdout = createDebouncedResizeStream(source, RESIZE_DEBOUNCE_MS)
+  let size = { columns: stdout.columns, rows: stdout.rows }
+  let unsubscribe = () => {}
+  let disposed = false
+  const dispose = () => {
+    if (disposed) return
+    disposed = true
+    unsubscribe()
+    stdout.dispose()
+  }
+  const dashboard = () => <DisposeOnUnmount dispose={dispose}>{view(size)}</DisposeOnUnmount>
+  let app: Instance
+  try {
+    app = render(dashboard(), { ...options, stdout })
+  } catch (error) {
+    dispose()
+    throw error
+  }
+  unsubscribe = stdout.onSettledResize(nextSize => {
+    if (disposed) return
+    size = nextSize
+    app.rerender(dashboard())
+  })
+  return Object.assign(app, { dispose, stdout })
+}
 
 export function getDailyActivityPageSize(columnCount: 1 | 2 | 3, projectRows: number, activityRows: number, dayMode = false): number {
   if (dayMode) return 1
@@ -1738,23 +1871,13 @@ export async function renderDashboard(period: Period = 'week', provider: string 
   const label = initialDay ? formatDayRangeLabel(initialDay) : customRangeLabel
   patchStdoutForWindows()
   if (isTTY) {
-    let windowColumns = process.stdout.columns
-    const dashboard = () => (
-      <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={period} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} windowColumns={windowColumns} />
-    )
-    const app = render(
-      dashboard(),
-      INTERACTIVE_RENDER_OPTIONS,
-    )
-    const resize = () => {
-      windowColumns = process.stdout.columns
-      app.rerender(dashboard())
-    }
-    process.stdout.prependListener('resize', resize)
+    const app = renderDebouncedInteractive(process.stdout, ({ columns }) => (
+      <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={period} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} windowColumns={columns} />
+    ))
     try {
       await app.waitUntilExit()
     } finally {
-      process.stdout.off('resize', resize)
+      app.dispose()
     }
   } else {
     const { unmount } = render(<StaticDashboard projects={filteredProjects} period={period} activeProvider={provider} planUsages={planUsages} label={label} dayMode={initialDay != null} durable={initialDurable} />, { patchConsole: false })

--- a/tests/dashboard-resize.test.ts
+++ b/tests/dashboard-resize.test.ts
@@ -1,0 +1,184 @@
+import { readFileSync } from 'node:fs'
+import { PassThrough } from 'node:stream'
+
+import React, { useEffect } from 'react'
+import { Text } from 'ink'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { RESIZE_DEBOUNCE_MS, createDebouncedResizeStream, renderDebouncedInteractive } from '../src/dashboard.js'
+import { stripSyncUpdateEscapes } from '../src/ink-win.js'
+
+function makeTerminal(columns = 100, rows = 24): PassThrough & NodeJS.WriteStream {
+  const terminal = new PassThrough() as PassThrough & NodeJS.WriteStream
+  terminal.isTTY = true
+  terminal.columns = columns
+  terminal.rows = rows
+  return terminal
+}
+
+function paintedFrames(writes: string[]): string[] {
+  return writes
+    .map(chunk => stripSyncUpdateEscapes(chunk))
+    .flatMap(chunk => chunk.match(/FRAME:[^\r\n]*/g) ?? [])
+}
+
+describe('interactive dashboard resize stream', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('does not intercept writes or parse synchronized-update frames', () => {
+    const source = readFileSync(new URL('../src/dashboard.tsx', import.meta.url), 'utf8')
+    expect(source).not.toContain('suppressingFrame')
+    expect(source).not.toContain('capturingResizeWrites')
+    expect(source).not.toContain('finalFramePreamble')
+    expect(source).not.toContain('indexOf(BSU)')
+    expect(source).not.toContain('indexOf(ESU)')
+    expect(source).not.toContain('process.stdout.prependListener')
+  })
+
+  it('publishes one settled paint after a resize burst', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const writes: string[] = []
+    terminal.on('data', chunk => writes.push(String(chunk)))
+    const app = renderDebouncedInteractive(terminal, size => (
+      React.createElement(Text, null, `FRAME:${size.columns}x${size.rows}`)
+    ), {
+      interactive: true,
+      patchConsole: false,
+      alternateScreen: true,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    writes.length = 0
+
+    terminal.columns = 99
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(50)
+    terminal.columns = 98
+    terminal.emit('resize')
+    await vi.advanceTimersByTimeAsync(50)
+    terminal.columns = 97
+    terminal.rows = 30
+    terminal.emit('resize')
+
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS + 100)
+
+    const frames = paintedFrames(writes)
+    expect(frames.filter(frame => frame !== 'FRAME:97x30'), 'a resize burst must not paint intermediate sizes').toEqual([])
+    expect(frames).toContain('FRAME:97x30')
+
+    app.unmount()
+    app.dispose()
+    await vi.runAllTimersAsync()
+    await app.waitUntilExit()
+  })
+
+  it('paints a mid-burst state update when the burst nets to no size change', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const writes: string[] = []
+    terminal.on('data', chunk => writes.push(String(chunk)))
+    let updateVisibleState = () => {}
+    const StatefulProbe = ({ size }: { size: { columns: number; rows: number } }) => {
+      const [revision, setRevision] = React.useState(0)
+      updateVisibleState = () => setRevision(value => value + 1)
+      return React.createElement(Text, null, `FRAME:revision=${revision}:size=${size.columns}x${size.rows}`)
+    }
+    const app = renderDebouncedInteractive(terminal, size => React.createElement(StatefulProbe, { size }), {
+      interactive: true,
+      patchConsole: false,
+      alternateScreen: true,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    writes.length = 0
+
+    terminal.columns = 80
+    terminal.emit('resize')
+    updateVisibleState()
+    terminal.columns = 100
+    terminal.emit('resize')
+
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS + 100)
+
+    expect(paintedFrames(writes).some(frame => frame.includes('revision=1')), 'a mid-burst state update must reach the terminal even when net size is unchanged').toBe(true)
+
+    app.unmount()
+    app.dispose()
+    await vi.runAllTimersAsync()
+    await app.waitUntilExit()
+  })
+
+  it('paints a state update after a spurious identical-dimension SIGWINCH', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const writes: string[] = []
+    terminal.on('data', chunk => writes.push(String(chunk)))
+    let updateVisibleState = () => {}
+    const StatefulProbe = ({ size }: { size: { columns: number; rows: number } }) => {
+      const [revision, setRevision] = React.useState(0)
+      updateVisibleState = () => setRevision(value => value + 1)
+      return React.createElement(Text, null, `FRAME:revision=${revision}:size=${size.columns}x${size.rows}`)
+    }
+    const app = renderDebouncedInteractive(terminal, size => React.createElement(StatefulProbe, { size }), {
+      interactive: true,
+      patchConsole: false,
+      alternateScreen: true,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    writes.length = 0
+
+    terminal.emit('resize')
+    updateVisibleState()
+
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS + 100)
+
+    expect(paintedFrames(writes).some(frame => frame.includes('revision=1')), 'a state update must still paint after a no-op SIGWINCH').toBe(true)
+
+    app.unmount()
+    app.dispose()
+    await vi.runAllTimersAsync()
+    await app.waitUntilExit()
+  })
+
+  it('removes the source relay and cancels pending resize delivery on dispose', async () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    const renderedSizes: Array<{ columns: number; rows: number }> = []
+    const Probe = ({ size }: { size: { columns: number; rows: number } }) => {
+      useEffect(() => {
+        renderedSizes.push(size)
+      }, [size])
+      return React.createElement(Text, null, `FRAME:${size.columns}x${size.rows}`)
+    }
+    const app = renderDebouncedInteractive(terminal, size => React.createElement(Probe, { size }), {
+      interactive: true,
+      patchConsole: false,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    renderedSizes.length = 0
+
+    terminal.columns = 90
+    terminal.emit('resize')
+    app.unmount()
+    app.dispose()
+    await vi.runAllTimersAsync()
+    await app.waitUntilExit()
+
+    await vi.advanceTimersByTimeAsync(RESIZE_DEBOUNCE_MS)
+    expect(renderedSizes).toEqual([])
+    expect(terminal.listenerCount('resize')).toBe(0)
+  })
+
+  it('disposes a stream that never rendered', () => {
+    const terminal = makeTerminal()
+    const stdout = createDebouncedResizeStream(terminal, RESIZE_DEBOUNCE_MS)
+    expect(terminal.listenerCount('resize')).toBe(1)
+    stdout.dispose()
+    expect(terminal.listenerCount('resize')).toBe(0)
+
+    const resize = vi.fn()
+    stdout.on('resize', resize)
+    terminal.emit('resize')
+    expect(resize).not.toHaveBeenCalled()
+    expect(terminal.listenerCount('resize')).toBe(0)
+  })
+})


### PR DESCRIPTION
## Problem

Terminal font zoom and window-resize bursts made the interactive dashboard repaint at intermediate widths. Draft #993 fixed the root cause (Ink has its own resize handler) but its `write()` interceptor could drop a mid-burst state update forever when net size was unchanged.

## Root cause

CodeBurn listened on `process.stdout` `resize` and rerendered immediately with live `columns`/`rows`. A local debounce of that listener alone cannot stop Ink painting. #993 then swallowed BSU/ESU frames in `write()`; Ink still advanced `lastOutput`, so a settle that produced the same string wrote zero bytes.

## Change

- Hold a frozen stdout facade (`columns` / `rows`) and a private resize emitter during a burst.
- On settle, `app.rerender(dashboard())` then let Ink see one resize.
- No `write()` interceptor, no BSU/ESU parser, no EventEmitter-facade matrix.
- Keep `windowColumns` (no `terminalSize` rename) so #1020 connector tests stay valid.
- Regression tests for both lost-update cases named on #993.

This replaces the closed #993 shape. It does not reopen that PR.

## User impact

Zooming the font or dragging the window produces one settled reflow. Mid-burst content is not dropped. One transient old-width frame during a burst is accepted.

## Preservation and out of scope

- Static / non-interactive output unchanged.
- Periodic refresh unchanged.
- #993 stays closed.

## Testing

- [x] I have tested this locally against real data (not just unit tests)
- [x] Focused dashboard suites pass
- [ ] Full `npm test` not re-run (TUI-only)

- `npx vitest run tests/dashboard-resize.test.ts tests/dashboard.test.ts`: 67/67, including mid-burst no-net-size-change and identical-dim SIGWINCH + state update.
- Local TUI launched from this worktree (`npx tsx src/cli.ts report --refresh 0`).

Fixes #977.
