### PR TITLE
test(cli): restore CI timeout headroom + lock-suite quarantine lost in packages/cli split

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,8 @@
     "build:cli": "tsup && node -e \"const fs=require('fs'); fs.copyFileSync('src/cli.ts','dist/cli.js'); fs.chmodSync('dist/cli.js',0o755)\"",
     "build:dash": "cd ../../dash && npm install --no-audit --no-fund --silent && npm run build",
     "dev": "NODE_OPTIONS=--no-deprecation tsx src/cli.ts",
-    "test": "vitest",
+    "test": "vitest run tests --exclude \"tests/cache-refresh-lock*\"",
+    "test:locks": "vitest run tests/cache-refresh-lock.test.ts tests/cache-refresh-lock-process.test.ts --poolOptions.forks.singleFork=true",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/packages/cli/tests/cli-status-menubar.test.ts
+++ b/packages/cli/tests/cli-status-menubar.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from 'node:os'
 import { delimiter as pathDelimiter, join } from 'node:path'
 import { spawnSync } from 'node:child_process'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+// Every case here spawns the real CLI and does genuine multi-provider parse
+// work; the 5s default is fine on a dev laptop and not on a shared 2-core
+// runner, where individual cases have been observed needing 6-8s.
+vi.setConfig({ testTimeout: 30_000 })
 
 function runCli(args: string[], home: string, extraEnv: Record<string, string | undefined> = {}) {
   return spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], {

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
     // session-discovery env vars (CLAUDE_CONFIG_DIRS, HOME, XDG_*, every
     // provider-specific *_HOME) don't bleed real local data into fixtures.
     setupFiles: ['./tests/setup/env-isolation.ts'],
+    // Real-I/O tests (session parses, sqlite fixtures, worker pools) exceed the
+    // 5s default under CI runner load; a hung test still fails at 30s.
+    testTimeout: 30_000,
     // A handful of integration tests exercise real servers, spawned CLI
     // subprocesses and real filesystem locks. Under a saturated full-suite run
     // an fs/socket op can starve and the operation fails closed (correct, but


### PR DESCRIPTION
## Summary

PR #923 wires `npm test --workspace=codeburn` into CI (job `cli`) for the
first time on `feat/core-extraction`. It then fails deterministically on 2
reruns x 2 node versions on exactly three tests, each timing out at the
vitest default 5000ms:

- `tests/cache-refresh-lock.test.ts` > "the fence never loses to its own heartbeat (in-process serialization)"
- `tests/cli-status-menubar.test.ts` > "filters the whole menubar payload to a selected Claude config source"
- `tests/parser-incremental-append.test.ts` > "EDGE: file replaced (inode change) falls back to a full re-parse"

All three pass locally and in isolated runs; the same test files pass in
`origin/main`'s `test` job on the same ubuntu runners. Root cause is not the
tests, or the new CI job's invocation — it's that `packages/cli`'s test
config/scripts are stale copies of `main`'s pre-Jul-26 versions and never
picked up three CI-stability fixes `main` merged afterward:

1. **30037b33** (main, Aug 18) - raised the global vitest `testTimeout` from
   the 5s default to 30s. `packages/cli/vitest.config.ts` was forked from
   main before this landed and never got it.
2. **8c758ddf** (main, Aug 4) - added a file-level `vi.setConfig({
   testTimeout: 30_000 })` to `cli-status-menubar.test.ts` (it spawns the
   real CLI and does multi-provider parses; individual cases were observed
   needing 6-8s on a shared 2-core runner). Missed even though it predates
   #921's "port upstream fixes" commit by a day, because that commit only
   cross-referenced one specific main SHA.
3. **4ca2d482** (main, Aug 9) - excluded `cache-refresh-lock*` tests from the
   parallel `test` run and quarantined them behind a serial `test:locks`
   script (`--poolOptions.forks.singleFork=true`), because they contend for
   the fork pool with the spawned-subprocess tests and starve everyone under
   load. `packages/cli/package.json`'s `test` script never got the exclusion.

None of this was visible before because nothing in CI ran the `packages/cli`
suite on ubuntu until #923 added the `cli` job.

## Changes

- `packages/cli/vitest.config.ts`: add `testTimeout: 30_000` (matches main;
  kept alongside the existing `retry: 2` added by #921, which addresses a
  different problem - starvation, not insufficient headroom).
- `packages/cli/tests/cli-status-menubar.test.ts`: add the file-level
  `vi.setConfig({ testTimeout: 30_000 })`, matching main verbatim.
- `packages/cli/package.json`: `test` now excludes `tests/cache-refresh-lock*`
  (matches main); added `test:locks` running those files serially with
  `singleFork=true` (matches main, minus `cache-refresh-lock-corrupt-body.test.ts`,
  which doesn't exist on this branch - it's an upstream test #921 explicitly
  chose not to port).

## Not included

#923's `cli` job doesn't yet run the quarantined `test:locks` script the way
main's `tests.yml` runs it as a separate serial, `continue-on-error` step -
that step only makes sense once this PR's `test:locks` script exists, so it
belongs in #923's branch as a follow-up once this merges, not here.

## Test plan

- [x] `npm run build --workspace=@codeburn/core && npm run test --workspace=codeburn` - 210 files / 2451 tests pass (excludes the 2 lock files, matching main's split)
- [x] `npm run test:locks --workspace=codeburn` (from `packages/cli`) - 2 files / 14 tests pass
- [x] `npm test` (root, both workspaces) - green