### PR TITLE
fix: stamp a build/schema fence on session cache entries

### DIFF
--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -4,6 +4,7 @@ import { createHash, randomBytes } from 'crypto'
 import { join } from 'path'
 
 import { getCodeburnCacheDir } from './cache-dir.js'
+import { DAILY_CACHE_VERSION } from './daily-cache.js'
 import type { ToolCall } from './types.js'
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -272,6 +273,23 @@ export const PROVIDER_ENV_VARS: Record<string, string[]> = {
 // disappear — they are preserved so month-to-date totals never drop.
 export const DURABLE_PROVIDER_NAMES: ReadonlySet<string> = new Set(['copilot'])
 
+// ── Cache Semantics Revision ───────────────────────────────────────────
+// Bump this when cost/accounting semantics change without a matching
+// PROVIDER_PARSE_VERSIONS bump. Issue #1095 / vidoluco's #946 postmortem:
+// an unpublished fork shared the same PROVIDER_PARSE_VERSIONS but wrote
+// synthetic/differently-priced calls into a shared cache dir, and the
+// published build adopted them because session-cache entries were
+// fingerprinted only by source file and parse version. This revision is
+// hashed into the envelope semantics token so foreign-build envelopes
+// mismatch and become cache misses.
+//
+// This fix does NOT bump DAILY_CACHE_VERSION: the semantics token changes
+// SESSION-CACHE ENVELOPE ADOPTION policy (whether a foreign envelope's
+// provider data is trusted), not the shape or content of daily-cache.v26
+// day records. daily-cache has its own independent versioning/migration
+// path for that.
+export const CACHE_SEMANTICS_REVISION = 1
+
 // Estimated-cost surfacing (#639): providers that set `costIsEstimated` carry a
 // `-est-cost` suffix (or a new entry) so their already-cached sessions reparse
 // once and the flag lands, instead of silently reading as measured. Copilot
@@ -390,6 +408,7 @@ type EnvelopeProvider = {
 type CacheEnvelope = {
   version: number
   complete?: boolean
+  semanticsToken?: string
   nonce: string
   providers: Record<string, EnvelopeProvider>
 }
@@ -512,6 +531,16 @@ export function computeEnvFingerprint(provider: string): string {
   const parts = vars.map(v => `${v}=${process.env[v] ?? ''}`)
   const parseVersion = PROVIDER_PARSE_VERSIONS[provider]
   if (parseVersion) parts.push(`parser=${parseVersion}`)
+  return createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 16)
+}
+
+export function computeCacheSemanticsToken(): string {
+  const parseVersions = Object.entries(PROVIDER_PARSE_VERSIONS).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+  const parts = [
+    JSON.stringify(parseVersions),
+    `daily=${DAILY_CACHE_VERSION}`,
+    `semantics=${CACHE_SEMANTICS_REVISION}`,
+  ]
   return createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 16)
 }
 
