### PR TITLE
test: guarantee a distinct inode in the file-replaced edge case

### DIFF
--- a/packages/cli/tests/parser-incremental-append.test.ts
+++ b/packages/cli/tests/parser-incremental-append.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mkdtemp, mkdir, writeFile, appendFile, readFile, rm, stat, unlink } from 'fs/promises'
+import { mkdtemp, mkdir, writeFile, appendFile, readFile, rename, rm, stat } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -286,14 +286,20 @@ describe('incremental append parsing', () => {
     await parseWith(warmCache)
     const inoBefore = (await stat(sessionPath)).ino
 
-    // Replace the file (new inode) with different, LARGER content.
-    await unlink(sessionPath)
+    // Replace the file (new inode) with different, LARGER content. Write the
+    // replacement to a sibling path FIRST, while the original still exists and
+    // its inode is still allocated, then rename over it: unlink-then-recreate
+    // lets ext4 hand the freed inode straight back (seen on CI runners), which
+    // turns this into a same-inode append case instead of a replacement.
     const replaced = [
       ...baseLines(),
       userLine('2026-05-01T12:00:00.000Z', 'brand new task'),
       asstLine('msg-z', '2026-05-01T12:00:02.000Z', { input_tokens: 500, output_tokens: 120 }, [readBlock('/z.ts')]),
     ].join('\n') + '\n'
-    await writeFile(sessionPath, replaced)
+    const replacementPath = sessionPath + '.replacement'
+    await writeFile(replacementPath, replaced)
+    expect((await stat(replacementPath)).ino).not.toBe(inoBefore)
+    await rename(replacementPath, sessionPath)
     expect((await stat(sessionPath)).ino).not.toBe(inoBefore)
 
     readLineCalls.length = 0


### PR DESCRIPTION
The `EDGE: file replaced (inode change) falls back to a full re-parse` test unlinks the session file and recreates it at the same path. On ext4 CI runners the freed inode is handed straight back, so `expect(ino).not.toBe(inoBefore)` fails as `expected N not to be N` — seen on #923's and #929's `cli` jobs.

Fix: write the replacement content to a sibling path first, while the original still exists (its inode still allocated, so the new file must get a different one), assert distinctness, then `rename` over the original — which preserves the replacement's inode and is also the realistic editor/tool replace pattern.

Test-only; 9/9 green locally.