### PR TITLE
fix(web): lead session chart legends with title when unique

### DIFF
--- a/src/granular-history.ts
+++ b/src/granular-history.ts
@@ -177,8 +177,13 @@ function preferredSessionTitle(titleCandidates: Map<string, SessionTitleCandidat
 
 // Chart legend is `max-w-40` at 10px ≈ 24–32 glyphs. A title that is unique in
 // that window can lead; otherwise the short id must stay in the prefix or
-// truncated series look identical (the #997 class).
+// truncated series look identical (the #997 class). Count code points, matching
+// the title cap — a UTF-16 slice can split an emoji and collide two titles.
 const VISIBLE_LEGEND_PREFIX = 24
+
+function visibleLegendPrefix(label: string): string {
+  return Array.from(label).slice(0, VISIBLE_LEGEND_PREFIX).join('')
+}
 
 function buildSessionLabels(inputs: Map<string, SessionLabelInfo>): Map<string, string> {
   // Stable raw-key order makes the residual used-label guard independent of
@@ -197,11 +202,11 @@ function buildSessionLabels(inputs: Map<string, SessionLabelInfo>): Map<string, 
 
   const titlePrefixCounts = new Map<string, number>()
   for (const entry of draft) {
-    const prefix = entry.baseLabel.slice(0, VISIBLE_LEGEND_PREFIX)
+    const prefix = visibleLegendPrefix(entry.baseLabel)
     titlePrefixCounts.set(prefix, (titlePrefixCounts.get(prefix) ?? 0) + 1)
   }
   const entries: SessionLabelEntry[] = draft.map(entry => {
-    const prefix = entry.baseLabel.slice(0, VISIBLE_LEGEND_PREFIX)
+    const prefix = visibleLegendPrefix(entry.baseLabel)
     const titleLeads = (titlePrefixCounts.get(prefix) ?? 0) === 1
     return { ...entry, baseLabel: titleLeads ? entry.baseLabel : entry.idFirst }
   })

--- a/src/granular-history.ts
+++ b/src/granular-history.ts
@@ -64,6 +64,7 @@ type SessionLabelEntry = {
   key: string
   info: SessionLabelInfo
   baseLabel: string
+  idFirst: string
 }
 
 function nonNegative(value: number): number {
@@ -174,19 +175,36 @@ function preferredSessionTitle(titleCandidates: Map<string, SessionTitleCandidat
   return cleaned[0]?.title
 }
 
+// Chart legend is `max-w-40` at 10px ≈ 24–32 glyphs. A title that is unique in
+// that window can lead; otherwise the short id must stay in the prefix or
+// truncated series look identical (the #997 class).
+const VISIBLE_LEGEND_PREFIX = 24
+
 function buildSessionLabels(inputs: Map<string, SessionLabelInfo>): Map<string, string> {
   // Stable raw-key order makes the residual used-label guard independent of
   // project/session discovery order when a title happens to match another
   // label shape.
-  const entries: SessionLabelEntry[] = [...inputs.entries()].map(([key, info]) => {
-    const sessionLabel = preferredSessionTitle(info.titleCandidates)
-      ?? shortProjectLabel(info.projectPath, preferredProjectName(info.projectNames))
-    return {
-      key,
-      info,
-      baseLabel: `${shortSessionId(info.sessionId)} (${info.provider}) · ${sessionLabel}`,
-    }
+  const draft: SessionLabelEntry[] = [...inputs.entries()].map(([key, info]) => {
+    const title = preferredSessionTitle(info.titleCandidates)
+    const project = shortProjectLabel(info.projectPath, preferredProjectName(info.projectNames))
+    const shortId = shortSessionId(info.sessionId)
+    const idFirst = title
+      ? `${shortId} (${info.provider}) · ${title}`
+      : `${shortId} (${info.provider}) · ${project}`
+    const titleFirst = title ? `${title} (${info.provider})` : idFirst
+    return { key, info, baseLabel: titleFirst, idFirst }
   }).sort((a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : 0)
+
+  const titlePrefixCounts = new Map<string, number>()
+  for (const entry of draft) {
+    const prefix = entry.baseLabel.slice(0, VISIBLE_LEGEND_PREFIX)
+    titlePrefixCounts.set(prefix, (titlePrefixCounts.get(prefix) ?? 0) + 1)
+  }
+  const entries: SessionLabelEntry[] = draft.map(entry => {
+    const prefix = entry.baseLabel.slice(0, VISIBLE_LEGEND_PREFIX)
+    const titleLeads = (titlePrefixCounts.get(prefix) ?? 0) === 1
+    return { ...entry, baseLabel: titleLeads ? entry.baseLabel : entry.idFirst }
+  })
   const byBaseLabel = new Map<string, SessionLabelEntry[]>()
   for (const entry of entries) {
     const group = byBaseLabel.get(entry.baseLabel) ?? []

--- a/tests/granular-history.test.ts
+++ b/tests/granular-history.test.ts
@@ -120,7 +120,7 @@ describe('granular history', () => {
     ])], { start, end }, end)
 
     expect(history.sessionSeries.map(series => series.label)).toEqual([
-      'sessio…3456 (claude) · Refactor billing module',
+      'Refactor billing module (claude)',
       'sessio…3457 (claude) · repos/demo',
       'sessio…3458 (claude) · repos/demo',
       'sessio…3459 (claude) · repos/demo',
@@ -175,7 +175,7 @@ describe('granular history', () => {
       calls: [apiCall({ timestamp, cost: 1 })],
     }])], { start, end }, end)
 
-    expect(history.sessionSeries[0]?.label).toBe('sessio…3456 (claude) · Refactor billing module')
+    expect(history.sessionSeries[0]?.label).toBe('Refactor billing module (claude)')
     expect(history.sessionSeries[0]?.label).not.toContain('\x1b')
     expect(history.sessionSeries[0]?.label).not.toContain('\x00')
   })
@@ -190,7 +190,7 @@ describe('granular history', () => {
       calls: [apiCall({ timestamp, cost: 1 })],
     }])], { start, end }, end)
 
