### PR TITLE
fix(cache): expose skipped-shard fingerprints on scoped loads

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -24,10 +24,12 @@ import {
   fingerprintFile,
   isCacheComplete,
   isCacheDirty,
+  isIndexOnly,
   loadCache,
+  lookupCachedFile,
   markCacheDirty,
   monthScopeForRange,
-  reconcileFile,
+  reconcileIndexedFile,
   saveCache,
 } from './session-cache.js'
 import { acquireCacheRefreshLock, type RefreshLockHandle } from './cache-refresh-lock.js'
@@ -1965,8 +1967,20 @@ async function scanProjectDirs(
       const fp = await fingerprintFile(filePath)
       if (!fp) continue
 
-      const cached = section.files[filePath]
-      const action = reconcileFile(fp, cached)
+      const cached = lookupCachedFile(diskCache, 'claude', filePath)
+      const indexOnly = isIndexOnly(diskCache, 'claude', filePath)
+      const action = reconcileIndexedFile(fp, cached, indexOnly)
+      if (indexOnly) {
+        // Out-of-range shard: fingerprint is enough to skip an unchanged file
+        // without loading turn bodies. Do not push empty-turn stubs into
+        // summaries or section.files (#1034).
+        if (readOnly || action.action === 'unchanged') {
+          if (readOnly && action.action !== 'unchanged') readOnlyServedStale = true
+          continue
+        }
+        if (!readOnly) changedFiles.push({ filePath, info: { dirName, fp, source } })
+        continue
+      }
       if (cached && (readOnly || action.action === 'unchanged')) {
         if (readOnly && action.action !== 'unchanged') readOnlyServedStale = true
         unchangedFiles.push({ filePath, dirName, source, cached: section.files[filePath]! })
@@ -3056,11 +3070,24 @@ async function parseProviderSources(
     const fp = await fingerprintFile(source.path)
     if (!fp) continue
 
-    const cached = section.files[source.path]
-    const action = reconcileFile(fp, cached)
+    const cached = lookupCachedFile(diskCache, providerName, source.path)
+    const indexOnly = isIndexOnly(diskCache, providerName, source.path)
+    const action = reconcileIndexedFile(fp, cached, indexOnly)
     // A cached parse failure at this same fingerprint stays skipped — don't
     // re-read a file that already threw and hasn't changed. It re-parses only
     // when the file changes (then `reconcileFile` reports non-'unchanged').
+    if (indexOnly) {
+      // Out-of-range shard: skip unchanged sources without loading turn bodies.
+      // Fingerprint growth cannot append (no body), so it falls through as a
+      // full re-parse (#1034).
+      if (readOnly || action.action === 'unchanged') {
+        if (readOnly && action.action !== 'unchanged') readOnlyServedStale = true
+        continue
+      }
+      if (!readOnly) changedSources.push({ source, fp })
+      else readOnlyServedStale = true
+      continue
+    }
     if (cached && (readOnly || (action.action === 'unchanged' && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))))) {
       if (readOnly && action.action !== 'unchanged') readOnlyServedStale = true
       unchangedSources.push({ source, cached })

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2853,6 +2853,15 @@ function cachedFileNeedsProviderReparse(providerName: string, sourcePath: string
   )
 }
 
+/** Index-only stubs have empty turns. Provider overrides that inspect the body
+ *  (Gemini legacy aggregates) cannot prove "safe to skip", and Devin/Antigravity
+ *  already force reparse via cachedFileNeedsProviderReparse even on a stub
+ *  (Devin always; Antigravity 0-turn). Gemini is fail-closed for the class. */
+function indexOnlyMustReparse(providerName: string, sourcePath: string, cached: CachedFile): boolean {
+  if (cachedFileNeedsProviderReparse(providerName, sourcePath, cached)) return true
+  return providerName === 'gemini'
+}
+
 const warnedProviderReadFailures = new Set<string>()
 
 function warnProviderReadFailureOnce(providerName: string, err: unknown): void {
@@ -3079,13 +3088,16 @@ async function parseProviderSources(
     if (indexOnly) {
       // Out-of-range shard: skip unchanged sources without loading turn bodies.
       // Fingerprint growth cannot append (no body), so it falls through as a
-      // full re-parse (#1034).
-      if (readOnly || action.action === 'unchanged') {
-        if (readOnly && action.action !== 'unchanged') readOnlyServedStale = true
+      // full re-parse (#1034). Provider overrides still apply: Devin always,
+      // Antigravity 0-turn/statusline, Gemini as a class (no body to inspect).
+      if (readOnly) {
+        if (action.action !== 'unchanged') readOnlyServedStale = true
         continue
       }
-      if (!readOnly) changedSources.push({ source, fp })
-      else readOnlyServedStale = true
+      if (action.action === 'unchanged' && cached && !indexOnlyMustReparse(providerName, source.path, cached)) {
+        continue
+      }
+      changedSources.push({ source, fp })
       continue
     }
     if (cached && (readOnly || (action.action === 'unchanged' && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))))) {

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -166,6 +166,10 @@ export type SessionCache = {
 // provider's whole (100MB-scale) history, and a ranged query loads only the
 // months it can possibly report on. Turn shape unchanged, so v8 and v7 both
 // migrate losslessly.
+// v9 envelope (additive, no version bump): an optional per-file fingerprint
+// `index` so a scoped load can classify out-of-range sources `unchanged`
+// without reading those shards' turn bodies (#1034). Absence means a pre-#1034
+// envelope; the next save backfills it. Old v9 readers ignore the extra field.
 export const CACHE_VERSION = 9
 
 // The cache directory is version-suffixed for the same reason the file used to
@@ -326,11 +330,24 @@ export function sessionCacheDir(): string {
 // turn), so the pair bounds every turn the shard can contribute and a ranged
 // load can skip the shard outright when the two do not overlap the query.
 type ShardRef = { name: string; until: string }
+/** Fingerprint (+ resume offset + bucket) of one cached file. Cheap enough to
+ *  live on the envelope so a scoped load can skip the shard body (#1034). */
+export type FileIndexEntry = {
+  fingerprint: FileFingerprint
+  lastCompleteLineOffset?: number
+  /** Shard bucket (`YYYY-MM` or `0000-00`). Lets a scoped save drop index
+   *  entries for months it loaded without reading those shards. */
+  bucket: string
+}
 type EnvelopeProvider = {
   envFingerprint: string
   durable?: boolean
   /** month (`YYYY-MM`, or `0000-00` for turn-less files) -> shard */
   shards: Record<string, ShardRef>
+  /** Every cached file's fingerprint, including months this load will skip.
+   *  Optional: pre-#1034 envelopes omit it and scoped loads re-parse
+   *  out-of-range files the way they used to. */
+  index?: Record<string, FileIndexEntry>
 }
 type CacheEnvelope = {
   version: number
@@ -394,6 +411,10 @@ type CacheState = {
   /** `provider\0path` -> the bucket the entry was loaded/saved under, so a
    *  delete or a re-bucketing can dirty the bucket it is leaving. */
   bucketOf: Map<string, string>
+  /** `provider\0path` -> fingerprint of a file whose turn body was not loaded
+   *  (out-of-range shard). Never copied into `section.files`: empty-turn stubs
+   *  would re-bucket into `0000-00` and prune the real shard entry. */
+  fileIndex: Map<string, FileIndexEntry>
   /** The load scope this cache was read under, for the cross-request memo. */
   scope: string
 }
@@ -409,6 +430,7 @@ function stateOf(cache: SessionCache): CacheState {
       loaded: new Map(),
       fingerprints: new Map(),
       bucketOf: new Map(),
+      fileIndex: new Map(),
       scope: 'all',
     }
     cacheStates.set(cache, state)
@@ -517,6 +539,46 @@ function validateFingerprint(fp: unknown): fp is FileFingerprint {
   if (!fp || typeof fp !== 'object') return false
   const f = fp as Record<string, unknown>
   return isNum(f['dev']) && isNum(f['ino']) && isNum(f['mtimeMs']) && isNum(f['sizeBytes'])
+}
+
+function isFileIndexEntry(v: unknown): v is FileIndexEntry {
+  if (!v || typeof v !== 'object') return false
+  const o = v as Record<string, unknown>
+  return validateFingerprint(o['fingerprint'])
+    && isOptionalNum(o['lastCompleteLineOffset'])
+    && typeof o['bucket'] === 'string'
+}
+
+/** Fail-open: a corrupt index costs the optimization, not the cache. */
+function readFileIndex(raw: unknown): Record<string, FileIndexEntry> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const out: Record<string, FileIndexEntry> = {}
+  for (const [path, entry] of Object.entries(raw as Record<string, unknown>)) {
+    if (isFileIndexEntry(entry)) out[path] = entry
+  }
+  return out
+}
+
+function toIndexEntry(file: CachedFile): FileIndexEntry {
+  return {
+    fingerprint: file.fingerprint,
+    ...(file.lastCompleteLineOffset !== undefined ? { lastCompleteLineOffset: file.lastCompleteLineOffset } : {}),
+    bucket: cacheFileSpan(file).bucket,
+  }
+}
+
+function fileIndexKey(provider: string, path: string): string {
+  return `${provider}\0${path}`
+}
+
+function fileIndexForProvider(state: CacheState, provider: string): Record<string, FileIndexEntry> | undefined {
+  const prefix = `${provider}\0`
+  const out: Record<string, FileIndexEntry> = {}
+  for (const [key, entry] of state.fileIndex) {
+    if (!key.startsWith(prefix)) continue
+    out[key.slice(prefix.length)] = entry
+  }
+  return Object.keys(out).length > 0 ? out : undefined
 }
 
 function validateUsage(u: unknown): u is CachedUsage {
@@ -861,6 +923,17 @@ export async function loadCache(scope?: CacheLoadScope): Promise<SessionCache> {
     state.fingerprints.set(provider, meta.envFingerprint)
   }
   await Promise.all(reads)
+  // Fingerprints of skipped shards: expose them for reconcileFile without
+  // installing empty-turn stubs into section.files (#1034).
+  for (const [provider, meta] of Object.entries(envelope.providers)) {
+    const section = cache.providers[provider]
+    if (!section) continue
+    const index = meta.index !== undefined ? readFileIndex(meta.index) : {}
+    for (const [path, entry] of Object.entries(index)) {
+      if (section.files[path]) continue
+      state.fileIndex.set(fileIndexKey(provider, path), entry)
+    }
+  }
   state.scope = scopeKey
   cacheMemo = { dir, nonce: envelope.nonce, scope: scopeKey, cache }
   return cache
@@ -1024,6 +1097,53 @@ type ProviderPlan = {
   refs: Record<string, ShardRef>
 }
 
+function toIndexFromFiles(files: Record<string, CachedFile>): Record<string, FileIndexEntry> {
+  const index: Record<string, FileIndexEntry> = {}
+  for (const [path, file] of Object.entries(files)) index[path] = toIndexEntry(file)
+  return index
+}
+
+/** Build the envelope fingerprint index for one provider.
+ *  Full load: exactly the files in memory.
+ *  Scoped load: in-memory overlay + carried months from the previous index,
+ *  backfilling from shard bodies only when the previous envelope had no index. */
+async function buildProviderIndex(
+  _provider: string,
+  plan: ProviderPlan,
+  shards: Record<string, ShardRef>,
+  priorIndex: Record<string, FileIndexEntry> | undefined,
+  dir: string,
+): Promise<Record<string, FileIndexEntry>> {
+  if (!plan.loaded) return toIndexFromFiles(plan.section.files)
+
+  const index: Record<string, FileIndexEntry> = {}
+  for (const [path, entry] of Object.entries(priorIndex ?? {})) {
+    if (plan.moved.has(path)) continue
+    if (plan.loaded.has(entry.bucket)) continue
+    index[path] = entry
+  }
+  for (const [path, file] of Object.entries(plan.section.files)) {
+    index[path] = toIndexEntry(file)
+  }
+
+  if (priorIndex !== undefined) return index
+
+  // Pre-#1034 envelope: read each carried shard once to mint the index so the
+  // next ranged run can skip those bodies.
+  const bucketsCovered = new Set(Object.values(index).map(e => e.bucket))
+  for (const [bucket, ref] of Object.entries(shards)) {
+    if (plan.loaded.has(bucket) || bucketsCovered.has(bucket)) continue
+    const files = await loadShard(join(dir, ref.name))
+    if (!files) continue
+    for (const [path, file] of Object.entries(files)) {
+      if (plan.moved.has(path) || index[path]) continue
+      index[path] = toIndexEntry(file)
+    }
+    bucketsCovered.add(bucket)
+  }
+  return index
+}
+
 export async function saveCache(cache: SessionCache, verifyStillOwner?: () => Promise<boolean>): Promise<boolean> {
   const dir = sessionCacheDir()
   if (!existsSync(dir)) await mkdir(dir, { recursive: true, mode: 0o700 })
@@ -1181,6 +1301,7 @@ export async function saveCache(cache: SessionCache, verifyStillOwner?: () => Pr
     // Last look before publishing: a concurrent save may have unlinked a shard
     // in the moment since. An envelope must never name a file that is already
     // gone — that reads back as a corrupt month and drops its history.
+    const latest = settled ?? live
     const providers: Record<string, EnvelopeProvider> = {}
     for (const [provider, plan] of plans) {
       const shards: Record<string, ShardRef> = {}
@@ -1192,10 +1313,15 @@ export async function saveCache(cache: SessionCache, verifyStillOwner?: () => Pr
         // option, and the sweep retires the name.
         if (files) shards[bucket] = await writeShard(provider, bucket, files)
       }
+      const rawIndex = latest?.providers[provider]?.index
+      const priorIndex = rawIndex !== undefined
+        ? readFileIndex(rawIndex)
+        : fileIndexForProvider(state, provider)
       providers[provider] = {
         envFingerprint: plan.section.envFingerprint,
         ...(plan.section.durable ? { durable: true } : {}),
         shards,
+        index: await buildProviderIndex(provider, plan, shards, priorIndex, dir),
       }
     }
 
@@ -1223,13 +1349,20 @@ export async function saveCache(cache: SessionCache, verifyStillOwner?: () => Pr
     state.shards.clear()
     state.fingerprints.clear()
     state.bucketOf.clear()
+    state.fileIndex.clear()
     // `loaded` deliberately survives: a merged-and-rewritten shard is complete
     // on disk but still partial in memory, so the next save has to merge again.
     for (const [provider, meta] of Object.entries(providers)) {
       state.shards.set(provider, meta.shards)
       state.fingerprints.set(provider, meta.envFingerprint)
-      for (const [path, file] of Object.entries(cache.providers[provider]!.files)) {
+      const liveFiles = cache.providers[provider]!.files
+      for (const [path, file] of Object.entries(liveFiles)) {
         state.bucketOf.set(`${provider}\0${path}`, cacheFileSpan(file).bucket)
+      }
+      // Skipped months stay index-only; in-memory files are the live copy.
+      for (const [path, entry] of Object.entries(meta.index ?? {})) {
+        if (liveFiles[path]) continue
+        state.fileIndex.set(fileIndexKey(provider, path), entry)
       }
     }
     // Write-through: the object just published IS the freshest state, so the
@@ -1373,6 +1506,38 @@ export function reconcileFile(
   }
 
   return { action: 'modified' }
+}
+
+/** CachedFile for reconcileFile: the loaded body, or a fingerprint-only stub
+ *  from a skipped shard. Stubs are never installed into `section.files`. */
+export function lookupCachedFile(cache: SessionCache, provider: string, path: string): CachedFile | undefined {
+  const live = cache.providers[provider]?.files[path]
+  if (live) return live
+  const entry = stateOf(cache).fileIndex.get(fileIndexKey(provider, path))
+  if (!entry) return undefined
+  return {
+    fingerprint: entry.fingerprint,
+    ...(entry.lastCompleteLineOffset !== undefined ? { lastCompleteLineOffset: entry.lastCompleteLineOffset } : {}),
+    mcpInventory: [],
+    turns: [],
+  }
+}
+
+export function isIndexOnly(cache: SessionCache, provider: string, path: string): boolean {
+  return cache.providers[provider]?.files[path] === undefined
+    && stateOf(cache).fileIndex.has(fileIndexKey(provider, path))
+}
+
+/** Index-only hits have fingerprints, not turn bodies: append is impossible
+ *  without loading the shard, so growth becomes a full re-parse. */
+export function reconcileIndexedFile(
+  current: FileFingerprint,
+  cached: CachedFile | undefined,
+  indexOnly: boolean,
+): ReconcileAction {
+  const action = reconcileFile(current, cached)
+  if (indexOnly && action.action === 'appended') return { action: 'modified' }
+  return action
 }
 
 // ── Dedup Merge ────────────────────────────────────────────────────────

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -330,8 +330,10 @@ export function sessionCacheDir(): string {
 // turn), so the pair bounds every turn the shard can contribute and a ranged
 // load can skip the shard outright when the two do not overlap the query.
 type ShardRef = { name: string; until: string }
-/** Fingerprint (+ resume offset + bucket) of one cached file. Cheap enough to
- *  live on the envelope so a scoped load can skip the shard body (#1034). */
+/** Fingerprint + bucket of one cached file in a *skipped* shard. Cheap enough
+ *  to live on the envelope so a scoped load can skip that shard body (#1034).
+ *  Loaded months are already in `section.files` — they must not be copied here
+ *  or a 1.9 GB corpus inflates the envelope for a two-file skip. */
 export type FileIndexEntry = {
   fingerprint: FileFingerprint
   lastCompleteLineOffset?: number
@@ -344,9 +346,8 @@ type EnvelopeProvider = {
   durable?: boolean
   /** month (`YYYY-MM`, or `0000-00` for turn-less files) -> shard */
   shards: Record<string, ShardRef>
-  /** Every cached file's fingerprint, including months this load will skip.
-   *  Optional: pre-#1034 envelopes omit it and scoped loads re-parse
-   *  out-of-range files the way they used to. */
+  /** Files in shards this load *skipped*. Optional. A full load omits it.
+   *  Pre-#1034 envelopes omit it and scoped loads re-parse out-of-range files. */
   index?: Record<string, FileIndexEntry>
 }
 type CacheEnvelope = {
@@ -562,7 +563,6 @@ function readFileIndex(raw: unknown): Record<string, FileIndexEntry> {
 function toIndexEntry(file: CachedFile): FileIndexEntry {
   return {
     fingerprint: file.fingerprint,
-    ...(file.lastCompleteLineOffset !== undefined ? { lastCompleteLineOffset: file.lastCompleteLineOffset } : {}),
     bucket: cacheFileSpan(file).bucket,
   }
 }
@@ -1107,51 +1107,42 @@ type ProviderPlan = {
   refs: Record<string, ShardRef>
 }
 
-function toIndexFromFiles(files: Record<string, CachedFile>): Record<string, FileIndexEntry> {
-  const index: Record<string, FileIndexEntry> = {}
-  for (const [path, file] of Object.entries(files)) index[path] = toIndexEntry(file)
-  return index
-}
-
 /** Build the envelope fingerprint index for one provider.
- *  Full load: exactly the files in memory.
- *  Scoped load: in-memory overlay + carried months from the previous index,
- *  backfilling from shard bodies only when the previous envelope had no index. */
+ *  Full load: omit — every file is already in memory / shards.
+ *  Scoped load: only files in skipped, still-named buckets. Never copy
+ *  in-memory files (that was the 5.6 MB envelope on a 2-file skip). */
 async function buildProviderIndex(
   _provider: string,
   plan: ProviderPlan,
   shards: Record<string, ShardRef>,
   priorIndex: Record<string, FileIndexEntry> | undefined,
   dir: string,
-): Promise<Record<string, FileIndexEntry>> {
-  if (!plan.loaded) return toIndexFromFiles(plan.section.files)
+): Promise<Record<string, FileIndexEntry> | undefined> {
+  if (!plan.loaded) return undefined
 
   const index: Record<string, FileIndexEntry> = {}
   for (const [path, entry] of Object.entries(priorIndex ?? {})) {
     if (plan.moved.has(path)) continue
+    if (plan.section.files[path]) continue
     if (plan.loaded.has(entry.bucket)) continue
-    index[path] = entry
-  }
-  for (const [path, file] of Object.entries(plan.section.files)) {
-    index[path] = toIndexEntry(file)
+    if (!(entry.bucket in shards)) continue
+    index[path] = { fingerprint: entry.fingerprint, bucket: entry.bucket }
   }
 
-  if (priorIndex !== undefined) return index
-
-  // Pre-#1034 envelope: read each carried, unloaded shard once and overlay
-  // every path not already in memory. Skip by path, not by "this bucket
-  // already has one in-memory file" — a reparsed sibling would otherwise
-  // hide the rest of the shard from the index.
-  for (const [bucket, ref] of Object.entries(shards)) {
-    if (plan.loaded.has(bucket)) continue
-    const files = await loadShard(join(dir, ref.name))
-    if (!files) continue
-    for (const [path, file] of Object.entries(files)) {
-      if (plan.moved.has(path) || index[path]) continue
-      index[path] = toIndexEntry(file)
+  if (priorIndex === undefined) {
+    // Pre-#1034 envelope: read each carried, unloaded shard once.
+    for (const [bucket, ref] of Object.entries(shards)) {
+      if (plan.loaded.has(bucket)) continue
+      const files = await loadShard(join(dir, ref.name))
+      if (!files) continue
+      for (const [path, file] of Object.entries(files)) {
+        if (plan.moved.has(path) || plan.section.files[path] || index[path]) continue
+        index[path] = toIndexEntry(file)
+      }
     }
   }
-  return index
+
+  return Object.keys(index).length > 0 ? index : undefined
 }
 
 export async function saveCache(cache: SessionCache, verifyStillOwner?: () => Promise<boolean>): Promise<boolean> {

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -923,14 +923,20 @@ export async function loadCache(scope?: CacheLoadScope): Promise<SessionCache> {
     state.fingerprints.set(provider, meta.envFingerprint)
   }
   await Promise.all(reads)
-  // Fingerprints of skipped shards: expose them for reconcileFile without
-  // installing empty-turn stubs into section.files (#1034).
+  // Fingerprints of shards this load deliberately skipped: expose them for
+  // reconcileFile without installing empty-turn stubs into section.files
+  // (#1034). A full load (loaded === null) has every attempted bucket in
+  // memory or dirty-empty — never index-only. A scoped load must not treat
+  // a selected-but-unreadable bucket as skipped: those paths have to reparse.
   for (const [provider, meta] of Object.entries(envelope.providers)) {
     const section = cache.providers[provider]
     if (!section) continue
+    const loaded = state.loaded.get(provider)
+    if (loaded == null) continue
     const index = meta.index !== undefined ? readFileIndex(meta.index) : {}
     for (const [path, entry] of Object.entries(index)) {
       if (section.files[path]) continue
+      if (loaded.has(entry.bucket)) continue
       state.fileIndex.set(fileIndexKey(provider, path), entry)
     }
   }
@@ -1128,18 +1134,18 @@ async function buildProviderIndex(
 
   if (priorIndex !== undefined) return index
 
-  // Pre-#1034 envelope: read each carried shard once to mint the index so the
-  // next ranged run can skip those bodies.
-  const bucketsCovered = new Set(Object.values(index).map(e => e.bucket))
+  // Pre-#1034 envelope: read each carried, unloaded shard once and overlay
+  // every path not already in memory. Skip by path, not by "this bucket
+  // already has one in-memory file" — a reparsed sibling would otherwise
+  // hide the rest of the shard from the index.
   for (const [bucket, ref] of Object.entries(shards)) {
-    if (plan.loaded.has(bucket) || bucketsCovered.has(bucket)) continue
+    if (plan.loaded.has(bucket)) continue
     const files = await loadShard(join(dir, ref.name))
     if (!files) continue
     for (const [path, file] of Object.entries(files)) {
       if (plan.moved.has(path) || index[path]) continue
       index[path] = toIndexEntry(file)
     }
-    bucketsCovered.add(bucket)
   }
   return index
 }
@@ -1203,8 +1209,16 @@ export async function saveCache(cache: SessionCache, verifyStillOwner?: () => Pr
       // trigger below reads shards it otherwise would not.
       if (loaded) {
         for (const [path, file] of Object.entries(section.files)) {
-          if (state.bucketOf.has(`${provider}\0${path}`)) continue
+          const priorBucket = state.bucketOf.get(`${provider}\0${path}`)
+            ?? state.fileIndex.get(fileIndexKey(provider, path))?.bucket
           const bucket = cacheFileSpan(file).bucket
+          if (priorBucket !== undefined) {
+            // Index-only files have no bucketOf from a shard read. If they
+            // reparsed into a loaded month, the old shard is still carried
+            // unless we mark the path moved.
+            if (priorBucket !== bucket) plan.moved.add(path)
+            continue
+          }
           if (!loaded.has(bucket) || bucket === UNDATED_BUCKET) plan.moved.add(path)
         }
       }

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -1322,10 +1322,15 @@ export async function saveCache(cache: SessionCache, verifyStillOwner?: () => Pr
         // option, and the sweep retires the name.
         if (files) shards[bucket] = await writeShard(provider, bucket, files)
       }
-      const rawIndex = latest?.providers[provider]?.index
-      const priorIndex = rawIndex !== undefined
-        ? readFileIndex(rawIndex)
-        : fileIndexForProvider(state, provider)
+      const latestProv = latest?.providers[provider]
+      // A concurrent full save omits `index` on purpose. That is not "no prior
+      // knowledge" — do not fall back to this process's stale fileIndex or we
+      // skip shard backfill and drop siblings the full writer just published.
+      const priorIndex = latestProv === undefined
+        ? fileIndexForProvider(state, provider)
+        : latestProv.index !== undefined
+          ? readFileIndex(latestProv.index)
+          : undefined
       providers[provider] = {
         envFingerprint: plan.section.envFingerprint,
         ...(plan.section.durable ? { durable: true } : {}),

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -937,6 +937,10 @@ export async function loadCache(scope?: CacheLoadScope): Promise<SessionCache> {
     for (const [path, entry] of Object.entries(index)) {
       if (section.files[path]) continue
       if (loaded.has(entry.bucket)) continue
+      // Envelope no longer names this bucket: the shard is gone. Trusting the
+      // index would hide the file forever (unchanged → skip parse and skip
+      // the next save). Fall through as uncached so it re-parses.
+      if (!(entry.bucket in meta.shards)) continue
       state.fileIndex.set(fileIndexKey(provider, path), entry)
     }
   }
@@ -1374,8 +1378,10 @@ export async function saveCache(cache: SessionCache, verifyStillOwner?: () => Pr
         state.bucketOf.set(`${provider}\0${path}`, cacheFileSpan(file).bucket)
       }
       // Skipped months stay index-only; in-memory files are the live copy.
+      // Do not re-install an index entry whose bucket this envelope dropped.
       for (const [path, entry] of Object.entries(meta.index ?? {})) {
         if (liveFiles[path]) continue
+        if (!(entry.bucket in meta.shards)) continue
         state.fileIndex.set(fileIndexKey(provider, path), entry)
       }
     }

--- a/tests/scoped-load-index-only-parser.test.ts
+++ b/tests/scoped-load-index-only-parser.test.ts
@@ -227,6 +227,11 @@ describe('scoped-load index-only parser guards', () => {
     const cache = await import('../src/session-cache.js')
     clearParserCache = parser.clearSessionCache
     await parser.parseAllSessions(undefined, 'gemini')
+    parser.clearSessionCache()
+    cache.clearLoadCacheMemo()
+    const seeded = await cache.loadCache(cache.monthScopeForRange(juneRange.start, juneRange.end))
+    cache.markCacheDirty(seeded, 'gemini')
+    await cache.saveCache(seeded)
     await poisonProviderTurns('gemini', marPath, 'POISON')
     await writeFile(junPath, geminiSession('g-jun', '2026-06-10T10:00:00.000Z', 'june gemini plus'))
     parser.clearSessionCache()

--- a/tests/scoped-load-index-only-parser.test.ts
+++ b/tests/scoped-load-index-only-parser.test.ts
@@ -1,0 +1,247 @@
+// Parser-layer guards for #1034. Cache-helper tests cannot see a stub installed
+// into section.files at scanProjectDirs / parseProviderSources; these would
+// fail that sabotage because an in-range save would then replace the real
+// out-of-range body with turns: [].
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  clearLoadCacheMemo,
+  loadCache,
+  sessionCacheDir,
+} from '../src/session-cache.js'
+import type { DateRange } from '../src/types.js'
+
+let home: string
+let cacheDir: string
+let clearParserCache: (() => void) | undefined
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), 'codeburn-1034-parser-home-'))
+  cacheDir = await mkdtemp(join(tmpdir(), 'codeburn-1034-parser-cache-'))
+  process.env['HOME'] = home
+  process.env['USERPROFILE'] = home
+  process.env['CODEBURN_CACHE_DIR'] = cacheDir
+  process.env['CLAUDE_CONFIG_DIR'] = join(home, '.claude')
+  process.env['CODEX_HOME'] = join(home, 'codex')
+  clearLoadCacheMemo()
+})
+
+afterEach(async () => {
+  clearParserCache?.()
+  clearParserCache = undefined
+  vi.resetModules()
+  clearLoadCacheMemo()
+  await rm(home, { recursive: true, force: true })
+  await rm(cacheDir, { recursive: true, force: true })
+})
+
+async function loadParser() {
+  vi.resetModules()
+  const parser = await import('../src/parser.js')
+  clearParserCache = parser.clearSessionCache
+  return parser.parseAllSessions
+}
+
+const juneRange: DateRange = {
+  start: new Date('2026-06-01T00:00:00Z'),
+  end: new Date('2026-06-30T23:59:59Z'),
+}
+
+function claudeUser(sessionId: string, timestamp: string, text: string): string {
+  return JSON.stringify({
+    type: 'user',
+    sessionId,
+    timestamp,
+    cwd: '/projects/app',
+    message: { role: 'user', content: text },
+  })
+}
+
+function claudeAssistant(sessionId: string, timestamp: string, messageId: string, text: string): string {
+  return JSON.stringify({
+    type: 'assistant',
+    sessionId,
+    timestamp,
+    message: {
+      id: messageId,
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [{ type: 'text', text }],
+      usage: { input_tokens: 100, output_tokens: 20 },
+    },
+  })
+}
+
+async function writeClaudeSession(name: string, sessionId: string, timestamp: string, text: string): Promise<string> {
+  const projectDir = join(home, '.claude', 'projects', 'app')
+  await mkdir(projectDir, { recursive: true })
+  const path = join(projectDir, name)
+  await writeFile(path, [
+    claudeUser(sessionId, timestamp, text),
+    claudeAssistant(sessionId, timestamp.replace('T10:00:00Z', 'T10:00:30Z'), `${sessionId}-a`, `ok ${text}`),
+  ].join('\n'))
+  return path
+}
+
+function codexRollout(sessionId: string, timestamp: string, prompt: string): string {
+  return [
+    JSON.stringify({
+      type: 'session_meta',
+      timestamp,
+      payload: { session_id: sessionId, model: 'gpt-5.5', cwd: '/Users/test/app', originator: 'codex_cli_rs' },
+    }),
+    JSON.stringify({
+      type: 'response_item',
+      timestamp,
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: prompt }] },
+    }),
+    JSON.stringify({
+      type: 'event_msg',
+      timestamp: timestamp.replace('T10:00:00Z', 'T10:01:00Z'),
+      payload: {
+        type: 'token_count',
+        info: {
+          last_token_usage: { input_tokens: 100, output_tokens: 20 },
+          total_token_usage: { total_tokens: 120 },
+        },
+      },
+    }),
+  ].join('\n') + '\n'
+}
+
+async function writeCodexSession(day: string, name: string, sessionId: string, timestamp: string, prompt: string): Promise<string> {
+  const [y, m, d] = day.split('-') as [string, string, string]
+  const dir = join(home, 'codex', 'sessions', y, m, d)
+  await mkdir(dir, { recursive: true })
+  const path = join(dir, name)
+  await writeFile(path, codexRollout(sessionId, timestamp, prompt))
+  return path
+}
+
+function geminiSession(sessionId: string, timestamp: string, prompt: string): string {
+  return JSON.stringify({
+    sessionId,
+    startTime: timestamp,
+    messages: [
+      { id: 'u1', timestamp, type: 'user', content: prompt },
+      {
+        id: 'g1',
+        timestamp: timestamp.replace('T10:00:00.000Z', 'T10:00:05.000Z'),
+        type: 'gemini',
+        content: `ok ${prompt}`,
+        model: 'gemini-3.1-pro-preview',
+        tokens: { input: 40, output: 10 },
+      },
+    ],
+  })
+}
+
+async function writeGeminiSession(name: string, sessionId: string, timestamp: string, prompt: string): Promise<string> {
+  const chatsDir = join(home, '.gemini', 'tmp', 'project-a', 'chats')
+  await mkdir(chatsDir, { recursive: true })
+  const path = join(chatsDir, name)
+  await writeFile(path, geminiSession(sessionId, timestamp, prompt))
+  return path
+}
+
+async function poisonProviderTurns(provider: string, path: string, poison: string): Promise<void> {
+  const env = JSON.parse(await readFile(join(sessionCacheDir(), 'envelope.json'), 'utf-8')) as {
+    providers: Record<string, { shards: Record<string, { name: string }> }>
+  }
+  const shards = env.providers[provider]?.shards ?? {}
+  for (const ref of Object.values(shards)) {
+    const shardPath = join(sessionCacheDir(), ref.name)
+    const files = JSON.parse(await readFile(shardPath, 'utf-8')) as Record<string, { turns: Array<{ userMessage?: string }> }>
+    if (!files[path]) continue
+    for (const turn of files[path]!.turns) turn.userMessage = poison
+    await writeFile(shardPath, JSON.stringify(files))
+    return
+  }
+  throw new Error(`no shard held ${path}`)
+}
+
+describe('scoped-load index-only parser guards', () => {
+  it('Claude: an in-range save keeps the real out-of-range body', async () => {
+    await writeClaudeSession('mar.jsonl', 's-mar', '2026-03-10T10:00:00Z', 'march work')
+    const junePath = await writeClaudeSession('jun.jsonl', 's-jun', '2026-06-10T10:00:00Z', 'june work')
+
+    const parseAllSessions = await loadParser()
+    await parseAllSessions(undefined, 'claude')
+    await writeFile(junePath, [
+      claudeUser('s-jun', '2026-06-10T10:00:00Z', 'june work'),
+      claudeAssistant('s-jun', '2026-06-10T10:00:30Z', 's-jun-a', 'ok june work'),
+      claudeUser('s-jun', '2026-06-20T10:00:00Z', 'june follow-up'),
+      claudeAssistant('s-jun', '2026-06-20T10:00:30Z', 's-jun-b', 'ok follow-up'),
+    ].join('\n'))
+    clearParserCache?.()
+    await parseAllSessions(juneRange, 'claude')
+
+    clearParserCache?.()
+    clearLoadCacheMemo()
+    const full = await loadCache()
+    const mar = Object.entries(full.providers['claude']?.files ?? {}).find(([p]) => p.endsWith('mar.jsonl'))?.[1]
+    expect(mar?.turns.length).toBeGreaterThan(0)
+    expect(mar?.turns[0]?.timestamp).toMatch(/^2026-03-10/)
+    expect(mar?.turns.some(t => t.userMessage.includes('march work'))).toBe(true)
+  })
+
+  it('Codex: an in-range save keeps the real out-of-range body', async () => {
+    await writeCodexSession('2026-03-10', 'rollout-mar.jsonl', 'c-mar', '2026-03-10T10:00:00Z', 'march codex')
+    const junePath = await writeCodexSession('2026-06-10', 'rollout-jun.jsonl', 'c-jun', '2026-06-10T10:00:00Z', 'june codex')
+
+    const parseAllSessions = await loadParser()
+    await parseAllSessions(undefined, 'codex')
+    await writeFile(junePath, codexRollout('c-jun', '2026-06-10T10:00:00Z', 'june codex')
+      + JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-06-20T10:00:00Z',
+        payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'june follow-up' }] },
+      }) + '\n'
+      + JSON.stringify({
+        type: 'event_msg',
+        timestamp: '2026-06-20T10:01:00Z',
+        payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 10, output_tokens: 5 }, total_token_usage: { total_tokens: 135 } } },
+      }) + '\n')
+    clearParserCache?.()
+    await parseAllSessions(juneRange, 'codex')
+
+    clearParserCache?.()
+    clearLoadCacheMemo()
+    const full = await loadCache()
+    const mar = Object.entries(full.providers['codex']?.files ?? {}).find(([p]) => p.endsWith('rollout-mar.jsonl'))?.[1]
+    expect(mar?.turns.length).toBeGreaterThan(0)
+    expect(mar?.turns[0]?.timestamp).toMatch(/^2026-03-10/)
+    expect(mar?.turns.some(t => (t.userMessage ?? '').includes('march codex'))).toBe(true)
+  })
+
+  it('Gemini index-only still reparses (body-dependent override)', async () => {
+    const marPath = await writeGeminiSession('session-mar.json', 'g-mar', '2026-03-10T10:00:00.000Z', 'march gemini')
+    const junPath = await writeGeminiSession('session-jun.json', 'g-jun', '2026-06-10T10:00:00.000Z', 'june gemini')
+
+    vi.resetModules()
+    const parser = await import('../src/parser.js')
+    const cache = await import('../src/session-cache.js')
+    clearParserCache = parser.clearSessionCache
+    await parser.parseAllSessions(undefined, 'gemini')
+    await poisonProviderTurns('gemini', marPath, 'POISON')
+    await writeFile(junPath, geminiSession('g-jun', '2026-06-10T10:00:00.000Z', 'june gemini plus'))
+    parser.clearSessionCache()
+    cache.clearLoadCacheMemo()
+    const june = await cache.loadCache(cache.monthScopeForRange(juneRange.start, juneRange.end))
+    expect(cache.isIndexOnly(june, 'gemini', marPath)).toBe(true)
+    expect(june.providers['gemini']?.files[marPath]).toBeUndefined()
+    await parser.parseAllSessions(juneRange, 'gemini')
+
+    parser.clearSessionCache()
+    cache.clearLoadCacheMemo()
+    const full = await cache.loadCache()
+    const mar = full.providers['gemini']?.files[marPath]
+    expect(mar?.turns.length).toBeGreaterThan(0)
+    expect(mar?.turns.some(t => t.userMessage === 'POISON')).toBe(false)
+    expect(mar?.turns.some(t => (t.userMessage ?? '').includes('march gemini'))).toBe(true)
+  })
+})

--- a/tests/session-cache-shards.test.ts
+++ b/tests/session-cache-shards.test.ts
@@ -1020,6 +1020,28 @@ describe('scoped-load fingerprints', () => {
     expect(lookupCachedFile(scoped, 'claude', '/live/mar.jsonl')).toBeUndefined()
   })
 
+  it('does not trust an index entry whose bucket the envelope no longer names', async () => {
+    await seedThreeMonths()
+    const env = await readEnvelopeJson()
+    delete env.providers['claude']!.shards['2026-03']
+    await writeFile(join(sessionCacheDir(), 'envelope.json'), JSON.stringify({
+      version: CACHE_VERSION, complete: true, nonce: 'unnamed', providers: env.providers,
+    }))
+    clearLoadCacheMemo()
+    const scoped = await loadCache(juneScope)
+    expect(isIndexOnly(scoped, 'claude', '/live/mar.jsonl')).toBe(false)
+    expect(lookupCachedFile(scoped, 'claude', '/live/mar.jsonl')).toBeUndefined()
+  })
+
+  it('a full load ignores the index even when it names skipped-looking paths', async () => {
+    await seedThreeMonths()
+    clearLoadCacheMemo()
+    const full = await loadCache()
+    expect(isIndexOnly(full, 'claude', '/live/mar.jsonl')).toBe(false)
+    expect(full.providers['claude']!.files['/live/mar.jsonl']).toBeDefined()
+    expect(lookupCachedFile(full, 'claude', '/live/mar.jsonl')?.turns.length).toBeGreaterThan(0)
+  })
+
   it('prunes the prior shard when an index-only file re-buckets into a loaded month', async () => {
     await seedThreeMonths()
     clearLoadCacheMemo()

--- a/tests/session-cache-shards.test.ts
+++ b/tests/session-cache-shards.test.ts
@@ -22,6 +22,9 @@ import {
   monthScopeForRange,
   saveCache,
   sessionCacheDir,
+  lookupCachedFile,
+  isIndexOnly,
+  reconcileIndexedFile,
   type CachedFile,
   type SessionCache,
 } from '../src/session-cache.js'
@@ -838,5 +841,169 @@ describe('retiring an orphaned prior layout', () => {
     await cleanupOrphanedTempFiles()
     expect(existsSync(v8Dir)).toBe(false)
     expect(existsSync(v7)).toBe(false)
+  })
+})
+
+// Envelope fingerprint index (#1034): a scoped load classifies out-of-range
+// files `unchanged` without reading those shards' turn bodies. The index is an
+// additive v9 envelope field — old envelopes omit it and still load.
+describe('scoped-load fingerprints', () => {
+  async function seedThreeMonths(): Promise<void> {
+    const cache: SessionCache = {
+      version: CACHE_VERSION,
+      complete: true,
+      providers: {
+        claude: {
+          envFingerprint: computeEnvFingerprint('claude'),
+          files: {
+            '/live/mar.jsonl': fileSpanning('2026-03-10T10:00:00Z'),
+            '/live/apr.jsonl': fileSpanning('2026-04-10T10:00:00Z'),
+            '/live/jun.jsonl': fileSpanning('2026-06-10T10:00:00Z'),
+          },
+        },
+      },
+    }
+    markCacheDirty(cache, 'claude')
+    await saveCache(cache)
+  }
+
+  const juneScope = monthScopeForRange(new Date('2026-06-01T00:00:00Z'), new Date('2026-06-30T23:59:59Z'))
+
+  type EnvelopeShape = {
+    providers: Record<string, {
+      shards: Record<string, { name: string; until: string }>
+      index?: Record<string, { fingerprint: { dev: number; ino: number; mtimeMs: number; sizeBytes: number }; lastCompleteLineOffset?: number; bucket: string }>
+    }>
+  }
+
+  async function readEnvelopeJson(): Promise<EnvelopeShape> {
+    return JSON.parse(await readFile(join(sessionCacheDir(), 'envelope.json'), 'utf-8')) as EnvelopeShape
+  }
+
+  it('save writes a fingerprint index for every file', async () => {
+    await seedThreeMonths()
+    const index = (await readEnvelopeJson()).providers['claude']!.index
+    expect(Object.keys(index ?? {}).sort()).toEqual(['/live/apr.jsonl', '/live/jun.jsonl', '/live/mar.jsonl'])
+    expect(index!['/live/mar.jsonl']!.bucket).toBe('2026-03')
+    expect(index!['/live/mar.jsonl']!.fingerprint).toEqual({ dev: 1, ino: 2, mtimeMs: 3, sizeBytes: 4 })
+    expect(index!['/live/mar.jsonl']!.lastCompleteLineOffset).toBe(128)
+  })
+
+  it('scoped load keeps skipped files out of section.files but visible to reconcile', async () => {
+    await seedThreeMonths()
+    clearLoadCacheMemo()
+    const scoped = await loadCache(juneScope)
+    expect(Object.keys(scoped.providers['claude']!.files)).toEqual(['/live/jun.jsonl'])
+    expect(isIndexOnly(scoped, 'claude', '/live/mar.jsonl')).toBe(true)
+    expect(isIndexOnly(scoped, 'claude', '/live/jun.jsonl')).toBe(false)
+
+    const stub = lookupCachedFile(scoped, 'claude', '/live/mar.jsonl')
+    expect(stub?.turns).toEqual([])
+    expect(stub?.fingerprint).toEqual({ dev: 1, ino: 2, mtimeMs: 3, sizeBytes: 4 })
+    expect(reconcileIndexedFile(stub!.fingerprint, stub, true)).toEqual({ action: 'unchanged' })
+    // Installing that stub into section.files would re-bucket it to 0000-00.
+    expect(scoped.providers['claude']!.files['/live/mar.jsonl']).toBeUndefined()
+  })
+
+  it('a pre-#1034 envelope (no index) still loads; skipped files look uncached', async () => {
+    await seedThreeMonths()
+    const env = await readEnvelopeJson()
+    for (const meta of Object.values(env.providers)) delete meta.index
+    await writeFile(join(sessionCacheDir(), 'envelope.json'), JSON.stringify({
+      version: CACHE_VERSION, complete: true, nonce: 'old', providers: env.providers,
+    }))
+    clearLoadCacheMemo()
+    const scoped = await loadCache(juneScope)
+    expect(Object.keys(scoped.providers['claude']!.files)).toEqual(['/live/jun.jsonl'])
+    expect(lookupCachedFile(scoped, 'claude', '/live/mar.jsonl')).toBeUndefined()
+    expect(isIndexOnly(scoped, 'claude', '/live/mar.jsonl')).toBe(false)
+  })
+
+  it('scoped save of a pre-#1034 envelope backfills the index from carried shards', async () => {
+    await seedThreeMonths()
+    const env = await readEnvelopeJson()
+    for (const meta of Object.values(env.providers)) delete meta.index
+    await writeFile(join(sessionCacheDir(), 'envelope.json'), JSON.stringify({
+      version: CACHE_VERSION, complete: true, nonce: 'old', providers: env.providers,
+    }))
+    clearLoadCacheMemo()
+    const scoped = await loadCache(juneScope)
+    scoped.providers['claude']!.files['/live/jun2.jsonl'] = fileSpanning('2026-06-20T10:00:00Z')
+    markCacheDirty(scoped, 'claude', '/live/jun2.jsonl')
+    await saveCache(scoped)
+
+    const index = (await readEnvelopeJson()).providers['claude']!.index
+    expect(Object.keys(index ?? {}).sort()).toEqual([
+      '/live/apr.jsonl', '/live/jun.jsonl', '/live/jun2.jsonl', '/live/mar.jsonl',
+    ])
+    expect(index!['/live/mar.jsonl']!.bucket).toBe('2026-03')
+
+    clearLoadCacheMemo()
+    const next = await loadCache(juneScope)
+    expect(isIndexOnly(next, 'claude', '/live/mar.jsonl')).toBe(true)
+    expect(next.providers['claude']!.files['/live/mar.jsonl']).toBeUndefined()
+  })
+
+  it('scoped save never writes an empty-turn stub into a skipped shard', async () => {
+    await seedThreeMonths()
+    clearLoadCacheMemo()
+    const scoped = await loadCache(juneScope)
+    // Reconcile would see March as unchanged; a buggy install would put the
+    // stub in section.files and the save would prune the real March body.
+    expect(isIndexOnly(scoped, 'claude', '/live/mar.jsonl')).toBe(true)
+    scoped.providers['claude']!.files['/live/jun2.jsonl'] = fileSpanning('2026-06-20T10:00:00Z')
+    markCacheDirty(scoped, 'claude', '/live/jun2.jsonl')
+    await saveCache(scoped)
+
+    clearLoadCacheMemo()
+    const full = await loadCache()
+    expect(full.providers['claude']!.files['/live/mar.jsonl']!.turns.length).toBeGreaterThan(0)
+    expect(full.providers['claude']!.files['/live/mar.jsonl']!.turns[0]!.timestamp).toBe('2026-03-10T10:00:00Z')
+  })
+
+  it('two writers: a scoped save does not drop another provider\'s index entries', async () => {
+    const cache: SessionCache = {
+      version: CACHE_VERSION,
+      complete: true,
+      providers: {
+        claude: {
+          envFingerprint: computeEnvFingerprint('claude'),
+          files: {
+            '/live/mar.jsonl': fileSpanning('2026-03-10T10:00:00Z'),
+            '/live/jun.jsonl': fileSpanning('2026-06-10T10:00:00Z'),
+          },
+        },
+        codex: {
+          envFingerprint: computeEnvFingerprint('codex'),
+          files: { '/live/r.jsonl': fileSpanning('2026-03-10T10:00:00Z') },
+        },
+      },
+    }
+    markCacheDirty(cache, 'claude')
+    markCacheDirty(cache, 'codex')
+    await saveCache(cache)
+
+    clearLoadCacheMemo()
+    const b = await loadCache(juneScope)
+    clearLoadCacheMemo()
+    const a = await loadCache(juneScope)
+    a.providers['claude']!.files['/live/jun2.jsonl'] = fileSpanning('2026-06-20T10:00:00Z')
+    markCacheDirty(a, 'claude', '/live/jun2.jsonl')
+    await saveCache(a)
+
+    b.providers['codex']!.files['/live/r2.jsonl'] = fileSpanning('2026-06-20T10:00:00Z')
+    markCacheDirty(b, 'codex', '/live/r2.jsonl')
+    await saveCache(b)
+
+    const env = await readEnvelopeJson()
+    expect(env.providers['claude']!.index!['/live/mar.jsonl']!.bucket).toBe('2026-03')
+    expect(env.providers['codex']!.index!['/live/r.jsonl']!.bucket).toBe('2026-03')
+    expect(env.providers['codex']!.index!['/live/r2.jsonl']!.bucket).toBe('2026-06')
+
+    clearLoadCacheMemo()
+    const full = await loadCache()
+    expect(full.providers['claude']!.files['/live/mar.jsonl']).toBeDefined()
+    expect(full.providers['codex']!.files['/live/r.jsonl']).toBeDefined()
+    expect(full.providers['codex']!.files['/live/r2.jsonl']).toBeDefined()
   })
 })

--- a/tests/session-cache-shards.test.ts
+++ b/tests/session-cache-shards.test.ts
@@ -1006,4 +1006,77 @@ describe('scoped-load fingerprints', () => {
     expect(full.providers['codex']!.files['/live/r.jsonl']).toBeDefined()
     expect(full.providers['codex']!.files['/live/r2.jsonl']).toBeDefined()
   })
+
+  it('does not treat a loaded-but-unreadable shard as index-only', async () => {
+    await seedThreeMonths()
+    const env = await readEnvelopeJson()
+    const march = env.providers['claude']!.shards['2026-03']!.name
+    await writeFile(join(sessionCacheDir(), march), '{"/x":{"turns":')
+    clearLoadCacheMemo()
+    const marchScope = monthScopeForRange(new Date('2026-03-01T00:00:00Z'), new Date('2026-03-31T23:59:59Z'))
+    const scoped = await loadCache(marchScope)
+    expect(scoped.providers['claude']!.files['/live/mar.jsonl']).toBeUndefined()
+    expect(isIndexOnly(scoped, 'claude', '/live/mar.jsonl')).toBe(false)
+    expect(lookupCachedFile(scoped, 'claude', '/live/mar.jsonl')).toBeUndefined()
+  })
+
+  it('prunes the prior shard when an index-only file re-buckets into a loaded month', async () => {
+    await seedThreeMonths()
+    clearLoadCacheMemo()
+    const scoped = await loadCache(juneScope)
+    expect(isIndexOnly(scoped, 'claude', '/live/mar.jsonl')).toBe(true)
+    scoped.providers['claude']!.files['/live/mar.jsonl'] = fileSpanning('2026-06-15T10:00:00Z')
+    markCacheDirty(scoped, 'claude', '/live/mar.jsonl')
+    await saveCache(scoped)
+
+    const env = await readEnvelopeJson()
+    expect(env.providers['claude']!.index!['/live/mar.jsonl']!.bucket).toBe('2026-06')
+    const marchRef = env.providers['claude']!.shards['2026-03']
+    if (marchRef) {
+      const marchFiles = JSON.parse(await readFile(join(sessionCacheDir(), marchRef.name), 'utf-8')) as Record<string, unknown>
+      expect(marchFiles['/live/mar.jsonl']).toBeUndefined()
+    }
+
+    clearLoadCacheMemo()
+    const full = await loadCache()
+    expect(full.providers['claude']!.files['/live/mar.jsonl']!.turns[0]!.timestamp).toBe('2026-06-15T10:00:00Z')
+    expect(full.providers['claude']!.files['/live/mar.jsonl']!.turns.some(t => t.timestamp.startsWith('2026-03'))).toBe(false)
+    expect(env.providers['claude']!.shards['2026-06']).toBeDefined()
+  })
+
+  it('pre-#1034 backfill indexes every sibling in a carried shard', async () => {
+    const cache: SessionCache = {
+      version: CACHE_VERSION,
+      complete: true,
+      providers: {
+        claude: {
+          envFingerprint: computeEnvFingerprint('claude'),
+          files: {
+            '/live/mar-a.jsonl': fileSpanning('2026-03-10T10:00:00Z'),
+            '/live/mar-b.jsonl': fileSpanning('2026-03-20T10:00:00Z'),
+            '/live/jun.jsonl': fileSpanning('2026-06-10T10:00:00Z'),
+          },
+        },
+      },
+    }
+    markCacheDirty(cache, 'claude')
+    await saveCache(cache)
+    const env = await readEnvelopeJson()
+    for (const meta of Object.values(env.providers)) delete meta.index
+    await writeFile(join(sessionCacheDir(), 'envelope.json'), JSON.stringify({
+      version: CACHE_VERSION, complete: true, nonce: 'old', providers: env.providers,
+    }))
+    clearLoadCacheMemo()
+    const scoped = await loadCache(juneScope)
+    scoped.providers['claude']!.files['/live/mar-a.jsonl'] = fileSpanning('2026-03-10T10:00:00Z')
+    scoped.providers['claude']!.files['/live/jun2.jsonl'] = fileSpanning('2026-06-20T10:00:00Z')
+    markCacheDirty(scoped, 'claude', '/live/jun2.jsonl')
+    await saveCache(scoped)
+
+    const index = (await readEnvelopeJson()).providers['claude']!.index
+    expect(Object.keys(index ?? {}).sort()).toEqual([
+      '/live/jun.jsonl', '/live/jun2.jsonl', '/live/mar-a.jsonl', '/live/mar-b.jsonl',
+    ])
+    expect(index!['/live/mar-b.jsonl']!.bucket).toBe('2026-03')
+  })
 })

