### PR TITLE
fix(cli): hermetic DeepSeek pricing + platform-aware proxy-path test, unblocks #923 cli CI job

### DIFF
--- a/packages/cli/src/models.ts
+++ b/packages/cli/src/models.ts
@@ -234,6 +234,16 @@ export async function loadPricing(): Promise<void> {
     return
   }
 
+  // Test-only escape hatch, set for the whole suite in
+  // tests/setup/env-isolation.ts: skip the live LiteLLM fetch and price purely
+  // off the bundled snapshot, so an upstream reprice can't turn tests red.
+  if (process.env['CODEBURN_PRICING_SNAPSHOT_ONLY']) {
+    pricingCache = mergeSnapshotFallbacks(new Map())
+    sortedPricingKeys = null
+    lowercasePricingIndex = null
+    return
+  }
+
   try {
     pricingCache = mergeSnapshotFallbacks(await fetchAndCachePricing())
     sortedPricingKeys = null

--- a/packages/cli/tests/parser-proxy-pricing.test.ts
+++ b/packages/cli/tests/parser-proxy-pricing.test.ts
@@ -40,9 +40,14 @@ describe('isProxiedPath: path matching rule', () => {
     expect(isProxiedPath('/Users/me/work/')).toBe(true)
   })
 
-  it('is case-insensitive (macOS/Windows default filesystems)', () => {
+  it('folds case exactly where the default filesystem does (macOS/Windows yes, Linux no)', () => {
+    // normalizeProxyPath lowercases only on darwin/win32, deliberately: ext4 is
+    // case-sensitive and folding there could credit unrelated spend. Assert the
+    // platform-correct behavior instead of hardcoding the macOS one, which made
+    // this case fail on Linux CI by design.
     setProxyPaths(['/Users/Me/Work'])
-    expect(isProxiedPath('/users/me/work/acme')).toBe(true)
+    const foldsCase = process.platform === 'darwin' || process.platform === 'win32'
+    expect(isProxiedPath('/users/me/work/acme')).toBe(foldsCase)
   })
 
   it('matches a Windows-style config against a forward-slash cwd', () => {

--- a/packages/cli/tests/setup/env-isolation.ts
+++ b/packages/cli/tests/setup/env-isolation.ts
@@ -103,6 +103,10 @@ function applyIsolation(): void {
     if (original === undefined) delete process.env[key]
     else process.env[key] = original
   }
+  // Price off the bundled LiteLLM snapshot only. Without this, loadPricing()
+  // fetches the live upstream table, so a mid-week reprice by a provider turns
+  // pricing assertions red with no local change.
+  process.env['CODEBURN_PRICING_SNAPSHOT_ONLY'] = '1'
   // Pin the timezone so date grouping is deterministic regardless of the dev's
   // shell TZ. Clearing it is not enough (Node falls back to the OS zone); a
   // non-UTC TZ would otherwise shift day buckets versus a clean CI runner. A


### PR DESCRIPTION
## Summary

Fixes the 2 pre-existing CLI-suite test files (4 assertions) that fail on `feat/core-extraction` and block PR #923's new `cli` CI job. Reference failing run: https://github.com/getagentseal/codeburn/actions/runs/32495563793

### Failure 1 — `tests/models.test.ts` "DeepSeek v4 models resolve to pricing" (x3)

`loadPricing()` fetched the live LiteLLM pricing table during tests, and live data wins over the bundled snapshot. When DeepSeek repriced upstream, the hardcoded DeepSeek v4 assertions went red with no local change.

Ports main's fix for the identical problem (`4866332b`, "price off the bundled snapshot so upstream reprices can't turn tests red") into `packages/cli`:
- `packages/cli/src/models.ts`: `loadPricing()` now checks `CODEBURN_PRICING_SNAPSHOT_ONLY` and, when set, skips the live fetch entirely and prices purely off the bundled snapshot (`mergeSnapshotFallbacks(new Map())`).
- `packages/cli/tests/setup/env-isolation.ts`: sets `CODEBURN_PRICING_SNAPSHOT_ONLY=1` for the whole suite.

Did not port the full #1064 env-isolation framework — only this one env var and the `loadPricing()` branch it gates.

Verified: failed before (`expected 0.00000132 to be 4.35e-7` etc.), passes after. Also verified hermeticity directly: with `global.fetch` overridden to throw and no on-disk pricing cache, `loadPricing()` under `CODEBURN_PRICING_SNAPSHOT_ONLY=1` still resolves `deepseek-v4-pro` to the correct bundled-snapshot price (`4.35e-7`) — no network call is made.

### Failure 2 — `tests/parser-proxy-pricing.test.ts` "is case-insensitive (macOS/Windows default filesystems)"

**Root cause: case (c) — the test asserts platform-dependent behavior unconditionally; the implementation is correct and unchanged.**

`isProxiedPath`/`normalizeProxyPath` in `packages/cli/src/models.ts:551-572` is byte-identical to `origin/main:src/models.ts:579-600` — case folding is deliberately restricted to `darwin`/`win32` (ext4 is case-sensitive; folding on Linux risks crediting unrelated spend, per the function's own doc comment). This is not a divergence to port.

The test itself hardcoded `expect(isProxiedPath(...)).toBe(true)`, which fails by design on Linux CI. Main hit this exact issue and fixed the test (not the implementation) in `bcf11552` ("test: fix the five environment-sensitive failures the first ubuntu run exposed"). This PR ports that same test fix verbatim: assert `foldsCase = process.platform === 'darwin' || process.platform === 'win32'` instead of a hardcoded `true`, preserving the macOS/Windows-passing assertion while being correct on Linux.

## Test plan

- [x] `npx vitest run tests/models.test.ts tests/parser-proxy-pricing.test.ts` from `packages/cli` — both files fail before the fix (3 + 1 = 4 assertions/tests), pass after.
- [x] Hermeticity probe: `loadPricing()` with `CODEBURN_PRICING_SNAPSHOT_ONLY=1` and `global.fetch` forced to throw still resolves correct pricing — confirms no network dependency.
- [x] Full CLI suite from `packages/cli`: `npx vitest run` → 212 passed | 2 skipped test files, 2465 passed | 5 skipped tests, 0 failures.
- [x] Core suite: `npm run test -w @codeburn/core` → 36 test files, 509 tests, all passed.
- [x] `npx tsc --noEmit -p tsconfig.json` in `packages/cli` — clean, no errors.

This unblocks #923's new `cli` CI job (previously red on this branch regardless of #923's own changes).