### PR TITLE
fix(omp): correct OMP period scoping, cost attribution, and Grok 4.6 prompt tiers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ const { version } = require('../package.json')
 // Bump when the menubar payload's rendering semantics change without a package
 // release or daily-cache version change. The envelope version in session-cache
 // protects record shape; this protects the meaning of an otherwise valid one.
-const STATUS_SNAPSHOT_RENDER_VERSION = 1
+const STATUS_SNAPSHOT_RENDER_VERSION = 2
 const STATUS_SNAPSHOT_SEMANTIC_KEY = `${version}:render-${STATUS_SNAPSHOT_RENDER_VERSION}:daily-${DAILY_CACHE_VERSION}`
 import { loadCurrency, getCurrency, isValidCurrencyCode } from './currency.js'
 import { CodexThroughputReader, newestCodexSession, renderCodexThroughput } from './codex-throughput.js'

--- a/src/menubar-json.ts
+++ b/src/menubar-json.ts
@@ -327,7 +327,19 @@ export type MenubarPayload = {
     }
     tools: Array<{ name: string; calls: number }>
     skills: Array<{ name: string; turns: number; cost: number }>
-    subagents: Array<{ name: string; calls: number; cost: number }>
+    subagents: Array<{
+      name: string
+      calls: number
+      cost: number
+      agentName?: string
+      model?: string
+      startedAt?: string
+      inputTokens?: number
+      outputTokens?: number
+      cacheReadTokens?: number
+      cacheWriteTokens?: number
+      totalTokens?: number
+    }>
     mcpServers: Array<{ name: string; calls: number }>
     /// Every pull request with attributed spend, cost-descending, plus the
     /// multi-link-safe distinct total. Absent when no PR links were observed and

--- a/src/models.ts
+++ b/src/models.ts
@@ -71,7 +71,7 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 // Also folded into getPricingGenerationKey() below: a resident/snapshot-caching
 // consumer needs the same "pricing behavior changed" signal this already gives
 // the on-disk LiteLLM cache, not just the on-disk cache itself.
-export const CACHE_SCHEMA_VERSION = 2
+export const CACHE_SCHEMA_VERSION = 3
 const WEB_SEARCH_COST = 0.01
 const ONE_HOUR_CACHE_WRITE_MULTIPLIER_FROM_FIVE_MINUTE_RATE = 1.6
 
@@ -109,6 +109,13 @@ function buildCosts(
     cacheWriteCostIsExplicit: cacheWrite !== null && cacheWrite !== undefined,
   }
 }
