### PR TITLE
test: make pricing and FX hermetic so upstream reprices can't turn CI red

### DIFF
--- a/src/currency.ts
+++ b/src/currency.ts
@@ -114,6 +114,11 @@ async function getExchangeRate(code: string): Promise<number> {
   const cached = await loadCachedRate(code)
   if (cached) return cached
 
+  // Test-only escape hatch, set for the whole suite in
+  // tests/setup/env-isolation.ts: skip the live Frankfurter fetch so a real FX
+  // move can't shift assertions. Same fallback an unreachable network gets.
+  if (process.env['CODEBURN_FX_NO_FETCH']) return 1
+
   let rate: number
   try {
     rate = await fetchRate(code)

--- a/src/models.ts
+++ b/src/models.ts
@@ -225,21 +225,30 @@ function mergeSnapshotFallbacks(pricing: Map<string, ModelCosts>): Map<string, M
   return applyBuiltinPriceOverrides(pricing)
 }
 
+function setPricingCache(pricing: Map<string, ModelCosts>): void {
+  pricingCache = pricing
+  sortedPricingKeys = null
+  lowercasePricingIndex = null
+  knownNamespaces = null
+}
+
 export async function loadPricing(): Promise<void> {
   const cached = await loadCachedPricing()
   if (cached) {
-    pricingCache = mergeSnapshotFallbacks(cached)
-    sortedPricingKeys = null
-    lowercasePricingIndex = null
-    knownNamespaces = null
+    setPricingCache(mergeSnapshotFallbacks(cached))
+    return
+  }
+
+  // Test-only escape hatch, set for the whole suite in
+  // tests/setup/env-isolation.ts: skip the live LiteLLM fetch and price purely
+  // off the bundled snapshot, so an upstream reprice can't turn tests red.
+  if (process.env['CODEBURN_PRICING_SNAPSHOT_ONLY']) {
+    setPricingCache(mergeSnapshotFallbacks(new Map()))
     return
   }
 
   try {
-    pricingCache = mergeSnapshotFallbacks(await fetchAndCachePricing())
-    sortedPricingKeys = null
-    lowercasePricingIndex = null
-    knownNamespaces = null
+    setPricingCache(mergeSnapshotFallbacks(await fetchAndCachePricing()))
   } catch {
     // snapshot already loaded at init; nothing more to do
   }

--- a/tests/setup/env-isolation.ts
+++ b/tests/setup/env-isolation.ts
@@ -106,6 +106,10 @@ function applyIsolation(): void {
     if (original === undefined) delete process.env[key]
     else process.env[key] = original
   }
+  // Price off the bundled LiteLLM snapshot only. Without this, loadPricing()
+  // fetches the live upstream table, so a mid-week reprice by a provider turns
+  // pricing assertions red with no local change.
+  process.env['CODEBURN_PRICING_SNAPSHOT_ONLY'] = '1'
   // Pin the timezone so date grouping is deterministic regardless of the dev's
   // shell TZ. Clearing it is not enough (Node falls back to the OS zone); a
   // non-UTC TZ would otherwise shift day buckets versus a clean CI runner. A

--- a/tests/setup/env-isolation.ts
+++ b/tests/setup/env-isolation.ts
@@ -110,6 +110,9 @@ function applyIsolation(): void {
   // fetches the live upstream table, so a mid-week reprice by a provider turns
   // pricing assertions red with no local change.
   process.env['CODEBURN_PRICING_SNAPSHOT_ONLY'] = '1'
+  // Same for FX: skip the live Frankfurter fetch and fall back to the
+  // USD-equivalent rate unless a test seeds its own exchange-rate.json cache.
+  process.env['CODEBURN_FX_NO_FETCH'] = '1'
   // Pin the timezone so date grouping is deterministic regardless of the dev's
   // shell TZ. Clearing it is not enough (Node falls back to the OS zone); a
   // non-UTC TZ would otherwise shift day buckets versus a clean CI runner. A


### PR DESCRIPTION
## Why (CI is red on every branch right now)

`tests/models.test.ts` fails 3 DeepSeek assertions on **every** branch since ~Aug 20, with no repo change: `loadPricing()` fetches the live LiteLLM table into the test sandbox's empty cache, and live data wins over the bundled snapshot. DeepSeek dropped its off-peak discount upstream (`deepseek-v4-pro` 4.35e-7 → 1.32e-6 input), so every pricing assertion was silently graded against whatever upstream shipped that hour. Main's CI was green Aug 19 and would be red today; #946's current run already is. The #1015 fragility class, now at suite scale.

## What

- `CODEBURN_PRICING_SNAPSHOT_ONLY` in `loadPricing()` — placed **after** the local-cache read (the four tests that deliberately seed a cached pricing file keep working) and before the fetch; uses the exact module-init state (snapshot + builtin overrides), which also fixes a leak where a failed reload left the previous run's table in place.
- `CODEBURN_FX_NO_FETCH` in `getExchangeRate()` — same placement; the deterministic fallback (rate 1) already existed as the unreachable-network path. The serve-stdio test that seeds a cached EUR rate keeps working (cache read wins).
- Both set for every test (and inherited by CLI subprocesses) in `tests/setup/env-isolation.ts`. Documented in code comments only — test-only escape hatches.
- No assertion changes: the 3 DeepSeek expectations match `src/data/litellm-snapshot.json` byte for byte. The tests were right; the input was wrong.

Verified hermetic: no `litellm-pricing.json` lands in any test sandbox after the change (it did before). Remaining known network caller (`vercel-gateway.ts`) needs a token so it can't fire in tests.

`tsc` clean · `npm test` **2953 passed, 0 failed** (was 3 failed on unmodified main today) · `test:locks` 26.