### PR TITLE
fix(macos): launch mise-installed CLI from Spotlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed (macOS)
+
+- **CodeBurnMenubar now launches mise-installed CodeBurn correctly from Spotlight.** Spotlight gives GUI apps a minimal PATH, so a persisted `mise use -g npm:codeburn` launcher could be found but then fail with exit 127 when its shell wrapper tried to resolve `node`. The menubar child environment now includes mise's stable shim directory (including a custom `MISE_DATA_DIR` when available), matching the existing Volta/asdf/nvm handling without invoking a shell. (#1124)
+
 ## 0.9.21 - 2026-08-24
 
 ### Added

--- a/mac/README.md
+++ b/mac/README.md
@@ -69,7 +69,7 @@ The app registers itself as a menubar accessory (`LSUIElement = true` at runtime
 
 On launch and every 60 seconds thereafter, the app spawns `codeburn status --format menubar-json --no-optimize` directly (argv, no shell) via `CodeburnCLI.makeProcess` and decodes the JSON into `MenubarPayload`. The manual refresh button in the footer invokes the same command without `--no-optimize`, which includes optimize findings but takes longer.
 
-Release installs record a persistent absolute CLI path in `~/Library/Application Support/CodeBurn/codeburn-cli-path.v1`, then fall back to Homebrew's common `codeburn` locations. For development only, set `CODEBURN_ALLOW_DEV_BIN=1` with `CODEBURN_BIN`; the value is validated against a strict allowlist before use, so a malicious env var can't inject shell commands.
+Release installs record a persistent absolute CLI path in `~/Library/Application Support/CodeBurn/codeburn-cli-path.v1`, then fall back to common Homebrew and Node-manager locations. GUI launches augment the minimal macOS PATH with Volta, npm-global, asdf, mise, and nvm runtime locations so a persisted JavaScript launcher also works when the app is opened from Spotlight. For development only, set `CODEBURN_ALLOW_DEV_BIN=1` with `CODEBURN_BIN`; the value is validated against a strict allowlist before use, so a malicious env var can't inject shell commands.
 
 ## Project layout
 

--- a/mac/Sources/CodeBurnMenubar/Security/CodeburnCLI.swift
+++ b/mac/Sources/CodeBurnMenubar/Security/CodeburnCLI.swift
@@ -14,13 +14,25 @@ enum CodeburnCLI {
     /// Homebrew and npm global installs.
     private static let additionalPathEntries = ["/opt/homebrew/bin", "/usr/local/bin"]
 
-    private static let userNodePaths: [String] = {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
+    private static func userNodePaths(
+        homeDirectory: String,
+        environment: [String: String]
+    ) -> [String] {
+        let home = homeDirectory
         var paths: [String] = []
         for dir in ["\(home)/.volta/bin", "\(home)/.npm-global/bin", "\(home)/.asdf/shims"] {
             paths.append(dir)
         }
-        let nvmDir = ProcessInfo.processInfo.environment["NVM_DIR"] ?? "\(home)/.nvm"
+        // `mise use -g npm:codeburn` installs the CLI under its npm backend, but
+        // that wrapper still resolves `node` through PATH. Apps opened by
+        // Spotlight inherit only the system PATH, so include mise's stable shim
+        // directory (the same integration its official docs prescribe for
+        // non-interactive environments). Respect a custom data directory when
+        // it is available to the GUI process; otherwise use mise's macOS default.
+        let miseDataDir = environment["MISE_DATA_DIR"] ?? "\(home)/.local/share/mise"
+        paths.append("\(miseDataDir)/shims")
+
+        let nvmDir = environment["NVM_DIR"] ?? "\(home)/.nvm"
         let versionsDir = "\(nvmDir)/versions/node"
         if let entries = try? FileManager.default.contentsOfDirectory(atPath: versionsDir) {
             for entry in entries.sorted().reversed() {
@@ -32,7 +44,7 @@ enum CodeburnCLI {
             }
         }
         return paths
-    }()
+    }
     private static let persistedPathFilename = "codeburn-cli-path.v1"
 
     /// Returns the argv that launches the CLI. Dev override via `CODEBURN_BIN` is honoured only
@@ -58,7 +70,12 @@ enum CodeburnCLI {
         if let persisted = persistedCLIPath(), isSafe(persisted), FileManager.default.isExecutableFile(atPath: persisted) {
             return [persisted]
         }
-        for candidate in (additionalPathEntries + userNodePaths).map({ "\($0)/codeburn" }) {
+        let environment = ProcessInfo.processInfo.environment
+        let userPaths = userNodePaths(
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path,
+            environment: environment
+        )
+        for candidate in (additionalPathEntries + userPaths).map({ "\($0)/codeburn" }) {
             if isSafe(candidate), FileManager.default.isExecutableFile(atPath: candidate) {
                 return [candidate]
             }
@@ -80,8 +97,8 @@ enum CodeburnCLI {
     }
 
     /// Builds a `Process` that runs the CLI with the given subcommand args. Uses `/usr/bin/env`
-    /// so PATH lookup happens without involving a shell, and augments PATH with Homebrew
-    /// defaults. Caller sets stdout/stderr pipes and calls `run()`.
+    /// so PATH lookup happens without involving a shell, and augments PATH with common package
+    /// manager locations. Caller sets stdout/stderr pipes and calls `run()`.
     static func makeProcess(
         subcommand: [String],
         qualityOfService: QualityOfService = .userInitiated
@@ -89,7 +106,11 @@ enum CodeburnCLI {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         var environment = ProcessInfo.processInfo.environment
-        environment["PATH"] = augmentedPath(environment["PATH"] ?? "")
+        environment["PATH"] = augmentedPath(
+            environment["PATH"] ?? "",
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path,
+            environment: environment
+        )
         process.environment = environment
         // `env --` treats everything following as argv, not VAR=val pairs -- guards against an
         // argument accidentally resembling an env assignment.
@@ -107,9 +128,14 @@ enum CodeburnCLI {
         return safeArgPattern.firstMatch(in: s, range: range) != nil
     }
 
-    private static func augmentedPath(_ existing: String) -> String {
+    static func augmentedPath(
+        _ existing: String,
+        homeDirectory: String,
+        environment: [String: String]
+    ) -> String {
         var parts = existing.split(separator: ":", omittingEmptySubsequences: true).map(String.init)
-        for extra in additionalPathEntries + userNodePaths where !parts.contains(extra) {
+        let userPaths = userNodePaths(homeDirectory: homeDirectory, environment: environment)
+        for extra in additionalPathEntries + userPaths where !parts.contains(extra) {
             parts.append(extra)
         }
         return parts.joined(separator: ":")

--- a/mac/Tests/CodeBurnMenubarTests/CodeburnCLIPathTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CodeburnCLIPathTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import CodeBurnMenubar
+
+@Suite("CodeburnCLI PATH")
+struct CodeburnCLIPathTests {
+    @Test("Spotlight-minimal PATH can launch a mise npm-backend CLI")
+    func spotlightCanLaunchMiseCLI() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodeburnCLIPathTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        let wrapper = home
+            .appendingPathComponent(".local/share/mise/installs/npm-codeburn/latest/node_modules/.bin/codeburn")
+        let nodeShim = home.appendingPathComponent(".local/share/mise/shims/node")
+        try FileManager.default.createDirectory(
+            at: wrapper.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: nodeShim.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "#!/bin/sh\nexec node \"$@\"\n".write(to: wrapper, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\nprintf 'mise-node-ok\\n'\n".write(to: nodeShim, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: wrapper.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: nodeShim.path)
+
+        let augmentedPath = CodeburnCLI.augmentedPath(
+            "/usr/bin:/bin",
+            homeDirectory: home.path,
+            environment: [:]
+        )
+        // Keep the behavior fixture independent of tools installed on the CI host.
+        // Every retained entry came from the production augmentation above.
+        let isolatedPath = augmentedPath
+            .split(separator: ":")
+            .map(String.init)
+            .filter { $0 == "/usr/bin" || $0 == "/bin" || $0.hasPrefix(home.path + "/") }
+            .joined(separator: ":")
+        #expect(isolatedPath.split(separator: ":").contains(Substring(nodeShim.deletingLastPathComponent().path)))
+
+        let process = Process()
+        let stdout = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["--", wrapper.path, "--version"]
+        process.environment = [
+            "HOME": home.path,
+            "PATH": isolatedPath,
+        ]
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+
+        try process.run()
+        process.waitUntilExit()
+        let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+
+        #expect(process.terminationStatus == 0)
+        #expect(output == "mise-node-ok\n")
+    }
+
+    @Test("custom mise data directory is added once")
+    func customMiseDataDirectoryIsDeduplicated() {
+        let customShims = "/Volumes/Tools/mise/shims"
+        let path = CodeburnCLI.augmentedPath(
+            "/usr/bin:\(customShims)",
+            homeDirectory: "/Users/test",
+            environment: ["MISE_DATA_DIR": "/Volumes/Tools/mise"]
+        )
+
+        #expect(path.split(separator: ":").filter { $0 == Substring(customShims) }.count == 1)
+    }
+}


### PR DESCRIPTION
## Summary

- add mise's stable shim directory to the PATH inherited by menubar child processes
- respect `MISE_DATA_DIR` when LaunchServices provides it, with mise's default data directory as the fallback
- add a behavior-level Swift regression fixture for an npm-backend launcher that must resolve `node` from the mise shim
- document the GUI PATH behavior and release note

## Reproduction

The persisted CLI path can point at mise's npm-backend launcher while Spotlight supplies only the system PATH. Before this change, the equivalent fixture fails exactly like the report:

```text
$ env -i HOME=<fixture-home> PATH=/usr/bin:/bin env -- \
    <fixture-home>/.local/share/mise/installs/npm-codeburn/latest/node_modules/.bin/codeburn --version
.../codeburn: line 2: exec: node: not found
exit=127
```

The production PATH augmentation now adds `<fixture-home>/.local/share/mise/shims`; the same launcher resolves the fake `node` shim and exits 0 with `mise-node-ok`.

## Why this is safe

The process remains argv-based through `/usr/bin/env --`; no shell or string interpolation was added. This only extends the existing GUI PATH handling for Volta, npm-global, asdf, and nvm with [mise's documented stable shim location](https://mise.jdx.dev/dev-tools/shims.html).

## Validation

- production `CodeburnCLI.augmentedPath` behavior harness: pass
- new Swift test file type-checks with the local Testing macro plugin
- `swift build -c release`: pass
- `npx tsc --noEmit`: pass
- `npm run build:cli`: pass
- root Vitest suite: 3,305 passed; two unrelated concurrency/timeout cases failed in the full parallel run, then both files passed immediately in isolation (17/17)
- `git diff --check`: pass

Fixes #1124
