### PR TITLE
feat(sessions): deterministic work-unit resolver and --by-work-unit view (CB-2 slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- **`codeburn sessions --by-work-unit` groups the sessions report into provider-recorded work units.** The new deterministic resolver (`src/work-units.ts`) folds each session carrying the #1140 `lineage` field under the orchestration root it names, giving one row per unit with the root's title and project, cost/calls summed over root plus children, and a child count, with the children listed indented beneath and standalone sessions rendered exactly as before. A work unit's id is `deriveTraceId(rootSessionId)`, the exact trace-id derivation sync already uses, so a unit's identity matches the root's existing trace identity. Evidence stays strictly provider-recorded: a session without lineage is its own standalone unit with role `unknown`, a child that names an in-range parent folds even when the parent recorded nothing (one-sided evidence), and anything ambiguous fails closed per the boundary spec's MAIN-02 - a parent id outside the parsed window leaves the child ungrouped, cycles and self-references are broken and marked `unknown`, and duplicate or cross-provider id collisions never fold. `--format json` with the flag emits an add-only `{ sessions, workUnits }` envelope: `sessions` is today's row array unchanged, `workUnits` is the resolver's full partition (standalone sessions included, so counts and totals reconcile). Default output without the flag is byte-identical, no wire/sync or daily-cache behavior changes, and a pinning test asserts the grouped footer total equals the ungrouped total. Implements slice CB-2 of the CodeBurn main/Teams boundary spec (CODEBURN-MAIN-TEAMS-BOUNDARY-v0.1). (#1140)
+
 ## 0.9.22 - 2026-08-25
 
 ### Added

--- a/src/main.ts
+++ b/src/main.ts
@@ -2375,12 +2375,13 @@ program
   .option('--provider <provider>', 'Filter by provider (e.g. claude, codex, cursor)', 'all')
   .option('--format <format>', 'Output format: table, json', 'table')
   .option('--by-pr', 'Group spend by the pull requests each session referenced')
+  .option('--by-work-unit', 'Group sessions into provider-recorded work units: one row per orchestration root with its delegated children folded beneath')
   .option('--no-pager', 'Print the complete table directly instead of opening the interactive browser')
   .action(async (opts) => {
     assertProvider(opts.provider, 'sessions')
     assertFormat(opts.format, ['table', 'json'], 'sessions')
-    const { aggregateSessions, buildPrAttribution, renderJson, renderTable } = await import('./sessions-report.js')
-    const wantsInteractive = opts.format === 'table' && !opts.byPr && opts.pager !== false && process.stdin.isTTY === true && process.stdout.isTTY === true
+    const { aggregateSessions, buildPrAttribution, renderJson, renderTable, renderWorkUnitJson, renderWorkUnitTable } = await import('./sessions-report.js')
+    const wantsInteractive = opts.format === 'table' && !opts.byPr && !opts.byWorkUnit && opts.pager !== false && process.stdin.isTTY === true && process.stdout.isTTY === true
     if (wantsInteractive) setInteractiveScanUI()
     await loadPricing()
 
@@ -2446,6 +2447,21 @@ program
       return
     }
     const rows = aggregateSessions(projects)
+    if (opts.byWorkUnit) {
+      const { resolveWorkUnits } = await import('./work-units.js')
+      const { inferSessionProvider } = await import('./session-output.js')
+      const resolution = resolveWorkUnits(projects.flatMap(project => project.sessions.map(session => ({
+        sessionId: session.sessionId,
+        provider: inferSessionProvider(session),
+        lineage: session.lineage,
+      }))))
+      if (opts.format === 'json') {
+        process.stdout.write(renderWorkUnitJson(rows, resolution) + '\n')
+        return
+      }
+      process.stdout.write(renderWorkUnitTable(rows, resolution) + '\n')
+      return
+    }
     if (opts.format === 'json') {
       process.stdout.write(renderJson(rows) + '\n')
       return

--- a/src/sessions-report.ts
+++ b/src/sessions-report.ts
@@ -3,6 +3,8 @@ import { getShortModelName } from './models.js'
 import { inferSessionProvider, sessionBillableOutputTokens } from './session-output.js'
 import { CATEGORY_LABELS } from './types.js'
 import type { ProjectSummary, SessionSummary, TaskCategory } from './types.js'
+import { workUnitSessionKey } from './work-units.js'
+import type { WorkUnitResolution } from './work-units.js'
 
 export type SessionRow = {
   sessionId: string
@@ -54,7 +56,7 @@ export function renderJson(rows: SessionRow[]): string {
   return JSON.stringify(rows, null, 2)
 }
 
-type SessionColumnKey = 'started' | 'session' | 'project' | 'provider' | 'models' | 'cost' | 'saved' | 'calls' | 'turns'
+type SessionColumnKey = 'started' | 'session' | 'children' | 'project' | 'provider' | 'models' | 'cost' | 'saved' | 'calls' | 'turns'
 type SessionColumn = {
   key: SessionColumnKey
   header: string
@@ -82,11 +84,11 @@ function frameWidth(columns: SessionColumn[]): number {
   return 2 + columns.reduce((sum, col) => sum + col.width + 2, 0) + Math.max(0, columns.length - 1)
 }
 
-function fitColumns(columns: SessionColumn[], available: number): SessionColumn[] {
+function fitColumns(columns: SessionColumn[], available: number, dropOrder?: SessionColumnKey[]): SessionColumn[] {
   const fitted = columns.map(col => ({ ...col }))
 
   // Remove low-value columns before squeezing names into unreadable slivers.
-  for (const key of ['turns', 'saved', 'provider', 'calls'] as SessionColumnKey[]) {
+  for (const key of dropOrder ?? ['turns', 'saved', 'provider', 'calls'] as SessionColumnKey[]) {
     if (frameWidth(fitted) <= available) break
     const index = fitted.findIndex(col => col.key === key && col.optional)
     if (index >= 0) fitted.splice(index, 1)
@@ -167,6 +169,9 @@ function cellValue(row: SessionRow, key: SessionColumnKey): string {
   switch (key) {
     case 'started': return row.startedAt ? row.startedAt.replace('T', ' ').slice(0, 16) : '-'
     case 'session': return sessionDisplayName(row)
+    // Only the work-unit view carries a Children column, and it renders
+    // through workUnitCell; a bare SessionRow has no child count.
+    case 'children': return ''
     case 'project': return cleanSessionProjectLabel(row.project)
     case 'provider': return row.provider
     case 'models': return sessionModelLabel(row.models)
@@ -177,12 +182,44 @@ function cellValue(row: SessionRow, key: SessionColumnKey): string {
   }
 }
 
-export function renderTable(rows: SessionRow[], opts: SessionTableOptions = {}): string {
-  const sorted = [...rows].sort((a, b) => b.startedAt.localeCompare(a.startedAt))
-  const hasSavings = sorted.some(row => row.savingsUSD > 0)
-  const allColumns: SessionColumn[] = [
+/// Shared bordered-grid renderer. `cell` produces the raw string for one item
+/// and column; fitting, width expansion, and borders are identical for every
+/// table this module emits, so the default sessions table stays byte-identical.
+function renderSessionGrid<T>(columns: SessionColumn[], items: T[], cell: (item: T, key: SessionColumnKey) => string, footer: string, available: number, dropOrder?: SessionColumnKey[]): string {
+  const fitted = fitColumns(columns, available, dropOrder)
+  const values = items.map(item => fitted.map(col => cell(item, col.key)))
+  // Content can use spare room, but never grow beyond the terminal frame.
+  for (let i = 0; i < fitted.length; i++) {
+    const col = fitted[i]!
+    const longest = Math.max(col.header.length, ...values.map(row => row[i]?.length ?? 0))
+    const spare = available - frameWidth(fitted)
+    const wanted = Math.max(0, Math.min(longest - col.width, spare))
+    col.width += wanted
+  }
+
+  const border = (left: string, middle: string, right: string): string =>
+    left + fitted.map(col => '\u2500'.repeat(col.width + 2)).join(middle) + right
+  const line = (cells: string[]): string => '\u2502' + fitted.map((col, i) => {
+    const value = truncate(cells[i] ?? '', col.width)
+    const padding = ' '.repeat(Math.max(0, col.width - value.length))
+    return ` ${col.right ? padding + value : value + padding} `
+  }).join('\u2502') + '\u2502'
+
+  return [
+    border('\u250c', '\u252c', '\u2510'),
+    line(fitted.map(col => col.header)),
+    border('\u251c', '\u253c', '\u2524'),
+    ...values.map(line),
+    border('\u2514', '\u2534', '\u2518'),
+    footer,
+  ].join('\n')
+}
+
+function sessionColumns(hasSavings: boolean, childrenColumn: boolean): SessionColumn[] {
+  return [
     { key: 'started', header: 'Started', width: 16, minWidth: 10 },
     { key: 'session', header: 'Session', width: 30, minWidth: 12, flex: 3 },
+    ...(childrenColumn ? [{ key: 'children' as const, header: 'Children', width: 8, minWidth: 5, right: true, optional: true }] : []),
     { key: 'project', header: 'Project', width: 24, minWidth: 10, flex: 2 },
     { key: 'provider', header: 'Provider', width: 9, minWidth: 8, optional: true },
     { key: 'models', header: 'Models', width: 22, minWidth: 10, flex: 2 },
@@ -191,36 +228,114 @@ export function renderTable(rows: SessionRow[], opts: SessionTableOptions = {}):
     { key: 'calls', header: 'Calls', width: 7, minWidth: 5, right: true, optional: true },
     { key: 'turns', header: 'Turns', width: 7, minWidth: 5, right: true, optional: true },
   ]
+}
+
+export function renderTable(rows: SessionRow[], opts: SessionTableOptions = {}): string {
+  const sorted = [...rows].sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+  const hasSavings = sorted.some(row => row.savingsUSD > 0)
   const available = Math.max(60, opts.terminalWidth ?? defaultTerminalWidth())
-  const columns = fitColumns(allColumns, available)
-  const values = sorted.map(row => columns.map(col => cellValue(row, col.key)))
-  // Content can use spare room, but never grow beyond the terminal frame.
-  for (let i = 0; i < columns.length; i++) {
-    const col = columns[i]!
-    const longest = Math.max(col.header.length, ...values.map(row => row[i]?.length ?? 0))
-    let spare = available - frameWidth(columns)
-    const wanted = Math.max(0, Math.min(longest - col.width, spare))
-    col.width += wanted
-  }
-
-  const border = (left: string, middle: string, right: string): string =>
-    left + columns.map(col => '\u2500'.repeat(col.width + 2)).join(middle) + right
-  const line = (cells: string[]): string => '\u2502' + columns.map((col, i) => {
-    const value = truncate(cells[i] ?? '', col.width)
-    const padding = ' '.repeat(Math.max(0, col.width - value.length))
-    return ` ${col.right ? padding + value : value + padding} `
-  }).join('\u2502') + '\u2502'
-
   const totalCost = sorted.reduce((sum, row) => sum + row.cost, 0)
   const footer = `${sorted.length.toLocaleString('en-US')} sessions  \u2022  $${totalCost.toFixed(2)} total  \u2022  newest first`
-  return [
-    border('\u250c', '\u252c', '\u2510'),
-    line(columns.map(col => col.header)),
-    border('\u251c', '\u253c', '\u2524'),
-    ...values.map(line),
-    border('\u2514', '\u2534', '\u2518'),
-    footer,
-  ].join('\n')
+  return renderSessionGrid(sessionColumns(hasSavings, false), sorted, cellValue, footer, available)
+}
+
+/// One printed line in the work-unit view: a unit row (aggregate of root plus
+/// children, `childCount > 0`), a standalone row, or an indented child detail
+/// row (`depth === 1`).
+export type WorkUnitDisplay = { row: SessionRow; depth: 0 | 1; childCount: number }
+
+function workUnitCell(display: WorkUnitDisplay, key: SessionColumnKey): string {
+  if (key === 'children') return display.childCount > 0 ? String(display.childCount) : ''
+  if (key === 'session') {
+    const name = sessionDisplayName(display.row)
+    return display.depth === 1 ? `  \u21b3 ${name}` : name
+  }
+  return cellValue(display.row, key)
+}
+
+/// The `sessions --by-work-unit` table: one row per multi-session work unit
+/// (root's title/project, cost/calls/savings/turns summed over root+children,
+/// child count in the Children column), its children indented beneath, and
+/// every standalone session exactly as in the default table. Entries sort
+/// newest-first by each unit's latest member activity. The footer total sums
+/// top-level entries only, so the grouped view reconciles exactly with the
+/// ungrouped table (no double count, no dropped spend).
+export function renderWorkUnitTable(rows: SessionRow[], resolution: WorkUnitResolution, opts: SessionTableOptions = {}): string {
+  const unitById = new Map(resolution.units.map(unit => [unit.workUnitId, unit]))
+  const membersByUnit = new Map<string, SessionRow[]>()
+  const singles: SessionRow[] = []
+  for (const row of rows) {
+    const unitId = resolution.bySession.get(workUnitSessionKey(row.provider, row.sessionId))
+    const unit = unitId !== undefined ? unitById.get(unitId) : undefined
+    // Group only units that actually have a root and at least one child in
+    // this view; everything else renders exactly as in the default table.
+    if (unitId === undefined || !unit || unit.childSessionIds.length === 0) { singles.push(row); continue }
+    const list = membersByUnit.get(unitId)
+    if (list) list.push(row)
+    else membersByUnit.set(unitId, [row])
+  }
+
+  type Entry = { display: WorkUnitDisplay; children: WorkUnitDisplay[]; sortKey: string }
+  const entries: Entry[] = singles.map(row => ({ display: { row, depth: 0 as const, childCount: 0 }, children: [], sortKey: row.startedAt }))
+  for (const [unitId, members] of membersByUnit) {
+    const unit = unitById.get(unitId)!
+    const rootRow = members.find(row => row.sessionId === unit.rootSessionId)
+    if (!rootRow || members.length < 2) {
+      for (const row of members) entries.push({ display: { row, depth: 0, childCount: 0 }, children: [], sortKey: row.startedAt })
+      continue
+    }
+    const childRows = members
+      .filter(row => row !== rootRow)
+      .sort((a, b) => b.startedAt.localeCompare(a.startedAt) || a.sessionId.localeCompare(b.sessionId))
+    const sum = (pick: (row: SessionRow) => number): number => members.reduce((total, row) => total + pick(row), 0)
+    const startedAt = members.reduce((min, row) => (row.startedAt < min ? row.startedAt : min), rootRow.startedAt)
+    const endedAt = members.reduce((max, row) => (row.endedAt > max ? row.endedAt : max), rootRow.endedAt)
+    const models: string[] = []
+    for (const member of [rootRow, ...childRows]) {
+      for (const model of member.models) if (!models.includes(model)) models.push(model)
+    }
+    const aggregate: SessionRow = {
+      ...rootRow,
+      models,
+      cost: sum(row => row.cost),
+      savingsUSD: sum(row => row.savingsUSD),
+      calls: sum(row => row.calls),
+      turns: sum(row => row.turns),
+      inputTokens: sum(row => row.inputTokens),
+      outputTokens: sum(row => row.outputTokens),
+      cacheReadTokens: sum(row => row.cacheReadTokens),
+      cacheWriteTokens: sum(row => row.cacheWriteTokens),
+      startedAt,
+      endedAt,
+      durationMs: durationMs(startedAt, endedAt),
+    }
+    const sortKey = members.reduce((max, row) => (row.startedAt > max ? row.startedAt : max), '')
+    entries.push({
+      display: { row: aggregate, depth: 0, childCount: childRows.length },
+      children: childRows.map(row => ({ row, depth: 1 as const, childCount: 0 })),
+      sortKey,
+    })
+  }
+  entries.sort((a, b) => b.sortKey.localeCompare(a.sortKey))
+
+  const displays = entries.flatMap(entry => [entry.display, ...entry.children])
+  const hasSavings = rows.some(row => row.savingsUSD > 0)
+  const available = Math.max(60, opts.terminalWidth ?? defaultTerminalWidth())
+  // Money invariant: the footer sums TOP-LEVEL entries (unit aggregates plus
+  // standalone rows), never the indented child detail, so grouped and
+  // ungrouped views total the same spend.
+  const totalCost = entries.reduce((total, entry) => total + entry.display.row.cost, 0)
+  const unitCount = entries.filter(entry => entry.display.childCount > 0).length
+  const footer = `${rows.length.toLocaleString('en-US')} sessions  \u2022  ${unitCount.toLocaleString('en-US')} work unit${unitCount === 1 ? '' : 's'}  \u2022  $${totalCost.toFixed(2)} total  \u2022  newest first`
+  return renderSessionGrid(sessionColumns(hasSavings, true), displays, workUnitCell, footer, available, ['children', 'turns', 'saved', 'provider', 'calls'])
+}
+
+/// `sessions --by-work-unit --format json`: an add-only envelope. `sessions`
+/// is the exact row array the default json output emits today; `workUnits` is
+/// the resolver's full partition (standalone sessions included, so consumers
+/// can reconcile counts and totals).
+export function renderWorkUnitJson(rows: SessionRow[], resolution: WorkUnitResolution): string {
+  return JSON.stringify({ sessions: rows, workUnits: resolution.units }, null, 2)
 }
 
 export type PrRow = {

--- a/src/work-units.ts
+++ b/src/work-units.ts
@@ -1,0 +1,157 @@
+/**
+ * Deterministic local work-unit resolver (CB-2, slice 1 of the CodeBurn
+ * main/Teams boundary spec). Groups parsed sessions carrying the #1140
+ * provider-recorded `lineage` field into work units: one observed root session
+ * plus its directly evidenced delegated children.
+ *
+ * Rules (spec sections 1 and 3, MAIN-01/MAIN-02):
+ * - Only provider-recorded lineage is honored. A session without lineage is its
+ *   own standalone unit (role `unknown`, never guessed).
+ * - One-sided evidence folds: a child that names an in-range parent folds under
+ *   it even when the parent recorded nothing itself.
+ * - Fail closed: a parent id that matches no session in range leaves the child
+ *   ungrouped for that view; a cycle or self-reference is broken and every
+ *   participant is marked `unknown`; a duplicate (provider, id) pair is
+ *   ambiguous and never folds either way.
+ * - No inference from time adjacency, shared projects, or directory layout.
+ * - Deterministic: the same input set yields byte-identical output regardless
+ *   of input order.
+ *
+ * No wire/sync changes and no daily-cache changes live here.
+ */
+
+import { deriveTraceId } from './sync/otlp.js'
+import type { SessionLineage } from './types.js'
+
+export type WorkUnitRole = 'root' | 'child' | 'unknown'
+
+/// Minimal session shape the resolver needs. `provider` scopes the lineage
+/// linkage so a cross-provider session-id collision can never fold (MAIN-02).
+export type WorkUnitSession = {
+  sessionId: string
+  provider: string
+  lineage?: SessionLineage
+}
+
+export type WorkUnit = {
+  /// deriveTraceId(rootSessionId): the exact trace-id derivation sync uses, so
+  /// a work unit's identity matches the root trace identity already on the wire.
+  workUnitId: string
+  rootSessionId: string
+  /// Sorted member children (transitive descendants fold under the top root).
+  childSessionIds: string[]
+  /// Role per member session id, root included. Standalone units carry their
+  /// single member as `unknown` unless the provider recorded it as a root.
+  roles: Record<string, WorkUnitRole>
+}
+
+export type WorkUnitResolution = {
+  /// Every input session belongs to exactly one unit. Sorted by workUnitId.
+  units: WorkUnit[]
+  /// workUnitSessionKey(provider, sessionId) -> workUnitId, for presentation.
+  /// Ambiguous duplicate (provider, id) records are deliberately absent.
+  bySession: Map<string, string>
+}
+
+// NUL delimiter: it cannot appear in a provider name or session id, so keys
+// never collide (mirrors the by-PR linkage keying in sessions-report.ts).
+const KEY_SEP = String.fromCharCode(0)
+
+export function workUnitSessionKey(provider: string, sessionId: string): string {
+  return `${provider}${KEY_SEP}${sessionId}`
+}
+
+/// A session is a child edge only when the provider durably recorded both the
+/// child role and the parent id. Any other shape (root, missing parent id, a
+/// future non-`provider-recorded` evidence class) contributes no edge.
+function isRecordedChild(session: WorkUnitSession): boolean {
+  return session.lineage?.evidence === 'provider-recorded'
+    && session.lineage.role === 'child'
+    && typeof session.lineage.parentSessionId === 'string'
+    && session.lineage.parentSessionId.length > 0
+}
+
+export function resolveWorkUnits(sessions: WorkUnitSession[]): WorkUnitResolution {
+  // Canonical processing order: provider+id, then lineage content as a
+  // tie-break so duplicate-id records order identically under any input order.
+  const sorted = [...sessions].sort((a, b) =>
+    workUnitSessionKey(a.provider, a.sessionId).localeCompare(workUnitSessionKey(b.provider, b.sessionId))
+    || JSON.stringify(a.lineage ?? null).localeCompare(JSON.stringify(b.lineage ?? null)))
+
+  const byKey = new Map<string, WorkUnitSession>()
+  const ambiguous = new Set<string>()
+  for (const session of sorted) {
+    const key = workUnitSessionKey(session.provider, session.sessionId)
+    if (byKey.has(key)) ambiguous.add(key)
+    else byKey.set(key, session)
+  }
+
+  // Walk a child's parent chain to the topmost in-range ancestor. Returns null
+  // (fail closed) on a missing or ambiguous parent link, a cycle, or a
+  // self-reference; the child then stays ungrouped for this view.
+  const resolveRoot = (start: WorkUnitSession): string | null => {
+    const visited = new Set<string>()
+    let current = start
+    while (isRecordedChild(current)) {
+      const currentKey = workUnitSessionKey(current.provider, current.sessionId)
+      if (visited.has(currentKey)) return null
+      visited.add(currentKey)
+      const parentKey = workUnitSessionKey(current.provider, current.lineage!.parentSessionId!)
+      if (ambiguous.has(parentKey)) return null
+      const parent = byKey.get(parentKey)
+      if (!parent) return null
+      current = parent
+    }
+    return workUnitSessionKey(current.provider, current.sessionId)
+  }
+
+  // Children fold under their resolved root, keyed by the root's session key.
+  // A record with an ambiguous (provider, id) key never folds and never roots
+  // a fold: two conflicting records share the id, so neither can be trusted.
+  const childrenByRootKey = new Map<string, WorkUnitSession[]>()
+  const foldedRecords = new Set<WorkUnitSession>()
+  for (const session of sorted) {
+    const key = workUnitSessionKey(session.provider, session.sessionId)
+    if (ambiguous.has(key) || !isRecordedChild(session)) continue
+    const rootKey = resolveRoot(session)
+    if (!rootKey || rootKey === key) continue
+    const list = childrenByRootKey.get(rootKey)
+    if (list) list.push(session)
+    else childrenByRootKey.set(rootKey, [session])
+    foldedRecords.add(session)
+  }
+
+  const units: WorkUnit[] = []
+  const bySession = new Map<string, string>()
+  for (const session of sorted) {
+    if (foldedRecords.has(session)) continue // emitted with its root's unit
+    const key = workUnitSessionKey(session.provider, session.sessionId)
+    const children = (childrenByRootKey.get(key) ?? [])
+      .map(child => child.sessionId)
+      .sort()
+    const role: WorkUnitRole =
+      children.length > 0 ? 'root'
+      : session.lineage?.evidence === 'provider-recorded' && session.lineage.role === 'root' ? 'root'
+      : 'unknown'
+    const roles: Record<string, WorkUnitRole> = { [session.sessionId]: role }
+    for (const childId of children) roles[childId] = 'child'
+    const unit: WorkUnit = {
+      workUnitId: deriveTraceId(session.sessionId),
+      rootSessionId: session.sessionId,
+      childSessionIds: children,
+      roles,
+    }
+    units.push(unit)
+    // Ambiguous duplicate records share one key; registering it would point
+    // both records at one arbitrary unit, so presentation leaves them alone.
+    if (!ambiguous.has(key)) {
+      bySession.set(key, unit.workUnitId)
+      for (const child of childrenByRootKey.get(key) ?? []) {
+        bySession.set(workUnitSessionKey(child.provider, child.sessionId), unit.workUnitId)
+      }
+    }
+  }
+
+  units.sort((a, b) => a.workUnitId.localeCompare(b.workUnitId))
+  return { units, bySession }
+}

--- a/tests/work-units.test.ts
+++ b/tests/work-units.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'vitest'
+
+import { aggregateSessions, renderJson, renderTable, renderWorkUnitJson, renderWorkUnitTable } from '../src/sessions-report.js'
+import { inferSessionProvider } from '../src/session-output.js'
+import { deriveTraceId } from '../src/sync/otlp.js'
+import { resolveWorkUnits, workUnitSessionKey } from '../src/work-units.js'
+import type { WorkUnitResolution, WorkUnitSession } from '../src/work-units.js'
+import type { ClassifiedTurn, ProjectSummary, SessionLineage, SessionSummary } from '../src/types.js'
+
+const recorded = (role: 'root' | 'child', parentSessionId?: string): SessionLineage => ({
+  ...(parentSessionId !== undefined ? { parentSessionId } : {}),
+  role,
+  evidence: 'provider-recorded',
+})
+
+const s = (sessionId: string, lineage?: SessionLineage, provider = 'claude'): WorkUnitSession => ({
+  sessionId, provider, ...(lineage ? { lineage } : {}),
+})
+
+/// Canonical serialization of a resolution (Maps do not JSON-serialize), used
+/// to pin determinism under shuffled input.
+function canonical(resolution: WorkUnitResolution): string {
+  return JSON.stringify({
+    units: resolution.units,
+    bySession: [...resolution.bySession.entries()].sort(),
+  })
+}
+
+describe('resolveWorkUnits', () => {
+  it('groups a two-sided family under the root, standalone sessions stay alone', () => {
+    const { units, bySession } = resolveWorkUnits([
+      s('root', recorded('root')),
+      s('child-2', recorded('child', 'root')),
+      s('solo'),
+      s('child-1', recorded('child', 'root')),
+    ])
+
+    expect(units).toHaveLength(2)
+    const family = units.find(unit => unit.rootSessionId === 'root')!
+    expect(family.workUnitId).toBe(deriveTraceId('root'))
+    expect(family.childSessionIds).toEqual(['child-1', 'child-2'])
+    expect(family.roles).toEqual({ root: 'root', 'child-1': 'child', 'child-2': 'child' })
+    const solo = units.find(unit => unit.rootSessionId === 'solo')!
+    expect(solo.childSessionIds).toEqual([])
+    expect(solo.roles).toEqual({ solo: 'unknown' })
+    expect(bySession.get(workUnitSessionKey('claude', 'child-1'))).toBe(family.workUnitId)
+    expect(bySession.get(workUnitSessionKey('claude', 'solo'))).toBe(solo.workUnitId)
+  })
+
+  it('folds a one-sided child under a parent that recorded nothing itself', () => {
+    const { units } = resolveWorkUnits([s('parent'), s('child', recorded('child', 'parent'))])
+    expect(units).toHaveLength(1)
+    expect(units[0]!.rootSessionId).toBe('parent')
+    expect(units[0]!.childSessionIds).toEqual(['child'])
+    expect(units[0]!.roles).toEqual({ parent: 'root', child: 'child' })
+  })
+
+  it('leaves a child ungrouped when its parent is out of window (fail closed)', () => {
+    const { units } = resolveWorkUnits([s('child', recorded('child', 'missing'))])
+    expect(units).toEqual([{
+      workUnitId: deriveTraceId('child'),
+      rootSessionId: 'child',
+      childSessionIds: [],
+      roles: { child: 'unknown' },
+    }])
+  })
+
+  it('breaks a parent cycle and marks both participants unknown', () => {
+    const { units } = resolveWorkUnits([
+      s('a', recorded('child', 'b')),
+      s('b', recorded('child', 'a')),
+    ])
+    expect(units).toHaveLength(2)
+    for (const unit of units) {
+      expect(unit.childSessionIds).toEqual([])
+      expect(Object.values(unit.roles)).toEqual(['unknown'])
+    }
+  })
+
+  it('breaks a self-reference without hanging and marks it unknown', () => {
+    const { units } = resolveWorkUnits([s('self', recorded('child', 'self'))])
+    expect(units).toHaveLength(1)
+    expect(units[0]!.rootSessionId).toBe('self')
+    expect(units[0]!.childSessionIds).toEqual([])
+    expect(units[0]!.roles).toEqual({ self: 'unknown' })
+  })
+
+  it('folds a nested chain under the topmost in-range root', () => {
+    const { units } = resolveWorkUnits([
+      s('grandchild', recorded('child', 'child')),
+      s('child', recorded('child', 'root')),
+      s('root', recorded('root')),
+    ])
+    expect(units).toHaveLength(1)
+    expect(units[0]!.rootSessionId).toBe('root')
+    expect(units[0]!.childSessionIds).toEqual(['child', 'grandchild'])
+    expect(units[0]!.roles).toEqual({ root: 'root', child: 'child', grandchild: 'child' })
+  })
+
+  it('never folds across providers on a session-id collision', () => {
+    const { units } = resolveWorkUnits([
+      s('kid', recorded('child', 'shared-id'), 'claude'),
+      s('shared-id', undefined, 'codex'),
+    ])
+    expect(units).toHaveLength(2)
+    const kid = units.find(unit => unit.rootSessionId === 'kid')!
+    expect(kid.childSessionIds).toEqual([])
+    expect(kid.roles).toEqual({ kid: 'unknown' })
+  })
+
+  it('fails closed on duplicate (provider, id) records', () => {
+    const { units, bySession } = resolveWorkUnits([
+      s('dup', recorded('root')),
+      s('dup'),
+      s('kid', recorded('child', 'dup')),
+    ])
+    expect(units).toHaveLength(3)
+    for (const unit of units) expect(unit.childSessionIds).toEqual([])
+    expect(units.find(unit => unit.rootSessionId === 'kid')!.roles).toEqual({ kid: 'unknown' })
+    // The ambiguous key is not registered for presentation grouping at all.
+    expect(bySession.has(workUnitSessionKey('claude', 'dup'))).toBe(false)
+  })
+
+  it('is deterministic: shuffled input yields identical output, every session in exactly one unit', () => {
+    const input = [
+      s('root', recorded('root')),
+      s('child-1', recorded('child', 'root')),
+      s('child-2', recorded('child', 'root')),
+      s('parent'),
+      s('kid', recorded('child', 'parent')),
+      s('orphan', recorded('child', 'missing')),
+      s('a', recorded('child', 'b')),
+      s('b', recorded('child', 'a')),
+      s('solo'),
+    ]
+    const base = canonical(resolveWorkUnits(input))
+    expect(canonical(resolveWorkUnits([...input].reverse()))).toBe(base)
+    expect(canonical(resolveWorkUnits([input[4]!, input[8]!, input[0]!, input[6]!, input[2]!, input[7]!, input[1]!, input[5]!, input[3]!]))).toBe(base)
+
+    const { units } = resolveWorkUnits(input)
+    const members = units.flatMap(unit => [unit.rootSessionId, ...unit.childSessionIds])
+    expect(members.sort()).toEqual(input.map(session => session.sessionId).sort())
+  })
+})
+
+function makeSession(opts: {
+  sessionId: string
+  title?: string
+  cost: number
+  calls: number
+  savings?: number
+  startedAt: string
+  endedAt: string
+  lineage?: SessionLineage
+}): SessionSummary {
+  const usage = {
+    inputTokens: 100,
+    outputTokens: 20,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    cachedInputTokens: 0,
+    reasoningTokens: 0,
+    webSearchRequests: 0,
+  }
+  const turn: ClassifiedTurn = {
+    userMessage: 'work',
+    timestamp: opts.startedAt,
+    sessionId: opts.sessionId,
+    category: 'feature',
+    retries: 0,
+    hasEdits: true,
+    assistantCalls: [{
+      provider: 'claude',
+      model: 'claude-sonnet-4-5',
+      usage,
+      costUSD: opts.cost,
+      tools: [],
+      mcpTools: [],
+      skills: [],
+      subagentTypes: [],
+      hasAgentSpawn: false,
+      hasPlanMode: false,
+      speed: 'standard',
+      timestamp: opts.startedAt,
+      bashCommands: [],
+      deduplicationKey: `call-${opts.sessionId}`,
+    }],
+  }
+  return {
+    sessionId: opts.sessionId,
+    project: 'codeburn',
+    ...(opts.title !== undefined ? { title: opts.title } : {}),
+    firstTimestamp: opts.startedAt,
+    lastTimestamp: opts.endedAt,
+    totalCostUSD: opts.cost,
+    totalSavingsUSD: opts.savings ?? 0,
+    totalInputTokens: 100,
+    totalOutputTokens: 20,
+    totalReasoningTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    apiCalls: opts.calls,
+    turns: [turn],
+    modelBreakdown: {
+      'claude-sonnet-4-5': { calls: opts.calls, costUSD: opts.cost, tokens: usage, savingsUSD: opts.savings ?? 0 },
+    },
+    toolBreakdown: {},
+    mcpBreakdown: {},
+    bashBreakdown: {},
+    categoryBreakdown: {} as SessionSummary['categoryBreakdown'],
+    skillBreakdown: {},
+    subagentBreakdown: {},
+    ...(opts.lineage ? { lineage: opts.lineage } : {}),
+  }
+}
+
+function makeProjects(sessions: SessionSummary[]): ProjectSummary[] {
+  return [{
+    project: 'codeburn',
+    projectPath: '/tmp/codeburn',
+    sessions,
+    totalCostUSD: sessions.reduce((sum, session) => sum + session.totalCostUSD, 0),
+    totalSavingsUSD: sessions.reduce((sum, session) => sum + session.totalSavingsUSD, 0),
+    totalApiCalls: sessions.reduce((sum, session) => sum + session.apiCalls, 0),
+    totalProxiedCostUSD: 0,
+  }]
+}
+
+function resolveProjects(projects: ProjectSummary[]): WorkUnitResolution {
+  return resolveWorkUnits(projects.flatMap(project => project.sessions.map(session => ({
+    sessionId: session.sessionId,
+    provider: inferSessionProvider(session),
+    ...(session.lineage ? { lineage: session.lineage } : {}),
+  }))))
+}
+
+function familyFixture(): ProjectSummary[] {
+  return makeProjects([
+    makeSession({
+      sessionId: 'root', title: 'Build the thing', cost: 1, calls: 4,
+      startedAt: '2026-08-20T10:00:00.000Z', endedAt: '2026-08-20T11:00:00.000Z',
+      lineage: recorded('root'),
+    }),
+    makeSession({
+      sessionId: 'child-1', cost: 0.25, calls: 1,
+      startedAt: '2026-08-20T10:05:00.000Z', endedAt: '2026-08-20T10:10:00.000Z',
+      lineage: recorded('child', 'root'),
+    }),
+    makeSession({
+      sessionId: 'child-2', cost: 0.5, calls: 2,
+      startedAt: '2026-08-20T10:20:00.000Z', endedAt: '2026-08-20T10:30:00.000Z',
+      lineage: recorded('child', 'root'),
+    }),
+    makeSession({
+      sessionId: 'solo', title: 'Unrelated session', cost: 2, calls: 3,
+      startedAt: '2026-08-21T09:00:00.000Z', endedAt: '2026-08-21T09:30:00.000Z',
+    }),
+  ])
+}
+
+const totalOf = (output: string): string | undefined => /\$([\d.]+) total/.exec(output)?.[1]
+
+describe('sessions --by-work-unit presentation', () => {
+  it('groups a family under one unit row with summed cost/calls and indented children', () => {
+    const rows = aggregateSessions(familyFixture())
+    const output = renderWorkUnitTable(rows, resolveProjects(familyFixture()), { terminalWidth: 200 })
+
+    const unitLine = output.split('\n').find(line => line.includes('Build the thing'))!
+    expect(unitLine).toContain('$1.75') // 1.00 + 0.25 + 0.50
+    expect(unitLine).toContain(' 7 ')   // 4 + 1 + 2 calls
+    expect(unitLine).toContain(' 2 ')   // child count
+    expect(output).toContain('↳ child-1')
+    expect(output).toContain('↳ child-2')
+    // The standalone session renders as a plain row, never indented.
+    const soloLine = output.split('\n').find(line => line.includes('Unrelated session'))!
+    expect(soloLine).not.toContain('↳')
+    expect(output).toContain('4 sessions')
+    expect(output).toContain('1 work unit')
+  })
+
+  it('keeps the money invariant: the grouped footer total equals the ungrouped total', () => {
+    const rows = aggregateSessions(familyFixture())
+    const grouped = renderWorkUnitTable(rows, resolveProjects(familyFixture()), { terminalWidth: 200 })
+    const ungrouped = renderTable(rows, { terminalWidth: 200 })
+    expect(totalOf(grouped)).toBe('3.75')
+    expect(totalOf(grouped)).toBe(totalOf(ungrouped))
+  })
+
+  it('extends json with an add-only workUnits array; the sessions rows are unchanged', () => {
+    const rows = aggregateSessions(familyFixture())
+    const resolution = resolveProjects(familyFixture())
+    const parsed = JSON.parse(renderWorkUnitJson(rows, resolution))
+
+    // Add-only: the envelope's sessions are exactly today's json rows.
+    expect(parsed.sessions).toEqual(JSON.parse(renderJson(rows)))
+    expect(Array.isArray(JSON.parse(renderJson(rows)))).toBe(true)
+
+    expect(parsed.workUnits).toHaveLength(2)
+    const family = parsed.workUnits.find((unit: { rootSessionId: string }) => unit.rootSessionId === 'root')
+    expect(family.workUnitId).toBe(deriveTraceId('root'))
+    expect(family.childSessionIds).toEqual(['child-1', 'child-2'])
+    expect(family.roles).toEqual({ root: 'root', 'child-1': 'child', 'child-2': 'child' })
+    const solo = parsed.workUnits.find((unit: { rootSessionId: string }) => unit.rootSessionId === 'solo')
+    expect(solo.roles).toEqual({ solo: 'unknown' })
+  })
+})


### PR DESCRIPTION
Second slice of the Teams boundary spec's CB track, building on #1140's provider-recorded lineage. A deterministic resolver groups each provider-recorded root with its provider-recorded children into a work unit (workUnitId = the exact trace-id derivation sync already uses; one-sided children fold under the parent they name; out-of-window parents leave children ungrouped per MAIN-02 fail-closed; cycles break to unknown, never hang). New `codeburn sessions --by-work-unit` renders one row per unit with children indented; `--format json` gains an add-only workUnits array under the flag. Default output byte-identical without the flag; grouped and ungrouped totals equal by pinned test.

Real-corpus acceptance (30 days): 16,640 units, 27 multi-session families folding 861 children - consistent with the recorded lineage baseline (29 roots / 881 children over 90 days). Suite green (one unrelated known-flaky Electron SIGTERM-timing test passed in isolation); tsc clean. Implemented by Kimi Code against the spec brief, independently validated.