-    expect(history.sessionSeries[0]?.label).toBe('sessio…3456 (claude) · ' + 'x'.repeat(80))
+    expect(history.sessionSeries[0]?.label).toBe('x'.repeat(80) + ' (claude)')
   })
 
   it('caps session titles by code point without splitting an emoji', () => {
@@ -205,9 +205,8 @@ describe('granular history', () => {
     }])], { start, end }, end)
 
     const label = history.sessionSeries[0]?.label ?? ''
-    const titlePart = label.slice(label.indexOf(' · ') + 3)
-    expect(titlePart).toBe('x'.repeat(79) + '😀')
-    expect([...titlePart]).toEqual([...('x'.repeat(79) + '😀')])
+    expect(label).toBe('x'.repeat(79) + '😀' + ' (claude)')
+    expect([...label]).toEqual([...'x'.repeat(79), '😀', ' ', '(', 'c', 'l', 'a', 'u', 'd', 'e', ')'])
   })
 
   it('prefers a title from any duplicate session summary sharing a key', () => {
@@ -230,7 +229,7 @@ describe('granular history', () => {
     ])], { start, end }, end)
 
     expect(history.sessionSeries).toHaveLength(1)
-    expect(history.sessionSeries[0]?.label).toBe('sessio…3456 (claude) · Z recovered session title')
+    expect(history.sessionSeries[0]?.label).toBe('Z recovered session title (claude)')
   })
 
   it('fills idle buckets and keeps separate model and session lines from real call timestamps', () => {

--- a/tests/granular-history.test.ts
+++ b/tests/granular-history.test.ts
@@ -157,12 +157,31 @@ describe('granular history', () => {
     // 160px at the chart's 10px font fits roughly 31-32 lowercase glyphs;
     // compare a conservative prefix that must be visible in that budget.
     const visibleCharacterBudget = 24
-    const visiblePrefixes = history.sessionSeries.map(series => series.label.slice(0, visibleCharacterBudget))
+    const visiblePrefixes = history.sessionSeries.map(series => Array.from(series.label).slice(0, visibleCharacterBudget).join(''))
     expect(new Set(visiblePrefixes).size).toBe(2)
     expect(history.sessionSeries.map(series => series.label)).toEqual(expect.arrayContaining([
       expect.stringMatching(/^a1b2c3…7f01 \(claude\) · /),
       expect.stringMatching(/^d4e5f6…8a02 \(claude\) · /),
     ]))
+  })
+
+  it('counts the visible title-lead window in code points, not UTF-16 units', () => {
+    const timestamp = '2026-07-15T12:05:00.000Z'
+    const start = new Date('2026-07-15T00:00:00.000Z')
+    const end = new Date('2026-07-15T23:59:59.999Z')
+    const emojiPrefix = '😀'.repeat(12)
+    const history = buildGranularHistory([project([
+      { id: 'emoji-alpha-aaaaaa', title: `${emojiPrefix} alpha work`, calls: [apiCall({ timestamp, cost: 1 })] },
+      { id: 'emoji-beta-bbbbbb', title: `${emojiPrefix} beta work`, calls: [apiCall({ timestamp, cost: 2 })] },
+    ])], { start, end }, end)
+
+    // 12 emoji = 12 glyphs / 24 UTF-16 units. A unit slice collides both
+    // titles on the emoji run and would id-first; a code-point window still
+    // sees " alpha" vs " beta" and can title-lead.
+    expect(history.sessionSeries.map(series => series.label).sort()).toEqual([
+      `${emojiPrefix} alpha work (claude)`,
+      `${emojiPrefix} beta work (claude)`,
+    ].sort())
   })
 
   it('sanitises control characters and ANSI escapes in session titles', () => {


### PR DESCRIPTION
## Problem

`codeburn web` Usage → Hourly buckets grouped by Sessions rendered each series as a truncated session UUID (plus a shared project prefix). In a monorepo every line looked the same. The Context tab and `codeburn sessions` already show titles.

Closes #997.

## Root cause

`buildGranularHistory` collected titles but always led the legend with `shortSessionId`. The chart clips labels at ~24 glyphs (`max-w-40`), so the human-readable title never made the visible prefix.

## Change

- Unique cleaned title in that visible window leads: `Refactor billing module (claude)`.
- Colliding titles or long shared prefixes stay short-id-first so truncated series stay distinguishable.
- Blank / missing titles keep the project-path fallback.
- Sanitise / 80-code-point cap unchanged.
- Visible uniqueness counts code points (`4065255`), matching the title cap — Extra High MERGE AFTER FIX on `088d264`.

## User impact

Session charts name the work, not the hex fragment, without collapsing two series into one truncated line.

## Preservation

- Untitled sessions unchanged.
- Model series unchanged.
- `sessionDisplayName` in sessions report / TUI already preferred title; not rewritten.
- Residual collision path still may include full path+id (pre-existing; not this class).

## Testing

`npx vitest run tests/granular-history.test.ts` — 17 passed.