### PR TITLE
ci: give the quarantined cache-lock step its own timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,10 @@ jobs:
       # tests spawn deliberately. Quarantined (reports, never gates): the process
       # suite still races its own takeover window even serially on slow runners -
       # tracked in #904; drop continue-on-error once that race is settled.
+      # Step-level timeout so a stalled lock suite fails soft here instead of
+      # tripping the job's 15-minute budget, which kills the whole job as
+      # "cancelled" and hides the parallel suite's green result.
       - name: Cache-lock suite (serial, quarantined)
         continue-on-error: true
+        timeout-minutes: 5
         run: npm run test:locks


### PR DESCRIPTION
The cache-lock suite is `continue-on-error` (quarantined, #904), but when it stalls it runs into the job's 15-minute budget and GitHub reports the whole `test (22)` job as **cancelled** — hiding the parallel suite's green result. It happened three times in a row on #1040 (normal duration is ~13 s; stalled runs hit 15 min). A 5-minute step timeout lets it fail soft as intended.