@@ -813,6 +842,7 @@ function isEnvelope(raw: unknown): raw is CacheEnvelope {
   if (!raw || typeof raw !== 'object') return false
   const o = raw as Record<string, unknown>
   if (o['version'] !== CACHE_VERSION || typeof o['nonce'] !== 'string') return false
+  if (!isOptionalString(o['semanticsToken'])) return false
   const providers = o['providers']
   if (!providers || typeof providers !== 'object' || Array.isArray(providers)) return false
   return Object.values(providers as Record<string, unknown>).every(p => {
@@ -865,6 +895,7 @@ export async function loadCache(scope?: CacheLoadScope): Promise<SessionCache> {
   const dir = sessionCacheDir()
   const envelope = await readEnvelope(dir)
   if (!envelope) return afterMissingShardCache()
+  const semanticsMismatch = envelope.semanticsToken !== undefined && envelope.semanticsToken !== computeCacheSemanticsToken()
   const scopeKey = scope ? `${scope.fromMonth}..${scope.toMonth}` : 'all'
   if (cacheMemo && cacheMemo.dir === dir && cacheMemo.nonce === envelope.nonce
     && (cacheMemo.scope === 'all' || cacheMemo.scope === scopeKey)) return cacheMemo.cache
@@ -888,7 +919,7 @@ export async function loadCache(scope?: CacheLoadScope): Promise<SessionCache> {
     // retires residuals over the complete cached serve set, so a scoped load
     // of a copilot section persisted before the durable stamp landed would
     // make pairing range-dependent. The name check closes that window.
-    const full = !scope || meta.durable === true || DURABLE_PROVIDER_NAMES.has(provider) || meta.envFingerprint !== computeEnvFingerprint(provider)
+    const full = !scope || meta.durable === true || DURABLE_PROVIDER_NAMES.has(provider) || meta.envFingerprint !== computeEnvFingerprint(provider) || semanticsMismatch
     const loaded: Set<string> | null = full ? null : new Set()
     // Shards are read concurrently but merged in envelope order, so the result
     // never depends on which read finished first. A path that somehow ended up
@@ -925,6 +956,23 @@ export async function loadCache(scope?: CacheLoadScope): Promise<SessionCache> {
     state.fingerprints.set(provider, meta.envFingerprint)
   }
   await Promise.all(reads)
+  if (semanticsMismatch) {
+    for (const [provider, section] of Object.entries(cache.providers)) {
+      const durable = section.durable === true || DURABLE_PROVIDER_NAMES.has(provider)
+      if (durable) {
+        for (const [path, file] of Object.entries(section.files)) {
+          if (existsSync(path)) {
+            delete file.lastCompleteLineOffset
+            delete file.failed
+            file.fingerprint = { dev: 0, ino: 0, mtimeMs: 0, sizeBytes: -1 }
+          }
+        }
+      } else {
+        section.files = {}
+      }
+      markCacheDirty(cache, provider)
+    }
+  }
   state.scope = scopeKey
   cacheMemo = { dir, nonce: envelope.nonce, scope: scopeKey, cache }
   return cache
@@ -1266,6 +1314,7 @@ export async function saveCache(cache: SessionCache, verifyStillOwner?: () => Pr
     const envelope: CacheEnvelope = {
       version: CACHE_VERSION,
       complete: cache.complete === true,
+      semanticsToken: computeCacheSemanticsToken(),
       nonce: randomBytes(8).toString('hex'),
       providers,
     }

--- a/tests/session-cache-semantics-fence.test.ts
+++ b/tests/session-cache-semantics-fence.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, readFile, rm, stat, writeFile } from 'fs/promises'
+import { existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  CACHE_VERSION,
+  clearLoadCacheMemo,
+  computeCacheSemanticsToken,
+  computeEnvFingerprint,
+  loadCache,
+  markCacheDirty,
+  saveCache,
+  sessionCacheDir,
+  type CachedFile,
+  type SessionCache,
+} from '../src/session-cache.js'
+
+let TMP_DIR: string
+let SRC_DIR: string
+
+beforeEach(async () => {
+  TMP_DIR = join(tmpdir(), `codeburn-semantics-cache-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  SRC_DIR = join(tmpdir(), `codeburn-semantics-src-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  process.env['CODEBURN_CACHE_DIR'] = TMP_DIR
+  await mkdir(TMP_DIR, { recursive: true })
+  await mkdir(SRC_DIR, { recursive: true })
+  clearLoadCacheMemo()
+})
+
+afterEach(async () => {
+  if (TMP_DIR && existsSync(TMP_DIR)) await rm(TMP_DIR, { recursive: true })
+  if (SRC_DIR && existsSync(SRC_DIR)) await rm(SRC_DIR, { recursive: true })
+})
+
+function cachedFile(overrides: Partial<CachedFile> = {}): CachedFile {
+  const timestamp = new Date().toISOString()
+  return {
+    fingerprint: { dev: 1, ino: 2, mtimeMs: 3, sizeBytes: 4 },
+    lastCompleteLineOffset: 128,
+    mcpInventory: ['mcp__github__list'],
+    turns: [{
+      timestamp,
+      sessionId: 'sess-1',
+      userMessage: 'do the thing',
+      calls: [{
+        provider: 'claude',
+        model: 'claude-sonnet-4-20250514',
+        usage: {
+          inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0,
+          webSearchRequests: 0, cacheCreationOneHourTokens: 0,
+        },
+        costUSD: 0.01,
+        speed: 'standard',
+        timestamp,
+        tools: ['Read'], bashCommands: [], skills: [], subagentTypes: [],
+        deduplicationKey: 'msg-1',
+      }],
+    }],
+    ...overrides,
+  }
+}
+
+async function envelope(): Promise<any> {
+  return JSON.parse(await readFile(join(sessionCacheDir(), 'envelope.json'), 'utf-8'))
+}
+
+async function sourceFile(name: string): Promise<string> {
+  const path = join(SRC_DIR, name)
+  await writeFile(path, 'a\n'.repeat(128), 'utf-8')
+  return path
+}
+
+async function seedCache(provider: string, filePath: string): Promise<CachedFile> {
+  const st = await stat(filePath)
+  const file = cachedFile({
+    fingerprint: { dev: st.dev, ino: st.ino, mtimeMs: st.mtimeMs, sizeBytes: st.size },
+  })
+
+  const cache: any = await loadCache()
+  cache.providers ??= {}
+  cache.providers[provider] ??= {}
+  cache.providers[provider].envFingerprint = computeEnvFingerprint(provider)
+  cache.providers[provider].files = { [filePath]: file }
+
+  markCacheDirty(cache, provider)
+  await saveCache(cache)
+
+  return file
+}
+
+describe('same-token adoption', () => {
+  it('keeps cached entries when the stamped token matches', async () => {
+    const filePath = await sourceFile('same-token.log')
+    const file = await seedCache('claude', filePath)
+
+    clearLoadCacheMemo()
+    const loaded: any = await loadCache()
+
+    expect(loaded.providers.claude.files[filePath]).toEqual(file)
+    expect((await envelope()).semanticsToken).toBe(computeCacheSemanticsToken())
+  })
+})
+
+describe('missing-token adoption', () => {
+  it('loads old envelopes unchanged and stamps the token on next save', async () => {
+    const filePath = await sourceFile('missing-token.log')
+    const file = await seedCache('claude', filePath)
+
+    const envelopePath = join(sessionCacheDir(), 'envelope.json')
+    const raw = JSON.parse(await readFile(envelopePath, 'utf-8'))
+    expect(raw.semanticsToken).toBe(computeCacheSemanticsToken())
+
+    delete raw.semanticsToken
+    await writeFile(envelopePath, JSON.stringify(raw), 'utf-8')
+
+    clearLoadCacheMemo()
+    const loaded: any = await loadCache()
+
+    expect(loaded.providers.claude.files[filePath]).toEqual(file)
+
+    markCacheDirty(loaded, 'claude')
+    await saveCache(loaded)
+
+    expect((await envelope()).semanticsToken).toBe(computeCacheSemanticsToken())
+  })
+})
+
+describe('Mismatched-token re-parse (revert-proof)', () => {
+  it('drops non-durable entries, forces durable re-read for existing sources, and preserves missing sources', async () => {
+    const existingPath = join(TMP_DIR, 'existing.jsonl')
+    const missingPath = join(TMP_DIR, 'missing', 'gone.jsonl')
+    const nondurablePath = join(TMP_DIR, 'non-durable.jsonl')
+    await writeFile(existingPath, '{"line":1}\n')
+    await writeFile(nondurablePath, '{"line":1}\n')
+
+    const nondurable = 'claude'
+    const durable = 'copilot'
+    const existingOriginal = cachedFile({ lastCompleteLineOffset: 64 })
+    const missingOriginal = cachedFile({ prLinks: ['https://github.com/o/r/pull/9'] })
+
+    const cache: SessionCache = {
+      version: CACHE_VERSION,
+      providers: {
+        [nondurable]: {
+          durable: false,
+          envFingerprint: computeEnvFingerprint(nondurable),
+          files: { [nondurablePath]: cachedFile() },
+        },
+        [durable]: {
+          durable: true,
+          envFingerprint: computeEnvFingerprint(durable),
+          files: {
+            [existingPath]: existingOriginal,
+            [missingPath]: missingOriginal,
+          },
+        },
+      },
+    }
+
+    markCacheDirty(cache, nondurable)
+    markCacheDirty(cache, durable)
+    await saveCache(cache)
+
+    const doctored = await envelope()
+    doctored.semanticsToken = 'foreign-build-xyz'
+    await writeFile(join(sessionCacheDir(), 'envelope.json'), JSON.stringify(doctored), 'utf-8')
+
+    clearLoadCacheMemo()
+    const reloaded = await loadCache()
+
+    expect(Object.keys(reloaded.providers[nondurable]?.files ?? {})).toHaveLength(0)
+
+    expect(reloaded.providers[durable]?.files[existingPath]).toBeDefined()
+    expect(reloaded.providers[durable]?.files[existingPath]?.fingerprint).toEqual({
+      dev: 0,
+      ino: 0,
+      mtimeMs: 0,
+      sizeBytes: -1,
+    })
+    expect(reloaded.providers[durable]?.files[existingPath]).not.toHaveProperty('lastCompleteLineOffset')
+    expect(reloaded.providers[durable]?.files[existingPath]).not.toHaveProperty('failed')
+
+    expect(reloaded.providers[durable]?.files[missingPath]).toEqual(missingOriginal)
+
+    markCacheDirty(reloaded, nondurable)
+    markCacheDirty(reloaded, durable)
+    await saveCache(reloaded)
+    expect((await envelope()).semanticsToken).toBe(computeCacheSemanticsToken())
+
+    clearLoadCacheMemo()
+    const final = await loadCache()
+    expect(final.providers[durable]?.files[existingPath]).toBeDefined()
+    expect(final.providers[durable]?.files[missingPath]).toBeDefined()
+    expect(Object.keys(final.providers[nondurable]?.files ?? {})).toHaveLength(0)
+  })
+})
+
+describe('Two-writer alternation, no silent mixing', () => {
+  it('discards mismatched non-durable shard data and re-stamps the local semantics token', async () => {
+    const provider = 'claude'
+    const filePath = join(TMP_DIR, 'writer-a.jsonl')
+    await writeFile(filePath, '{"line":1}\n')
+
+    const cache: SessionCache = {
+      version: CACHE_VERSION,
+      providers: {
+        [provider]: {
+          durable: false,
+          envFingerprint: computeEnvFingerprint(provider),
+          files: { [filePath]: cachedFile() },
+        },
+      },
+    }
+
+    markCacheDirty(cache, provider)
+    await saveCache(cache)
+
+    const env = await envelope()
+    const shardName = Object.values((env.providers[provider].shards ?? {}) as Record<string, { name: string; until: string }>)[0]?.name
+    expect(shardName).toBeTruthy()
+    const shardPath = join(sessionCacheDir(), shardName as string)
+    const shard = JSON.parse(await readFile(shardPath, 'utf-8'))
+
+    const doctorCosts = (value: any): void => {
+      if (Array.isArray(value)) {
+        for (const item of value) doctorCosts(item)
+        return
+      }
+      if (value && typeof value === 'object') {
+        if (typeof value.costUSD === 'number') value.costUSD = 999
+        for (const key of Object.keys(value)) doctorCosts(value[key])
+      }
+    }
+
+    doctorCosts(shard)
+    expect(JSON.stringify(shard)).toContain('"costUSD":999')
+    await writeFile(shardPath, JSON.stringify(shard), 'utf-8')
+
+    env.semanticsToken = 'build-b-token-y'
+    await writeFile(join(sessionCacheDir(), 'envelope.json'), JSON.stringify(env), 'utf-8')
+
+    clearLoadCacheMemo()
+    const loaded = await loadCache()
+
+    expect(Object.keys(loaded.providers[provider]?.files ?? {})).toHaveLength(0)
+    expect(JSON.stringify(loaded)).not.toContain('"costUSD":999')
+
+    markCacheDirty(loaded, provider)
+    await saveCache(loaded)
+
+    clearLoadCacheMemo()
+    const final = await loadCache()
+    expect(Object.keys(final.providers[provider]?.files ?? {})).toHaveLength(0)
+    expect(JSON.stringify(final)).not.toContain('"costUSD":999')
+    expect((await envelope()).semanticsToken).toBe(computeCacheSemanticsToken())
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes #1095: two builds with different cost/accounting semantics sharing `CODEBURN_CACHE_DIR` could mix silently, because `session-cache.v9` entries were fenced only by source-file fingerprint + `PROVIDER_PARSE_VERSIONS` — and a fork that shared the same parse-version strings but different cost math (vidoluco's #946 postmortem) matched fingerprints and got served.
- Adds `CACHE_SEMANTICS_REVISION` (bumped when cost/accounting semantics change without a matching `PROVIDER_PARSE_VERSIONS` bump) and `computeCacheSemanticsToken()`, a hash of `PROVIDER_PARSE_VERSIONS ∪ DAILY_CACHE_VERSION ∪ CACHE_SEMANTICS_REVISION`, stamped on the v9 envelope on every save.
- Load-time behavior:
  - Envelope with **no** `semanticsToken` (pre-fix cache): loads unchanged, no forced re-parse. The next save stamps the token — adoption happens once, going forward, with zero special-casing.
  - Envelope with a **matching** token: no change.
  - Envelope with a **mismatched** token: every non-durable provider's cached files are dropped (`{}` — hard cache miss, the foreign numbers are never surfaced from `loadCache()`); durable providers (`copilot`, or any section with `durable: true`) keep entries whose source no longer exists (unrecoverable history) but force a full re-read on entries whose source still exists (mirrors the existing durable carry-forward already used for `envFingerprint` mismatches in `getOrCreateProviderSection`).
- Deliberately **not** a `CACHE_VERSION` or `DAILY_CACHE_VERSION` bump — this changes envelope *adoption policy*, not the shard layout or `daily-cache.v26` day-record shape, so there's no migration path to extend.

## Test plan

- [x] New `tests/session-cache-semantics-fence.test.ts`: same-token adoption, missing-token adoption + stamp, mismatched-token re-parse (durable carry-forward + non-durable drop, revert-proof), two-writer alternation (build A's token never lets build B's mismatched cost data leak into a caller-visible value, and republishing always re-stamps the local build's real token).
- [x] All four new tests verified to **fail** against pre-fix `src/session-cache.ts` (only the test file reverted-tested; confirmed each fails without the fence and passes with it).
- [x] Full suite: `npm test` — 226 files / 3143 tests passed, 5 skipped (pre-existing lock-suite/e2e skips, unrelated).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run verify:upgrade` — PASSED, parity `ok`. Confirms a cache written by the last published CLI (0.9.20, pre-fence, no `semanticsToken`) upgrades cleanly with no forced global re-parse and no payload drift beyond the pre-existing, already-documented codex/#1075 and grok/#1015 repricing.

🤖 Drafted with `cline-pass/qwen3.8-max` via local gateway; reviewed and verified by the operator.