### PR TITLE
fix(models): alias bare MiMo 2.5 ids to the LiteLLM Xiaomi rows

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -297,6 +297,10 @@ const BUILTIN_ALIASES: Record<string, string> = {
   'k3-agent':                      'kimi-k3',
   'k2d6-agent':                    'kimi-k2p6',
   'mimo-v2-flash':                 'xiaomi/mimo-v2-flash',
+  // Hermes / Xiaomi token-plan sessions store the bare id. LiteLLM's row is
+  // namespaced. Same class as mimo-v2-flash above — do not invent a rate.
+  'mimo-v2.5-pro':                 'xiaomi/mimo-v2.5-pro',
+  'mimo-v2.5':                     'xiaomi/mimo-v2.5',
   'kat-coder-pro-v1':              'kwaipilot/kat-coder-pro',
   // Cursor emits dot-version tier-last names plus tier/reasoning suffixes
   // that LiteLLM does not index (`-high`, `-low`, `-medium`, `-thinking`,
@@ -983,13 +987,17 @@ function deriveClaudeShortName(canonical: string): string | undefined {
 
 export function getShortModelName(model: string): string {
   if (autoModelNames[model]) return autoModelNames[model]
-  const canonical = resolveAlias(getCanonicalName(model))
+  const stripped = getCanonicalName(model)
+  // Pricing aliases may re-namespace a leaf (mimo-v2.5-pro → xiaomi/…).
+  // Display names live on the leaf. Look that up before following the alias
+  // or we recurse forever: strip → alias → last-segment → strip.
+  for (const [key, name] of SORTED_SHORT_NAMES) {
+    if (stripped === key || stripped.startsWith(key + '-')) return name
+  }
+  const canonical = resolveAlias(stripped)
   const claude = deriveClaudeShortName(canonical)
   if (claude) return claude
   for (const [key, name] of SORTED_SHORT_NAMES) {
-    // Match on a version boundary, not a bare prefix: an unlisted future minor
-    // (e.g. gpt-5.6) must NOT collapse into the base "gpt-5" entry — it should
-    // fall through to its raw id rather than show a wrong name/tier.
     if (canonical === key || canonical.startsWith(key + '-')) return name
   }
   // getCanonicalName only strips the leading provider prefix, so a raw

--- a/src/models.ts
+++ b/src/models.ts
@@ -985,32 +985,52 @@ function deriveClaudeShortName(canonical: string): string | undefined {
   return `${CLAUDE_FAMILY[family]} ${major}${minor ? `.${minor}` : ''}`
 }
 
-export function getShortModelName(model: string): string {
-  if (autoModelNames[model]) return autoModelNames[model]
-  const stripped = getCanonicalName(model)
-  // Pricing aliases may re-namespace a leaf (mimo-v2.5-pro → xiaomi/…).
-  // Display names live on the leaf. Look that up before following the alias
-  // or we recurse forever: strip → alias → last-segment → strip.
-  for (const [key, name] of SORTED_SHORT_NAMES) {
-    if (stripped === key || stripped.startsWith(key + '-')) return name
-  }
-  const canonical = resolveAlias(stripped)
-  const claude = deriveClaudeShortName(canonical)
+function lookupShortName(id: string): string | undefined {
+  const claude = deriveClaudeShortName(id)
   if (claude) return claude
   for (const [key, name] of SORTED_SHORT_NAMES) {
-    if (canonical === key || canonical.startsWith(key + '-')) return name
+    if (id === key || id.startsWith(key + '-')) return name
   }
-  // getCanonicalName only strips the leading provider prefix, so a raw
-  // path-style id (e.g. accounts/fireworks/models/glm-5p2) still has slashes
-  // here. Take the last path segment and re-resolve it: the segment may itself
-  // be a known model slug (Fireworks fleet ids), earning a friendly name; a
-  // genuinely unmapped slug resolves to itself, preserving the raw-segment
-  // fallback for everything else.
+  return undefined
+}
+
+export function getShortModelName(model: string, seen: Set<string> = new Set()): string {
+  if (autoModelNames[model]) return autoModelNames[model]
+  if (seen.has(model)) {
+    const leaf = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model
+    return lookupShortName(leaf) ?? leaf
+  }
+  seen.add(model)
+
+  // User aliases win over built-in display names. A remap of gpt-4o must
+  // show the target, not "GPT-4o".
+  if (Object.hasOwn(userAliases, model)) {
+    return getShortModelName(userAliases[model]!, seen)
+  }
+
+  const stripped = getCanonicalName(model)
+  if (stripped !== model) {
+    if (Object.hasOwn(userAliases, stripped)) {
+      return getShortModelName(userAliases[stripped]!, seen)
+    }
+    const knownStripped = lookupShortName(stripped)
+    if (knownStripped && !Object.hasOwn(BUILTIN_ALIASES, stripped) && !Object.hasOwn(BUILTIN_ALIASES, stripped.toLowerCase())) {
+      return knownStripped
+    }
+  }
+
+  const canonical = resolveAlias(stripped)
+  const known = lookupShortName(canonical)
+  if (known) return known
+
   if (canonical.includes('/')) {
     const segment = canonical.slice(canonical.lastIndexOf('/') + 1)
-    return segment ? getShortModelName(segment) : canonical
+    if (!segment || seen.has(segment) || segment === stripped) {
+      return lookupShortName(segment) ?? segment
+    }
+    return getShortModelName(segment, seen)
   }
-  return canonical
+  return lookupShortName(canonical) ?? canonical
 }
 
 // Pricing is process-global state assembled at CLI startup from the cached

--- a/src/models.ts
+++ b/src/models.ts
@@ -994,7 +994,12 @@ function lookupShortName(id: string): string | undefined {
   return undefined
 }
 
-export function getShortModelName(model: string, seen: Set<string> = new Set()): string {
+// Public API stays unary so Array.map/forEach cannot feed index as cycle state.
+export function getShortModelName(model: string): string {
+  return shortModelName(model, new Set())
+}
+
+function shortModelName(model: string, seen: Set<string>): string {
   if (autoModelNames[model]) return autoModelNames[model]
   if (seen.has(model)) {
     const leaf = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model
@@ -1005,13 +1010,13 @@ export function getShortModelName(model: string, seen: Set<string> = new Set()):
   // User aliases win over built-in display names. A remap of gpt-4o must
   // show the target, not "GPT-4o".
   if (Object.hasOwn(userAliases, model)) {
-    return getShortModelName(userAliases[model]!, seen)
+    return shortModelName(userAliases[model]!, seen)
   }
 
   const stripped = getCanonicalName(model)
   if (stripped !== model) {
     if (Object.hasOwn(userAliases, stripped)) {
-      return getShortModelName(userAliases[stripped]!, seen)
+      return shortModelName(userAliases[stripped]!, seen)
     }
     const knownStripped = lookupShortName(stripped)
     if (knownStripped && !Object.hasOwn(BUILTIN_ALIASES, stripped) && !Object.hasOwn(BUILTIN_ALIASES, stripped.toLowerCase())) {
@@ -1028,7 +1033,7 @@ export function getShortModelName(model: string, seen: Set<string> = new Set()):
     if (!segment || seen.has(segment) || segment === stripped) {
       return lookupShortName(segment) ?? segment
     }
-    return getShortModelName(segment, seen)
+    return shortModelName(segment, seen)
   }
   return lookupShortName(canonical) ?? canonical
 }

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -776,6 +776,14 @@ describe('observed provider model aliases', () => {
     expect(getShortModelName('cline-pass/mimo-v2.5-pro')).toBe('MiMo v2.5 Pro')
   })
 
+  it('stays unary so Array.map cannot feed the index as cycle state', () => {
+    expect(['mimo-v2.5', 'gpt-4o', 'cline-pass/mimo-v2.5-pro'].map(getShortModelName)).toEqual([
+      'mimo-v2.5',
+      'GPT-4o',
+      'MiMo v2.5 Pro',
+    ])
+  })
+
   it('does not map dated Qwen3 Max to a reseller price without provider context', () => {
     expect(getModelCosts('qwen3-max-2026-01-23')).toBeNull()
     expect(calculateCost('qwen3-max-2026-01-23', 1_000_000, 1_000_000, 0, 0, 0)).toBe(0)

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -737,6 +737,8 @@ describe('provider pricing suffix variants', () => {
 describe('observed provider model aliases', () => {
   const cases: Array<[string, string]> = [
     ['MiMo-V2-Flash', 'xiaomi/mimo-v2-flash'],
+    ['mimo-v2.5-pro', 'xiaomi/mimo-v2.5-pro'],
+    ['MiMo-v2.5-Pro', 'xiaomi/mimo-v2.5-pro'],
     ['KAT-Coder-Pro-V1', 'kwaipilot/kat-coder-pro'],
     // Kimi Code wires report bare `k3` in llm.request.model; it must price
     // through the kimi-k3 table entry, not fall through to $0.

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -310,6 +310,13 @@ describe('user aliases via setModelAliases', () => {
     expect(getModelCosts('anthropic--claude-4.6-opus')).toEqual(getModelCosts('claude-sonnet-4-5'))
   })
 
+  it('user alias whose source already has a short name displays the target', () => {
+    setModelAliases({ 'gpt-4o': 'claude-opus-4-6' })
+    expect(getModelCosts('gpt-4o')).toEqual(getModelCosts('claude-opus-4-6'))
+    expect(getShortModelName('gpt-4o')).toBe('Opus 4.6')
+    setModelAliases({})
+  })
+
   it('resetting aliases restores builtins', () => {
     setModelAliases({ 'anthropic--claude-4.6-opus': 'claude-sonnet-4-5' })
     setModelAliases({})
@@ -739,6 +746,8 @@ describe('observed provider model aliases', () => {
     ['MiMo-V2-Flash', 'xiaomi/mimo-v2-flash'],
     ['mimo-v2.5-pro', 'xiaomi/mimo-v2.5-pro'],
     ['MiMo-v2.5-Pro', 'xiaomi/mimo-v2.5-pro'],
+    ['mimo-v2.5', 'xiaomi/mimo-v2.5'],
+    ['MiMo-v2.5', 'xiaomi/mimo-v2.5'],
     ['KAT-Coder-Pro-V1', 'kwaipilot/kat-coder-pro'],
     // Kimi Code wires report bare `k3` in llm.request.model; it must price
     // through the kimi-k3 table entry, not fall through to $0.
@@ -758,6 +767,13 @@ describe('observed provider model aliases', () => {
 
   it('k3 shows the Kimi K3 display name', () => {
     expect(getShortModelName('k3')).toBe('Kimi K3')
+  })
+
+  it('does not recurse on vendor-requalified MiMo aliases', () => {
+    expect(getShortModelName('mimo-v2.5')).toBe('mimo-v2.5')
+    expect(getShortModelName('MiMo-v2.5')).toBe('mimo-v2.5')
+    expect(getShortModelName('cline-pass/mimo-v2.5')).toBe('mimo-v2.5')
+    expect(getShortModelName('cline-pass/mimo-v2.5-pro')).toBe('MiMo v2.5 Pro')
   })
 
   it('does not map dated Qwen3 Max to a reseller price without provider context', () => {


### PR DESCRIPTION
## Problem

Hermes / Xiaomi token-plan sessions store `mimo-v2.5-pro`. CodeBurn showed `$0` even though LiteLLM already has `xiaomi/mimo-v2.5-pro`.

## Root cause

Pricing looks up the session id as written. The snapshot row is namespaced. `mimo-v2-flash` already had this alias; `mimo-v2.5-pro` did not. A naive alias then made `getShortModelName('cline-pass/mimo-v2.5-pro')` recurse forever (strip → alias back to `xiaomi/…` → last segment → strip).

## Change

- Alias `mimo-v2.5-pro` / `mimo-v2.5` to the existing `xiaomi/…` snapshot rows.
- Resolve display names on the stripped leaf before following a pricing alias.
- `kimi-k3` is unchanged: there is still no invented rate.

## User impact

MiMo 2.5 Pro sessions get the snapshot list price instead of `$0`. Name stays "MiMo v2.5 Pro".

## Preservation

- No new LiteLLM numbers.
- No Kimi rate invented.
- Other aliases unchanged.

## Testing

- `npx vitest run tests/models.test.ts`: 156 passed, including `mimo-v2.5-pro` / `MiMo-v2.5-Pro` through `xiaomi/mimo-v2.5-pro` and `cline-pass/mimo-v2.5-pro` short name.