--- a/tests/session-cache-shards.test.ts
+++ b/tests/session-cache-shards.test.ts
@@ -1027,6 +1027,65 @@ describe('scoped-load fingerprints', () => {
     expect(full.providers['codex']!.files['/live/r2.jsonl']).toBeDefined()
   })
 
+  it('stale scoped writer rebuilds skipped index after a concurrent full save omitted it', async () => {
+    const cache: SessionCache = {
+      version: CACHE_VERSION,
+      complete: true,
+      providers: {
+        claude: {
+          envFingerprint: computeEnvFingerprint('claude'),
+          files: {
+            '/claude/mar.jsonl': fileSpanning('2026-03-10T10:00:00Z'),
+            '/claude/jun.jsonl': fileSpanning('2026-06-10T10:00:00Z'),
+          },
+        },
+        codex: {
+          envFingerprint: computeEnvFingerprint('codex'),
+          files: {
+            '/codex/mar-a.jsonl': fileSpanning('2026-03-10T10:00:00Z'),
+            '/codex/jun.jsonl': fileSpanning('2026-06-10T10:00:00Z'),
+          },
+        },
+      },
+    }
+    markCacheDirty(cache, 'claude')
+    markCacheDirty(cache, 'codex')
+    await saveCache(cache)
+    clearLoadCacheMemo()
+    const indexSeed = await loadCache(juneScope)
+    markCacheDirty(indexSeed, 'claude')
+    markCacheDirty(indexSeed, 'codex')
+    await saveCache(indexSeed)
+
+    clearLoadCacheMemo()
+    const staleScoped = await loadCache(juneScope)
+
+    clearLoadCacheMemo()
+    const fullWriter = await loadCache()
+    fullWriter.providers['codex']!.files['/codex/mar-b.jsonl'] = fileSpanning('2026-03-20T10:00:00Z')
+    markCacheDirty(fullWriter, 'codex', '/codex/mar-b.jsonl')
+    await saveCache(fullWriter)
+    expect((await readEnvelopeJson()).providers['codex']!.index).toBeUndefined()
+
+    staleScoped.providers['claude']!.files['/claude/jun2.jsonl'] = fileSpanning('2026-06-20T10:00:00Z')
+    markCacheDirty(staleScoped, 'claude', '/claude/jun2.jsonl')
+    await saveCache(staleScoped)
+
+    const env = await readEnvelopeJson()
+    expect(Object.keys(env.providers['codex']!.index ?? {}).sort()).toEqual([
+      '/codex/mar-a.jsonl', '/codex/mar-b.jsonl',
+    ])
+    expect(env.providers['codex']!.index!['/codex/jun.jsonl']).toBeUndefined()
+    expect(env.providers['claude']!.index!['/claude/mar.jsonl']!.bucket).toBe('2026-03')
+    expect(env.providers['claude']!.index!['/claude/jun.jsonl']).toBeUndefined()
+
+    clearLoadCacheMemo()
+    const nextJune = await loadCache(juneScope)
+    expect(isIndexOnly(nextJune, 'codex', '/codex/mar-a.jsonl')).toBe(true)
+    expect(isIndexOnly(nextJune, 'codex', '/codex/mar-b.jsonl')).toBe(true)
+    expect(isIndexOnly(nextJune, 'codex', '/codex/jun.jsonl')).toBe(false)
+  })
+
   it('does not treat a loaded-but-unreadable shard as index-only', async () => {
     await seedThreeMonths()
     await backfillSkippedIndex()

--- a/tests/session-cache-shards.test.ts
+++ b/tests/session-cache-shards.test.ts
@@ -869,6 +869,13 @@ describe('scoped-load fingerprints', () => {
 
   const juneScope = monthScopeForRange(new Date('2026-06-01T00:00:00Z'), new Date('2026-06-30T23:59:59Z'))
 
+  async function backfillSkippedIndex(): Promise<void> {
+    clearLoadCacheMemo()
+    const scoped = await loadCache(juneScope)
+    markCacheDirty(scoped, 'claude')
+    await saveCache(scoped)
+  }
+
   type EnvelopeShape = {
     providers: Record<string, {
       shards: Record<string, { name: string; until: string }>
@@ -880,17 +887,26 @@ describe('scoped-load fingerprints', () => {
     return JSON.parse(await readFile(join(sessionCacheDir(), 'envelope.json'), 'utf-8')) as EnvelopeShape
   }
 
-  it('save writes a fingerprint index for every file', async () => {
+  it('full save omits the fingerprint index', async () => {
     await seedThreeMonths()
     const index = (await readEnvelopeJson()).providers['claude']!.index
-    expect(Object.keys(index ?? {}).sort()).toEqual(['/live/apr.jsonl', '/live/jun.jsonl', '/live/mar.jsonl'])
+    expect(index).toBeUndefined()
+  })
+
+  it('scoped save indexes only skipped buckets, not in-memory files', async () => {
+    await seedThreeMonths()
+    await backfillSkippedIndex()
+    const index = (await readEnvelopeJson()).providers['claude']!.index
+    expect(Object.keys(index ?? {}).sort()).toEqual(['/live/apr.jsonl', '/live/mar.jsonl'])
     expect(index!['/live/mar.jsonl']!.bucket).toBe('2026-03')
     expect(index!['/live/mar.jsonl']!.fingerprint).toEqual({ dev: 1, ino: 2, mtimeMs: 3, sizeBytes: 4 })
-    expect(index!['/live/mar.jsonl']!.lastCompleteLineOffset).toBe(128)
+    expect(index!['/live/mar.jsonl']!.lastCompleteLineOffset).toBeUndefined()
+    expect(index!['/live/jun.jsonl']).toBeUndefined()
   })
 
   it('scoped load keeps skipped files out of section.files but visible to reconcile', async () => {
     await seedThreeMonths()
+    await backfillSkippedIndex()
     clearLoadCacheMemo()
     const scoped = await loadCache(juneScope)
     expect(Object.keys(scoped.providers['claude']!.files)).toEqual(['/live/jun.jsonl'])
@@ -934,9 +950,11 @@ describe('scoped-load fingerprints', () => {
 
     const index = (await readEnvelopeJson()).providers['claude']!.index
     expect(Object.keys(index ?? {}).sort()).toEqual([
-      '/live/apr.jsonl', '/live/jun.jsonl', '/live/jun2.jsonl', '/live/mar.jsonl',
+      '/live/apr.jsonl', '/live/mar.jsonl',
     ])
     expect(index!['/live/mar.jsonl']!.bucket).toBe('2026-03')
+    expect(index!['/live/jun.jsonl']).toBeUndefined()
+    expect(index!['/live/jun2.jsonl']).toBeUndefined()
 
     clearLoadCacheMemo()
     const next = await loadCache(juneScope)
@@ -946,6 +964,7 @@ describe('scoped-load fingerprints', () => {
 
   it('scoped save never writes an empty-turn stub into a skipped shard', async () => {
     await seedThreeMonths()
+    await backfillSkippedIndex()
     clearLoadCacheMemo()
     const scoped = await loadCache(juneScope)
     // Reconcile would see March as unchanged; a buggy install would put the
@@ -998,7 +1017,8 @@ describe('scoped-load fingerprints', () => {
     const env = await readEnvelopeJson()
     expect(env.providers['claude']!.index!['/live/mar.jsonl']!.bucket).toBe('2026-03')
     expect(env.providers['codex']!.index!['/live/r.jsonl']!.bucket).toBe('2026-03')
-    expect(env.providers['codex']!.index!['/live/r2.jsonl']!.bucket).toBe('2026-06')
+    expect(env.providers['claude']!.index!['/live/jun.jsonl']).toBeUndefined()
+    expect(env.providers['codex']!.index!['/live/r2.jsonl']).toBeUndefined()
 
     clearLoadCacheMemo()
     const full = await loadCache()
@@ -1009,6 +1029,7 @@ describe('scoped-load fingerprints', () => {
 
   it('does not treat a loaded-but-unreadable shard as index-only', async () => {
     await seedThreeMonths()
+    await backfillSkippedIndex()
     const env = await readEnvelopeJson()
     const march = env.providers['claude']!.shards['2026-03']!.name
     await writeFile(join(sessionCacheDir(), march), '{"/x":{"turns":')
@@ -1022,6 +1043,7 @@ describe('scoped-load fingerprints', () => {
 
   it('does not trust an index entry whose bucket the envelope no longer names', async () => {
     await seedThreeMonths()
+    await backfillSkippedIndex()
     const env = await readEnvelopeJson()
     delete env.providers['claude']!.shards['2026-03']
     await writeFile(join(sessionCacheDir(), 'envelope.json'), JSON.stringify({
@@ -1044,6 +1066,7 @@ describe('scoped-load fingerprints', () => {
 
   it('prunes the prior shard when an index-only file re-buckets into a loaded month', async () => {
     await seedThreeMonths()
+    await backfillSkippedIndex()
     clearLoadCacheMemo()
     const scoped = await loadCache(juneScope)
     expect(isIndexOnly(scoped, 'claude', '/live/mar.jsonl')).toBe(true)
@@ -1052,7 +1075,7 @@ describe('scoped-load fingerprints', () => {
     await saveCache(scoped)
 
     const env = await readEnvelopeJson()
-    expect(env.providers['claude']!.index!['/live/mar.jsonl']!.bucket).toBe('2026-06')
+    expect(env.providers['claude']!.index!['/live/mar.jsonl']).toBeUndefined()
     const marchRef = env.providers['claude']!.shards['2026-03']
     if (marchRef) {
       const marchFiles = JSON.parse(await readFile(join(sessionCacheDir(), marchRef.name), 'utf-8')) as Record<string, unknown>
@@ -1097,8 +1120,10 @@ describe('scoped-load fingerprints', () => {
 
     const index = (await readEnvelopeJson()).providers['claude']!.index
     expect(Object.keys(index ?? {}).sort()).toEqual([
-      '/live/jun.jsonl', '/live/jun2.jsonl', '/live/mar-a.jsonl', '/live/mar-b.jsonl',
+      '/live/mar-b.jsonl',
     ])
     expect(index!['/live/mar-b.jsonl']!.bucket).toBe('2026-03')
+    expect(index!['/live/mar-a.jsonl']).toBeUndefined()
+    expect(index!['/live/jun.jsonl']).toBeUndefined()
   })
 })

--- a/tests/session-cache.test.ts
+++ b/tests/session-cache.test.ts
@@ -20,6 +20,7 @@ import {
   loadCache,
   mergeCallByDedupKey,
   reconcileFile,
+  reconcileIndexedFile,
   saveCache,
   sessionCacheDir,
 } from '../src/session-cache.js'
@@ -628,6 +629,26 @@ describe('reconcileFile', () => {
     })
     const current: FileFingerprint = { dev: 2, ino: 100, mtimeMs: 2000, sizeBytes: 8000 }
     expect(reconcileFile(current, cached)).toEqual({ action: 'modified' })
+  })
+})
+
+describe('reconcileIndexedFile', () => {
+  it('unchanged index-only stays unchanged', () => {
+    const fp: FileFingerprint = { dev: 1, ino: 100, mtimeMs: 1000, sizeBytes: 5000 }
+    const stub = makeCachedFile({ fingerprint: fp, lastCompleteLineOffset: 4500, turns: [] })
+    expect(reconcileIndexedFile(fp, stub, true)).toEqual({ action: 'unchanged' })
+  })
+
+  it('size growth on index-only is modified, not appended — no turn body to resume into', () => {
+    const cached = makeCachedFile({
+      fingerprint: { dev: 1, ino: 100, mtimeMs: 1000, sizeBytes: 5000 },
+      lastCompleteLineOffset: 4500,
+      turns: [],
+    })
+    const current: FileFingerprint = { dev: 1, ino: 100, mtimeMs: 2000, sizeBytes: 8000 }
+    expect(reconcileFile(current, cached)).toEqual({ action: 'appended', readFromOffset: 4500 })
+    expect(reconcileIndexedFile(current, cached, true)).toEqual({ action: 'modified' })
+    expect(reconcileIndexedFile(current, cached, false)).toEqual({ action: 'appended', readFromOffset: 4500 })
   })
 })
 


### PR DESCRIPTION
## Problem

Month-scoped `loadCache` (#1007) skips out-of-range shards, so those files have no entry in `section.files`. `reconcileFile` then treats them as uncached and the parser re-parses them on every ranged run.

Maintainer review on the first index: a 1.9 GB corpus `status --day` skipped **2 files / 0 MB**, wall time unchanged (~6.2 s), while the envelope grew **3 KB → 5.6 MB** because the index copied every in-memory file.

Closes #1034.

## Root cause

The envelope named skipped shards but did not expose their fingerprints. The first index then stored *every* file, including months already in memory.

## Change

- Additive v9 `providers[p].index`: path → `{ fingerprint, bucket }` for **skipped, still-named buckets only**.
- Full save **omits** the index.
- Index-only entries are never installed for attempted-but-unreadable shards, dropped buckets, or a full load (080bf62 / 3b52fc3).
- No `lastCompleteLineOffset` on new index rows.
- No `CACHE_VERSION` bump.

## User impact

Warm ranged runs skip unchanged out-of-range JSONL **when the skipped set is real**. A day query that barely skips anything no longer pays a multi-MB envelope. SQLite sources whose fingerprint moved still re-parse.

## Preservation

No shard layout change. Failed markers stay in `0000-00`. Durable providers still load in full. SQLite half of #1034 is still not claimed.

## Testing

- `npx vitest run tests/session-cache.test.ts tests/session-cache-shards.test.ts tests/scoped-load-index-only-parser.test.ts` — **130 passed**.
- Sabotage: full save has no `index`; scoped save keys are skipped buckets only.
