### PR TITLE
fix(sync): wire truth — no filesystem paths in ai.project, billable output tokens

### DIFF
--- a/src/sync/cli.ts
+++ b/src/sync/cli.ts
@@ -23,7 +23,7 @@ import {
 import { createCredentialStore } from './credentials.js'
 import { readSyncConfig, writeSyncConfig, deleteSyncConfig, updateLastSync } from './config.js'
 import { collectUnsentCalls, collectUnsentAttribution, sendBatches, sendAttributionBatches, batchCalls, MAX_PER_PUSH, MAX_ATTRIBUTION_PER_PUSH, type PushResult } from './push.js'
-import { batchAttributionItems } from './otlp.js'
+import { batchAttributionItems, wireProjectName } from './otlp.js'
 
 export function registerSyncCommands(program: Command): void {
   const sync = program
@@ -274,7 +274,8 @@ export function registerSyncCommands(program: Command): void {
           process.exit(1)
         }
         const { range } = getDateRange(period)
-        const projects = await parseAllSessions(range)
+        const projects = (await parseAllSessions(range))
+          .map(p => ({ ...p, project: wireProjectName(p.projectPath, p.project) }))
 
         // Flatten + filter against sent-ledger
         const { allCalls, unsent, held, frozen } = collectUnsentCalls(projects)

--- a/src/sync/otlp.ts
+++ b/src/sync/otlp.ts
@@ -65,6 +65,16 @@ export function deriveTraceId(sessionId: string): string {
   return createHash('sha256').update(sessionId).digest('hex').slice(0, 32)
 }
 
+/**
+ * Wire-safe project identity: the leaf directory name. Several providers key a
+ * project by its sanitized absolute path ("-Users-me-Projects-app"), and
+ * docs/sync/README.md promises file paths stay local.
+ */
+export function wireProjectName(projectPath: string, fallback: string): string {
+  const normalized = projectPath.trim().replace(/\\/g, '/').replace(/\/+$/, '')
+  return normalized.split('/').filter(Boolean).pop() ?? fallback
+}
+
 // --- Timestamp conversion ---
 
 function toUnixNano(isoTimestamp: string): string {

--- a/src/sync/otlp.ts
+++ b/src/sync/otlp.ts
@@ -8,6 +8,7 @@
 import { createHash } from 'crypto'
 import { hostname, userInfo } from 'os'
 import type { ParsedApiCall } from '../types.js'
+import { billableOutputTokens } from '../models.js'
 import type { SessionAttributionRecord } from '../yield.js'
 
 export interface OtlpSpan {
@@ -103,7 +104,10 @@ export function buildOtlpPayload(calls: CallWithSession[]): OtlpPayload {
       { key: 'ai.provider', value: { stringValue: call.provider } },
       { key: 'ai.model', value: { stringValue: call.model } },
       { key: 'ai.input_tokens', value: { intValue: String(call.usage.inputTokens) } },
-      { key: 'ai.output_tokens', value: { intValue: String(call.usage.outputTokens) } },
+      // Billable output, not raw: for providers that bill reasoning separately
+      // the raw output under-reports by the reasoning volume. Same routing the
+      // display layer adopted in #1115/#1116.
+      { key: 'ai.output_tokens', value: { intValue: String(billableOutputTokens(call.provider, call.usage.outputTokens, call.usage.reasoningTokens)) } },
       { key: 'ai.cost_usd', value: { doubleValue: call.costUSD } },
       { key: 'ai.project', value: { stringValue: project } },
       { key: 'ai.speed', value: { stringValue: call.speed } },

--- a/tests/sync-attribution-cli.test.ts
+++ b/tests/sync-attribution-cli.test.ts
@@ -10,7 +10,7 @@
 import { execFileSync } from 'node:child_process'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest'
 import { Command } from 'commander'
@@ -153,5 +153,25 @@ describe('sync push --attribution (CLI level)', () => {
     expect(names).toContain('codeburn.commit')                // commit span
     const wire = JSON.stringify(idp.tracesRequests)
     expect(wire).toContain('github.com/acme/cli-widget')
+  })
+
+  it('never puts a filesystem path on the wire as ai.project', async () => {
+    const now = Date.now()
+    const first = new Date(now - 90 * 60 * 1000).toISOString()
+    const last = new Date(now - 30 * 60 * 1000).toISOString()
+    const session = makeSession('cli-sess-1', first, last, [makeCall(`call-${now}`, first)])
+    parseAllSessionsMock.mockResolvedValue([
+      { project: `-${repoDir.replace(/^\//, '').replace(/\//g, '-')}`, projectPath: repoDir, sessions: [session] } as ProjectSummary,
+    ])
+    await runPush(['--attribution'])
+    const wire = JSON.stringify(idp.tracesRequests)
+    expect(wire).not.toContain(repoDir)                    // no absolute path
+    expect(wire).not.toContain(repoDir.replace(/\//g, '-')) // no slugified path
+    const projects = idp.tracesRequests.flatMap(r => (r.body as any).resourceSpans
+      .flatMap((rs: any) => rs.scopeSpans.flatMap((ss: any) => ss.spans))
+      .flatMap((s: any) => s.attributes.filter((a: any) => a.key === 'ai.project')
+        .map((a: any) => a.value.stringValue)))
+    expect(projects.length).toBeGreaterThanOrEqual(2)       // usage + attribution spans
+    expect(new Set(projects)).toEqual(new Set([basename(repoDir)]))
   })
 })

--- a/tests/sync-ledger-otlp.test.ts
+++ b/tests/sync-ledger-otlp.test.ts
@@ -159,6 +159,44 @@ describe('buildOtlpPayload', () => {
     expect(attrMap['ai.session_id']).toBeUndefined()
   })
 
+  it('bills reasoning into ai.output_tokens for exclusive providers (opencode)', () => {
+    const payload = buildOtlpPayload([makeCallWithSession({
+      provider: 'opencode',
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        cachedInputTokens: 0,
+        reasoningTokens: 250,
+        webSearchRequests: 0,
+      },
+    })])
+    const attrs = payload.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.attributes
+    const attrMap = Object.fromEntries(attrs.map(a => [a.key, a.value]))
+
+    expect(attrMap['ai.output_tokens']).toEqual({ intValue: '750' })
+  })
+
+  it('keeps ai.output_tokens raw for inclusive providers (claude)', () => {
+    const payload = buildOtlpPayload([makeCallWithSession({
+      provider: 'claude',
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        cachedInputTokens: 0,
+        reasoningTokens: 250,
+        webSearchRequests: 0,
+      },
+    })])
+    const attrs = payload.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.attributes
+    const attrMap = Object.fromEntries(attrs.map(a => [a.key, a.value]))
+
+    expect(attrMap['ai.output_tokens']).toEqual({ intValue: '500' })
+  })
+
   it('includes tools as array attribute', () => {
     const payload = buildOtlpPayload([makeCallWithSession()])
     const attrs = payload.resourceSpans[0]!.scopeSpans[0]!.spans[0]!.attributes


### PR DESCRIPTION
Two sync wire-truth fixes, both diagnosed by a real-data pilot push against a local receiver (37.8k spans, $5.1k of real usage reconciled three-layer). Implementation by Kimi Code from written specs; reviewed and re-verified by maintainer.

## 1. ai.project must never carry a filesystem path
Every synced span carried `ai.project` as the slugified absolute path (`-Users-torukmakto-Projects-eywa`), contradicting docs/sync/README.md ('paths stay local') and COMPATIBILITY.md ('safe project basename'). Fixed with `wireProjectName()` (leaf directory name) at the single choke point after `parseAllSessions` — covers both wire paths; `codeburn yield` local output untouched. Never-lose: usage span ids + commit attribution keys carry no project (unchanged, no re-send); session attribution re-emits once per session and the receiver upserts by (org, trace) — replaced, not duplicated. Same-leaf directories collapse to one wire identity (the contract's definition); `git.repo` disambiguates.

## 2. ai.output_tokens must be billable output, not raw
Exclusive-reasoning providers were under-reported on the wire by exactly their reasoning volume (measured: opencode short 37,848 = summed reasoningTokens). Routed through `billableOutputTokens` — the same correction the display layer took in #1115. Inclusive providers (claude/codex/copilot) byte-identical. Cost unaffected (priced before export). Span ids carry no token counts → no re-send, no duplication.

## Tests
New wire-boundary tests: path-shaped project never reaches the wire (usage + attribution spans all equal the basename); exclusive provider output = output+reasoning, inclusive stays raw. Targeted sync suites 106/106; full suite 240 files / 3,253 green; tsc clean — all re-run by reviewer per commit.

Pilot note: the local pilot teams.db will be reset after merge (old rows carry path-shaped projects and raw outputs); no production receiver exists yet.