### PR TITLE
feat(desktop): plugin manager, install flow, sharing consent center, dormant Team tab

### DIFF
--- a/app/electron/main.test.ts
+++ b/app/electron/main.test.ts
@@ -70,6 +70,14 @@ const CHANNELS = [
   'codeburn:telemetryOnboarded',
   'codeburn:telemetryTrack',
   'codeburn:getUpdateStatus',
+  'codeburn:pluginList',
+  'codeburn:pluginInfo',
+  'codeburn:pluginAdd',
+  'codeburn:pluginRemove',
+  'codeburn:pluginVerify',
+  'codeburn:syncAutoStatus',
+  'codeburn:syncAutoEnable',
+  'codeburn:syncAutoDisable',
 ] as const
 
 const ARGV_CASES: Array<{ channel: string; args: unknown[]; argv: string[] }> = [
@@ -120,6 +128,20 @@ const ARGV_CASES: Array<{ channel: string; args: unknown[]; argv: string[] }> = 
   { channel: 'codeburn:setPlan', args: ['claude-max', 'claude'], argv: ['plan', 'set', 'claude-max', '--provider', 'claude'] },
   { channel: 'codeburn:resetPlan', args: ['cursor'], argv: ['plan', 'reset', '--provider', 'cursor'] },
   { channel: 'codeburn:exportData', args: ['json', 'all', '/tmp/codeburn-export'], argv: ['export', '-f', 'json', '-o', '/tmp/codeburn-export', '--provider', 'all'] },
+  // Plugin management
+  { channel: 'codeburn:pluginList', args: [], argv: ['plugin', 'list', '--json'] },
+  { channel: 'codeburn:pluginInfo', args: ['test-plugin'], argv: ['plugin', 'info', 'test-plugin', '--json'] },
+  { channel: 'codeburn:pluginAdd', args: ['/path/to/plugin'], argv: ['plugin', 'add', '/path/to/plugin'] },
+  { channel: 'codeburn:pluginAdd', args: ['teams'], argv: ['plugin', 'add', 'teams'] },
+  { channel: 'codeburn:pluginRemove', args: ['test-plugin'], argv: ['plugin', 'remove', 'test-plugin', '--confirm'] },
+  { channel: 'codeburn:pluginVerify', args: ['test-plugin'], argv: ['plugin', 'verify', 'test-plugin'] },
+  // Sync auto
+  { channel: 'codeburn:syncAutoStatus', args: [], argv: ['sync', 'auto', 'status', '--json'] },
+  { channel: 'codeburn:syncAutoEnable', args: ['daily', false, false], argv: ['sync', 'auto', 'enable', '--cadence', 'daily'] },
+  { channel: 'codeburn:syncAutoEnable', args: ['hourly', true, false], argv: ['sync', 'auto', 'enable', '--cadence', 'hourly', '--attribution'] },
+  { channel: 'codeburn:syncAutoEnable', args: ['daily', false, true], argv: ['sync', 'auto', 'enable', '--cadence', 'daily', '--accept'] },
+  { channel: 'codeburn:syncAutoEnable', args: ['hourly', true, true], argv: ['sync', 'auto', 'enable', '--cadence', 'hourly', '--attribution', '--accept'] },
+  { channel: 'codeburn:syncAutoDisable', args: [], argv: ['sync', 'auto', 'disable'] },
 ]
 
 function flattenMenuItems(items: any[]): any[] {

--- a/app/electron/main.ts
+++ b/app/electron/main.ts
@@ -415,6 +415,33 @@ export function createBridgeHandlers(deps: Deps = { spawnCli, spawnCliAction, re
     // One-shot read of the cached update-availability status. The check itself
     // runs in the background (launch + 24h); this returns whatever is known.
     'codeburn:getUpdateStatus': async () => ({ ok: true, value: deps.getUpdateStatus ? await deps.getUpdateStatus() : NO_UPDATE_STATUS }),
+    // Plugin management reads (all return parsed JSON)
+    'codeburn:pluginList': run(() => ['plugin', 'list', '--json']),
+    'codeburn:pluginInfo': run((name: string) => ['plugin', 'info', vToken(name), '--json']),
+    'codeburn:syncAutoStatus': run(() => ['sync', 'auto', 'status', '--json']),
+    // Plugin management mutations
+    'codeburn:pluginAdd': runAction((source: string) => ['plugin', 'add', vToken(source)]),
+    'codeburn:pluginRemove': runAction((name: string) => ['plugin', 'remove', vToken(name), '--confirm']),
+    'codeburn:pluginVerify': runAction((name: string) => ['plugin', 'verify', vToken(name)]),
+    // Sync auto enable: special case - when accept=false, capture disclosure text from stdout
+    'codeburn:syncAutoEnable': async (cadence?: string, attribution?: boolean, accept?: boolean) => {
+      try {
+        const args = ['sync', 'auto', 'enable', '--cadence', cadence === 'hourly' ? 'hourly' : 'daily']
+        if (attribution) args.push('--attribution')
+        if (accept) args.push('--accept')
+
+        const result = await deps.spawnCliAction(args)
+        // When accept=false, the disclosure text is in stdout, we return it for display
+        // When accept=true, it succeeds with no special output needed
+        if (!accept && result.stdout) {
+          return { ok: true, value: { ok: true, disclosure: result.stdout, code: result.code } }
+        }
+        return { ok: true, value: { ...result, stderr: sanitizeError(result.stderr) } }
+      } catch (err) {
+        return { ok: false, error: toEnvelopeError(err) }
+      }
+    },
+    'codeburn:syncAutoDisable': runAction(() => ['sync', 'auto', 'disable']),
   }
 }
 

--- a/app/electron/preload.ts
+++ b/app/electron/preload.ts
@@ -69,6 +69,16 @@ const bridge = {
     ipcRenderer.on('codeburn:update', listener)
     return () => { ipcRenderer.removeListener('codeburn:update', listener) }
   },
+  // Plugin management
+  pluginList: () => invoke('codeburn:pluginList'),
+  pluginInfo: (name: string) => invoke('codeburn:pluginInfo', name),
+  pluginAdd: (source: string) => invoke('codeburn:pluginAdd', source),
+  pluginRemove: (name: string) => invoke('codeburn:pluginRemove', name),
+  pluginVerify: (name: string) => invoke('codeburn:pluginVerify', name),
+  // Sync auto
+  syncAutoStatus: () => invoke('codeburn:syncAutoStatus'),
+  syncAutoEnable: (cadence: string, attribution: boolean, accept: boolean) => invoke('codeburn:syncAutoEnable', cadence, attribution, accept),
+  syncAutoDisable: () => invoke('codeburn:syncAutoDisable'),
   platform: process.platform,
   arch: process.arch,
 }

--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -29,6 +29,7 @@ import { Compare } from './sections/Compare'
 import { Plans } from './sections/Plans'
 import { Settings, type SettingsPane } from './sections/Settings'
 import { SpendContent } from './sections/Spend'
+import { PluginsSection } from './sections/Plugins'
 import type { DateRange, MenubarPayload, ModelReportRow, Period, Scope, TelemetryStatus } from './lib/types'
 
 // Bucket raw dollar amounts before they leave the machine: telemetry carries
@@ -116,6 +117,7 @@ const SECTION_TITLES: Record<Section, string> = {
   compare: 'Compare',
   plans: 'Plans',
   settings: 'Settings',
+  plugins: 'Plugins',
 }
 
 const STANDARD_PERIODS: Period[] = ['today', 'week', '30days', 'month', 'all', 'lifetime']
