### PR TITLE
fix(daily-cache): ranged parses never write days outside their range

### DIFF
--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -1190,6 +1190,17 @@ export function isTurnResidueOnly(day: DailyEntry): boolean {
   return Object.values(day.categories).some(c => c.turns > 0)
 }
 
+/// Keep only the days a RANGED parse actually covered (issue #1130): a turn
+/// anchored before the range start survives range slicing whole, so the
+/// aggregator can emit a residue day outside the parsed range — and out-of-range
+/// residue days must not reach durable history even with the merge guards.
+/// Date keys are zero-padded YYYY-MM-DD, so a string compare is exact.
+export function daysInRange(days: DailyEntry[], range: DateRange, dateKeyFn: (date: Date) => string = toDateString): DailyEntry[] {
+  const first = dateKeyFn(range.start)
+  const last = dateKeyFn(range.end)
+  return days.filter(d => d.date >= first && d.date <= last)
+}
+
 export async function ensureCacheHydrated(
   parseSessions: (range: DateRange) => Promise<ProjectSummary[]>,
   aggregateDays: (projects: ProjectSummary[]) => DailyEntry[],
@@ -1318,7 +1329,7 @@ export async function ensureCacheHydrated(
         // cache, breaking that reconciliation - so the subtraction below gets
         // its own through-now parse instead.
         projects = await parseSessions({ start: backfillStart, end: yesterdayEnd })
-        freshDays = aggregateDays(projects)
+        freshDays = daysInRange(aggregateDays(projects), { start: backfillStart, end: yesterdayEnd })
       }
       const parseWasComplete = sessionComplete()
       // A PARTIAL parse must not overwrite finalized baseline days with
@@ -1390,7 +1401,7 @@ export async function ensureCacheHydrated(
     if (gapStart.getTime() <= yesterdayEnd.getTime()) {
       const gapRange: DateRange = { start: gapStart, end: yesterdayEnd }
       const gapProjects = await parseSessions(gapRange)
-      const gapDays = aggregateDays(gapProjects)
+      const gapDays = daysInRange(aggregateDays(gapProjects), gapRange)
       const parseWasComplete = sessionComplete()
       const priorWatermark = c.lastComputedDate
       // Gate the merge on parse completeness (issue #1127): replacing cached

--- a/tests/daily-cache-degraded-completeness.test.ts
+++ b/tests/daily-cache-degraded-completeness.test.ts
@@ -13,6 +13,7 @@ import {
   type ProviderDaySlice,
   currentTzKey,
   ensureCacheHydrated,
+  loadDailyCache,
   saveDailyCache,
   toDateString,
 } from '../src/daily-cache.js'
@@ -271,6 +272,27 @@ describe('daily cache: a residue-only day is re-derived, not served', () => {
     expect(healed.cost).toBe(33)
     expect(healed.calls).toBe(210)
     expect(out.days.find(d => d.date === daysAgoStr(10))).toMatchObject({ cost: 80, calls: 700 })
+    expect(out.lastComputedDate).toBe(daysAgoStr(1))
+    expect(out.complete).toBe(true)
+  })
+})
+
+describe('daily cache: out-of-range residue days never reach the gap merge', () => {
+  it('a straddling turn anchored before the gap leaves the cached day untouched', async () => {
+    // Issue #1130: the gap range starts on D+1, but a turn anchored on day D
+    // survives range slicing whole, so the aggregator emits a residue day for
+    // D — outside the parsed range. Previously the merge guard had to defuse
+    // it; now the range filter drops it before the merge runs at all.
+    const populatedD = day(daysAgoStr(4), { claude: slice(120, 900) })
+    await seed({ days: [VANISHED, populatedD] })
+    const before = (await loadDailyCache()).days.find(d => d.date === daysAgoStr(4))!
+    const residue = residueDay(daysAgoStr(4))
+    const inRange = day(daysAgoStr(2), { claude: slice(30, 300) })
+    const out = await ensureCacheHydrated(noSessions, () => [residue, inRange], 'cfg-A', () => true)
+    // Day D persisted untouched: no residue categories leaked in.
+    const kept = out.days.find(d => d.date === daysAgoStr(4))!
+    expect(kept).toEqual(before)
+    expect(out.days.map(d => d.date)).toEqual([daysAgoStr(40), daysAgoStr(4), daysAgoStr(2)])
     expect(out.lastComputedDate).toBe(daysAgoStr(1))
     expect(out.complete).toBe(true)
   })


### PR DESCRIPTION
Closes #1130 part 1 (part 2 — the cache-version bump — already shipped via #1118's v29). A midnight-straddling turn survives range slicing with its original anchor, so `aggregateProjectsIntoDays` can emit a residue day outside the parsed range; #1129's merge guards defuse the overwrite, but the residue should never reach durable history at all. `daysInRange` filters at both ranged call sites (re-derive + gap); aggregator and slicer untouched — whole-corpus callers unaffected. New test: a gap over D+1 with a straddler anchored on D writes nothing to D (persisted entry compares equal before/after hydration). Implementation by Kimi Code from the diagnosis spec; suite 3,286 green + tsc clean re-run by maintainer.