### PR TITLE
fix(models): cite unpriced session ids or leave them $0

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -51,6 +51,11 @@ const BUILTIN_PRICE_OVERRIDES: Record<string, SnapshotEntry> = {
   'composer-2': [0.5e-6, 2.5e-6, 0.5e-6, 0.2e-6],
   'composer-1.5': [3.5e-6, 17.5e-6, 3.5e-6, 0.35e-6],
   'composer-1': [1.25e-6, 10e-6, 1.25e-6, 0.125e-6],
+  // Moonshot official K3 list price. LiteLLM has no kimi-k3 row; do not
+  // inherit K2. https://platform.kimi.ai/docs/pricing/chat-k3
+  // $3.00 input / $15.00 output / $0.30 cache-read per 1M. No published
+  // cache-write (buildCosts uses the 1.25x input heuristic).
+  'kimi-k3': [3e-6, 15e-6, null, 0.3e-6],
 }
 
 // Assemble a ModelCosts, applying the cache-cost heuristics (write = 1.25x
@@ -297,6 +302,12 @@ const BUILTIN_ALIASES: Record<string, string> = {
   'k3-agent':                      'kimi-k3',
   'k2d6-agent':                    'kimi-k2p6',
   'mimo-v2-flash':                 'xiaomi/mimo-v2-flash',
+  // Hermes / Cline Pass emit the bare id. LiteLLM's row is vendor-prefixed.
+  // Cited: bundled litellm-snapshot.json keys `xiaomi/mimo-v2.5-pro` and
+  // `xiaomi/mimo-v2.5`. Do not invent a sibling of mimo-v2-flash or a family
+  // `mimo-v2.5-*` beyond those exact rows.
+  'mimo-v2.5-pro':                 'xiaomi/mimo-v2.5-pro',
+  'mimo-v2.5':                     'xiaomi/mimo-v2.5',
   'kat-coder-pro-v1':              'kwaipilot/kat-coder-pro',
   // Cursor emits dot-version tier-last names plus tier/reasoning suffixes
   // that LiteLLM does not index (`-high`, `-low`, `-medium`, `-thinking`,
@@ -981,28 +992,36 @@ function deriveClaudeShortName(canonical: string): string | undefined {
   return `${CLAUDE_FAMILY[family]} ${major}${minor ? `.${minor}` : ''}`
 }
 
-export function getShortModelName(model: string): string {
-  if (autoModelNames[model]) return autoModelNames[model]
-  const canonical = resolveAlias(getCanonicalName(model))
-  const claude = deriveClaudeShortName(canonical)
+function shortNameFor(id: string): string | undefined {
+  const claude = deriveClaudeShortName(id)
   if (claude) return claude
   for (const [key, name] of SORTED_SHORT_NAMES) {
     // Match on a version boundary, not a bare prefix: an unlisted future minor
     // (e.g. gpt-5.6) must NOT collapse into the base "gpt-5" entry — it should
     // fall through to its raw id rather than show a wrong name/tier.
-    if (canonical === key || canonical.startsWith(key + '-')) return name
+    if (id === key || id.startsWith(key + '-')) return name
   }
-  // getCanonicalName only strips the leading provider prefix, so a raw
-  // path-style id (e.g. accounts/fireworks/models/glm-5p2) still has slashes
-  // here. Take the last path segment and re-resolve it: the segment may itself
-  // be a known model slug (Fireworks fleet ids), earning a friendly name; a
-  // genuinely unmapped slug resolves to itself, preserving the raw-segment
-  // fallback for everything else.
-  if (canonical.includes('/')) {
-    const segment = canonical.slice(canonical.lastIndexOf('/') + 1)
-    return segment ? getShortModelName(segment) : canonical
+  return undefined
+}
+
+export function getShortModelName(model: string): string {
+  if (autoModelNames[model]) return autoModelNames[model]
+  const stripped = getCanonicalName(model)
+  const aliased = resolveAlias(stripped)
+  // Display names are keyed by the session/bare id (`mimo-v2.5-pro`). Aliases
+  // that point at a vendor-prefixed LiteLLM key (`xiaomi/mimo-v2.5-pro`) must
+  // still hit that row — and must not recurse forever when the last path
+  // segment aliases back to the same vendor/model.
+  const named = shortNameFor(stripped) ?? shortNameFor(aliased)
+  if (named) return named
+  if (aliased.includes('/')) {
+    const segment = aliased.slice(aliased.lastIndexOf('/') + 1)
+    if (segment && segment !== stripped && segment !== model) {
+      return getShortModelName(segment)
+    }
+    return shortNameFor(segment) ?? segment ?? aliased
   }
-  return canonical
+  return aliased
 }
 
 // Pricing is process-global state assembled at CLI startup from the cached

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -764,6 +764,46 @@ describe('observed provider model aliases', () => {
   })
 })
 
+// Unpriced-without-a-row: only an explicit cited alias/override may price a
+// model LiteLLM does not index under the session id. No family fallback.
+describe('unpriced-without-a-row class', () => {
+  it('prices kimi-k3 at Moonshot official $3 / $15 / $0.30 per 1M', () => {
+    // https://platform.kimi.ai/docs/pricing/chat-k3
+    expect(calculateCost('kimi-k3', 1_000_000, 0, 0, 0, 0)).toBeCloseTo(3, 6)
+    expect(calculateCost('kimi-k3', 0, 1_000_000, 0, 0, 0)).toBeCloseTo(15, 6)
+    expect(calculateCost('kimi-k3', 0, 0, 0, 1_000_000, 0)).toBeCloseTo(0.3, 6)
+    expect(getModelCosts('k3')).toEqual(getModelCosts('kimi-k3'))
+    expect(getModelCosts('cline-pass/kimi-k3')).toEqual(getModelCosts('kimi-k3'))
+  })
+
+  it('prices bare mimo-v2.5-pro through the LiteLLM xiaomi/ row, not $0', () => {
+    const expected = getModelCosts('xiaomi/mimo-v2.5-pro')
+    expect(expected).not.toBeNull()
+    expect(getModelCosts('mimo-v2.5-pro')).toEqual(expected)
+    expect(getModelCosts('cline-pass/mimo-v2.5-pro')).toEqual(expected)
+    expect(getModelCosts('mimo-v2.5')).toEqual(getModelCosts('xiaomi/mimo-v2.5'))
+    expect(calculateCost('mimo-v2.5-pro', 1_000_000, 0, 0, 0, 0)).toBeCloseTo(1, 6)
+    expect(calculateCost('mimo-v2.5-pro', 0, 1_000_000, 0, 0, 0)).toBeCloseTo(3, 6)
+  })
+
+  it('does not invent a next-gen or sibling rate', () => {
+    expect(getModelCosts('kimi-k4')).toBeNull()
+    expect(getModelCosts('mimo-v2.6-pro')).toBeNull()
+    expect(getModelCosts('mimo-v3-pro')).toBeNull()
+    expect(calculateCost('kimi-k4', 1_000_000, 1_000_000, 0, 0, 0)).toBe(0)
+    expect(calculateCost('mimo-v2.6-pro', 1_000_000, 1_000_000, 0, 0, 0)).toBe(0)
+  })
+
+  it('names bare→vendor aliases without recursing through the vendor prefix', () => {
+    expect(getShortModelName('mimo-v2.5-pro')).toBe('MiMo v2.5 Pro')
+    expect(getShortModelName('cline-pass/mimo-v2.5-pro')).toBe('MiMo v2.5 Pro')
+    expect(getShortModelName('xiaomi/mimo-v2.5-pro')).toBe('MiMo v2.5 Pro')
+    // Same class as the older mimo-v2-flash alias.
+    expect(getShortModelName('mimo-v2-flash')).toBeTruthy()
+    expect(getShortModelName('mimo-v2-flash')).not.toBe('xiaomi/mimo-v2-flash')
+  })
+})
+
 describe('findUnpricedModels', () => {
   it('flags an unknown paid-looking model with $0 cost and skips priced ones', () => {
     const rows = [


### PR DESCRIPTION
## Problem

Session ids `kimi-k3` and `mimo-v2.5-pro` (and the Cline Pass / Hermes spellings) had no LiteLLM row under that exact string. `kimi-k3` only priced via last-resort gap-fill. Bare `mimo-v2.5-pro` stayed $0 even though LiteLLM already has `xiaomi/mimo-v2.5-pro`. Aliasing the bare id to the vendor-prefixed row made `getShortModelName` recurse forever (`mimo-v2.5-pro` → `xiaomi/mimo-v2.5-pro` → last segment → same alias).

## Root cause

Unpriced-without-a-row was treated as a missing screenshot string. The class is: a session id with no table row stays $0 unless there is an explicit cited alias or override. Display names are keyed by the bare id, so a bare→`vendor/model` alias must not re-enter path fallback.

## Change

- Pin `kimi-k3` to Moonshot official list price ($3 / $15 / $0.30 per 1M). Cite: https://platform.kimi.ai/docs/pricing/chat-k3. Do not inherit K2.
- Explicit aliases `mimo-v2.5-pro` → `xiaomi/mimo-v2.5-pro` and `mimo-v2.5` → `xiaomi/mimo-v2.5` (existing LiteLLM rows). Same pattern as `mimo-v2-flash`.
- `getShortModelName` looks up the pre-alias session id and refuses to recurse when the last path segment aliases back to `vendor/model`.

## User impact

Kimi K3 and MiMo v2.5 / v2.5 Pro session ids that previously showed $0 now price. Unknown next-gen ids (`kimi-k4`, `mimo-v2.6-pro`) stay unpriced.

## Preservation

- No invented family fallback (`glm-5.x`, `mimo-v2.5-*`).
- LiteLLM's `xiaomi/mimo-v2.5-pro` rates are used as-is; this PR does not invent a second Xiaomi official override.
- Fireworks `accounts/fireworks/models/<slug>` naming still peels the last segment.

## Testing

- `npx vitest run tests/models.test.ts tests/models-hoist.test.ts tests/menubar-json.test.ts tests/providers/kimicode.test.ts tests/model-breakdown.test.ts`: 204 passed.
- Sabotage: removing the `mimo-v2.5-pro` alias fails the new test (bare id returns null).