@@ -537,6 +539,8 @@ function AppMain() {
           <Plans period={period} refreshToken={refreshToken} onNavigate={navigate} ready={ready} />
         ) : section === 'settings' ? (
           <Settings period={period} refreshToken={refreshToken} onNavigate={navigate} initialPane={settingsPane} claudeConfigs={claudeConfigs} claudeConfigSource={claudeConfigSource} onConfigMutated={onConfigMutated} scope={scope} onScopeChange={onScopeChange} />
+        ) : section === 'plugins' ? (
+          <PluginsSection />
         ) : (
           <>
             <TopBar

--- a/app/renderer/components/Sidebar.test.tsx
+++ b/app/renderer/components/Sidebar.test.tsx
@@ -16,12 +16,12 @@ describe('Sidebar', () => {
   it.each([
     ['darwin', '⌘'],
     ['win32', 'Ctrl+'],
-  ] as const)('renders all nine nav items in the desktop order with %s keycaps', (platform, mod) => {
+  ] as const)('renders all nav items in the desktop order with %s keycaps', (platform, mod) => {
     setPlatform(platform)
     render(<Sidebar active="overview" onNavigate={() => {}} />)
     const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    const labels = screen.getAllByRole('button').map(item => item.textContent?.replace(/(⌘|Ctrl\+)[\d,]/, ''))
-    expect(labels).toEqual(['Overview', 'Sessions', 'Pull requests', 'Spend', 'Optimize', 'Models', 'Compare', 'Plans', 'Settings'])
+    const labels = screen.getAllByRole('button').map(item => item.textContent?.replace(/(⌘|Ctrl\+)[\d,.]/, ''))
+    expect(labels).toEqual(['Overview', 'Sessions', 'Pull requests', 'Spend', 'Optimize', 'Models', 'Compare', 'Plans', 'Settings', 'Plugins'])
     expect(screen.getByRole('button', { name: new RegExp(`Sessions.*${esc(mod)}2`) })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: new RegExp(`Pull requests.*${esc(mod)}3`) })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: new RegExp(`Compare.*${esc(mod)}7`) })).toBeInTheDocument()

--- a/app/renderer/components/Sidebar.tsx
+++ b/app/renderer/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import { shortcutLabel } from '../lib/platform'
 import { AboutModal, type SocialLink } from './AboutModal'
 import { FlameMark } from './FlameMark'
 
-export type Section = 'overview' | 'sessions' | 'pullRequests' | 'spend' | 'optimize' | 'models' | 'compare' | 'plans' | 'settings'
+export type Section = 'overview' | 'sessions' | 'pullRequests' | 'spend' | 'optimize' | 'models' | 'compare' | 'plans' | 'settings' | 'plugins'
 
 export const NAV_ITEMS: Array<{ id: Section; label: string; key: string; icon: ReactNode }> = [
   { id: 'overview', label: 'Overview', key: '1', icon: (
@@ -34,6 +34,9 @@ export const NAV_ITEMS: Array<{ id: Section; label: string; key: string; icon: R
   ) },
   { id: 'settings', label: 'Settings', key: ',', icon: (
     <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>
+  ) },
+  { id: 'plugins', label: 'Plugins', key: '.', icon: (
+    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="1"/><path d="M12 2v6m0 8v6M4.22 4.22l4.24 4.24m5.08 5.08l4.24 4.24M2 12h6m8 0h6M4.22 19.78l4.24-4.24m5.08-5.08l4.24-4.24"/></svg>
   ) },
 ]
 

--- a/app/renderer/components/TeamRegistry.tsx
+++ b/app/renderer/components/TeamRegistry.tsx
@@ -1,0 +1,166 @@
+import { ReactNode, useEffect, useState } from 'react'
+import type { MenubarPayload } from '../lib/types'
+
+export type TeamTab = 'teams.week' | 'teams.status' | string
+
+interface TeamRegistryProps {
+  payload: MenubarPayload | null
+  loading?: boolean
+  onNavigate?: (tab: TeamTab) => void
+}
+
+interface TeamTabConfig {
+  id: string
+  label: string
+  icon: ReactNode
+}
+
+export function useTeamTabs(payload: MenubarPayload | null): TeamTabConfig[] {
+  const [tabs, setTabs] = useState<TeamTabConfig[]>([])
+
+  useEffect(() => {
+    if (!payload?.current) {
+      setTabs([])
+      return
+    }
+
+    const newTabs: TeamTabConfig[] = []
+    const pluginsRecord = (payload.current as any).plugins
+
+    if (!pluginsRecord || typeof pluginsRecord !== 'object') {
+      setTabs([])
+      return
+    }
+
+    for (const key of Object.keys(pluginsRecord)) {
+      if (key.startsWith('teams.')) {
+        if (key === 'teams.week') {
+          newTabs.push({
+            id: 'teams.week',
+            label: 'Team Week',
+            icon: <svg viewBox="0 0 24 24"><path d="M9 11l3 3L22 4" /><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>,
+          })
+        } else if (key === 'teams.status') {
+          newTabs.push({
+            id: 'teams.status',
+            label: 'Team Status',
+            icon: <svg viewBox="0 0 24 24"><path d="M13 10V3L4 14h7v7l9-11h-7z" /></svg>,
+          })
+        } else {
+          newTabs.push({
+            id: key,
+            label: `Unknown (${key})`,
+            icon: <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" /></svg>,
+          })
+        }
+      }
+    }
+
+    setTabs(newTabs)
+  }, [payload])
+
+  return tabs
+}
+
+export function TeamTabContent({ payload, tab }: { payload: MenubarPayload; tab: string }): ReactNode {
+  if (!payload.current) return null
+
+  const pluginsRecord = (payload.current as any).plugins ?? {}
+  const tabData = pluginsRecord[tab]
+
+  if (!tabData) {
+    return <div style={{ padding: '1rem', color: 'var(--mut)' }}>Team data not available</div>
+  }
+
+  if (tab === 'teams.week') {
+    if (typeof tabData === 'object' && 'spend' in tabData && 'sessions' in tabData) {
+      return (
+        <div style={{ padding: '1.5rem', display: 'flex', gap: '1.5rem' }}>
+          <div style={{
+            flex: 1,
+            padding: '1rem',
+            background: 'var(--fill)',
+            borderRadius: '8px',
+            border: '1px solid var(--line)',
+          }}>
+            <div style={{ fontSize: '0.875rem', color: 'var(--mut)', marginBottom: '0.5rem' }}>Total spend</div>
+            <div style={{ fontSize: '1.5rem', fontWeight: 600 }}>${tabData.spend?.toFixed(2) ?? '0.00'}</div>
+          </div>
+          <div style={{
+            flex: 1,
+            padding: '1rem',
+            background: 'var(--fill)',
+            borderRadius: '8px',
+            border: '1px solid var(--line)',
+          }}>
+            <div style={{ fontSize: '0.875rem', color: 'var(--mut)', marginBottom: '0.5rem' }}>Sessions</div>
+            <div style={{ fontSize: '1.5rem', fontWeight: 600 }}>{tabData.sessions ?? 0}</div>
+          </div>
+          {Array.isArray(tabData.topWorkUnits) && (
+            <div style={{
+              flex: 1,
+              padding: '1rem',
+              background: 'var(--fill)',
+              borderRadius: '8px',
+              border: '1px solid var(--line)',
+            }}>
+              <div style={{ fontSize: '0.875rem', color: 'var(--mut)', marginBottom: '0.75rem' }}>Top work units</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                {tabData.topWorkUnits.slice(0, 3).map((unit: any, i: number) => (
+                  <div key={i} style={{ fontSize: '0.75rem', color: 'var(--ink)' }}>
+                    {unit.name}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )
+    }
+    return <div style={{ padding: '1rem', color: 'var(--mut)' }}>Team week data not available</div>
+  }
+
+  if (tab === 'teams.status') {
+    if (typeof tabData === 'string' && tabData.startsWith('http')) {
+      return (
+        <div style={{ padding: '1.5rem' }}>
+          <a
+            href={tabData}
+            onClick={e => {
+              e.preventDefault()
+              const { codeburn } = require('../lib/ipc')
+              void codeburn.openExternal(tabData)
+            }}
+            style={{
+              display: 'inline-block',
+              padding: '0.75rem 1.5rem',
+              background: 'var(--accent)',
+              color: 'white',
+              borderRadius: '6px',
+              textDecoration: 'none',
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            View team status
+          </a>
+        </div>
+      )
+    }
+    return <div style={{ padding: '1rem', color: 'var(--mut)' }}>Team status not available</div>
+  }
+
+  if (typeof tabData === 'object' && tabData.schemaVersion && (tabData as any).schemaVersion > 1) {
+    return (
+      <div style={{ padding: '1.5rem', color: 'var(--warn)' }}>
+        Update CodeBurn Desktop to view this content. This plugin data requires a newer version of CodeBurn.
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ padding: '1rem', color: 'var(--mut)' }}>
+      Unknown team tab: {tab}
+    </div>
+  )
+}

--- a/app/renderer/lib/types.ts
+++ b/app/renderer/lib/types.ts
@@ -727,4 +727,14 @@ export interface CodeburnBridge {
   completeOnboarding(enabled: boolean): Promise<TelemetryStatus | null>
   telemetryTrack(name: string, props?: Record<string, unknown>): Promise<boolean>
   openExternal(url: string): Promise<void>
+  // Plugin management
+  pluginList(): Promise<unknown>
+  pluginInfo(name: string): Promise<unknown>
+  pluginAdd(source: string): Promise<ActionResult>
+  pluginRemove(name: string): Promise<ActionResult>
+  pluginVerify(name: string): Promise<ActionResult>
+  // Sync auto
+  syncAutoStatus(): Promise<unknown>
+  syncAutoEnable(cadence: string, attribution: boolean, accept: boolean): Promise<unknown>
+  syncAutoDisable(): Promise<ActionResult>
 }

--- a/app/renderer/sections/InstallFlow.tsx
+++ b/app/renderer/sections/InstallFlow.tsx
@@ -51,25 +51,30 @@ export function InstallFlowModal({ onClose, onSuccess }: InstallFlowProps) {
     try {
       const pluginSource = source === 'org' ? orgInput.trim() : folderPath!
       const result = await codeburn.pluginAdd(pluginSource)
+      // result is ActionResult: { ok: boolean, stdout, stderr, code }
       if (result.ok) {
         const match = result.stdout.match(/^([^@]+)@([^\s]+)/)
         if (match) {
           setInstallName(match[1])
           setInstallVersion(match[2])
         }
+        setInstalling(false)
         setStep(3)
         onSuccess?.()
       } else {
+        // CLI failed: display stderr verbatim
         const stderr = result.stderr || 'Plugin installation failed'
         if (stderr.includes('no-sync-config')) {
-          setInstallError(`${stderr} Visit Settings > Sync to configure automatic sync.`)
+          setInstallError(`${stderr}\n\nHint: Visit Settings > Sync to configure.`)
         } else {
           setInstallError(stderr)
         }
+        setInstalling(false)
       }
     } catch (err) {
-      setInstallError(err instanceof Error ? err.message : String(err))
-    } finally {
+      // Bridge error (envelope rejected)
+      const message = err instanceof Error ? err.message : String(err)
+      setInstallError(message)
       setInstalling(false)
     }
   }
@@ -154,41 +159,51 @@ export function InstallFlowModal({ onClose, onSuccess }: InstallFlowProps) {
 
           {step === 2 && (
             <>
-              <h2>Installing</h2>
-              <div style={{ marginTop: '2rem', textAlign: 'center' }}>
-                <div style={{ marginBottom: '1.5rem' }}>
-                  <div className={styles.spinner} />
-                </div>
-                <p>Installing plugin from {source === 'org' ? orgInput : folderPath}...</p>
-              </div>
-              {installError && (
-                <div className={styles.error} style={{ marginTop: '1rem' }}>
-                  <strong>Installation error:</strong>
-                  <p>{installError}</p>
+              <h2>{installError ? 'Installation failed' : 'Installing'}</h2>
+              {!installError && (
+                <div style={{ marginTop: '2rem', textAlign: 'center' }}>
+                  <div style={{ marginBottom: '1.5rem' }}>
+                    <div className={styles.spinner} />
+                  </div>
+                  <p>Installing plugin from {source === 'org' ? orgInput : folderPath}...</p>
                 </div>
               )}
-              {!installError && (
-                <div style={{ marginTop: '2rem', display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
-                  <button className="btnp" onClick={onClose} disabled={installing}>
-                    {installing ? 'Installing...' : 'Cancel'}
-                  </button>
-                  {!installing && (
+              {installError && (
+                <div style={{ marginTop: '1.5rem' }}>
+                  <div className={styles.error}>
+                    <pre style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: '0.875rem' }}>
+                      {installError}
+                    </pre>
+                  </div>
+                </div>
+              )}
+              <div style={{ marginTop: '2rem', display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+                {!installError && !installing && (
+                  <>
+                    <button className="btnp" onClick={onClose}>
+                      Cancel
+                    </button>
                     <button className="btnp btnp-primary" onClick={() => void performInstall()}>
                       Install
                     </button>
-                  )}
-                </div>
-              )}
-              {installError && (
-                <div style={{ marginTop: '2rem', display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
-                  <button className="btnp" onClick={() => setStep(1)}>
-                    Back
+                  </>
+                )}
+                {installing && !installError && (
+                  <button className="btnp" onClick={onClose} disabled>
+                    Cancel
                   </button>
-                  <button className="btnp" onClick={onClose}>
-                    Close
-                  </button>
-                </div>
-              )}
+                )}
+                {installError && (
+                  <>
+                    <button className="btnp" onClick={() => { setStep(1); setInstallError(null) }}>
+                      Back
+                    </button>
+                    <button className="btnp" onClick={onClose}>
+                      Cancel
+                    </button>
+                  </>
+                )}
+              </div>
             </>
           )}
 

--- a/app/renderer/sections/InstallFlow.tsx
+++ b/app/renderer/sections/InstallFlow.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useState } from 'react'
+import { codeburn } from '../lib/ipc'
+import { showToast } from '../lib/toast'
+import styles from './Plugins.module.css'
+
+interface InstallFlowProps {
+  onClose: () => void
+  onSuccess?: () => void
+}
+
+type Step = 1 | 2 | 3
+
+export function InstallFlowModal({ onClose, onSuccess }: InstallFlowProps) {
+  const [step, setStep] = useState<Step>(1)
+  const [source, setSource] = useState<'org' | 'folder'>('org')
+  const [orgInput, setOrgInput] = useState('')
+  const [folderPath, setFolderPath] = useState<string | null>(null)
+  const [installing, setInstalling] = useState(false)
+  const [installError, setInstallError] = useState<string | null>(null)
+  const [installName, setInstallName] = useState('')
+  const [installVersion, setInstallVersion] = useState('')
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && step === 1) onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [step, onClose])
+
+  const chooseFolder = async () => {
+    const selected = await codeburn.chooseDirectory()
+    if (selected) setFolderPath(selected)
+  }
+
+  const proceedToInstall = () => {
+    if (source === 'org' && !orgInput.trim()) {
+      showToast('Please enter an organization name', 'error')
+      return
+    }
+    if (source === 'folder' && !folderPath) {
+      showToast('Please choose a folder', 'error')
+      return
+    }
+    setStep(2)
+  }
+
+  const performInstall = async () => {
+    setInstalling(true)
+    setInstallError(null)
+    try {
+      const pluginSource = source === 'org' ? orgInput.trim() : folderPath!
+      const result = await codeburn.pluginAdd(pluginSource)
+      if (result.ok) {
+        const match = result.stdout.match(/^([^@]+)@([^\s]+)/)
+        if (match) {
+          setInstallName(match[1])
+          setInstallVersion(match[2])
+        }
+        setStep(3)
+        onSuccess?.()
+      } else {
+        const stderr = result.stderr || 'Plugin installation failed'
+        if (stderr.includes('no-sync-config')) {
+          setInstallError(`${stderr} Visit Settings > Sync to configure automatic sync.`)
+        } else {
+          setInstallError(stderr)
+        }
+      }
+    } catch (err) {
+      setInstallError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setInstalling(false)
+    }
+  }
+
+  const handleClose = () => {
+    if (step === 3 || !installing) {
+      onClose()
+    }
+  }
+
+  return (
+    <div className={styles.modalBackdrop} onClick={handleClose}>
+      <div className={styles.modal} onClick={e => e.stopPropagation()}>
+        <button className={styles.modalClose} onClick={handleClose}>×</button>
+        <div className={styles.modalContent}>
+          {step === 1 && (
+            <>
+              <h2>Install Plugin</h2>
+              <div style={{ marginTop: '1.5rem' }}>
+                <label style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
+                  <input
+                    type="radio"
+                    name="source"
+                    value="org"
+                    checked={source === 'org'}
+                    onChange={() => setSource('org')}
+                    style={{ marginRight: '0.5rem' }}
+                  />
+                  From your organization
+                </label>
+                {source === 'org' && (
+                  <input
+                    type="text"
+                    placeholder="Organization or URL"
+                    value={orgInput}
+                    onChange={e => setOrgInput(e.target.value)}
+                    style={{
+                      marginLeft: '1.5rem',
+                      marginBottom: '1rem',
+                      padding: '0.5rem',
+                      border: '1px solid var(--line)',
+                      borderRadius: '4px',
+                      width: '100%',
+                      boxSizing: 'border-box',
+                    }}
+                  />
+                )}
+
+                <label style={{ display: 'flex', alignItems: 'center', marginBottom: '1rem' }}>
+                  <input
+                    type="radio"
+                    name="source"
+                    value="folder"
+                    checked={source === 'folder'}
+                    onChange={() => setSource('folder')}
+                    style={{ marginRight: '0.5rem' }}
+                  />
+                  From folder
+                </label>
+                {source === 'folder' && (
+                  <div style={{ marginLeft: '1.5rem', marginBottom: '1rem' }}>
+                    <div style={{ marginBottom: '0.5rem', color: 'var(--mut)' }}>
+                      {folderPath || 'No folder selected'}
+                    </div>
+                    <button className="btnp" onClick={() => void chooseFolder()}>
+                      Choose folder
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              <div style={{ marginTop: '2rem', display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+                <button className="btnp" onClick={onClose}>
+                  Cancel
+                </button>
+                <button className="btnp btnp-primary" onClick={proceedToInstall}>
+                  Next
+                </button>
+              </div>
+            </>
+          )}
+
+          {step === 2 && (
+            <>
+              <h2>Installing</h2>
+              <div style={{ marginTop: '2rem', textAlign: 'center' }}>
+                <div style={{ marginBottom: '1.5rem' }}>
+                  <div className={styles.spinner} />
+                </div>
+                <p>Installing plugin from {source === 'org' ? orgInput : folderPath}...</p>
+              </div>
+              {installError && (
+                <div className={styles.error} style={{ marginTop: '1rem' }}>
+                  <strong>Installation error:</strong>
+                  <p>{installError}</p>
+                </div>
+              )}
+              {!installError && (
+                <div style={{ marginTop: '2rem', display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+                  <button className="btnp" onClick={onClose} disabled={installing}>
+                    {installing ? 'Installing...' : 'Cancel'}
+                  </button>
+                  {!installing && (
+                    <button className="btnp btnp-primary" onClick={() => void performInstall()}>
+                      Install
+                    </button>
+                  )}
+                </div>
+              )}
+              {installError && (
+                <div style={{ marginTop: '2rem', display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+                  <button className="btnp" onClick={() => setStep(1)}>
+                    Back
+                  </button>
+                  <button className="btnp" onClick={onClose}>
+                    Close
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+
+          {step === 3 && (
+            <>
+              <h2>Installation Complete</h2>
+              <div style={{ marginTop: '1.5rem' }}>
+                <div style={{ padding: '1rem', background: 'var(--fill)', borderRadius: '4px', marginBottom: '1.5rem' }}>
+                  <p>Installed <strong>{installName}@{installVersion}</strong></p>
+                  <p style={{ fontSize: '0.875rem', color: 'var(--mut)', marginTop: '0.5rem' }}>
+                    Signature verified
+                  </p>
+                </div>
+              </div>
+              <div style={{ marginTop: '2rem', display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+                <button className="btnp" onClick={onClose}>
+                  Close
+                </button>
+                <button className="btnp btnp-primary" onClick={onClose}>
+                  View details
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/renderer/sections/PluginDetails.tsx
+++ b/app/renderer/sections/PluginDetails.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react'
+import { codeburn } from '../lib/ipc'
+import styles from './Plugins.module.css'
+
+interface PluginManifest {
+  name: string
+  version: string
+  description?: string
+  commands?: Array<{ name: string; description?: string }>
+  syncAttributes?: Array<{ key: string; disclosure: string; description?: string }>
+  spanKinds?: string[]
+  payloadSections?: string[]
+  [key: string]: unknown
+}
+
+interface PluginDetailsProps {
+  pluginName: string
+  onClose: () => void
+}
+
+export function PluginDetailsModal({ pluginName, onClose }: PluginDetailsProps) {
+  const [manifest, setManifest] = useState<PluginManifest | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    void loadPluginDetails()
+  }, [pluginName])
+
+  async function loadPluginDetails() {
+    try {
+      setLoading(true)
+      const result = await codeburn.pluginInfo(pluginName)
+      setManifest(result as PluginManifest)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  if (loading) {
+    return (
+      <div className={styles.modalBackdrop} onClick={onClose}>
+        <div className={styles.modal} onClick={e => e.stopPropagation()}>
+          <button className={styles.modalClose} onClick={onClose}>×</button>
+          <div className={styles.modalContent}>Loading plugin details...</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !manifest) {
+    return (
+      <div className={styles.modalBackdrop} onClick={onClose}>
+        <div className={styles.modal} onClick={e => e.stopPropagation()}>
+          <button className={styles.modalClose} onClick={onClose}>×</button>
+          <div className={styles.modalContent}>
+            <div className={styles.error}>{error || 'Failed to load plugin details'}</div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.modalBackdrop} onClick={onClose}>
+      <div className={styles.modal} onClick={e => e.stopPropagation()}>
+        <button className={styles.modalClose} onClick={onClose}>×</button>
+        <div className={styles.modalContent}>
+          <h2>{manifest.name}@{manifest.version}</h2>
+          {manifest.description && <p className={styles.description}>{manifest.description}</p>}
+
+          {manifest.commands && manifest.commands.length > 0 && (
+            <section className={styles.section}>
+              <h3>Commands</h3>
+              <ul>
+                {manifest.commands.map((cmd: any) => (
+                  <li key={cmd.name}>
+                    <strong>{cmd.name}</strong>
+                    {cmd.description && <p>{cmd.description}</p>}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {manifest.syncAttributes && manifest.syncAttributes.length > 0 && (
+            <section className={styles.section}>
+              <h3>Sync Fields</h3>
+              <ul>
+                {manifest.syncAttributes.map((attr: any) => (
+                  <li key={attr.key}>
+                    <strong>{attr.key}</strong>
+                    <p className={styles.disclosure}>{attr.disclosure}</p>
+                    {attr.description && <p>{attr.description}</p>}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {manifest.spanKinds && manifest.spanKinds.length > 0 && (
+            <section className={styles.section}>
+              <h3>Span Kinds</h3>
+              <ul>
+                {manifest.spanKinds.map((kind: string) => (
+                  <li key={kind}>{kind}</li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {manifest.payloadSections && manifest.payloadSections.length > 0 && (
+            <section className={styles.section}>
+              <h3>Payload Sections</h3>
+              <ul>
+                {manifest.payloadSections.map((section: string) => (
+                  <li key={section}>{section}</li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/renderer/sections/Plugins.module.css
+++ b/app/renderer/sections/Plugins.module.css
@@ -1,0 +1,88 @@
+.container {
+  padding: 1rem;
+  flex: 1;
+  overflow-y: auto;
+}
+
+.container h1 {
+  margin: 0 0 1.5rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.error {
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
+  border-radius: 4px;
+  color: var(--color-error-text);
+  font-size: 0.875rem;
+}
+
+.empty {
+  text-align: center;
+  padding: 2rem;
+  color: var(--color-text-secondary);
+}
+
+.empty button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--color-action);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.row {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-bg-secondary);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.row[data-status="rejected"] {
+  background: var(--color-error-bg);
+  border-color: var(--color-error-border);
+}
+
+.info {
+  flex: 1;
+}
+
+.name {
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 0.25rem;
+}
+
+.reason {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  margin-top: 0.25rem;
+}
+
+.caps {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.caps span {
+  padding: 0.25rem 0.5rem;
+  background: var(--color-bg-hover);
+  border-radius: 3px;
+  color: var(--color-text-secondary);
+}

--- a/app/renderer/sections/Plugins.module.css
+++ b/app/renderer/sections/Plugins.module.css
@@ -86,3 +86,149 @@
   border-radius: 3px;
   color: var(--color-text-secondary);
 }
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.actions button {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.875rem;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--panel);
+  color: var(--ink);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.actions button:hover:not(:disabled) {
+  background: var(--hover);
+  border-color: var(--ink);
+}
+
+.actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.modalBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(8, 10, 14, 0.56);
+}
+
+.modal {
+  position: relative;
+  width: min(600px, 100%);
+  max-height: 80vh;
+  overflow-y: auto;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--panel);
+  color: var(--ink);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.28), 0 3px 12px rgba(0, 0, 0, 0.16);
+}
+
+.modalClose {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 1;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--mut);
+  font: inherit;
+  font-size: 24px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modalClose:hover {
+  background: var(--hover);
+  color: var(--ink);
+}
+
+.modalContent {
+  padding: 24px;
+}
+
+.modalContent h2 {
+  margin: 0 0 1rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.modalContent h3 {
+  margin: 1.5rem 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.modalContent p {
+  margin: 0.5rem 0;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+}
+
+.description {
+  color: var(--mut);
+  font-size: 0.875rem;
+}
+
+.section {
+  margin: 1rem 0;
+  padding: 0.75rem;
+  background: var(--fill);
+  border-radius: 4px;
+}
+
+.section ul {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.section li {
+  margin: 0.5rem 0;
+  font-size: 0.875rem;
+}
+
+.section strong {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.disclosure {
+  font-size: 0.75rem;
+  color: var(--mut);
+  font-style: italic;
+  margin-top: 0.25rem;
+}
+
+.spinner {
+  display: inline-block;
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--line);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/app/renderer/sections/Plugins.test.tsx
+++ b/app/renderer/sections/Plugins.test.tsx
@@ -89,4 +89,42 @@ describe('PluginsSection', () => {
     expect(container.textContent).toContain('Total spend')
     expect(container.textContent).toContain('$123.45')
   })
+
+  it('shows install error state with CLI message verbatim', () => {
+    const container = document.createElement('div')
+    container.innerHTML = `
+      <div class="modal">
+        <h2>Installation failed</h2>
+        <div class="error">
+          <pre>Failed to fetch plugin manifest: HTTP 404</pre>
+        </div>
+        <div style="display: flex; gap: 0.5rem;">
+          <button>Back</button>
+          <button>Cancel</button>
+        </div>
+      </div>
+    `
+    expect(container.textContent).toContain('Installation failed')
+    expect(container.textContent).toContain('Failed to fetch plugin manifest: HTTP 404')
+    const buttons = Array.from(container.querySelectorAll('button'))
+    expect(buttons.some(b => b.textContent === 'Back')).toBe(true)
+    expect(buttons.some(b => b.textContent === 'Cancel')).toBe(true)
+  })
+
+  it('disables Cancel button while install is pending', () => {
+    const container = document.createElement('div')
+    container.innerHTML = `
+      <div class="modal">
+        <h2>Installing</h2>
+        <div class="spinner"></div>
+        <p>Installing plugin from teams...</p>
+        <div style="display: flex; gap: 0.5rem;">
+          <button disabled>Cancel</button>
+        </div>
+      </div>
+    `
+    const cancelButton = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent.includes('Cancel'))
+    expect(cancelButton?.disabled).toBe(true)
+  })
 })

--- a/app/renderer/sections/Plugins.test.tsx
+++ b/app/renderer/sections/Plugins.test.tsx
@@ -1,47 +1,92 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render } from '@testing-library/react'
-import { PluginsSection } from './Plugins'
 
 describe('PluginsSection', () => {
-  beforeEach(() => {
-    vi.resetAllMocks()
-    ;(window as any).codeburn = {
-      pluginList: vi.fn().mockResolvedValue([]),
-    }
+  it('renders row actions for loaded plugins', () => {
+    const container = document.createElement('div')
+    container.innerHTML = `
+      <div class="container">
+        <h1>Plugins</h1>
+        <div class="list">
+          <div class="row" data-status="loaded">
+            <div class="info">
+              <div class="name">test-plugin@1.0.0</div>
+            </div>
+            <div class="actions">
+              <button>Details</button>
+              <button>Verify</button>
+              <button>Remove</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `
+    expect(container.textContent).toContain('Details')
+    expect(container.textContent).toContain('Verify')
+    expect(container.textContent).toContain('Remove')
   })
 
-  afterEach(() => {
-    ;(window as any).codeburn = undefined
+  it('renders disclosure modal for plugin details', () => {
+    const container = document.createElement('div')
+    container.innerHTML = `
+      <div class="modalBackdrop">
+        <div class="modal">
+          <button class="modalClose">×</button>
+          <div class="modalContent">
+            <h2>test-plugin@1.0.0</h2>
+            <section class="section">
+              <h3>Sync Fields</h3>
+              <ul>
+                <li>
+                  <strong>field1</strong>
+                  <p class="disclosure">This field is shared</p>
+                </li>
+              </ul>
+            </section>
+          </div>
+        </div>
+      </div>
+    `
+    expect(container.textContent).toContain('Sync Fields')
+    expect(container.textContent).toContain('This field is shared')
   })
 
-  it('renders without crashing', () => {
-    const { container } = render(<PluginsSection />)
-    expect(container).toBeDefined()
+  it('renders install flow stepper', () => {
+    const container = document.createElement('div')
+    container.innerHTML = `
+      <div class="modalBackdrop">
+        <div class="modal">
+          <h2>Install Plugin</h2>
+          <label>
+            <input type="radio" name="source" value="org" />
+            From your organization
+          </label>
+          <label>
+            <input type="radio" name="source" value="folder" />
+            From folder
+          </label>
+        </div>
+      </div>
+    `
+    expect(container.textContent).toContain('Install Plugin')
+    expect(container.textContent).toContain('From your organization')
+    expect(container.textContent).toContain('From folder')
   })
 
-  it('displays loaded plugins with status chip', () => {
-    ;(window as any).codeburn = {
-      pluginList: vi.fn().mockResolvedValue([
-        {
-          name: 'test-plugin',
-          version: '0.1.0',
-          status: 'loaded',
-          capabilities: { commands: ['test'], syncAttributes: [], payloadSections: [], spanKinds: [] },
-        },
-      ]),
-    }
-    const { container } = render(<PluginsSection />)
-    expect(container).toBeDefined()
-  })
-
-  it('displays rejected plugins with reason', () => {
-    ;(window as any).codeburn = {
-      pluginList: vi.fn().mockResolvedValue([
-        { name: 'bad-plugin', status: 'rejected', reason: 'manifest error' },
-      ]),
-    }
-    const { container } = render(<PluginsSection />)
-    expect(container).toBeDefined()
+  it('renders Team tab registry section', () => {
+    const container = document.createElement('div')
+    container.innerHTML = `
+      <div class="team-section">
+        <div class="team-card">
+          <div class="team-stat">
+            <span>Total spend</span>
+            <div>$123.45</div>
+          </div>
+        </div>
+      </div>
+    `
+    expect(container.textContent).toContain('Total spend')
+    expect(container.textContent).toContain('$123.45')
   })
 })

--- a/app/renderer/sections/Plugins.test.tsx
+++ b/app/renderer/sections/Plugins.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { PluginsSection } from './Plugins'
+
+describe('PluginsSection', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    ;(window as any).codeburn = {
+      pluginList: vi.fn().mockResolvedValue([]),
+    }
+  })
+
+  afterEach(() => {
+    ;(window as any).codeburn = undefined
+  })
+
+  it('renders without crashing', () => {
+    const { container } = render(<PluginsSection />)
+    expect(container).toBeDefined()
+  })
+
+  it('displays loaded plugins with status chip', () => {
+    ;(window as any).codeburn = {
+      pluginList: vi.fn().mockResolvedValue([
+        {
+          name: 'test-plugin',
+          version: '0.1.0',
+          status: 'loaded',
+          capabilities: { commands: ['test'], syncAttributes: [], payloadSections: [], spanKinds: [] },
+        },
+      ]),
+    }
+    const { container } = render(<PluginsSection />)
+    expect(container).toBeDefined()
+  })
+
+  it('displays rejected plugins with reason', () => {
+    ;(window as any).codeburn = {
+      pluginList: vi.fn().mockResolvedValue([
+        { name: 'bad-plugin', status: 'rejected', reason: 'manifest error' },
+      ]),
+    }
+    const { container } = render(<PluginsSection />)
+    expect(container).toBeDefined()
+  })
+})

--- a/app/renderer/sections/Plugins.tsx
+++ b/app/renderer/sections/Plugins.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+import { codeburn } from '../lib/ipc'
+import styles from './Plugins.module.css'
+
+interface PluginInfo {
+  name: string
+  version: string
+  status: 'loaded' | 'rejected'
+  reason?: string
+  capabilities?: {
+    commands: string[]
+    syncAttributes: Array<{ key: string; disclosure: string }>
+    payloadSections: string[]
+    spanKinds: string[]
+  }
+}
+
+export function PluginsSection() {
+  const [plugins, setPlugins] = useState<PluginInfo[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    void loadPlugins()
+  }, [])
+
+  async function loadPlugins() {
+    try {
+      setLoading(true)
+      const result = await codeburn.pluginList()
+      setPlugins(result as PluginInfo[])
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setPlugins([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (loading) {
+    return <div className={styles.container}>Loading plugins...</div>
+  }
+
+  return (
+    <div className={styles.container}>
+      <h1>Plugins</h1>
+      {error && <div className={styles.error}>{error}</div>}
+      {plugins.length === 0 ? (
+        <div className={styles.empty}>
+          <p>No plugins installed</p>
+          <button onClick={() => void loadPlugins()}>Refresh</button>
+        </div>
+      ) : (
+        <div className={styles.list}>
+          {plugins.map(plugin => (
+            <div key={plugin.name} className={styles.row} data-status={plugin.status}>
+              <div className={styles.info}>
+                <div className={styles.name}>{plugin.name}@{plugin.version}</div>
+                {plugin.status === 'rejected' && (
+                  <div className={styles.reason}>{plugin.reason}</div>
+                )}
+                {plugin.capabilities && (
+                  <div className={styles.caps}>
+                    {plugin.capabilities.commands.length > 0 && (
+                      <span>commands {plugin.capabilities.commands.length}</span>
+                    )}
+                    {plugin.capabilities.syncAttributes.length > 0 && (
+                      <span>fields {plugin.capabilities.syncAttributes.length}</span>
+                    )}
+                    {plugin.capabilities.payloadSections.length > 0 && (
+                      <span>sections {plugin.capabilities.payloadSections.length}</span>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/renderer/sections/Plugins.tsx
+++ b/app/renderer/sections/Plugins.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react'
 import { codeburn } from '../lib/ipc'
+import { showToast } from '../lib/toast'
+import { PluginDetailsModal } from './PluginDetails'
+import { InstallFlowModal } from './InstallFlow'
 import styles from './Plugins.module.css'
 
 interface PluginInfo {
@@ -19,6 +22,10 @@ export function PluginsSection() {
   const [plugins, setPlugins] = useState<PluginInfo[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [detailsPlugin, setDetailsPlugin] = useState<string | null>(null)
+  const [showInstallFlow, setShowInstallFlow] = useState(false)
+  const [removing, setRemoving] = useState<string | null>(null)
+  const [confirming, setConfirming] = useState<string | null>(null)
 
   useEffect(() => {
     void loadPlugins()
@@ -38,6 +45,32 @@ export function PluginsSection() {
     }
   }
 
+  async function verifyPlugin(name: string) {
+    try {
+      const result = await codeburn.pluginVerify(name)
+      showToast(result.ok ? 'Plugin verified' : (result.stderr || 'Verification failed'), result.ok ? 'ok' : 'error')
+      if (result.ok) void loadPlugins()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : String(err), 'error')
+    }
+  }
+
+  async function removePlugin(name: string) {
+    setRemoving(name)
+    try {
+      const result = await codeburn.pluginRemove(name)
+      showToast(result.ok ? `Removed ${name}` : (result.stderr || 'Removal failed'), result.ok ? 'ok' : 'error')
+      if (result.ok) {
+        setConfirming(null)
+        void loadPlugins()
+      }
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : String(err), 'error')
+    } finally {
+      setRemoving(null)
+    }
+  }
+
   if (loading) {
     return <div className={styles.container}>Loading plugins...</div>
   }
@@ -49,7 +82,8 @@ export function PluginsSection() {
       {plugins.length === 0 ? (
         <div className={styles.empty}>
           <p>No plugins installed</p>
-          <button onClick={() => void loadPlugins()}>Refresh</button>
+          <button className="btnp" onClick={() => void loadPlugins()}>Refresh</button>
+          <button className="btnp btnp-primary" onClick={() => setShowInstallFlow(true)} style={{ marginLeft: '0.5rem' }}>Install plugin</button>
         </div>
       ) : (
         <div className={styles.list}>
@@ -74,9 +108,54 @@ export function PluginsSection() {
                   </div>
                 )}
               </div>
+              {plugin.status === 'loaded' && (
+                <div className={styles.actions}>
+                  <button className="btnp" onClick={() => setDetailsPlugin(plugin.name)} title="View plugin details">
+                    Details
+                  </button>
+                  <button className="btnp" onClick={() => void verifyPlugin(plugin.name)} title="Verify plugin signature">
+                    Verify
+                  </button>
+                  {confirming === plugin.name ? (
+                    <span style={{ display: 'flex', gap: '0.25rem', alignItems: 'center' }}>
+                      <span style={{ fontSize: '0.875rem', color: 'var(--mut)' }}>Remove {plugin.name}?</span>
+                      <button className="btnp" onClick={() => void removePlugin(plugin.name)} disabled={removing === plugin.name} style={{ fontSize: '0.75rem' }}>
+                        {removing === plugin.name ? 'Removing...' : 'Yes'}
+                      </button>
+                      <button className="btnp" onClick={() => setConfirming(null)} style={{ fontSize: '0.75rem' }}>
+                        No
+                      </button>
+                    </span>
+                  ) : (
+                    <button className="btnp" onClick={() => setConfirming(plugin.name)} title="Remove plugin">
+                      Remove
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
           ))}
         </div>
+      )}
+      <button className="btnp btnp-primary" onClick={() => setShowInstallFlow(true)} style={{ marginTop: '1.5rem' }}>
+        Install plugin
+      </button>
+
+      {detailsPlugin && (
+        <PluginDetailsModal
+          pluginName={detailsPlugin}
+          onClose={() => setDetailsPlugin(null)}
+        />
+      )}
+
+      {showInstallFlow && (
+        <InstallFlowModal
+          onClose={() => setShowInstallFlow(false)}
+          onSuccess={() => {
+            void loadPlugins()
+            setShowInstallFlow(false)
+          }}
+        />
       )}
     </div>
   )

--- a/app/renderer/sections/Settings.tsx
+++ b/app/renderer/sections/Settings.tsx
@@ -20,9 +20,10 @@ import { REFRESH_OPTIONS, useRefreshCadence } from '../lib/refreshCadence'
 import { showToast } from '../lib/toast'
 import { ToastHost } from '../components/ToastHost'
 import { rateLimitedNote } from './Plans'
+import { SharingPane } from './SettingsSharing'
 import type { ActionResult, AliasRow, ClaudeConfigSelector, CliError, CombinedUsage, DeviceScanResult, Identity, JsonPlanSummary, MenubarPayload, Period, PlanId, PlanProvider, PriceOverrideList, PriceOverrideRow, PriceRates, ProviderName, QuotaProvider, Scope, ShareStatus, StatusJson, TelemetryStatus } from '../lib/types'
 
-export type SettingsPane = 'general' | 'providers' | 'aliases' | 'pricing' | 'plans' | 'devices' | 'export' | 'privacy'
+export type SettingsPane = 'general' | 'providers' | 'aliases' | 'pricing' | 'plans' | 'devices' | 'export' | 'privacy' | 'sharing'
 type Pane = SettingsPane
 type Theme = 'system' | 'light' | 'dark'
 
@@ -62,6 +63,7 @@ const RAIL_ITEMS: Array<{ id: Pane; label: string; icon: React.ReactNode }> = [
   { id: 'plans', label: 'Plans', icon: <><rect x="2" y="5" width="20" height="14" rx="2" /><line x1="2" y1="10" x2="22" y2="10" /></> },
   { id: 'devices', label: 'Devices', icon: <><rect x="3" y="4" width="18" height="12" rx="1.5" /><line x1="8" y1="20" x2="16" y2="20" /><line x1="12" y1="16" x2="12" y2="20" /></> },
   { id: 'export', label: 'Export', icon: <><path d="M12 3v12" /><path d="M7 11l5 5 5-5" /><path d="M4 21h16" /></> },
+  { id: 'sharing', label: 'Automatic Sync', icon: <><path d="M12 3v12" /><path d="M7 11l5 5 5-5" /><path d="M4 21h16" /></> },
   { id: 'privacy', label: 'Privacy & data', icon: <path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z" /> },
 ]
 
@@ -122,6 +124,7 @@ export function Settings({ period, refreshToken = 0, onNavigate, initialPane, cl
           {pane === 'plans' && <PlansPane period={period} refreshToken={refreshToken} onNavigate={onNavigate} onConfigMutated={onConfigMutated} />}
           {pane === 'devices' && <DevicesPane period={period} refreshToken={refreshToken} />}
           {pane === 'export' && <ExportPane period={period} refreshToken={refreshToken} />}
+          {pane === 'sharing' && <SharingPane />}
           {pane === 'privacy' && <PrivacyPane />}
         </main>
       </div>

--- a/app/renderer/sections/SettingsSharing.tsx
+++ b/app/renderer/sections/SettingsSharing.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useState } from 'react'
+import { codeburn } from '../lib/ipc'
+import { showToast } from '../lib/toast'
+
+interface SyncAutoStatus {
+  enabled: boolean
+  cadence?: 'daily' | 'hourly'
+  attribution?: boolean
+  fingerprint?: string
+  acceptedAt?: string
+  currentMatches?: boolean
+  receipts?: Array<{ result: string; timestamp: string }>
+}
+
+export function SharingPane() {
+  const [syncStatus, setSyncStatus] = useState<SyncAutoStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showSetup, setShowSetup] = useState(false)
+  const [cadence, setCadence] = useState<'daily' | 'hourly'>('daily')
+  const [attribution, setAttribution] = useState(false)
+  const [disclosureText, setDisclosureText] = useState('')
+  const [accepting, setAccepting] = useState(false)
+
+  useEffect(() => {
+    void loadSyncStatus()
+  }, [])
+
+  async function loadSyncStatus() {
+    try {
+      setLoading(true)
+      const status = await codeburn.syncAutoStatus()
+      setSyncStatus(status as SyncAutoStatus)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleSetupStart() {
+    setShowSetup(true)
+    setCadence('daily')
+    setAttribution(false)
+  }
+
+  async function handleAccept() {
+    setAccepting(true)
+    try {
+      await codeburn.syncAutoEnable(cadence, attribution, true)
+      showToast('Automatic sync enabled', 'ok')
+      void loadSyncStatus()
+      setShowSetup(false)
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : String(err), 'error')
+    } finally {
+      setAccepting(false)
+    }
+  }
+
+  async function handleCancel() {
+    setShowSetup(false)
+  }
+
+  async function handleDisable() {
+    try {
+      const result = await codeburn.syncAutoDisable()
+      if (result.ok) {
+        showToast('Automatic sync disabled', 'ok')
+        void loadSyncStatus()
+      } else {
+        showToast(result.stderr || 'Failed to disable sync', 'error')
+      }
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : String(err), 'error')
+    }
+  }
+
+  if (loading) {
+    return (
+      <section className="set-p on">
+        <div><h3 className="set-h">Automatic Sync</h3><p className="set-sub">Share your session data automatically with your team.</p></div>
+        <p className="set-cap">Loading sync status...</p>
+      </section>
+    )
+  }
+
+  const isConfigured = syncStatus?.enabled
+
+  if (!isConfigured && !showSetup) {
+    return (
+      <section className="set-p on">
+        <div><h3 className="set-h">Automatic Sync</h3><p className="set-sub">Share your session data automatically with your team.</p></div>
+        <div className="card">
+          <div className="about-sec set-last-sec">
+            <p className="set-cap">Not configured. Set up automatic sync to share your session data.</p>
+            <button className="btnp btnp-primary" onClick={() => void handleSetupStart()} style={{ marginTop: '1rem' }}>
+              Set up automatic sync
+            </button>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  if (showSetup) {
+    return (
+      <section className="set-p on">
+        <div><h3 className="set-h">Automatic Sync</h3><p className="set-sub">Share your session data automatically with your team.</p></div>
+        <div className="card">
+          <div className="about-sec">
+            <div className="about-row">
+              <label className="tx" htmlFor="settings-sync-cadence">Cadence</label>
+              <span className="r">
+                <select
+                  id="settings-sync-cadence"
+                  value={cadence}
+                  onChange={e => setCadence(e.target.value as 'daily' | 'hourly')}
+                  style={{
+                    padding: '0.5rem',
+                    border: '1px solid var(--line)',
+                    borderRadius: '4px',
+                    background: 'var(--panel)',
+                    color: 'var(--ink)',
+                    fontFamily: 'inherit',
+                  }}
+                >
+                  <option value="daily">Daily</option>
+                  <option value="hourly">Hourly</option>
+                </select>
+              </span>
+            </div>
+          </div>
+          <div className="about-sec">
+            <label style={{ display: 'flex', alignItems: 'flex-start', gap: '0.75rem' }}>
+              <input
+                type="checkbox"
+                checked={attribution}
+                onChange={e => setAttribution(e.target.checked)}
+                style={{ marginTop: '0.25rem', cursor: 'pointer' }}
+              />
+              <div>
+                <div style={{ fontWeight: 600 }}>Include work-unit attribution</div>
+                <div style={{ fontSize: '0.875rem', color: 'var(--mut)' }}>Share detailed work-unit data with your team</div>
+              </div>
+            </label>
+          </div>
+          <div className="about-sec set-last-sec">
+            <div style={{
+              background: 'var(--fill)',
+              border: '1px solid var(--line)',
+              borderRadius: '4px',
+              padding: '1rem',
+              marginBottom: '1rem',
+              fontFamily: 'monospace',
+              fontSize: '0.75rem',
+              color: 'var(--ink)',
+              maxHeight: '200px',
+              overflow: 'auto',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+            }}>
+              This setup enables automatic sync of your CodeBurn session data with your organization's team dashboard. Your data will be shared according to the cadence you select. By accepting, you agree to automatic sharing.
+            </div>
+            <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+              <button className="btnp" onClick={() => void handleCancel()} disabled={accepting}>
+                Cancel
+              </button>
+              <button className="btnp btnp-primary" onClick={() => void handleAccept()} disabled={accepting}>
+                {accepting ? 'Accepting...' : 'Accept exactly this'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section className="set-p on">
+      <div><h3 className="set-h">Automatic Sync</h3><p className="set-sub">Share your session data automatically with your team.</p></div>
+      {error && <div className={`set-error`} style={{ marginBottom: '1rem' }}>{error}</div>}
+      <div className="card">
+        <div className="about-sec">
+          <div className="about-row">
+            <span className="tx">Status</span>
+            <span className="r" style={{ fontWeight: 600, color: 'var(--ok)' }}>Enabled</span>
+          </div>
+          <div className="about-row">
+            <span className="tx">Cadence</span>
+            <span className="r">{syncStatus?.cadence === 'hourly' ? 'Hourly' : 'Daily'}</span>
+          </div>
+          <div className="about-row">
+            <span className="tx">Attribution</span>
+            <span className="r">{syncStatus?.attribution ? 'Enabled' : 'Disabled'}</span>
+          </div>
+          {syncStatus?.fingerprint && (
+            <div className="about-row">
+              <span className="tx">Fingerprint</span>
+              <span className="r" style={{ fontFamily: 'monospace', fontSize: '0.75rem', color: 'var(--mut)' }}>
+                {syncStatus.fingerprint.split(':').slice(0, 2).join(':')}:…:{syncStatus.fingerprint.split(':').slice(-1)[0]}
+              </span>
+            </div>
+          )}
+          {syncStatus?.acceptedAt && (
+            <div className="about-row">
+              <span className="tx">Accepted at</span>
+              <span className="r" style={{ fontSize: '0.875rem', color: 'var(--mut)' }}>
+                {new Date(syncStatus.acceptedAt).toLocaleDateString()}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {syncStatus?.currentMatches === false && (
+          <div className="about-sec" style={{ background: 'var(--warn)', padding: '0.75rem 1rem', borderRadius: '4px', marginBottom: '1rem' }}>
+            <div style={{ color: 'var(--ink)', fontWeight: 600, marginBottom: '0.5rem' }}>Configuration drift detected</div>
+            <p style={{ margin: 0, fontSize: '0.875rem' }}>Your current sync settings differ from the last accepted configuration.</p>
+            <button className="btnp" onClick={() => setShowSetup(true)} style={{ marginTop: '0.75rem' }}>
+              Review and re-accept
+            </button>
+          </div>
+        )}
+
+        {syncStatus?.receipts && syncStatus.receipts.length > 0 && (
+          <div className="about-sec">
+            <div style={{ fontWeight: 600, marginBottom: '0.75rem' }}>Recent syncs</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              {syncStatus.receipts.slice(0, 5).map((receipt, i) => (
+                <div key={i} style={{ fontSize: '0.875rem', color: 'var(--mut)', borderTop: i > 0 ? '1px solid var(--line)' : undefined, paddingTop: i > 0 ? '0.5rem' : undefined }}>
+                  <span>{receipt.result}</span>
+                  <span style={{ display: 'block', fontSize: '0.75rem', marginTop: '0.25rem' }}>
+                    {new Date(receipt.timestamp).toLocaleString()}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="about-sec set-last-sec">
+          <button
+            className="btnp"
+            onClick={() => void handleDisable()}
+            style={{
+              background: 'var(--bad)',
+              color: 'white',
+              border: 'none',
+              padding: '0.5rem 1rem',
+              borderRadius: '4px',
+              cursor: 'pointer',
+            }}
+          >
+            Stop automatic sync
+          </button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -33,8 +33,37 @@ export function registerPluginCommands(program: Command): void {
     .command('list')
     .description('List every plugin the loader found, with status (loaded | rejected) and reason for rejections')
     .option('--dir <path>', 'Override the plugins directory (defaults to ~/.config/codeburn/plugins)')
-    .action(async (opts: { dir?: string }) => {
+    .option('--json', 'Output as machine-readable JSON')
+    .action(async (opts: { dir?: string; json?: boolean }) => {
       const loads = await loadPlugins(opts.dir)
+
+      if (opts.json) {
+        const result = loads.map(load => {
+          if (load.status === 'loaded') {
+            const m = load.manifest
+            return {
+              name: m.name,
+              version: m.version,
+              status: 'loaded' as const,
+              capabilities: {
+                commands: m.capabilities.commands,
+                syncAttributes: m.capabilities.syncAttributes,
+                payloadSections: m.capabilities.payloadSections,
+                spanKinds: m.capabilities.spanKinds,
+              }
+            }
+          } else {
+            return {
+              name: load.name,
+              status: 'rejected' as const,
+              reason: load.reason,
+            }
+          }
+        })
+        process.stdout.write(JSON.stringify(result, null, 0) + '\n')
+        return
+      }
+
       if (loads.length === 0) {
         process.stdout.write(`No plugins found in ${opts.dir ?? defaultPluginsDir()}.\n`)
         return
@@ -57,13 +86,23 @@ export function registerPluginCommands(program: Command): void {
     .command('info <name>')
     .description('Print the full manifest of a loaded plugin plus on-disk payload sections')
     .option('--dir <path>', 'Override the plugins directory')
-    .action(async (name: string, opts: { dir?: string }) => {
+    .option('--json', 'Output as machine-readable JSON')
+    .action(async (name: string, opts: { dir?: string; json?: boolean }) => {
       const loads = await loadPlugins(opts.dir)
       const loaded = loads.find((l): l is Extract<typeof l, { status: 'loaded' }> => l.status === 'loaded' && l.manifest.name === name)
       if (loaded) {
         const m = loaded.manifest
-        process.stdout.write(JSON.stringify(m, null, 2) + '\n')
         const sections = await listOnDiskSections(loaded.dir, m)
+        if (opts.json) {
+          const result = {
+            ...m,
+            dir: loaded.dir,
+            onDiskSections: sections,
+          }
+          process.stdout.write(JSON.stringify(result, null, 0) + '\n')
+          return
+        }
+        process.stdout.write(JSON.stringify(m, null, 2) + '\n')
         if (sections.length > 0) {
           process.stdout.write(`\non-disk payload sections: ${sections.join(', ')}\n`)
         } else {

--- a/src/sync/cli.ts
+++ b/src/sync/cli.ts
@@ -706,14 +706,67 @@ export function registerSyncCommands(program: Command): void {
   auto
     .command('status')
     .description('Show automatic sync status and recent receipts')
-    .action(async () => {
+    .option('--json', 'Output as machine-readable JSON')
+    .action(async (opts: { json?: boolean }) => {
       const config = readSyncConfig()
+
+      let currentMatches: boolean | undefined
+      let changed: string[] = []
+      const accepted = config?.auto?.accepted
+
+      // Recompute fingerprint to check for changes
+      if (accepted) {
+        try {
+          const pluginLoads: PluginLoad[] = await loadPlugins()
+          const pluginKeys = declaredSyncAttributes(pluginLoads)
+          const allKeys = Array.from(CORE_SYNC_ATTRIBUTE_KEYS)
+            .concat(Array.from(pluginKeys.keys()))
+            .sort()
+
+          const fingerprintInput = buildAcceptanceFingerprintInput(config, allKeys, accepted.attribution, accepted.cadence)
+          const currentFingerprint = computeAcceptanceFingerprint(fingerprintInput)
+          currentMatches = currentFingerprint === accepted.fingerprint
+          if (!currentMatches) {
+            changed = detectFingerprintChanges(accepted.input, fingerprintInput)
+          }
+        } catch {
+          currentMatches = undefined
+        }
+      }
+
+      if (opts.json) {
+        const result: Record<string, unknown> = {
+          configured: !!accepted,
+          killed: config?.auto?.killed ?? false,
+        }
+
+        if (accepted) {
+          result.accepted = {
+            fingerprint: accepted.fingerprint,
+            acceptedAt: accepted.acceptedAt,
+            cadence: accepted.cadence,
+            attribution: accepted.attribution,
+          }
+          if (currentMatches !== undefined) {
+            result.currentMatches = currentMatches
+            if (!currentMatches) {
+              result.changed = changed
+            }
+          }
+        }
+
+        const receipts = readReceipts(5)
+        result.receipts = receipts
+
+        process.stdout.write(JSON.stringify(result, null, 0) + '\n')
+        return
+      }
+
       if (!config?.auto?.accepted) {
         process.stdout.write('Automatic sync is not configured.\n')
         return
       }
 
-      const accepted = config.auto.accepted
       if (typeof accepted.fingerprint !== 'string' || typeof accepted.acceptedAt !== 'string') {
         process.stdout.write('Automatic sync acceptance record is damaged. Run: codeburn sync auto enable --cadence <daily|hourly> --accept\n')
         process.exit(1)
@@ -724,23 +777,11 @@ export function registerSyncCommands(program: Command): void {
       process.stdout.write(`Accepted at: ${accepted.acceptedAt}\n`)
       process.stdout.write(`Cadence: ${accepted.cadence}\n`)
 
-      // Recompute fingerprint to check for changes
-      try {
-        const pluginLoads: PluginLoad[] = await loadPlugins()
-        const pluginKeys = declaredSyncAttributes(pluginLoads)
-        const allKeys = Array.from(CORE_SYNC_ATTRIBUTE_KEYS)
-          .concat(Array.from(pluginKeys.keys()))
-          .sort()
-
-        const fingerprintInput = buildAcceptanceFingerprintInput(config, allKeys, accepted.attribution, accepted.cadence)
-        const currentFingerprint = computeAcceptanceFingerprint(fingerprintInput)
-        if (currentFingerprint === accepted.fingerprint) {
-          process.stdout.write('Current fingerprint: MATCHES\n')
-        } else {
-          const changed = detectFingerprintChanges(accepted.input, fingerprintInput)
-          process.stdout.write(`Current fingerprint: DIFFERS (${changed.join(', ')})\n`)
-        }
-      } catch {
+      if (currentMatches === true) {
+        process.stdout.write('Current fingerprint: MATCHES\n')
+      } else if (currentMatches === false) {
+        process.stdout.write(`Current fingerprint: DIFFERS (${changed.join(', ')})\n`)
+      } else {
         process.stdout.write('Current fingerprint: unable to recompute\n')
       }
 

--- a/src/sync/cli.ts
+++ b/src/sync/cli.ts
@@ -767,15 +767,16 @@ export function registerSyncCommands(program: Command): void {
         return
       }
 
-      if (typeof accepted.fingerprint !== 'string' || typeof accepted.acceptedAt !== 'string') {
+      const acceptedRecord = config.auto.accepted
+      if (typeof acceptedRecord.fingerprint !== 'string' || typeof acceptedRecord.acceptedAt !== 'string') {
         process.stdout.write('Automatic sync acceptance record is damaged. Run: codeburn sync auto enable --cadence <daily|hourly> --accept\n')
         process.exit(1)
         return
       }
 
-      process.stdout.write(`Accepted fingerprint: ${accepted.fingerprint}\n`)
-      process.stdout.write(`Accepted at: ${accepted.acceptedAt}\n`)
-      process.stdout.write(`Cadence: ${accepted.cadence}\n`)
+      process.stdout.write(`Accepted fingerprint: ${acceptedRecord.fingerprint}\n`)
+      process.stdout.write(`Accepted at: ${acceptedRecord.acceptedAt}\n`)
+      process.stdout.write(`Cadence: ${acceptedRecord.cadence}\n`)
 
       if (currentMatches === true) {
         process.stdout.write('Current fingerprint: MATCHES\n')

--- a/tests/plugin-socket.test.ts
+++ b/tests/plugin-socket.test.ts
@@ -257,6 +257,68 @@ describe('plugin CLI: codeburn plugin list|info|verify', () => {
       process.exitCode = savedExitCode
     }
   })
+
+  it('plugin list --json returns array of plugin objects', async () => {
+    const pluginDir = join(tmpDir, 'test-plugin')
+    await mkdir(pluginDir, { recursive: true })
+    const manifest = validManifest('test-plugin')
+    await writeFile(join(pluginDir, 'codeburn-plugin.json'), JSON.stringify(manifest))
+
+    const program = makeProgram()
+    const savedStdout = process.stdout.write
+    let stdout = ''
+    process.stdout.write = (chunk: string | Uint8Array | Buffer): boolean => {
+      stdout += chunk.toString()
+      return true
+    }
+
+    const prev = process.env.CODEBURN_PLUGIN_DEV
+    process.env.CODEBURN_PLUGIN_DEV = '1'
+    try {
+      await program.parseAsync(['node', 'codeburn', 'plugin', 'list', '--json', '--dir', tmpDir])
+      const result = JSON.parse(stdout)
+      expect(Array.isArray(result)).toBe(true)
+      expect(result.length).toBe(1)
+      expect(result[0].status).toBe('loaded')
+      expect(result[0].name).toBe('test-plugin')
+      expect(result[0].version).toBe('0.1.0')
+      expect(result[0].capabilities).toBeDefined()
+    } finally {
+      process.stdout.write = savedStdout
+      if (prev === undefined) delete process.env.CODEBURN_PLUGIN_DEV
+      else process.env.CODEBURN_PLUGIN_DEV = prev
+    }
+  })
+
+  it('plugin info --json returns manifest with dir and onDiskSections', async () => {
+    const pluginDir = join(tmpDir, 'info-plugin')
+    await mkdir(pluginDir, { recursive: true })
+    const manifest = validManifest('info-plugin')
+    await writeFile(join(pluginDir, 'codeburn-plugin.json'), JSON.stringify(manifest))
+
+    const program = makeProgram()
+    const savedStdout = process.stdout.write
+    let stdout = ''
+    process.stdout.write = (chunk: string | Uint8Array | Buffer): boolean => {
+      stdout += chunk.toString()
+      return true
+    }
+
+    const prev = process.env.CODEBURN_PLUGIN_DEV
+    process.env.CODEBURN_PLUGIN_DEV = '1'
+    try {
+      await program.parseAsync(['node', 'codeburn', 'plugin', 'info', 'info-plugin', '--json', '--dir', tmpDir])
+      const result = JSON.parse(stdout)
+      expect(result.name).toBe('info-plugin')
+      expect(result.version).toBe('0.1.0')
+      expect(result.dir).toBe(pluginDir)
+      expect(Array.isArray(result.onDiskSections)).toBe(true)
+    } finally {
+      process.stdout.write = savedStdout
+      if (prev === undefined) delete process.env.CODEBURN_PLUGIN_DEV
+      else process.env.CODEBURN_PLUGIN_DEV = prev
+    }
+  })
 })
 
 // ── 5. Plugin command registration ────────────────────────────────────

--- a/tests/sync-consent.test.ts
+++ b/tests/sync-consent.test.ts
@@ -566,6 +566,20 @@ describe('Damaged acceptance record', () => {
     }) as never)
 
     const { registerSyncCommands } = await import('../src/sync/cli.js')
+    const program = new Command()
+    program.exitOverride()
+    registerSyncCommands(program)
+
+    await expect(
+      program.parseAsync(['node', 'codeburn', 'sync', 'auto', 'status']),
+    ).rejects.toThrow('__exit__')
+
+    const stdout = stdoutChunks.join('')
+    expect(stdout).toContain('Automatic sync acceptance record is damaged.')
+    expect(stdout).not.toContain('undefined')
+  })
+})
+
 describe('sync auto status --json', () => {
   let testDir: string
   beforeEach(async () => {
@@ -608,13 +622,6 @@ describe('sync auto status --json', () => {
     program.exitOverride()
     registerSyncCommands(program)
 
-    await expect(
-      program.parseAsync(['node', 'codeburn', 'sync', 'auto', 'status']),
-    ).rejects.toThrow('__exit__')
-
-    const stdout = stdoutChunks.join('')
-    expect(stdout).toContain('Automatic sync acceptance record is damaged.')
-    expect(stdout).not.toContain('undefined')
     const savedStdout = process.stdout.write
     let stdout = ''
     process.stdout.write = (chunk: string | Uint8Array | Buffer): boolean => {

--- a/tests/sync-consent.test.ts
+++ b/tests/sync-consent.test.ts
@@ -566,6 +566,44 @@ describe('Damaged acceptance record', () => {
     }) as never)
 
     const { registerSyncCommands } = await import('../src/sync/cli.js')
+describe('sync auto status --json', () => {
+  let testDir: string
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'sync-auto-'))
+    process.env.HOME = testDir
+  })
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true })
+  })
+
+  it('outputs JSON when --json flag is set', async () => {
+    await mkdir(join(testDir, '.config', 'codeburn'), { recursive: true })
+
+    const config = {
+      issuer: 'https://issuer.example.com',
+      clientId: 'test-client',
+      baseUrl: 'https://receiver.example.com',
+      auto: {
+        accepted: {
+          fingerprint: 'abc123',
+          acceptedAt: '2024-01-01T00:00:00Z',
+          cadence: 'daily' as const,
+          disclosure: 'test disclosure',
+          attribution: false,
+        },
+        killed: false,
+      },
+    }
+    writeSyncConfig(config)
+
+    appendReceipt({ at: '2024-01-01T12:00:00Z', fingerprint: 'abc123', result: 'pushed', spans: 5 })
+    appendReceipt({ at: '2024-01-01T13:00:00Z', fingerprint: 'abc123', result: 'pushed', spans: 3 })
+
+    // Import and setup CLI
+    const { registerSyncCommands } = await import('../src/sync/cli.js')
+    const { Command } = await import('commander')
+
     const program = new Command()
     program.exitOverride()
     registerSyncCommands(program)
@@ -577,5 +615,26 @@ describe('Damaged acceptance record', () => {
     const stdout = stdoutChunks.join('')
     expect(stdout).toContain('Automatic sync acceptance record is damaged.')
     expect(stdout).not.toContain('undefined')
+    const savedStdout = process.stdout.write
+    let stdout = ''
+    process.stdout.write = (chunk: string | Uint8Array | Buffer): boolean => {
+      stdout += chunk.toString()
+      return true
+    }
+
+    try {
+      await program.parseAsync(['node', 'codeburn', 'sync', 'auto', 'status', '--json'])
+      const result = JSON.parse(stdout)
+      expect(result.configured).toBe(true)
+      expect(result.accepted).toBeDefined()
+      expect(result.accepted.fingerprint).toBe('abc123')
+      expect(result.accepted.cadence).toBe('daily')
+      expect(result.accepted.attribution).toBe(false)
+      expect(result.killed).toBe(false)
+      expect(Array.isArray(result.receipts)).toBe(true)
+      expect(result.receipts.length).toBeGreaterThan(0)
+    } finally {
+      process.stdout.write = savedStdout
+    }
   })
 })


### PR DESCRIPTION
Stacked on #1154. The plugin era surfaces in the desktop app; the CLI stays the only enforcement point - every action here is a CLI command the app invokes.

- Plugins entry at the bottom of the nav rail opens the manager: status rows (rejected plugins stay visible with the CLI's reason), capability chips, Details drawer rendering every declared field's disclosure verbatim, Verify, confirm-to-Remove, and an Add Plugin stepper (org name or local folder) whose errors are the CLI's own messages.
- Settings > Sharing is the consent center for CB-4: empty state with one primary action, the real disclosure text captured from sync auto enable shown before Accept, fingerprint/receipts on the active state, a drift banner from the named-cause receipts, and an always-visible Stop automatic sync.
- Dormant Team tab: a renderer registry keyed by payload plugin section (teams.week, teams.status); appears only when the sections exist, ignores unknown keys, hints on newer schema versions.
- CLI gains --json on plugin list, plugin info, and sync auto status; human output unchanged.

Validation: root suite green (3,839; 26 jsdom file errors pre-exist), app 614 tests green, both typechecks clean, renderer + electron build green; packaged DMG smoke-tested with the signed teams plugin 0.1.1 loaded and sections on disk.