+// For grok-4.6, prompt tokens mean input tokens plus cached input tokens for a
+// request. At 200k prompt tokens, xAI prices every priced bucket at this high
+// tier rather than applying a marginal rate. Cache creation stays unset because
+// xAI publishes no separate cache-write rate.
+const GROK_4_6_PROMPT_TOKEN_THRESHOLD = 200_000
+const GROK_4_6_HIGH_PROMPT_COSTS = buildCosts(4e-6, 12e-6, null, 1e-6, null)
+
 
 function tupleToCosts(raw: SnapshotEntry): ModelCosts {
   const [input, output, cacheWrite, cacheRead, fast] = raw
@@ -1188,24 +1195,29 @@ export function calculateCost(
     return 0
   }
 
-  const multiplier = speed === 'fast' ? costs.fastMultiplier : 1
+  const safe = (n: number) => (Number.isFinite(n) && n > 0 ? n : 0)
+  const safeOneHourCacheCreation = safe(oneHourCacheCreationTokens)
+  const safeCacheCreation = Math.max(safe(cacheCreationTokens), safeOneHourCacheCreation)
+  const safeFiveMinuteCacheCreation = Math.max(0, safeCacheCreation - safeOneHourCacheCreation)
+  const promptTokens = safe(inputTokens) + safe(cacheReadTokens)
+  const tieredCosts = (
+    !exactPriceOverrideFor(model)
+    && resolveCanonicalModelId(model) === 'grok-4.6'
+    && promptTokens >= GROK_4_6_PROMPT_TOKEN_THRESHOLD
+  ) ? GROK_4_6_HIGH_PROMPT_COSTS : costs
+  const multiplier = speed === 'fast' ? tieredCosts.fastMultiplier : 1
 
   // Clamp negative inputs to 0. A corrupt JSONL that emits a negative token
   // count would otherwise produce a negative cost that silently subtracts
   // from real spend in aggregate totals. NaN is also handled here; the
   // arithmetic below short-circuits to 0 when any operand is non-finite.
-  const safe = (n: number) => (Number.isFinite(n) && n > 0 ? n : 0)
-  const safeOneHourCacheCreation = safe(oneHourCacheCreationTokens)
-  const safeCacheCreation = Math.max(safe(cacheCreationTokens), safeOneHourCacheCreation)
-  const safeFiveMinuteCacheCreation = Math.max(0, safeCacheCreation - safeOneHourCacheCreation)
-
   return multiplier * (
-    safe(inputTokens) * costs.inputCostPerToken +
-    safe(outputTokens) * costs.outputCostPerToken +
-    safeFiveMinuteCacheCreation * costs.cacheWriteCostPerToken +
-    safeOneHourCacheCreation * costs.cacheWriteCostPerToken * ONE_HOUR_CACHE_WRITE_MULTIPLIER_FROM_FIVE_MINUTE_RATE +
-    safe(cacheReadTokens) * costs.cacheReadCostPerToken +
-    safe(webSearchRequests) * costs.webSearchCostPerRequest
+    safe(inputTokens) * tieredCosts.inputCostPerToken +
+    safe(outputTokens) * tieredCosts.outputCostPerToken +
+    safeFiveMinuteCacheCreation * tieredCosts.cacheWriteCostPerToken +
+    safeOneHourCacheCreation * tieredCosts.cacheWriteCostPerToken * ONE_HOUR_CACHE_WRITE_MULTIPLIER_FROM_FIVE_MINUTE_RATE +
+    safe(cacheReadTokens) * tieredCosts.cacheReadCostPerToken +
+    safe(webSearchRequests) * tieredCosts.webSearchCostPerRequest
   )
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -116,6 +116,18 @@ function buildCosts(
 const GROK_4_6_PROMPT_TOKEN_THRESHOLD = 200_000
 const GROK_4_6_HIGH_PROMPT_COSTS = buildCosts(4e-6, 12e-6, null, 1e-6, null)
 
+// Swap in the vendor's high tier when a request's prompt crosses the published
+// threshold. A user-set exact priceOverride still wins over the built-in tier.
+// Kept as a helper so the next tiered model extends this one branch instead of
+// copy-pasting the inline condition.
+function tieredCostsFor(model: string, baseCosts: ModelCosts, promptTokens: number): ModelCosts {
+  if (exactPriceOverrideFor(model)) return baseCosts
+  if (resolveCanonicalModelId(model) === 'grok-4.6' && promptTokens >= GROK_4_6_PROMPT_TOKEN_THRESHOLD) {
+    return GROK_4_6_HIGH_PROMPT_COSTS
+  }
+  return baseCosts
+}
+
 
 function tupleToCosts(raw: SnapshotEntry): ModelCosts {
   const [input, output, cacheWrite, cacheRead, fast] = raw
@@ -1200,11 +1212,7 @@ export function calculateCost(
   const safeCacheCreation = Math.max(safe(cacheCreationTokens), safeOneHourCacheCreation)
   const safeFiveMinuteCacheCreation = Math.max(0, safeCacheCreation - safeOneHourCacheCreation)
   const promptTokens = safe(inputTokens) + safe(cacheReadTokens)
-  const tieredCosts = (
-    !exactPriceOverrideFor(model)
-    && resolveCanonicalModelId(model) === 'grok-4.6'
-    && promptTokens >= GROK_4_6_PROMPT_TOKEN_THRESHOLD
-  ) ? GROK_4_6_HIGH_PROMPT_COSTS : costs
+  const tieredCosts = tieredCostsFor(model, costs, promptTokens)
   const multiplier = speed === 'fast' ? tieredCosts.fastMultiplier : 1
 
   // Clamp negative inputs to 0. A corrupt JSONL that emits a negative token

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2549,7 +2549,7 @@ function providerCallToCachedCall(call: ParsedProviderCall): CachedCall {
       webSearchRequests: call.webSearchRequests,
       cacheCreationOneHourTokens: 0,
     },
-    costUSD: (call.provider === 'mistral-vibe' || call.provider === 'antigravity' || call.provider === 'devin' || call.provider === 'vercel-gateway' || call.provider === 'hermes' || call.provider === 'kiro' || call.provider === 'codewhale' || call.provider === 'quickdesk' || call.provider === 'cline-cli') ? call.costUSD : undefined,
+    costUSD: (call.provider === 'mistral-vibe' || call.provider === 'antigravity' || call.provider === 'devin' || call.provider === 'vercel-gateway' || call.provider === 'hermes' || call.provider === 'kiro' || call.provider === 'codewhale' || call.provider === 'quickdesk' || call.provider === 'cline-cli' || call.provider === 'omp') ? call.costUSD : undefined,
     isEstimated: call.costIsEstimated || undefined,
     speed: call.speed,
     timestamp: call.timestamp,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3534,6 +3534,10 @@ export async function parseProviderSources(
         // every other provider returns `undefined` here, so the install path
         // stays a no-op for them.
         const sourceLineage = await resolveProviderLineage(providerName, source)
+        const sourceAgentMetadata = {
+          ...(source.agentName ? { agentName: source.agentName } : {}),
+          ...(source.agentStartedAt ? { agentStartedAt: source.agentStartedAt } : {}),
+        }
 
         // Store/merge parsed turns into the cache.
         // Durable providers use a union-by-deduplicationKey merge: existing turns
@@ -3582,7 +3586,7 @@ export async function parseProviderSources(
             // role to `root` here, never silently drops the field.
             if (sourceLineage) existingEntry.lineage = sourceLineage
           } else {
-            section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns, ...(prLinks.length ? { prLinks } : {}), ...(sourceLineage ? { lineage: sourceLineage } : {}) }
+            section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns, ...sourceAgentMetadata, ...(prLinks.length ? { prLinks } : {}), ...(sourceLineage ? { lineage: sourceLineage } : {}) }
           }
         } else {
           // Non-durable: overwrite (clearedPaths already deleted stale entry above)
@@ -3595,7 +3599,7 @@ export async function parseProviderSources(
             if (prLinks.length) existingCacheEntry.prLinks = [...new Set([...(existingCacheEntry.prLinks ?? []), ...prLinks])]
             if (sourceLineage) existingCacheEntry.lineage = sourceLineage
           } else {
-            section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns, ...(prLinks.length ? { prLinks } : {}), ...(sourceLineage ? { lineage: sourceLineage } : {}) }
+            section.files[source.path] = { fingerprint: fp, mcpInventory: [], turns, ...sourceAgentMetadata, ...(prLinks.length ? { prLinks } : {}), ...(sourceLineage ? { lineage: sourceLineage } : {}) }
           }
         }
         didParse = true
@@ -3953,7 +3957,7 @@ export async function parseProviderSources(
 
   // Query-time: derive SessionSummary from all cached turns.
   // Uses seenKeys (shared across providers) for cross-provider dedup.
-  const sessionMap = new Map<string, { project: string; projectPath?: string; workingDirectory?: string; turns: ClassifiedTurn[]; prLinks?: Set<string>; title?: string; lineage?: SessionLineage }>()
+  const sessionMap = new Map<string, { project: string; projectPath?: string; workingDirectory?: string; turns: ClassifiedTurn[]; prLinks?: Set<string>; title?: string; lineage?: SessionLineage; agentName?: string; agentStartedAt?: string }>()
 
   for (const source of servedSources) {
     const cachedFile = section.files[source.path]
@@ -4010,6 +4014,8 @@ export async function parseProviderSources(
         // every contributing file's evidence. A second cache entry that
         // re-states the same evidence is dropped silently.
         if (!existing.lineage && cachedFile.lineage) existing.lineage = cachedFile.lineage
+        if (!existing.agentName && cachedFile.agentName) existing.agentName = cachedFile.agentName
+        if (!existing.agentStartedAt && cachedFile.agentStartedAt) existing.agentStartedAt = cachedFile.agentStartedAt
       } else {
         sessionMap.set(key, {
           project,
@@ -4019,6 +4025,8 @@ export async function parseProviderSources(
           ...(cachedFile.prLinks?.length ? { prLinks: new Set(cachedFile.prLinks) } : {}),
           ...(cachedFile.title ? { title: cachedFile.title } : {}),
           ...(cachedFile.lineage ? { lineage: cachedFile.lineage } : {}),
+          ...(cachedFile.agentName ? { agentName: cachedFile.agentName } : {}),
+          ...(cachedFile.agentStartedAt ? { agentStartedAt: cachedFile.agentStartedAt } : {}),
         })
       }
     }
@@ -4209,7 +4217,7 @@ export async function parseProviderSources(
   }
 
   const projectMap = new Map<string, { projectPath?: string; sessions: SessionSummary[] }>()
-  for (const [key, { project, projectPath, workingDirectory, turns, prLinks, title, lineage }] of sessionMap) {
+  for (const [key, { project, projectPath, workingDirectory, turns, prLinks, title, lineage, agentName, agentStartedAt }] of sessionMap) {
     const sessionId = key.split(':')[1] ?? key
     const assembledTurns = providerName === 'copilot'
       ? foldCopilotSupplementaryTurns(sessionId, turns, copilotRecon?.supplementaryStoreKeys)
@@ -4224,6 +4232,8 @@ export async function parseProviderSources(
     if (workingDirectory) session.workingDirectory = workingDirectory
     if (title) session.title = title
     if (lineage) session.lineage = lineage
+    if (agentName) session.agentName = agentName
+    if (agentStartedAt) session.agentStartedAt = agentStartedAt
     // Supplementary-only sessions (e.g. a rollup with no per-turn calls) have
     // apiCalls 0 by design but their tokens/cost are real and must serve.
     if (session.apiCalls > 0 || session.totalCostUSD > 0 || session.totalInputTokens + session.totalOutputTokens + session.totalCacheReadTokens + session.totalCacheWriteTokens + session.totalReasoningTokens > 0) {

--- a/src/providers/pi.ts
+++ b/src/providers/pi.ts
@@ -180,6 +180,19 @@ async function discoverSessionsInDir(sessionsDir: string, providerName: string):
   return sources
 }
 
+// OMP records a session-level model (`model_change` entry) plus an optional
+// per-message `model`. The per-message value may be a bare model name without
+// the provider prefix (e.g. "gpt-5.6-terra" vs "openai-codex/gpt-5.6-terra").
+// Prefer the fully-qualified form when the two agree; fall back to whatever
+// the message carries, then the session model, then a safe default.
+function resolveMessageModel(messageModel: string, resolvedModel: string): string {
+  if (messageModel.includes('/')) return messageModel
+  if (resolvedModel && (!messageModel || resolvedModel === messageModel || resolvedModel.endsWith(`/${messageModel}`))) {
+    return resolvedModel
+  }
+  return messageModel || resolvedModel || 'gpt-5'
+}
+
 function createParser(source: SessionSource, seenKeys: Set<string>): SessionParser {
   return {
     async *parse(): AsyncGenerator<ParsedProviderCall> {
@@ -242,11 +255,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         if (input === 0 && output === 0) continue
 
         const messageModel = msg.model ?? ''
-        const model = messageModel.includes('/')
-          ? messageModel
-          : resolvedModel && (!messageModel || resolvedModel === messageModel || resolvedModel.endsWith(`/${messageModel}`))
-            ? resolvedModel
-            : messageModel || resolvedModel || 'gpt-5'
+        const model = resolveMessageModel(messageModel, resolvedModel)
         const responseId = msg.responseId ?? ''
         const dedupKey = `${source.provider}:${source.path}:${responseId || entry.id || entry.timestamp || String(lineIdx)}`
 
@@ -281,6 +290,10 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           })
 
         const reportedCost = msg.usage.cost?.total
+        // A zero reported cost acts as absent: OMP writes cost.total = 0 for
+        // xai-oauth calls, so the alias table and price overrides never apply.
+        // A genuinely free call would recompute to a small nonzero number;
+        // that is the trade-off we accept for fixing the OAuth zero.
         const costUSD = typeof reportedCost === 'number' && Number.isFinite(reportedCost) && reportedCost !== 0
           ? reportedCost
           : calculateCost(messageModel || resolvedModel || model, input, output, cacheWrite, cacheRead, 0)

--- a/src/providers/pi.ts
+++ b/src/providers/pi.ts
@@ -73,7 +73,6 @@ type PiEntry = {
   message?: {
     role?: string
     content?: Array<{ type?: string; text?: string; name?: string; arguments?: Record<string, unknown> }> | string
-    provider?: string
     model?: string
     responseId?: string
     usage?: {

--- a/src/providers/pi.ts
+++ b/src/providers/pi.ts
@@ -81,6 +81,9 @@ type PiEntry = {
       output: number
       cacheRead: number
       cacheWrite: number
+      cost?: {
+        total?: number
+      }
     }
   }
 }
@@ -219,9 +222,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         if (msg.role !== 'assistant' || !msg.usage) continue
 
         // Coerce undefined/null token fields to 0. Pi/OMP session files
-        // sometimes omit individual usage fields; the destructure used to
-        // pass undefined into calculateCost which then returned NaN, and
-        // that NaN propagated into every aggregate cost total.
+        // sometimes omit individual usage fields; pass only numeric values to
+        // the pricing fallback so it cannot contaminate aggregates with NaN.
         const input = msg.usage.input ?? 0
         const output = msg.usage.output ?? 0
         const cacheRead = msg.usage.cacheRead ?? 0
@@ -267,7 +269,10 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
             return typeof cmd === 'string' ? extractBashCommands(cmd) : []
           })
 
-        const costUSD = calculateCost(model, input, output, cacheWrite, cacheRead, 0)
+        const reportedCost = msg.usage.cost?.total
+        const costUSD = typeof reportedCost === 'number' && Number.isFinite(reportedCost)
+          ? reportedCost
+          : calculateCost(messageModel || resolvedModel || model, input, output, cacheWrite, cacheRead, 0)
         const timestamp = entry.timestamp ?? ''
 
         yield {

--- a/src/providers/pi.ts
+++ b/src/providers/pi.ts
@@ -75,6 +75,9 @@ type PiEntry = {
     content?: Array<{ type?: string; text?: string; name?: string; arguments?: Record<string, unknown> }> | string
     model?: string
     responseId?: string
+    attribution?: {
+      timestamp?: number
+    }
     usage?: {
       input: number
       output: number
@@ -186,6 +189,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       let sessionId = basename(source.path, '.jsonl')
       let resolvedModel = ''
       let pendingUserMessage = ''
+      let sessionTimestamp = ''
+      let pendingUserTimestamp = ''
 
       for (const [lineIdx, line] of lines.entries()) {
         let entry: PiEntry
@@ -197,6 +202,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
         if (entry.type === 'session') {
           sessionId = entry.id ?? sessionId
+          if (typeof entry.timestamp === 'string' && entry.timestamp) sessionTimestamp = entry.timestamp
           continue
         }
         if (entry.type === 'model_change') {
@@ -210,6 +216,12 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         if (!msg) continue
 
         if (msg.role === 'user') {
+          const attributedTimestamp = msg.attribution?.timestamp
+          if (typeof entry.timestamp === 'string' && entry.timestamp) {
+            pendingUserTimestamp = entry.timestamp
+          } else if (typeof attributedTimestamp === 'number' && Number.isFinite(attributedTimestamp)) {
+            pendingUserTimestamp = new Date(attributedTimestamp).toISOString()
+          }
           const texts = normalizeContentBlocks(msg.content)
             .filter(c => c.type === 'text')
             .map(c => c.text ?? '')
@@ -269,11 +281,11 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           })
 
         const reportedCost = msg.usage.cost?.total
-        const costUSD = typeof reportedCost === 'number' && Number.isFinite(reportedCost)
+        const costUSD = typeof reportedCost === 'number' && Number.isFinite(reportedCost) && reportedCost !== 0
           ? reportedCost
           : calculateCost(messageModel || resolvedModel || model, input, output, cacheWrite, cacheRead, 0)
-        const timestamp = entry.timestamp ?? ''
-
+        const timestamp = entry.timestamp || pendingUserTimestamp || sessionTimestamp
+        if (!timestamp) continue
         yield {
           provider: source.provider,
           model,

--- a/src/providers/pi.ts
+++ b/src/providers/pi.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from 'node:fs'
 import { readdir, stat } from 'fs/promises'
 import { basename, join } from 'path'
 import { homedir } from 'os'
@@ -68,9 +69,11 @@ type PiEntry = {
   id?: string
   timestamp?: string
   cwd?: string
+  model?: string
   message?: {
     role?: string
     content?: Array<{ type?: string; text?: string; name?: string; arguments?: Record<string, unknown> }> | string
+    provider?: string
     model?: string
     responseId?: string
     usage?: {
@@ -131,24 +134,41 @@ async function discoverSessionsInDir(sessionsDir: string, providerName: string):
     const dirStat = await stat(dirPath).catch(() => null)
     if (!dirStat?.isDirectory()) continue
 
-    let files: string[]
+    let entries: Dirent[]
     try {
-      files = await readdir(dirPath)
+      entries = await readdir(dirPath, { withFileTypes: true })
     } catch {
       continue
     }
 
-    for (const file of files) {
-      if (!file.endsWith('.jsonl')) continue
-      const filePath = join(dirPath, file)
-      const fileStat = await stat(filePath).catch(() => null)
-      if (!fileStat?.isFile()) continue
-
+    const addSession = async (filePath: string, agentName?: string): Promise<void> => {
       const entry = await readSessionEntry(filePath)
-      if (!entry) continue
-
+      if (!entry) return
       const cwd = entry.cwd ?? dirName
-      sources.push({ path: filePath, project: basename(cwd), provider: providerName })
+      sources.push({
+        path: filePath,
+        project: basename(cwd),
+        provider: providerName,
+        ...(agentName ? {
+          agentName,
+          ...(typeof entry.timestamp === 'string' ? { agentStartedAt: entry.timestamp } : {}),
+        } : {}),
+      })
+    }
+
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        await addSession(join(dirPath, entry.name))
+        continue
+      }
+      if (providerName !== 'omp' || !entry.isDirectory()) continue
+
+      const agentDir = join(dirPath, entry.name)
+      const agentEntries = await readdir(agentDir, { withFileTypes: true }).catch(() => [])
+      for (const agentEntry of agentEntries) {
+        if (!agentEntry.isFile() || !agentEntry.name.endsWith('.jsonl')) continue
+        await addSession(join(agentDir, agentEntry.name), basename(agentEntry.name, '.jsonl'))
+      }
     }
   }
 
@@ -162,6 +182,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       if (content === null) return
       const lines = content.split('\n').filter(l => l.trim())
       let sessionId = basename(source.path, '.jsonl')
+      let resolvedModel = ''
       let pendingUserMessage = ''
 
       for (const [lineIdx, line] of lines.entries()) {
@@ -174,6 +195,10 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
 
         if (entry.type === 'session') {
           sessionId = entry.id ?? sessionId
+          continue
+        }
+        if (entry.type === 'model_change') {
+          if (typeof entry.model === 'string' && entry.model) resolvedModel = entry.model
           continue
         }
 
@@ -203,7 +228,12 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         const cacheWrite = msg.usage.cacheWrite ?? 0
         if (input === 0 && output === 0) continue
 
-        const model = msg.model ?? 'gpt-5'
+        const messageModel = msg.model ?? ''
+        const model = messageModel.includes('/')
+          ? messageModel
+          : resolvedModel && (!messageModel || resolvedModel === messageModel || resolvedModel.endsWith(`/${messageModel}`))
+            ? resolvedModel
+            : messageModel || resolvedModel || 'gpt-5'
         const responseId = msg.responseId ?? ''
         const dedupKey = `${source.provider}:${source.path}:${responseId || entry.id || entry.timestamp || String(lineIdx)}`
 

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -8,6 +8,10 @@ export type SessionSource = {
   sourceLabel?: string
   sourcePath?: string
   sourceKind?: 'claude-config' | 'claude-desktop'
+  // OMP stores each crewmate transcript under its parent-session directory.
+  // These fields retain that per-agent identity through the shared cache path.
+  agentName?: string
+  agentStartedAt?: string
   // This file IS the durable record of its provider's usage — copilot's
   // session-store.db, whose crash-only rows have no rollup to fall back to —
   // rather than a journal the provider could re-emit. Two effects:

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -113,6 +113,10 @@ export type CachedFile = {
   // the `agentType` from its sibling `.meta.json` (e.g. `workflow-subagent`,
   // `Explore`, `general-purpose`). Drives the Claude-scoped agent-type breakdown.
   agentType?: string
+  // OMP nested agent transcripts retain their file-stem identity and session
+  // header timestamp for the menubar's per-agent activity rows.
+  agentName?: string
+  agentStartedAt?: string
   // Negative-result marker: this file threw while parsing at the recorded
   // fingerprint. Cached so we don't re-read + re-throw it on every refresh; it
   // is re-parsed only when the file changes (fingerprint differs). Carries no
@@ -697,6 +701,8 @@ function validateCachedFile(f: unknown): f is CachedFile {
     && (o['prLinks'] === undefined || isStringArray(o['prLinks']))
     && isOptionalBool(o['isSidechain'])
     && isOptionalString(o['agentType'])
+    && isOptionalString(o['agentName'])
+    && isOptionalString(o['agentStartedAt'])
     && isOptionalBool(o['failed'])
     && isOptionalString(o['parentSessionId'])
     && isOptionalStringRecord(o['agentSpawnLinks'])

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -382,6 +382,10 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   // the git repo. Cached entries from before the bump lack projectPath and
   // would serve attribution-blind sessions forever without a re-parse.
   kiro: 'ide-parsing-v1-est-cost-project-path-v1',
+  // nested-agent-v1: OMP writes crewmate transcripts one directory below each
+  // parent session. reported-cost-v2 persists those measured costs through the
+  // cache, including the explicit zero on xai-oauth turns.
+  omp: 'nested-agent-v1-reported-cost-v2',
   opencode: 'session-model-v1',
   quickdesk: 'emf-sqlite-v2-est-cost',
   // session-lineage-capture-v1: SessionLineage (CB-1, slice 1) is now carried

--- a/src/types.ts
+++ b/src/types.ts
@@ -253,6 +253,10 @@ export type SessionSummary = {
   // (`workflow-subagent`, `Explore`, `general-purpose`, …); undefined for
   // ordinary sessions. Drives the Claude-scoped agent-type breakdown.
   agentType?: string
+  /// OMP nested-agent file stem. Kept separate from Claude's agentType metadata.
+  agentName?: string
+  /// OMP nested-agent session-header timestamp.
+  agentStartedAt?: string
   /// Claude Code only: for a sidechain (subagent) transcript, the id of the
   /// session that spawned it (the transcript's internal `sessionId`, which is the
   /// parent, cross-checked against the owning directory). Lets by-PR attribution

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -19,6 +19,15 @@ import { buildGranularHistory } from './granular-history.js'
 
 // Row caps for the by-PR / by-branch payload aggregations, ranked by cost.
 const TOP_BRANCHES = 15
+type SubagentRow = NonNullable<BreakdownArrays['subagents']>[number]
+
+
+function compactTokenCount(totalTokens: number): string {
+  if (totalTokens >= 1_000_000) return `${(totalTokens / 1_000_000).toFixed(totalTokens >= 10_000_000 ? 0 : 2).replace(/\.?0+$/, '')}M`
+  if (totalTokens >= 1_000) return `${(totalTokens / 1_000).toFixed(totalTokens >= 100_000 ? 0 : 1).replace(/\.?0+$/, '')}k`
+  return String(totalTokens)
+}
+
 
 export function buildPeriodData(label: string, projects: ProjectSummary[]): PeriodData {
   const sessions = projects.flatMap(p => p.sessions)
@@ -918,6 +927,17 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
     const toolMap: Record<string, number> = {}
     const skillMap: Record<string, { turns: number; cost: number }> = {}
     const subagentMap: Record<string, { calls: number; cost: number }> = {}
+    const ompSubagentMap = new Map<string, {
+      agentName: string
+      model: string
+      startedAt: string
+      calls: number
+      cost: number
+      inputTokens: number
+      outputTokens: number
+      cacheReadTokens: number
+      cacheWriteTokens: number
+    }>()
     const mcpMap: Record<string, number> = {}
     // Local-model savings rollup: avoided spend (cost forced to $0, baseline
     // recorded) grouped by model and provider. Mirrors the per-call savingsUSD
@@ -930,6 +950,31 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
       for (const [t, d] of Object.entries(s.toolBreakdown)) { if (!t.startsWith('lang:')) toolMap[t] = (toolMap[t] ?? 0) + d.calls }
       for (const [sk, d] of Object.entries(s.skillBreakdown)) { const e = skillMap[sk] ?? { turns: 0, cost: 0 }; e.turns += d.turns; e.cost += d.costUSD; skillMap[sk] = e }
       for (const [sa, d] of Object.entries(s.subagentBreakdown)) { const e = subagentMap[sa] ?? { calls: 0, cost: 0 }; e.calls += d.calls; e.cost += d.costUSD; subagentMap[sa] = e }
+      if (s.agentName && s.turns.some(turn => turn.assistantCalls.some(call => call.provider === 'omp'))) {
+        const calls = s.turns.flatMap(turn => turn.assistantCalls)
+        const models = Array.from(new Set(calls.map(call => call.model))).sort()
+        const model = models.join(', ') || 'unknown'
+        const startedAt = s.agentStartedAt ?? s.firstTimestamp
+        const key = `${s.agentName}\u0000${model}\u0000${startedAt}`
+        const entry = ompSubagentMap.get(key) ?? {
+          agentName: s.agentName,
+          model,
+          startedAt,
+          calls: 0,
+          cost: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        }
+        entry.calls += s.apiCalls
+        entry.cost += s.totalCostUSD
+        entry.inputTokens += s.totalInputTokens
+        entry.outputTokens += s.totalOutputTokens
+        entry.cacheReadTokens += s.totalCacheReadTokens
+        entry.cacheWriteTokens += s.totalCacheWriteTokens
+        ompSubagentMap.set(key, entry)
+      }
       for (const [m, d] of Object.entries(s.mcpBreakdown)) { mcpMap[m] = (mcpMap[m] ?? 0) + d.calls }
       for (const turn of s.turns) for (const call of turn.assistantCalls) {
         if (!call.savingsUSD || call.savingsUSD <= 0) continue
@@ -961,10 +1006,22 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
       byModel: Array.from(savingsByModel.entries()).sort(([, a], [, b]) => b.savingsUSD - a.savingsUSD).slice(0, 5).map(([name, d]) => ({ name, ...d })),
       byProvider: Array.from(savingsByProvider.entries()).sort(([, a], [, b]) => b.savingsUSD - a.savingsUSD).slice(0, 5).map(([name, d]) => ({ name, ...d })),
     }
+    const subagents: SubagentRow[] = [
+      ...Object.entries(subagentMap).map(([name, d]) => ({ name, ...d })),
+      ...Array.from(ompSubagentMap.values()).map(entry => {
+        const totalTokens = entry.inputTokens + entry.outputTokens + entry.cacheReadTokens + entry.cacheWriteTokens
+        const startTime = entry.startedAt.match(/T(\d{2}:\d{2})/)?.[1]
+        return {
+          name: `${entry.agentName} ${entry.model} ${startTime ? `${startTime}Z` : entry.startedAt} ${entry.calls}t ${compactTokenCount(totalTokens)}`,
+          ...entry,
+          totalTokens,
+        }
+      }),
+    ]
     return {
       tools: Object.entries(toolMap).sort(([, a], [, b]) => b - a).slice(0, 10).map(([name, calls]) => ({ name, calls })),
       skills: Object.entries(skillMap).sort(([, a], [, b]) => b.cost - a.cost).slice(0, 10).map(([name, d]) => ({ name, ...d })),
-      subagents: Object.entries(subagentMap).sort(([, a], [, b]) => b.cost - a.cost).slice(0, 10).map(([name, d]) => ({ name, ...d })),
+      subagents: subagents.sort((a, b) => b.cost - a.cost || (b.totalTokens ?? 0) - (a.totalTokens ?? 0)).slice(0, 10),
       mcpServers: Object.entries(mcpMap).sort(([, a], [, b]) => b - a).slice(0, 10).map(([name, calls]) => ({ name, calls })),
       localModelSavings,
     }

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -22,13 +22,6 @@ const TOP_BRANCHES = 15
 type SubagentRow = NonNullable<BreakdownArrays['subagents']>[number]
 
 
-function compactTokenCount(totalTokens: number): string {
-  if (totalTokens >= 1_000_000) return `${(totalTokens / 1_000_000).toFixed(totalTokens >= 10_000_000 ? 0 : 2).replace(/\.?0+$/, '')}M`
-  if (totalTokens >= 1_000) return `${(totalTokens / 1_000).toFixed(totalTokens >= 100_000 ? 0 : 1).replace(/\.?0+$/, '')}k`
-  return String(totalTokens)
-}
-
-
 export function buildPeriodData(label: string, projects: ProjectSummary[]): PeriodData {
   const sessions = projects.flatMap(p => p.sessions)
   const catTotals: Record<string, { turns: number; cost: number; savingsUSD: number; editTurns: number; oneShotTurns: number }> = {}
@@ -1008,15 +1001,11 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
     }
     const subagents: SubagentRow[] = [
       ...Object.entries(subagentMap).map(([name, d]) => ({ name, ...d })),
-      ...Array.from(ompSubagentMap.values()).map(entry => {
-        const totalTokens = entry.inputTokens + entry.outputTokens + entry.cacheReadTokens + entry.cacheWriteTokens
-        const startTime = entry.startedAt.match(/T(\d{2}:\d{2})/)?.[1]
-        return {
-          name: `${entry.agentName} ${entry.model} ${startTime ? `${startTime}Z` : entry.startedAt} ${entry.calls}t ${compactTokenCount(totalTokens)}`,
-          ...entry,
-          totalTokens,
-        }
-      }),
+      ...Array.from(ompSubagentMap.values()).map(entry => ({
+        name: entry.agentName,
+        ...entry,
+        totalTokens: entry.inputTokens + entry.outputTokens + entry.cacheReadTokens + entry.cacheWriteTokens,
+      })),
     ]
     return {
       tools: Object.entries(toolMap).sort(([, a], [, b]) => b - a).slice(0, 10).map(([name, calls]) => ({ name, calls })),

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -1021,7 +1021,7 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
     return {
       tools: Object.entries(toolMap).sort(([, a], [, b]) => b - a).slice(0, 10).map(([name, calls]) => ({ name, calls })),
       skills: Object.entries(skillMap).sort(([, a], [, b]) => b.cost - a.cost).slice(0, 10).map(([name, d]) => ({ name, ...d })),
-      subagents: subagents.sort((a, b) => b.cost - a.cost || (b.totalTokens ?? 0) - (a.totalTokens ?? 0)).slice(0, 10),
+      subagents: subagents.sort((a, b) => b.cost - a.cost || (b.totalTokens ?? 0) - (a.totalTokens ?? 0)),
       mcpServers: Object.entries(mcpMap).sort(([, a], [, b]) => b - a).slice(0, 10).map(([name, calls]) => ({ name, calls })),
       localModelSavings,
     }

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -9,6 +9,7 @@ import {
   getShortModelName,
   resolveCanonicalModelId,
   calculateCost,
+  CACHE_SCHEMA_VERSION,
   loadPricing,
   setModelAliases,
   setPriceOverrides,
@@ -119,6 +120,26 @@ describe('getModelCosts', () => {
 
     expect(calculateCost('gpt-5.6-codex', 1_000_000, 1_000_000, 0, 0, 0)).toBeGreaterThan(0)
     expect(calculateCost('gpt-5.6-codex-max', 1_000_000, 1_000_000, 0, 0, 0)).toBeGreaterThan(0)
+  })
+
+  describe('grok-4.6 prompt tier', () => {
+    it('uses the low tier below 200000 prompt tokens', () => {
+      expect(calculateCost('grok-4.6', 100_000, 10_000, 0, 99_999, 0)).toBeCloseTo(0.3099995, 12)
+    })
+
+    it('uses the high tier for every token at exactly 200000 prompt tokens', () => {
+      expect(calculateCost('grok-4.6', 100_000, 10_000, 0, 100_000, 0)).toBeCloseTo(0.62, 12)
+    })
+
+    it('uses the high tier above 200000 prompt tokens', () => {
+      expect(calculateCost('grok-4.6', 100_001, 10_000, 0, 100_000, 0)).toBeCloseTo(0.620004, 12)
+    })
+
+    it('uses a price override instead of the built-in prompt tier', () => {
+      setPriceOverrides({ 'grok-4.6': { input: 2, output: 6, cacheRead: 0.5 } })
+
+      expect(calculateCost('grok-4.6', 100_000, 10_000, 0, 100_000, 0)).toBeCloseTo(0.31, 12)
+    })
   })
 
   it('prices claude-haiku-4.5 (copilot session-store raw id), aliased to the existing claude-haiku-4-5 row (#1093)', () => {
@@ -909,7 +930,7 @@ describe('DeepSeek v4 models resolve to pricing', () => {
       process.env['CODEBURN_CACHE_DIR'] = cacheRoot
       await mkdir(cacheRoot, { recursive: true })
       await writeFile(join(cacheRoot, 'litellm-pricing.json'), JSON.stringify({
-        version: 2, // must match models.ts's CACHE_SCHEMA_VERSION or the cache is treated as a miss
+        version: CACHE_SCHEMA_VERSION,
         timestamp: Date.now(),
         data: {
           'gpt-4o-mini': {
@@ -1108,7 +1129,7 @@ describe('findUnpricedModels', () => {
     try {
       process.env['CODEBURN_CACHE_DIR'] = cacheRoot
       await writeFile(join(cacheRoot, 'litellm-pricing.json'), JSON.stringify({
-        version: 2, // must match models.ts's CACHE_SCHEMA_VERSION or the cache is treated as a miss
+        version: CACHE_SCHEMA_VERSION,
         timestamp: Date.now(),
         data: {
           'zz-zero-stub-model': {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -135,10 +135,11 @@ describe('getModelCosts', () => {
       expect(calculateCost('grok-4.6', 100_001, 10_000, 0, 100_000, 0)).toBeCloseTo(0.620004, 12)
     })
 
-    it('uses a price override instead of the built-in prompt tier', () => {
+    it('uses an aliased price override instead of the built-in prompt tier', () => {
+      setModelAliases({ 'xai-oauth/grok-4.6': 'grok-4.6' })
       setPriceOverrides({ 'grok-4.6': { input: 2, output: 6, cacheRead: 0.5 } })
 
-      expect(calculateCost('grok-4.6', 100_000, 10_000, 0, 100_000, 0)).toBeCloseTo(0.31, 12)
+      expect(calculateCost('xai-oauth/grok-4.6', 100_000, 10_000, 0, 100_000, 0)).toBeCloseTo(0.31, 12)
     })
   })
 

--- a/tests/providers/omp.test.ts
+++ b/tests/providers/omp.test.ts
@@ -48,6 +48,7 @@ function assistantMessage(opts: {
   output?: number
   cacheRead?: number
   cacheWrite?: number
+  cost?: number
   tools?: Array<{ name: string; command?: string }>
 }) {
   const content = (opts.tools ?? []).map(t => ({
@@ -72,7 +73,7 @@ function assistantMessage(opts: {
         output: opts.output ?? 200,
         cacheRead: opts.cacheRead ?? 0,
         cacheWrite: opts.cacheWrite ?? 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: opts.cost ?? 0 },
       },
       timestamp: 1776023230000,
     },
@@ -211,11 +212,12 @@ describe('omp provider - JSONL parsing', () => {
     expect(call.deduplicationKey).toContain('resp-omp-1')
   })
 
-  it('ignores the embedded usage.cost and recalculates cost', async () => {
+  it('preserves a provider-reported cost, including an explicit zero', async () => {
     const projectDir = join(tmpDir, '--Users-test-myproject--')
     const filePath = await writeSession(projectDir, 'session.jsonl', [
       sessionMeta(),
-      assistantMessage({ input: 1000, output: 200, cacheRead: 0, cacheWrite: 0 }),
+      assistantMessage({ input: 1000, output: 200, cacheRead: 0, cacheWrite: 0, cost: 1.234 }),
+      assistantMessage({ id: 'msg-asst-2', responseId: 'resp-002', input: 500, output: 100, cost: 0 }),
     ])
 
     const provider = createOmpProvider(tmpDir)
@@ -225,8 +227,7 @@ describe('omp provider - JSONL parsing', () => {
       calls.push(call)
     }
 
-    // cost must be calculated by codeburn, not taken from usage.cost (which is zeroed in fixture)
-    expect(calls[0]!.costUSD).toBeGreaterThanOrEqual(0)
+    expect(calls.map(call => call.costUSD)).toEqual([1.234, 0])
   })
 
   it('collects tool names from toolCall content items', async () => {

--- a/tests/providers/omp.test.ts
+++ b/tests/providers/omp.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
+import { setModelAliases, setPriceOverrides } from '../../src/models.js'
+import { filterProjectsByDateRange } from '../../src/parser.js'
 import { createOmpProvider } from '../../src/providers/pi.js'
+import { aggregateSessions } from '../../src/sessions-report.js'
+import type { ParsedApiCall, ProjectSummary } from '../../src/types.js'
 import type { ParsedProviderCall } from '../../src/providers/types.js'
 
 let tmpDir: string
@@ -42,7 +46,7 @@ function userMessage(text: string) {
 function assistantMessage(opts: {
   id?: string
   responseId?: string
-  timestamp?: string
+  timestamp?: string | null
   model?: string
   input?: number
   output?: number
@@ -61,7 +65,7 @@ function assistantMessage(opts: {
   return JSON.stringify({
     type: 'message',
     id: opts.id ?? 'msg-asst-1',
-    timestamp: opts.timestamp ?? '2026-04-14T10:00:30.000Z',
+    ...(opts.timestamp === null ? {} : { timestamp: opts.timestamp ?? '2026-04-14T10:00:30.000Z' }),
     message: {
       role: 'assistant',
       content,
@@ -85,6 +89,52 @@ async function writeSession(projectDir: string, filename: string, lines: string[
   const filePath = join(projectDir, filename)
   await writeFile(filePath, lines.join('\n') + '\n')
   return filePath
+}
+
+function projectWithCalls(calls: ParsedProviderCall[]): ProjectSummary[] {
+  return [{
+    project: 'myproject',
+    projectPath: '/Users/test/myproject',
+    sessions: [{
+      sessionId: calls[0]!.sessionId,
+      project: 'myproject',
+      turns: calls.map(call => {
+        const assistantCall: ParsedApiCall = {
+          provider: call.provider,
+          model: call.model,
+          usage: {
+            inputTokens: call.inputTokens,
+            outputTokens: call.outputTokens,
+            cacheCreationInputTokens: call.cacheCreationInputTokens,
+            cacheReadInputTokens: call.cacheReadInputTokens,
+            cachedInputTokens: call.cachedInputTokens,
+            reasoningTokens: call.reasoningTokens,
+            webSearchRequests: call.webSearchRequests,
+          },
+          costUSD: call.costUSD,
+          tools: call.tools,
+          mcpTools: call.tools.filter(tool => tool.startsWith('mcp__')),
+          skills: call.skills ?? [],
+          subagentTypes: call.subagentTypes ?? [],
+          hasAgentSpawn: call.tools.includes('Agent'),
+          hasPlanMode: call.tools.includes('EnterPlanMode'),
+          speed: call.speed,
+          timestamp: call.timestamp,
+          bashCommands: call.bashCommands,
+          deduplicationKey: call.deduplicationKey,
+        }
+        return {
+          userMessage: call.userMessage,
+          assistantCalls: [assistantCall],
+          timestamp: call.timestamp,
+          sessionId: call.sessionId,
+          category: 'general' as const,
+          retries: 0,
+          hasEdits: false,
+        }
+      }),
+    }],
+  }] as unknown as ProjectSummary[]
 }
 
 describe('omp provider - identity', () => {
@@ -212,12 +262,11 @@ describe('omp provider - JSONL parsing', () => {
     expect(call.deduplicationKey).toContain('resp-omp-1')
   })
 
-  it('preserves a provider-reported cost, including an explicit zero', async () => {
+  it('preserves a provider-reported nonzero cost', async () => {
     const projectDir = join(tmpDir, '--Users-test-myproject--')
     const filePath = await writeSession(projectDir, 'session.jsonl', [
       sessionMeta(),
       assistantMessage({ input: 1000, output: 200, cacheRead: 0, cacheWrite: 0, cost: 1.234 }),
-      assistantMessage({ id: 'msg-asst-2', responseId: 'resp-002', input: 500, output: 100, cost: 0 }),
     ])
 
     const provider = createOmpProvider(tmpDir)
@@ -227,9 +276,92 @@ describe('omp provider - JSONL parsing', () => {
       calls.push(call)
     }
 
-    expect(calls.map(call => call.costUSD)).toEqual([1.234, 0])
+    expect(calls.map(call => call.costUSD)).toEqual([1.234])
   })
 
+  it('prices a zero reported cost through its alias and price override', async () => {
+    setModelAliases({ 'xai-oauth/grok-4.6': 'omp-grok-price-test' })
+    setPriceOverrides({ 'omp-grok-price-test': { input: 2, output: 4 } })
+    try {
+      const projectDir = join(tmpDir, '--Users-test-myproject--')
+      const filePath = await writeSession(projectDir, 'session.jsonl', [
+        sessionMeta(),
+        assistantMessage({
+          model: 'xai-oauth/grok-4.6',
+          input: 1_000_000,
+          output: 1_000_000,
+          cost: 0,
+        }),
+      ])
+
+      const provider = createOmpProvider(tmpDir)
+      const source = { path: filePath, project: 'myproject', provider: 'omp' }
+      const calls: ParsedProviderCall[] = []
+      for await (const call of provider.createSessionParser(source, new Set()).parse()) {
+        calls.push(call)
+      }
+
+      expect(calls[0]!.costUSD).toBeCloseTo(6, 12)
+    } finally {
+      setModelAliases({})
+      setPriceOverrides({})
+    }
+  })
+
+  it('uses user attribution timestamps to date-slice records in one OMP session', async () => {
+    const projectDir = join(tmpDir, '--Users-test-myproject--')
+    const firstTimestamp = '2026-04-15T10:00:00.000Z'
+    const secondTimestamp = '2026-04-16T10:00:00.000Z'
+    const filePath = await writeSession(projectDir, 'session.jsonl', [
+      sessionMeta(),
+      assistantMessage({ id: 'assistant-header', responseId: 'response-header', timestamp: null }),
+      JSON.stringify({
+        type: 'message',
+        id: 'user-first',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'first request' }],
+          attribution: { timestamp: Date.parse(firstTimestamp) },
+        },
+      }),
+      assistantMessage({ id: 'assistant-first', responseId: 'response-first', timestamp: null }),
+      JSON.stringify({
+        type: 'message',
+        id: 'user-second',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'second request' }],
+          attribution: { timestamp: Date.parse(secondTimestamp) },
+        },
+      }),
+      assistantMessage({ id: 'assistant-second', responseId: 'response-second', timestamp: null }),
+    ])
+
+    const provider = createOmpProvider(tmpDir)
+    const source = { path: filePath, project: 'myproject', provider: 'omp' }
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(source, new Set()).parse()) {
+      calls.push(call)
+    }
+
+    expect(calls.map(call => call.timestamp)).toEqual([
+      '2026-04-14T10:00:00.000Z',
+      firstTimestamp,
+      secondTimestamp,
+    ])
+
+    const filtered = filterProjectsByDateRange(projectWithCalls(calls), {
+      start: new Date('2026-04-16T00:00:00.000Z'),
+      end: new Date('2026-04-16T23:59:59.999Z'),
+    })
+    const filteredCalls = filtered.flatMap(project =>
+      project.sessions.flatMap(session => session.turns.flatMap(turn => turn.assistantCalls)),
+    )
+
+    expect(filteredCalls).toHaveLength(1)
+    expect(filteredCalls[0]!.timestamp).toBe(secondTimestamp)
+    expect(aggregateSessions(filtered)[0]!.startedAt).toBe(secondTimestamp)
+  })
   it('collects tool names from toolCall content items', async () => {
     const projectDir = join(tmpDir, '--Users-test-myproject--')
     const filePath = await writeSession(projectDir, 'session.jsonl', [

--- a/tests/providers/omp.test.ts
+++ b/tests/providers/omp.test.ts
@@ -16,12 +16,12 @@ afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true })
 })
 
-function sessionMeta(opts: { id?: string; cwd?: string } = {}) {
+function sessionMeta(opts: { id?: string; cwd?: string; timestamp?: string } = {}) {
   return JSON.stringify({
     type: 'session',
     version: 3,
     id: opts.id ?? 'sess-001',
-    timestamp: '2026-04-14T10:00:00.000Z',
+    timestamp: opts.timestamp ?? '2026-04-14T10:00:00.000Z',
     cwd: opts.cwd ?? '/Users/test/myproject',
   })
 }
@@ -125,6 +125,32 @@ describe('omp provider - session discovery', () => {
     expect(sessions).toHaveLength(1)
     expect(sessions[0]!.provider).toBe('omp')
     expect(sessions[0]!.project).toBe('myproject')
+  })
+
+  it('discovers nested per-agent sessions with their resolved model and start time', async () => {
+    const projectDir = join(tmpDir, '--Users-test-myproject--')
+    const agentDir = join(projectDir, '2026-04-14T10-00-00-000Z_parent-001')
+    const filePath = await writeSession(agentDir, 'KillSwitch.jsonl', [
+      sessionMeta({ id: 'agent-001', timestamp: '2026-04-14T10:00:00.000Z' }),
+      JSON.stringify({ type: 'model_change', model: 'openai-codex/gpt-5.6-terra' }),
+      assistantMessage({ model: 'gpt-5.6-terra' }),
+    ])
+
+    const provider = createOmpProvider(tmpDir)
+    const sessions = await provider.discoverSessions()
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]).toMatchObject({
+      path: filePath,
+      agentName: 'KillSwitch',
+      agentStartedAt: '2026-04-14T10:00:00.000Z',
+    })
+
+    const calls: ParsedProviderCall[] = []
+    for await (const call of provider.createSessionParser(sessions[0]!, new Set()).parse()) {
+      calls.push(call)
+    }
+    expect(calls[0]!.model).toBe('openai-codex/gpt-5.6-terra')
   })
 
   it('returns empty for non-existent directory', async () => {


### PR DESCRIPTION
## Summary

This pull request corrects 3 defects in OMP-provider accounting and Grok 4.6 pricing.

### 1. OMP rows ignored the period filter

`codeburn models -p <period>` returned an identical OMP aggregate at every scope, while a comparison provider varied by period. Independent session output showed records across multiple dates. The row labelled `today` therefore reflected a cumulative total rather than a daily total.

Cause: `src/providers/pi.ts` stamped calls from `entry.timestamp`, but the session-header branch did not retain its timestamp. When `entry.timestamp` was absent, the range filter received an invalid date.

The shared range helpers remain unchanged: `callsInRange`, `classifiedTurnSlicedToRange`, and `filterProjectsByDateRange`.

### 2. OMP cost attribution stayed at zero

A valid alias plus price override still yielded a zero-cost OMP row, although the audit path recomputed a nonzero cost.

Cause: `src/providers/pi.ts` treated any finite `msg.usage.cost.total` as authoritative and skipped `calculateCost`. OMP writes `cost.total = 0` for `xai-oauth` IDs, so neither the alias table nor the price override applied. `audit` recomputes through `getModelCosts`, while `attributedCostUSD` sums the cached per-call value.

The alias loader remains unchanged. A zero reported cost now acts as absent. A nonzero reported cost keeps its existing behavior.

### 3. Grok 4.6 lacked the 200k prompt tier

xAI prices Grok 4.6 in 2 tiers. Once a request reaches 200k prompt tokens, xAI applies the higher rate to every token in that request.

| Tier | Input | Cached input | Output |
|---|---:|---:|---:|
| Under 200k prompt tokens | $2.00 | $0.50 | $6.00 |
| 200k or more prompt tokens | $4.00 | $1.00 | $12.00 |

Source: https://docs.x.ai/developers/models/grok-4.6 and https://docs.x.ai/developers/pricing, retrieved 2026-08-26.

The bundled rate card carried only the low tier, so large-context Grok traffic under-reported. Prompt tokens equal input plus cached input. The high tier triggers inclusively at exactly 200000 prompt tokens. An exact configured `priceOverrides` entry still wins over the built-in tier. `CACHE_SCHEMA_VERSION` moves to 3 so cached rendered costs recompute.

## Change evidence

| Change | Why | Receipt |
|---|---|---|
| Nested OMP agent discovery and payload metadata | Retain nested-agent identity, resolved model, and start time through the shared cache and menubar payload. | Ran `npx vitest run tests/providers/omp.test.ts`: 12 passed, 0 failed, duration 623 ms. Test title: "discovers nested per-agent sessions with their resolved model and start time". |
| Reported nonzero OMP cost retention | Preserve a provider-reported nonzero cost through parsing and caching. | Ran `npx vitest run tests/providers/omp.test.ts`: 12 passed, 0 failed, duration 623 ms. Test title: "preserves a provider-reported nonzero cost". |
| Removal of the unused Pi message field | Remove a message field that the parser does not consume. | The removed field was `message.provider` (`provider?: string`). A search of `src` for `msg.provider`, `msg?.provider`, `message.provider`, `message?.provider`, `entry.message.provider`, or `entry.message?.provider` returned 0 hits. No test applies to this type-only deletion. |
| Status snapshot render version | Invalidate a stale status snapshot after OMP payload semantics changed. | Ran `npx vitest run tests/cli-status-menubar.test.ts -t "invalidates the snapshot when a model is newly marked flat-rate"`: 1 passed, 0 failed, duration 1.49 s. Test title: "invalidates the snapshot when a model is newly marked flat-rate". It verifies invalidation behavior. No test asserts the literal `STATUS_SNAPSHOT_RENDER_VERSION = 2`. |
| Grok 4.6 prompt-tier pricing and pricing-cache version | Apply the vendor's high tier at and above the prompt threshold and invalidate cached pricing. | Ran `npx vitest run tests/models.test.ts`: 192 passed, 0 failed, duration 900 ms. Test titles: "uses the low tier below 200000 prompt tokens", "uses the high tier for every token at exactly 200000 prompt tokens", and "uses the high tier above 200000 prompt tokens". The cited tests do not assert `CACHE_SCHEMA_VERSION = 3` or rejection of a version-2 pricing cache. |
| OMP timestamp fallback and zero-cost repricing | Retain timestamps for date slicing and route a zero reported cost through aliases and overrides. | Ran `npx vitest run tests/providers/omp.test.ts`: 12 passed, 0 failed, duration 623 ms. Test titles: "prices a zero reported cost through its alias and price override" and "uses user attribution timestamps to date-slice records in one OMP session". |
| Aliased Grok price-override test | Confirm that an alias reaches an exact override instead of the built-in tier. | Ran `npx vitest run tests/models.test.ts`: 192 passed, 0 failed, duration 900 ms. Test title: "uses an aliased price override instead of the built-in prompt tier". |

The prior description recorded a passing model test command and a successful CLI build. This sanitation pass did not run either command. Those historical statements are not execution receipts for this metadata update.

## Notes

A retired catalog model intentionally retains zero rates.
