### PR TITLE
fix(desktop): say why the PR tab is empty

### DIFF
--- a/app/renderer/App.test.tsx
+++ b/app/renderer/App.test.tsx
@@ -268,7 +268,7 @@ describe('App shortcuts', () => {
     expect(await screen.findByText('No sessions in this range yet.')).toBeInTheDocument()
 
     fireEvent.keyDown(document, { key: '3', ...chord })
-    expect(await screen.findByText(/PR links are captured as sessions are parsed/)).toBeInTheDocument()
+    expect(await screen.findByText(/No sessions in Last 30 days mentioned a pull request URL/)).toBeInTheDocument()
 
     fireEvent.keyDown(document, { key: '4', ...chord })
     expect(await screen.findByText('Cost flow · model → project')).toBeInTheDocument()

--- a/app/renderer/App.test.tsx
+++ b/app/renderer/App.test.tsx
@@ -485,6 +485,27 @@ describe('App shortcuts', () => {
     expect(screen.getByText('30D')).not.toHaveClass('on')
   })
 
+  it('names a selected custom range on the Pull requests empty note', async () => {
+    render(<App />)
+    fireEvent.keyDown(document, { key: '3', metaKey: true })
+    expect(await screen.findByText(/No sessions in Last 30 days mentioned a pull request URL/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose date range' }))
+    const to = new Date()
+    const from = new Date(to.getFullYear(), to.getMonth(), to.getDate() - 2)
+    const fromLabel = from.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })
+    const toLabel = to.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })
+    fireEvent.mouseDown(screen.getByRole('button', { name: fromLabel }))
+    fireEvent.mouseEnter(screen.getByRole('button', { name: toLabel }))
+    fireEvent.mouseUp(screen.getByRole('button', { name: toLabel }))
+
+    const left = from.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    const right = to.toLocaleDateString('en-US', { month: from.getMonth() === to.getMonth() ? undefined : 'short', day: 'numeric' })
+    expect(await screen.findByText(new RegExp(`No sessions in ${left} [–-] ${right} mentioned a pull request URL`))).toBeInTheDocument()
+    expect(screen.getByText('30D')).not.toHaveClass('on')
+    expect(screen.queryByText(/No sessions in Last 30 days/)).toBeNull()
+  })
+
   it('shows no daily budget banner when none is configured', async () => {
     render(<App />)
     expect(await screen.findByText('Most expensive sessions')).toBeInTheDocument()

--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -18,7 +18,7 @@ import { formatCompact, formatUsd, setActiveCurrency } from './lib/format'
 import { motionClass } from './lib/motion'
 import { codeburn } from './lib/ipc'
 import { isModifierChord, shortcutLabel } from './lib/platform'
-import { localDateKey } from './lib/period'
+import { localDateKey, PERIOD_LABELS } from './lib/period'
 import { persistRefreshValue, readRefreshValue, refreshValueToMs, RefreshCadenceContext, type RefreshCadence } from './lib/refreshCadence'
 import { OverviewContent } from './sections/Overview'
 import { OptimizeContent } from './sections/Optimize'
@@ -116,15 +116,6 @@ const SECTION_TITLES: Record<Section, string> = {
   compare: 'Compare',
   plans: 'Plans',
   settings: 'Settings',
-}
-
-const PERIOD_LABELS: Record<Period, string> = {
-  today: 'Today',
-  week: 'Last 7 days',
-  month: 'This month',
-  '30days': 'Last 30 days',
-  all: 'Last 6 months',
-  lifetime: 'Lifetime',
 }
 
 const STANDARD_PERIODS: Period[] = ['today', 'week', '30days', 'month', 'all', 'lifetime']
@@ -565,7 +556,7 @@ function AppMain() {
               ) : section === 'sessions' ? (
                 <Sessions period={period} provider={provider} range={customRange} refreshToken={refreshToken} detectedProviders={detectedProviders} onProviderChange={onProviderSelect} ready={ready} />
               ) : section === 'pullRequests' ? (
-                <PullRequestsContent overview={overview} />
+                <PullRequestsContent overview={overview} period={period} provider={provider} range={customRange} />
               ) : section === 'spend' ? (
                 <SpendContent period={period} provider={provider} range={customRange} overview={overview} refreshToken={refreshToken} ready={ready} />
               ) : section === 'optimize' ? (

--- a/app/renderer/lib/period.ts
+++ b/app/renderer/lib/period.ts
@@ -1,5 +1,15 @@
 import type { DailyHistoryEntry, Period } from './types'
 
+/** Same words the desktop TopBar and empty states must use. `all` is last six months, not lifetime. */
+export const PERIOD_LABELS: Record<Period, string> = {
+  today: 'Today',
+  week: 'Last 7 days',
+  month: 'This month',
+  '30days': 'Last 30 days',
+  all: 'Last 6 months',
+  lifetime: 'Lifetime',
+}
+
 // The CLI emits `history.daily` as a SPARSE list of active days only (not a
 // backfilled calendar). Charts must zero-fill inactive days client-side to keep
 // the time axis honest; helpers here own that windowing.

--- a/app/renderer/sections/PullRequests.test.tsx
+++ b/app/renderer/sections/PullRequests.test.tsx
@@ -280,11 +280,11 @@ describe('PullRequests', () => {
     expect(screen.queryByText(/Other \(/)).toBeNull()
   })
 
-  it('shows the quiet empty state (never a fake table) when no PR links exist', async () => {
+  it('shows a period-aware empty state (never a fake table) when no PR links exist', async () => {
     getOverview.mockResolvedValue(makePayload())
     render(<PullRequests period="lifetime" provider="all" />)
 
-    expect(await screen.findByText(/PR links are captured as sessions are parsed/)).toBeInTheDocument()
+    expect(await screen.findByText(/No sessions in All mentioned a pull request URL/)).toBeInTheDocument()
     expect(screen.queryByRole('table')).toBeNull()
   })
 
@@ -292,7 +292,19 @@ describe('PullRequests', () => {
     getOverview.mockResolvedValue(makePayload({ rows: [], distinctCost: 0, distinctSessions: 0, attributedCost: 0, unattributedCost: 0 }))
     render(<PullRequests period="lifetime" provider="all" />)
 
-    expect(await screen.findByText(/PR links are captured as sessions are parsed/)).toBeInTheDocument()
+    expect(await screen.findByText(/No sessions in All mentioned a pull request URL/)).toBeInTheDocument()
     expect(screen.queryByRole('table')).toBeNull()
+  })
+
+  it('names Today and points at All when a wider window has rows', async () => {
+    getOverview.mockImplementation(async (period: string) => {
+      if (period === 'all') return makePayload(SAMPLE)
+      return makePayload()
+    })
+    render(<PullRequests period="today" provider="all" />)
+
+    expect(await screen.findByText(/No sessions in Today mentioned a pull request URL/)).toBeInTheDocument()
+    expect(await screen.findByText(/All time has 2 pull requests/)).toBeInTheDocument()
+    expect(getOverview).toHaveBeenCalledWith('all', 'all')
   })
 })

--- a/app/renderer/sections/PullRequests.test.tsx
+++ b/app/renderer/sections/PullRequests.test.tsx
@@ -307,4 +307,12 @@ describe('PullRequests', () => {
     expect(await screen.findByText(/Lifetime has 2 pull requests/)).toBeInTheDocument()
     expect(getOverview).toHaveBeenCalledWith('lifetime', 'all')
   })
+
+  it('names the custom range, not the dormant standard period', async () => {
+    getOverview.mockResolvedValue(makePayload())
+    render(<PullRequests period="30days" provider="all" range={{ from: '2026-08-20', to: '2026-08-22' }} />)
+
+    expect(await screen.findByText(/No sessions in Aug 20 – 22 mentioned a pull request URL/)).toBeInTheDocument()
+    expect(screen.queryByText(/Last 30 days/)).toBeNull()
+  })
 })

--- a/app/renderer/sections/PullRequests.test.tsx
+++ b/app/renderer/sections/PullRequests.test.tsx
@@ -284,7 +284,7 @@ describe('PullRequests', () => {
     getOverview.mockResolvedValue(makePayload())
     render(<PullRequests period="lifetime" provider="all" />)
 
-    expect(await screen.findByText(/No sessions in All mentioned a pull request URL/)).toBeInTheDocument()
+    expect(await screen.findByText(/No sessions in Lifetime mentioned a pull request URL/)).toBeInTheDocument()
     expect(screen.queryByRole('table')).toBeNull()
   })
 
@@ -292,19 +292,19 @@ describe('PullRequests', () => {
     getOverview.mockResolvedValue(makePayload({ rows: [], distinctCost: 0, distinctSessions: 0, attributedCost: 0, unattributedCost: 0 }))
     render(<PullRequests period="lifetime" provider="all" />)
 
-    expect(await screen.findByText(/No sessions in All mentioned a pull request URL/)).toBeInTheDocument()
+    expect(await screen.findByText(/No sessions in Lifetime mentioned a pull request URL/)).toBeInTheDocument()
     expect(screen.queryByRole('table')).toBeNull()
   })
 
-  it('names Today and points at All when a wider window has rows', async () => {
+  it('names Today and points at Lifetime when a wider window has rows', async () => {
     getOverview.mockImplementation(async (period: string) => {
-      if (period === 'all') return makePayload(SAMPLE)
+      if (period === 'lifetime') return makePayload(SAMPLE)
       return makePayload()
     })
     render(<PullRequests period="today" provider="all" />)
 
     expect(await screen.findByText(/No sessions in Today mentioned a pull request URL/)).toBeInTheDocument()
-    expect(await screen.findByText(/All time has 2 pull requests/)).toBeInTheDocument()
-    expect(getOverview).toHaveBeenCalledWith('all', 'all')
+    expect(await screen.findByText(/Lifetime has 2 pull requests/)).toBeInTheDocument()
+    expect(getOverview).toHaveBeenCalledWith('lifetime', 'all')
   })
 })

--- a/app/renderer/sections/PullRequests.tsx
+++ b/app/renderer/sections/PullRequests.tsx
@@ -9,6 +9,7 @@ import { StaleBanner } from '../components/StaleBanner'
 import { type Polled, usePolled } from '../hooks/usePolled'
 import { formatDayShort, formatUsd } from '../lib/format'
 import { codeburn } from '../lib/ipc'
+import { PERIOD_LABELS } from '../lib/period'
 import type { CliError, DateRange, MenubarPayload, Period } from '../lib/types'
 
 type PullRequests = NonNullable<MenubarPayload['current']['pullRequests']>
@@ -63,19 +64,10 @@ export function PullRequests({ period, provider, range = null }: { period: Perio
   return <PullRequestsContent key={`${period}|${provider}|${range?.from ?? ''}|${range?.to ?? ''}`} overview={overview} period={period} provider={provider} range={range} />
 }
 
-const PERIOD_LABEL: Record<Period, string> = {
-  today: 'Today',
-  week: 'This week',
-  '30days': 'Last 30 days',
-  month: 'This month',
-  all: 'All',
-  lifetime: 'All',
-}
-
-export function PullRequestsContent({ overview, period = 'today', provider = 'all', range = null }: {
+export function PullRequestsContent({ overview, period, provider, range = null }: {
   overview: Polled<MenubarPayload>
-  period?: Period
-  provider?: string
+  period: Period
+  provider: string
   range?: DateRange | null
 }) {
   if (!overview.data) {
@@ -113,11 +105,11 @@ function PullRequestsPage({ pullRequests, staleError, period, provider, range }:
 
 function PrEmptyNote({ period, provider, range }: { period: Period; provider: string; range: DateRange | null }) {
   const [widerCount, setWiderCount] = useState<number | null>(null)
-  const canProbeWider = !range && period !== 'all' && period !== 'lifetime'
+  const canProbeWider = !range && period !== 'lifetime'
   useEffect(() => {
     if (!canProbeWider) return
     let cancelled = false
-    void codeburn.getOverview('all', provider).then(payload => {
+    void codeburn.getOverview('lifetime', provider).then(payload => {
       if (cancelled) return
       setWiderCount(payload.current.pullRequests?.rows.length ?? 0)
     }).catch(() => {
@@ -126,9 +118,9 @@ function PrEmptyNote({ period, provider, range }: { period: Period; provider: st
     return () => { cancelled = true }
   }, [canProbeWider, provider])
 
-  const periodLabel = PERIOD_LABEL[period]
+  const periodLabel = PERIOD_LABELS[period]
   const widerHint = widerCount && widerCount > 0
-    ? ` All time has ${widerCount.toLocaleString('en-US')} pull requests — switch the period control to All.`
+    ? ` Lifetime has ${widerCount.toLocaleString('en-US')} pull requests — switch the period control to Life.`
     : ''
   return (
     <EmptyNote>

--- a/app/renderer/sections/PullRequests.tsx
+++ b/app/renderer/sections/PullRequests.tsx
@@ -60,27 +60,81 @@ export function PullRequests({ period, provider, range = null }: { period: Perio
   )
   // The key remounts the content on a period/provider/range switch so row state
   // (an open expansion) never survives onto the same PR rendered from new data.
-  return <PullRequestsContent key={`${period}|${provider}|${range?.from ?? ''}|${range?.to ?? ''}`} overview={overview} />
+  return <PullRequestsContent key={`${period}|${provider}|${range?.from ?? ''}|${range?.to ?? ''}`} overview={overview} period={period} provider={provider} range={range} />
 }
 
-export function PullRequestsContent({ overview }: { overview: Polled<MenubarPayload> }) {
+const PERIOD_LABEL: Record<Period, string> = {
+  today: 'Today',
+  week: 'This week',
+  '30days': 'Last 30 days',
+  month: 'This month',
+  all: 'All',
+  lifetime: 'All',
+}
+
+export function PullRequestsContent({ overview, period = 'today', provider = 'all', range = null }: {
+  overview: Polled<MenubarPayload>
+  period?: Period
+  provider?: string
+  range?: DateRange | null
+}) {
   if (!overview.data) {
     if (overview.error) return <CliErrorPanel error={overview.error} subject="pull requests" />
     return <SectionSkeleton label="Scanning pull requests…" rows={5} />
   }
-  return <PullRequestsPage pullRequests={overview.data.current.pullRequests} staleError={overview.error} />
+  return <PullRequestsPage
+    pullRequests={overview.data.current.pullRequests}
+    staleError={overview.error}
+    period={period}
+    provider={provider}
+    range={range}
+  />
 }
 
-function PullRequestsPage({ pullRequests, staleError }: { pullRequests?: PullRequests; staleError: CliError | null }) {
+function PullRequestsPage({ pullRequests, staleError, period, provider, range }: {
+  pullRequests?: PullRequests
+  staleError: CliError | null
+  period: Period
+  provider: string
+  range: DateRange | null
+}) {
+  const empty = !pullRequests || pullRequests.rows.length === 0
   return (
     <>
       {staleError && <StaleBanner error={staleError} />}
       <Panel title="Pull request spend">
-        {pullRequests && pullRequests.rows.length > 0
-          ? <PrTable pullRequests={pullRequests} />
-          : <EmptyNote>PR links are captured as sessions are parsed. Once a session references a pull request, it appears here.</EmptyNote>}
+        {empty
+          ? <PrEmptyNote period={period} provider={provider} range={range} />
+          : <PrTable pullRequests={pullRequests} />}
       </Panel>
     </>
+  )
+}
+
+function PrEmptyNote({ period, provider, range }: { period: Period; provider: string; range: DateRange | null }) {
+  const [widerCount, setWiderCount] = useState<number | null>(null)
+  const canProbeWider = !range && period !== 'all' && period !== 'lifetime'
+  useEffect(() => {
+    if (!canProbeWider) return
+    let cancelled = false
+    void codeburn.getOverview('all', provider).then(payload => {
+      if (cancelled) return
+      setWiderCount(payload.current.pullRequests?.rows.length ?? 0)
+    }).catch(() => {
+      if (!cancelled) setWiderCount(null)
+    })
+    return () => { cancelled = true }
+  }, [canProbeWider, provider])
+
+  const periodLabel = PERIOD_LABEL[period]
+  const widerHint = widerCount && widerCount > 0
+    ? ` All time has ${widerCount.toLocaleString('en-US')} pull requests — switch the period control to All.`
+    : ''
+  return (
+    <EmptyNote>
+      No sessions in {periodLabel} mentioned a pull request URL. Spend is attributed only when a transcript contains a github.com/…/pull/N link.
+      {widerHint}
+    </EmptyNote>
   )
 }
 

--- a/app/renderer/sections/PullRequests.tsx
+++ b/app/renderer/sections/PullRequests.tsx
@@ -11,6 +11,7 @@ import { formatDayShort, formatUsd } from '../lib/format'
 import { codeburn } from '../lib/ipc'
 import { PERIOD_LABELS } from '../lib/period'
 import type { CliError, DateRange, MenubarPayload, Period } from '../lib/types'
+import { rangeLabel } from '../components/TopBar'
 
 type PullRequests = NonNullable<MenubarPayload['current']['pullRequests']>
 type PrRow = PullRequests['rows'][number]
@@ -118,7 +119,7 @@ function PrEmptyNote({ period, provider, range }: { period: Period; provider: st
     return () => { cancelled = true }
   }, [canProbeWider, provider])
 
-  const periodLabel = PERIOD_LABELS[period]
+  const periodLabel = range ? rangeLabel(range) : PERIOD_LABELS[period]
   const widerHint = widerCount && widerCount > 0
     ? ` Lifetime has ${widerCount.toLocaleString('en-US')} pull requests — switch the period control to Life.`
     : ''

--- a/app/renderer/sections/PullRequests.tsx
+++ b/app/renderer/sections/PullRequests.tsx
@@ -121,7 +121,7 @@ function PrEmptyNote({ period, provider, range }: { period: Period; provider: st
 
   const periodLabel = range ? rangeLabel(range) : PERIOD_LABELS[period]
   const widerHint = widerCount && widerCount > 0
-    ? ` Lifetime has ${widerCount.toLocaleString('en-US')} pull requests — switch the period control to Life.`
+    ? ` Lifetime has ${widerCount.toLocaleString('en-US')} pull requests. Switch the period control to Life.`
     : ''
   return (
     <EmptyNote>


### PR DESCRIPTION
## Problem

Desktop Pull requests on Today/week/month looks broken: empty copy, no hint. On this Mac the extractor works — `status --format menubar-json --period all` returns 73 rows; today/month omit `pullRequests`. Default period is Today.

Closes nothing yet (no issue number). Class: empty-state / period honesty.

## Root cause

Empty copy did not name the selected period. Sessions only appear when a transcript contains a PR URL. Hermes/Grok work this week never writes those URLs.

## Change

- Period-aware empty note.
- If All has N rows, say so and point at the period control.
- No `buildPrAttribution` change. Default period unchanged.

## User impact

Today still empty if no linked sessions today. The tab explains why and how to see All.

## Preservation

No aggregator / gh-invented links.

## Testing

`npx vitest run renderer/sections/PullRequests.test.tsx` — 17 passed (including Today-empty + All-has-2).
