### PR TITLE
test: isolate provider-home env vars so developer shells cannot leak sessions

### DIFF
--- a/tests/env-isolation-declarations.test.ts
+++ b/tests/env-isolation-declarations.test.ts
@@ -4,30 +4,18 @@
 // sessions into fixture parses — green on CI (no HERMES_HOME), red on a
 // Hermes-shell laptop. The named hole was HERMES_HOME; the class is every
 // sibling override that session-cache already knows about.
+//
+// The lists are imported from the same module applyIsolation() uses. Extra
+// High #1064: scraping setup-file source treated a comment containing
+// `'HERMES_HOME'` as isolation (false-green). Runtime membership cannot.
 import { describe, expect, it } from 'vitest'
-import { readFileSync } from 'fs'
-import { dirname, join } from 'path'
-import { fileURLToPath } from 'url'
 
 import { PROVIDER_ENV_VARS } from '../src/session-cache.js'
-
-const SETUP_PATH = join(dirname(fileURLToPath(import.meta.url)), 'setup', 'env-isolation.ts')
-
-function extractConstStringArray(source: string, name: string): string[] {
-  const match = source.match(new RegExp(`const ${name} = \\[([\\s\\S]*?)\\] as const`))
-  if (!match) {
-    throw new Error(`tests/setup/env-isolation.ts: const ${name} = [...] as const not found`)
-  }
-  return [...match[1]!.matchAll(/'([A-Z0-9_]+)'/g)].map(m => m[1]!)
-}
+import { CLEARED, REDIRECTED } from './setup/env-isolation-vars.js'
 
 describe('env-isolation covers PROVIDER_ENV_VARS', () => {
   it('clears or redirects every provider data-dir override so a developer shell cannot leak real sessions into fixtures', () => {
-    const source = readFileSync(SETUP_PATH, 'utf8')
-    const isolated = new Set([
-      ...extractConstStringArray(source, 'CLEARED'),
-      ...extractConstStringArray(source, 'REDIRECTED'),
-    ])
+    const isolated = new Set<string>([...CLEARED, ...REDIRECTED])
 
     const missing: string[] = []
     for (const [provider, vars] of Object.entries(PROVIDER_ENV_VARS)) {

--- a/tests/env-isolation-declarations.test.ts
+++ b/tests/env-isolation-declarations.test.ts
@@ -1,0 +1,41 @@
+// Static guard: every PROVIDER_ENV_VARS entry must be CLEARED or REDIRECTED
+// by tests/setup/env-isolation.ts. A data-dir override that is fingerprinted
+// for cache invalidation but not isolated in tests leaks the developer's real
+// sessions into fixture parses — green on CI (no HERMES_HOME), red on a
+// Hermes-shell laptop. The named hole was HERMES_HOME; the class is every
+// sibling override that session-cache already knows about.
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+import { PROVIDER_ENV_VARS } from '../src/session-cache.js'
+
+const SETUP_PATH = join(dirname(fileURLToPath(import.meta.url)), 'setup', 'env-isolation.ts')
+
+function extractConstStringArray(source: string, name: string): string[] {
+  const match = source.match(new RegExp(`const ${name} = \\[([\\s\\S]*?)\\] as const`))
+  if (!match) {
+    throw new Error(`tests/setup/env-isolation.ts: const ${name} = [...] as const not found`)
+  }
+  return [...match[1]!.matchAll(/'([A-Z0-9_]+)'/g)].map(m => m[1]!)
+}
+
+describe('env-isolation covers PROVIDER_ENV_VARS', () => {
+  it('clears or redirects every provider data-dir override so a developer shell cannot leak real sessions into fixtures', () => {
+    const source = readFileSync(SETUP_PATH, 'utf8')
+    const isolated = new Set([
+      ...extractConstStringArray(source, 'CLEARED'),
+      ...extractConstStringArray(source, 'REDIRECTED'),
+    ])
+
+    const missing: string[] = []
+    for (const [provider, vars] of Object.entries(PROVIDER_ENV_VARS)) {
+      for (const varName of vars) {
+        if (!isolated.has(varName)) missing.push(`${provider}:${varName}`)
+      }
+    }
+
+    expect(missing).toEqual([])
+  })
+})

--- a/tests/setup/env-isolation-vars.ts
+++ b/tests/setup/env-isolation-vars.ts
@@ -1,0 +1,79 @@
+// Side-effect-free lists for tests/setup/env-isolation.ts.
+// Imported by the setup file (which applies them) and by
+// tests/env-isolation-declarations.test.ts (which asserts coverage).
+// Do not put applyIsolation() here — importing this module from a test
+// must not re-sandbox the process or register another beforeEach.
+//
+// A comment containing 'HERMES_HOME' is not isolation. The declaration
+// test imports these arrays, so a commented-out name cannot false-green.
+
+export const REDIRECTED = [
+  'HOME',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_CACHE_HOME',
+  'XDG_STATE_HOME',
+  'APPDATA',
+  'LOCALAPPDATA',
+] as const
+
+export const CLEARED = [
+  // Provider session-discovery dirs
+  'CLAUDE_CONFIG_DIR',
+  'CLAUDE_CONFIG_DIRS',
+  'CLINE_DIR',
+  'CLINE_DATA_DIR',
+  'CLINE_SESSION_DATA_DIR',
+  'CODEX_HOME',
+  'CODEWHALE_HOME',
+  'CRUSH_GLOBAL_DATA',
+  'CODEBUFF_DATA_DIR',
+  'DSH_HOME',
+  'FACTORY_DIR',
+  'GOOSE_PATH_ROOT',
+  'GROK_HOME',
+  'HERMES_HOME',
+  'KIRO_HOME',
+  'KIMI_CODE_HOME',
+  'KIMI_SHARE_DIR',
+  'LINGTAI_HOME',
+  'LINGTAI_TUI_GLOBAL_DIR',
+  'LINGTAI_TUI_HOME',
+  'MUX_ROOT',
+  'OPENCODE_DATA_DIR',
+  'OPENCODE_DB_PREFIX',
+  'QUICKWORK_HOME',
+  'QWEN_DATA_DIR',
+  'VIBE_HOME',
+  'WARP_DB_PATH',
+  'ZS_DATA_DIR',
+  // codeburn override dirs / paths
+  'CODEBURN_CACHE_DIR',
+  'CODEBURN_COPILOT_GLOBAL_STORAGE_DIR',
+  'CODEBURN_COPILOT_JETBRAINS_DIR',
+  'CODEBURN_COPILOT_OTEL_DB',
+  'CODEBURN_COPILOT_SESSION_STATE_DIR',
+  'CODEBURN_COPILOT_WS_STORAGE_DIR',
+  'CODEBURN_DESKTOP_SESSIONS_DIR',
+  'CODEBURN_MUX_DIR',
+  'CODEBURN_OPEN_DESIGN_DIR',
+  'CODEBURN_OPENCLAUDE_DIR',
+  'CODEBURN_ANTIGRAVITY_SETTINGS_PATH',
+  // codeburn behavior toggles (set by the dev to tweak local runs)
+  'CODEBURN_COPILOT_DISABLE_OTEL',
+  'CODEBURN_TZ',
+  'CODEBURN_VERBOSE',
+  'CODEBURN_CURSOR_MAX_BUBBLES',
+  'CODEBURN_FORCE_MACOS_MAJOR',
+  // Provider model/credential overrides
+  'KIMI_MODEL_NAME',
+  'AI_GATEWAY_API_KEY',
+  'VERCEL_OIDC_TOKEN',
+  // Read by detectBashBloat - a dev's real shell limit must not bleed in
+  'BASH_MAX_OUTPUT_LENGTH',
+] as const
+
+// Snapshotted from the dev's shell and restored every test. These can't be
+// wiped (Node needs PATH for spawn / module resolution, dashboard/table layout
+// reads COLUMNS) but a test that mutates them shouldn't leak.
+export const PRESERVED = ['PATH', 'COLUMNS'] as const

--- a/tests/setup/env-isolation.ts
+++ b/tests/setup/env-isolation.ts
@@ -34,78 +34,10 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { beforeEach } from 'vitest'
 
+import { CLEARED, PRESERVED, REDIRECTED } from './env-isolation-vars.js'
+
 const sandbox = mkdtempSync(join(tmpdir(), 'codeburn-test-env-'))
 
-const REDIRECTED = [
-  'HOME',
-  'XDG_CONFIG_HOME',
-  'XDG_DATA_HOME',
-  'XDG_CACHE_HOME',
-  'XDG_STATE_HOME',
-  'APPDATA',
-  'LOCALAPPDATA',
-] as const
-
-const CLEARED = [
-  // Provider session-discovery dirs
-  'CLAUDE_CONFIG_DIR',
-  'CLAUDE_CONFIG_DIRS',
-  'CLINE_DIR',
-  'CLINE_DATA_DIR',
-  'CLINE_SESSION_DATA_DIR',
-  'CODEX_HOME',
-  'CODEWHALE_HOME',
-  'CRUSH_GLOBAL_DATA',
-  'CODEBUFF_DATA_DIR',
-  'DSH_HOME',
-  'FACTORY_DIR',
-  'GOOSE_PATH_ROOT',
-  'GROK_HOME',
-  'HERMES_HOME',
-  'KIRO_HOME',
-  'KIMI_CODE_HOME',
-  'KIMI_SHARE_DIR',
-  'LINGTAI_HOME',
-  'LINGTAI_TUI_GLOBAL_DIR',
-  'LINGTAI_TUI_HOME',
-  'MUX_ROOT',
-  'OPENCODE_DATA_DIR',
-  'OPENCODE_DB_PREFIX',
-  'QUICKWORK_HOME',
-  'QWEN_DATA_DIR',
-  'VIBE_HOME',
-  'WARP_DB_PATH',
-  'ZS_DATA_DIR',
-  // codeburn override dirs / paths
-  'CODEBURN_CACHE_DIR',
-  'CODEBURN_COPILOT_GLOBAL_STORAGE_DIR',
-  'CODEBURN_COPILOT_JETBRAINS_DIR',
-  'CODEBURN_COPILOT_OTEL_DB',
-  'CODEBURN_COPILOT_SESSION_STATE_DIR',
-  'CODEBURN_COPILOT_WS_STORAGE_DIR',
-  'CODEBURN_DESKTOP_SESSIONS_DIR',
-  'CODEBURN_MUX_DIR',
-  'CODEBURN_OPEN_DESIGN_DIR',
-  'CODEBURN_OPENCLAUDE_DIR',
-  'CODEBURN_ANTIGRAVITY_SETTINGS_PATH',
-  // codeburn behavior toggles (set by the dev to tweak local runs)
-  'CODEBURN_COPILOT_DISABLE_OTEL',
-  'CODEBURN_TZ',
-  'CODEBURN_VERBOSE',
-  'CODEBURN_CURSOR_MAX_BUBBLES',
-  'CODEBURN_FORCE_MACOS_MAJOR',
-  // Provider model/credential overrides
-  'KIMI_MODEL_NAME',
-  'AI_GATEWAY_API_KEY',
-  'VERCEL_OIDC_TOKEN',
-  // Read by detectBashBloat - a dev's real shell limit must not bleed in
-  'BASH_MAX_OUTPUT_LENGTH',
-] as const
-
-// Snapshotted from the dev's shell and restored every test. These can't be
-// wiped (Node needs PATH for spawn / module resolution, dashboard/table layout
-// reads COLUMNS) but a test that mutates them shouldn't leak.
-const PRESERVED = ['PATH', 'COLUMNS'] as const
 const preservedSnapshot = new Map<string, string | undefined>()
 for (const key of PRESERVED) preservedSnapshot.set(key, process.env[key])
 

--- a/tests/setup/env-isolation.ts
+++ b/tests/setup/env-isolation.ts
@@ -1,12 +1,13 @@
 // Vitest setup file: isolates every test from the developer's shell environment.
 //
 // codeburn discovers sessions through a long list of provider-specific env
-// vars (CLAUDE_CONFIG_DIR, CODEX_HOME, CRUSH_GLOBAL_DATA, …) and via HOME /
-// XDG_* / APPDATA / LOCALAPPDATA. Without this file, any value set in the
-// developer's shell (e.g. CLAUDE_CONFIG_DIRS=/Users/me/.claude:…) bleeds into
+// vars (CLAUDE_CONFIG_DIR, CODEX_HOME, HERMES_HOME, CRUSH_GLOBAL_DATA, …) and
+// via HOME / XDG_* / APPDATA / LOCALAPPDATA. Without this file, any value set
+// in the developer's shell (e.g. HERMES_HOME=/Users/me/.hermes) bleeds into
 // fixture-based tests: the parser reads the developer's REAL sessions instead
 // of the temp-dir fixture, producing nonsense totals and false failures that
-// pass on a clean CI runner.
+// pass on a clean CI runner. tests/env-isolation-declarations.test.ts fails
+// closed if PROVIDER_ENV_VARS grows a data-dir override that is not listed.
 //
 // What this file does:
 //   1. Mints an empty sandbox temp dir once per worker.
@@ -56,26 +57,36 @@ const CLEARED = [
   'CODEWHALE_HOME',
   'CRUSH_GLOBAL_DATA',
   'CODEBUFF_DATA_DIR',
+  'DSH_HOME',
   'FACTORY_DIR',
   'GOOSE_PATH_ROOT',
   'GROK_HOME',
+  'HERMES_HOME',
   'KIRO_HOME',
+  'KIMI_CODE_HOME',
   'KIMI_SHARE_DIR',
+  'LINGTAI_HOME',
+  'LINGTAI_TUI_GLOBAL_DIR',
+  'LINGTAI_TUI_HOME',
   'MUX_ROOT',
   'OPENCODE_DATA_DIR',
   'OPENCODE_DB_PREFIX',
+  'QUICKWORK_HOME',
   'QWEN_DATA_DIR',
   'VIBE_HOME',
   'WARP_DB_PATH',
   'ZS_DATA_DIR',
   // codeburn override dirs / paths
   'CODEBURN_CACHE_DIR',
+  'CODEBURN_COPILOT_GLOBAL_STORAGE_DIR',
   'CODEBURN_COPILOT_JETBRAINS_DIR',
   'CODEBURN_COPILOT_OTEL_DB',
   'CODEBURN_COPILOT_SESSION_STATE_DIR',
   'CODEBURN_COPILOT_WS_STORAGE_DIR',
   'CODEBURN_DESKTOP_SESSIONS_DIR',
   'CODEBURN_MUX_DIR',
+  'CODEBURN_OPEN_DESIGN_DIR',
+  'CODEBURN_OPENCLAUDE_DIR',
   'CODEBURN_ANTIGRAVITY_SETTINGS_PATH',
   // codeburn behavior toggles (set by the dev to tweak local runs)
   'CODEBURN_COPILOT_DISABLE_OTEL',


### PR DESCRIPTION
## Problem

Fixture-based tests parse the developer's real provider sessions whenever a data-dir override is set in the shell. The named hole is `HERMES_HOME`: vitest setup redirects `HOME` into a sandbox but left `HERMES_HOME` intact, so `src/providers/hermes.ts` (`override ?? process.env['HERMES_HOME'] ?? ~/.hermes`) reads the live Hermes DB. That is green on CI (no `HERMES_HOME`) and red on a Hermes-shell laptop — 50 local failures in one wave, all pre-existing, none from product code.

This is not a Hermes-only spelling. `PROVIDER_ENV_VARS` already fingerprints the override for cache invalidation; eight other entries in that map were equally missing from the test CLEARED list.

## Root cause

`tests/setup/env-isolation.ts` claims to delete every provider's explicit override. The list was maintained by hand and drifted from `PROVIDER_ENV_VARS`. There was no guard that a new `*_HOME` / `CODEBURN_*_DIR` in the fingerprint map also has to be isolated.

## Change

- Clear the missing data-dir overrides: `HERMES_HOME`, `DSH_HOME`, `KIMI_CODE_HOME`, `LINGTAI_HOME`, `LINGTAI_TUI_HOME`, `LINGTAI_TUI_GLOBAL_DIR`, `QUICKWORK_HOME`, `CODEBURN_OPEN_DESIGN_DIR`, `CODEBURN_OPENCLAUDE_DIR`.
- Also clear `CODEBURN_COPILOT_GLOBAL_STORAGE_DIR` next to the other Copilot dir overrides already on the list (Copilot stays undeclared in `PROVIDER_ENV_VARS` on purpose).
- Add `tests/env-isolation-declarations.test.ts`: every `PROVIDER_ENV_VARS` entry must appear in `CLEARED` ∪ `REDIRECTED`. Sabotage: drop `HERMES_HOME` from `CLEARED` → the new test fails with `hermes:HERMES_HOME`.

## User impact

None for `codeburn status` / caches / pricing. Developers running the suite inside a Hermes (or Lingtai / DSH / …) shell no longer ingest live session DBs into fixture parses.

## Preservation

No `src/` change. No `CACHE_VERSION` / parse-version bump. `CODEBURN_PRICING_SNAPSHOT_ONLY` and `CODEBURN_FX_NO_FETCH` stay forced-on (not cleared). Copilot remains undeclared in `PROVIDER_ENV_VARS`. No Keychain / Buzz / #868 / #916 / #998. Does not invent rates.

## Testing

- 1 new declaration test; sabotage proven
- `tests/provider-env-declarations.test.ts` (3)
- `tests/providers/hermes.test.ts` (26) + `tests/hermes-pr-links-pipeline.test.ts` (1)
- sibling provider suites whose homes were added: dsh, kimicode, lingtai-tui, open-design, openclaude, quickdesk
- Extra High MERGE AFTER FIX (`/tmp/codeburn-xhigh-review/VERDICT-1064.md`): source-scrape treated a comment containing `'HERMES_HOME'` as isolation. Follow-up `094f9f1` moves CLEARED/REDIRECTED to a side-effect-free module that applyIsolation and the guard both import. Comment-only sabotage now fails with `hermes:HERMES_HOME`.
- 31 focused tests after the follow-up; `tsc --noEmit` clean
