### PR TITLE
perf(tui): show cached periods before refreshing sources

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -10,7 +10,8 @@ import { parseAllSessions, filterProjectsByDateRange, filterProjectsByName, setI
 import { isColdCacheOnDisk } from './session-cache.js'
 import { findUnpricedModels, isExpectedFreeModel, loadPricing } from './models.js'
 import { aggregateModelTotals } from './model-breakdown.js'
-import { buildDurablePeriod } from './usage-aggregator.js'
+import { buildDurableOverviewFromNormalizedIndex, buildDurablePeriod, hydrateDailyCacheFromNormalizedProjects } from './usage-aggregator.js'
+import { loadDailyCache, type DailyCache } from './daily-cache.js'
 import { getAllProviders } from './providers/index.js'
 import { classHeaderLine, classTotals, findingBasis, findingClass, scanAndDetect, type FindingClass, type WasteFinding, type WasteAction, type OptimizeResult } from './optimize.js'
 import { appliedFixGlyph, formatAppliedFix, type AppliedFix } from './act/types.js'
@@ -34,6 +35,7 @@ export type DailyActivityRow = {
 
 export const DAILY_ACTIVITY_PAGE_SIZE = 10
 export const INDEX_PROGRESS_TICK_MS = 1000
+export const LARGE_HISTORY_FILE_THRESHOLD = 1000
 export const INTERACTIVE_RENDER_OPTIONS = { alternateScreen: true } as const
 export const RESIZE_DEBOUNCE_MS = 150
 
@@ -1478,7 +1480,7 @@ function ScrollableViewport({ children, width, lineScroll = true }: { children: 
   )
 }
 
-export function InteractiveDashboard({ initialProjects, initialDailyHistoryProjects, initialPeriod, initialProvider, initialPlanUsages, initialDurable, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel, initialDay, windowColumns, initialIndexPendingFiles }: {
+export function InteractiveDashboard({ initialProjects, initialDailyHistoryProjects, initialPeriod, initialProvider, initialPlanUsages, initialDurable, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel, initialDay, windowColumns, initialIndexPendingFiles, initialHistoryIndexing = false, initialCacheWasCold = false, initialHistoryIndex }: {
   initialProjects: ProjectSummary[]
   initialDailyHistoryProjects?: ProjectSummary[]
   initialPeriod: Period
@@ -1492,9 +1494,12 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   customRangeLabel?: string
   initialDay?: string
   windowColumns: number
-  /// Files the cold first paint deferred (#1107). Non-zero means the numbers on
-  /// screen cover only what is indexed so far, and a background fill is owed.
+  /// Files the Today-first paint deferred. Non-zero means older periods still
+  /// need the background index before they can be selected truthfully.
   initialIndexPendingFiles?: number
+  initialHistoryIndexing?: boolean
+  initialCacheWasCold?: boolean
+  initialHistoryIndex?: DashboardHistoryIndex
 }) {
   const { exit } = useApp()
   const [period, setPeriod] = useState<Period>(initialPeriod)
@@ -1520,8 +1525,9 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   // whole set rotates through without demanding attention.
   const [noteTick, setNoteTick] = useState(0)
   const indexPendingFiles = initialIndexPendingFiles ?? 0
-  const [indexing, setIndexing] = useState(indexPendingFiles > 0)
+  const [indexing, setIndexing] = useState((initialHistoryIndexing || indexPendingFiles > 0) && initialHistoryIndex == null)
   const [indexedFiles, setIndexedFiles] = useState(0)
+  const historyIndexRef = useRef<DashboardHistoryIndex | null>(initialHistoryIndex ?? null)
   // #1143: first q during the cold-start fill arms a confirmation so the user
   // sees feedback instead of a silent ~16.5s drain. The second q (or any
   // Ctrl+C) takes the abrupt path; #1109 already made abrupt exit kill-safe.
@@ -1553,6 +1559,12 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   const compareAvailable = modelCount >= 2
   const viewRef = useRef(view)
   viewRef.current = view
+  const periodRef = useRef(period)
+  periodRef.current = period
+  const providerRef = useRef(activeProvider)
+  providerRef.current = activeProvider
+  const dayRef = useRef(dayDate)
+  dayRef.current = dayDate
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const reloadGenerationRef = useRef(0)
   const reloadInFlightRef = useRef(false)
@@ -1697,19 +1709,39 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
     return () => clearInterval(id)
   }, [refreshSeconds, period, activeProvider, dayDate, reloadData, view])
 
-  // Background fill for the progressive cold start. The first paint deliberately
-  // skipped every file too old to show in the selected period; this is the pass
-  // that indexes them, and it is an ordinary unscoped reload, so what it writes
-  // to the caches — and what it puts back on screen — is exactly what a full
-  // cold parse would have produced. Mount-only: one fill per launch.
+  // One background lifetime index for this provider. The first paint deliberately
+  // skipped every file too old to show in Today; this pass normalizes them through
+  // the existing session cache and completes the existing durable day cache. All
+  // period tabs then project from this one result instead of reparsing the corpus.
+  // Mount-only: one index for the launch provider; provider changes retain the
+  // existing explicit reload path.
   useEffect(() => {
-    if (indexPendingFiles === 0) return
+    if (!initialHistoryIndexing || initialHistoryIndex) return
     const parsedBefore = filesParsedFromSourceCount()
     const id = setInterval(() => setIndexedFiles(filesParsedFromSourceCount() - parsedBefore), INDEX_PROGRESS_TICK_MS)
-    void reloadData(initialPeriod, initialProvider, initialDay ?? null, true).finally(() => {
-      clearInterval(id)
-      setIndexing(false)
-    })
+    void buildDashboardHistoryIndex(initialProvider, projectFilter, excludeFilter)
+      .then(async index => {
+        historyIndexRef.current = index
+        if (providerRef.current !== index.provider || dayRef.current != null || customRange != null) return
+        const selected = selectDashboardHistoryIndex(index, periodRef.current)
+        setDailyHistoryProjects(filterProjectsByName(index.normalizedProjects, projectFilter, excludeFilter))
+        setProjects(selected.projects)
+        setDurable(selected.durable)
+        setPlanUsages(index.planUsages)
+        setLoading(false)
+        setIndexedFiles(indexPendingFiles)
+        await nextTick()
+      })
+      .catch(error => {
+        console.error(error)
+        if (providerRef.current === initialProvider && dayRef.current == null && customRange == null) {
+          void reloadData(periodRef.current, initialProvider, null)
+        }
+      })
+      .finally(() => {
+        clearInterval(id)
+        setIndexing(false)
+      })
     return () => clearInterval(id)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -1718,8 +1750,22 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
     if (!indexing && quitArmed) setQuitArmed(false)
   }, [indexing, quitArmed])
 
+  const selectIndexedPeriod = useCallback((np: Period): boolean => {
+    const index = historyIndexRef.current
+    if (!index || index.provider !== activeProvider) return false
+    const selected = selectDashboardHistoryIndex(index, np)
+    setPeriod(np)
+    setDailyHistoryCursor(0)
+    setDayDate(null)
+    setProjects(selected.projects)
+    setDurable(selected.durable)
+    setLoading(false)
+    return true
+  }, [activeProvider])
+
   const switchPeriod = useCallback((np: Period) => {
     if (np === period && !dayDate) return
+    if (selectIndexedPeriod(np)) return
     // Clear projects + flip loading synchronously so the dashboard never
     // renders the new period label over the old period's numbers between
     // setPeriod() and the reloadData() promise resolving. Without this,
@@ -1729,21 +1775,26 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
     setDailyHistoryCursor(0)
     setDayDate(null)
     setProjects([])
+    setDurable(undefined)
     setLoading(true)
     if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (indexing) return
     debounceRef.current = setTimeout(() => { reloadData(np, activeProvider, null) }, 600)
-  }, [period, activeProvider, dayDate, reloadData])
+  }, [period, activeProvider, dayDate, reloadData, selectIndexedPeriod, indexing])
 
   const switchPeriodImmediate = useCallback(async (np: Period) => {
     if (np === period && !dayDate) return
+    if (selectIndexedPeriod(np)) return
     setPeriod(np)
     setDailyHistoryCursor(0)
     setDayDate(null)
     setProjects([])
+    setDurable(undefined)
     setLoading(true)
     if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (indexing) return
     await reloadData(np, activeProvider, null)
-  }, [period, activeProvider, dayDate, reloadData])
+  }, [period, activeProvider, dayDate, reloadData, selectIndexedPeriod, indexing])
 
   const switchDay = useCallback(async (nextDay: string) => {
     const today = parseDayFlag('today')!.day
@@ -1859,7 +1910,7 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
         {!isCustomRange && !isDayMode && <PeriodTabs active={period} providerName={activeProvider} showProvider={view !== 'compare' && multipleProviders} />}
         {isDayMode && <DayBanner label={headerLabel} width={dashWidth} />}
         {isCustomRange && <CustomRangeBanner label={headerLabel} width={dashWidth} />}
-        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} />}
+        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} cold={initialCacheWasCold} />}
         {view === 'compare'
           ? <Box flexDirection="column" paddingX={2} paddingY={1}>
               <Box flexDirection="column" borderStyle="round" borderColor={ORANGE} paddingX={1}>
@@ -1880,7 +1931,7 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
         {!isCustomRange && !isDayMode && <PeriodTabs active={period} providerName={activeProvider} showProvider={multipleProviders && view !== 'compare'} />}
         {isDayMode && <DayBanner label={headerLabel} width={dashWidth} />}
         {isCustomRange && <CustomRangeBanner label={headerLabel} width={dashWidth} />}
-        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} />}
+        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} cold={initialCacheWasCold} />}
         {view === 'compare'
           ? <CompareView projects={projects} onBack={() => setView('dashboard')} />
           : view === 'optimize' && optimizeResult
@@ -1907,16 +1958,19 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   )
 }
 
-/// Honest partial state while the background fill runs: the panels below show
-/// only what is indexed so far, and every period the fill has not reached yet
-/// (month, 6 months, lifetime) reads short until it lands.
-function IndexingBanner({ width, done, total }: { width: number; done: number; total: number }) {
+/// Honest phase and file-count state while Today remains usable and older
+/// periods wait for the shared normalized index.
+function IndexingBanner({ width, done, total, cold }: { width: number; done: number; total: number; cold: boolean }) {
+  const largeFirstIndex = cold && total >= LARGE_HISTORY_FILE_THRESHOLD
   return (
-    <Box width={width} paddingX={1}>
+    <Box width={width} paddingX={1} flexDirection="column">
       <Text wrap="truncate-end">
-        <Text color={ORANGE} bold>indexing </Text>
-        <Text dimColor>history · {Math.min(done, total)}/{total} files · totals below cover what is indexed so far</Text>
+        <Text color={ORANGE} bold>{cold ? 'indexing ' : 'loading '}</Text>
+        <Text dimColor>
+          {cold ? 'source history' : 'normalized history'} · {Math.min(done, total)}/{total} files · Today is ready; older periods fill from this index
+        </Text>
       </Text>
+      {largeFirstIndex && <Text color={ORANGE}>large first index · may take a few minutes</Text>}
     </Box>
   )
 }
@@ -1986,6 +2040,7 @@ export async function assembleDashboardData(
   initialDay: string | null,
   scrollableDailyHistory: boolean,
   autoFallback = false,
+  includePlanUsages = true,
 ): Promise<{ period: Period; scannedProjects: ProjectSummary[]; filteredProjects: ProjectSummary[]; planUsages: PlanUsage[]; initialDurable: DurableOverview }> {
   const range = getDashboardScanRange(period, customRange, initialDay, scrollableDailyHistory)
   // With the fallback armed the scope must cover the period it can land on too,
@@ -2006,13 +2061,98 @@ export async function assembleDashboardData(
       ? AUTO_FALLBACK_PERIOD
       : period
     const filteredProjects = selectDashboardPeriodProjects(scannedProjects, opened, scrollableDailyHistory)
-    const planUsages = await getPlanUsages()
+    // A Today-scoped progressive pass cannot truthfully compute a monthly plan
+    // window. Keep that panel absent until the lifetime background index lands.
+    const planUsages = includePlanUsages ? await getPlanUsages() : []
     // Durable headline totals for the initial paint (carry-forward cache + today),
     // matching the menubar/report. The interactive tree recomputes this on every
     // period/provider/refresh change; the static one-shot render uses just this.
     const initialDurable = await computeDurableOverview(opened, provider, projectFilter, excludeFilter, customRange, initialDay)
     return { period: opened, scannedProjects, filteredProjects, planUsages, initialDurable }
   })
+}
+
+export type DashboardHistoryIndex = {
+  provider: string
+  normalizedProjects: ProjectSummary[]
+  cache: DailyCache
+  planUsages: PlanUsage[]
+  projectFilter?: string[]
+  excludeFilter?: string[]
+}
+
+/** Build the one normalized lifetime result every standard period tab shares. */
+export async function buildDashboardHistoryIndex(
+  provider: string,
+  projectFilter: string[] | undefined,
+  excludeFilter: string[] | undefined,
+): Promise<DashboardHistoryIndex> {
+  const normalizedProjects = await parseAllSessions(getPeriodRange('lifetime'), provider)
+  // The durable cache is all-provider state. Only an all-provider normalized
+  // index can safely advance it; a provider-scoped index reads but never
+  // rewrites that shared history.
+  const cache = provider === 'all'
+    ? await hydrateDailyCacheFromNormalizedProjects(normalizedProjects)
+    : await loadDailyCache()
+  const planUsages = await getPlanUsages()
+  return { provider, normalizedProjects, cache, planUsages, projectFilter, excludeFilter }
+}
+
+/** Pure period projection: no discovery, transcript reads, or parser calls. */
+export function selectDashboardHistoryIndex(
+  index: DashboardHistoryIndex,
+  period: Period,
+): { projects: ProjectSummary[]; durable: DurableOverview } {
+  const filtered = filterProjectsByName(index.normalizedProjects, index.projectFilter, index.excludeFilter)
+  const projects = filterProjectsByDateRange(filtered, getPeriodRange(period))
+  const durable = buildDurableOverviewFromNormalizedIndex(
+    { range: getPeriodRange(period), label: PERIOD_LABELS[period] },
+    index.normalizedProjects,
+    index.cache,
+    { provider: index.provider, project: index.projectFilter, exclude: index.excludeFilter },
+  )
+  return { projects, durable }
+}
+
+/**
+ * Assemble the first interactive frame from only the period it is about to
+ * label. This is intentionally independent of cache coldness: a complete
+ * sharded cache can still contain years of normalized sessions, and loading
+ * that lifetime result before Ink starts is the warm-start regression this
+ * seam prevents.
+ *
+ * The returned deferred count is passed to the mounted dashboard, which owns
+ * the one lifetime background index. If the unset default falls back from an
+ * empty Today to 7 Days, repaint under the wider floor before anything is
+ * shown so the fallback is truthful too.
+ */
+export async function assembleDashboardFirstPaint(
+  period: Period,
+  provider: string,
+  projectFilter: string[] | undefined,
+  excludeFilter: string[] | undefined,
+  customRange: DateRange | null | undefined,
+  initialDay: string | null,
+  autoFallback = false,
+): Promise<{ result: Awaited<ReturnType<typeof assembleDashboardData>>; deferredFiles: number }> {
+  const run = (p: Period, fallback: boolean) => withColdFirstPaintFloor(
+    getPeriodRange(p).start,
+    () => assembleDashboardData(
+      p,
+      provider,
+      projectFilter,
+      excludeFilter,
+      customRange,
+      initialDay,
+      false,
+      fallback,
+      false,
+    ),
+    true,
+  )
+  let paint = await run(period, autoFallback)
+  if (paint.result.period !== period) paint = await run(paint.result.period, false)
+  return paint
 }
 
 /// Where the unset interactive default lands when today has no sessions yet (#1111).
@@ -2028,41 +2168,34 @@ export async function renderDashboard(period: Period = 'week', provider: string 
   const dayRange = initialDay ? getDayRange(initialDay) : null
   const isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY)
   const scrollableDailyHistory = isTTY && dayRange == null && customRange == null
-  const range = getDashboardScanRange(period, customRange, initialDay ?? null, scrollableDailyHistory)
-  // Progressive cold start (#1107): the first paint of the standard dated view
-  // only needs the files that can hold data the selected period displays, so on
-  // a cold cache it parses those first and hands the rest to a background fill
-  // once the dashboard is on screen. Interactive only — every one-shot output
+  // Progressive interactive start: the first paint of the standard dated view
+  // only needs the selected period, regardless of whether the normalized cache
+  // is cold or complete. Older history is handed to one background index once
+  // the dashboard is on screen. Interactive only — every one-shot output
   // (json/csv/markdown, report, sessions, the app and menubar payloads) keeps
   // the full parse and can never return a partial total.
-  const progressive = isTTY && dayRange == null && customRange == null && await isColdCacheOnDisk()
+  const progressive = isTTY && dayRange == null && customRange == null
+  const cacheWasCold = progressive ? await isColdCacheOnDisk() : false
   // #1111: with no explicit period the interactive dashboard opens on Today and
   // falls back to 7 days only when today holds nothing yet. Explicit -p/--day/
   // --from/--to and the non-interactive render keep the 7-day default.
   const auto = autoPeriod && isTTY && dayRange == null && customRange == null
   const openPeriod: Period = auto ? 'today' : period
-  const runPaint = async (p: Period, fallback: boolean) => {
-    const assemble = () =>
-      assembleDashboardData(p, provider, projectFilter, excludeFilter, customRange, initialDay ?? null, scrollableDailyHistory, fallback)
-    return progressive
-      ? await withColdFirstPaintFloor(getPeriodRange(p).start, assemble)
-      : { result: await assemble(), deferredFiles: 0 }
-  }
-  let paint = await runPaint(openPeriod, auto)
-  // A cold first paint is floored to the files its period needs, so a fallback
-  // decided under the Today floor would paint 7 days off today's files alone.
-  // Repaint it on the 7-day floor instead — pass one's files are in the cache
-  // it just wrote, so they are served rather than parsed again.
-  if (progressive && paint.result.period !== openPeriod) paint = await runPaint(paint.result.period, false)
+  const paint = progressive
+    ? await assembleDashboardFirstPaint(openPeriod, provider, projectFilter, excludeFilter, customRange, initialDay ?? null, auto)
+    : {
+        result: await assembleDashboardData(openPeriod, provider, projectFilter, excludeFilter, customRange, initialDay ?? null, scrollableDailyHistory, auto),
+        deferredFiles: 0,
+      }
   if (process.env['CODEBURN_VERBOSE'] === '1') {
-    process.stderr.write(`codeburn: progressive cold start ${progressive ? 'on' : 'off'}, ${paint.deferredFiles} files deferred to the background fill\n`)
+    process.stderr.write(`codeburn: progressive startup ${progressive ? 'on' : 'off'}, ${paint.deferredFiles} files deferred to the background index\n`)
   }
   const { period: opened, scannedProjects, filteredProjects, planUsages, initialDurable } = paint.result
   const label = initialDay ? formatDayRangeLabel(initialDay) : customRangeLabel
   patchStdoutForWindows()
   if (isTTY) {
     const app = renderDebouncedInteractive(process.stdout, ({ columns }) => (
-      <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={opened} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} windowColumns={columns} initialIndexPendingFiles={paint.deferredFiles} />
+      <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={opened} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} windowColumns={columns} initialIndexPendingFiles={paint.deferredFiles} initialHistoryIndexing={progressive} initialCacheWasCold={cacheWasCold} />
     ))
     try {
       await app.waitUntilExit()

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1730,13 +1730,13 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
       historyIndexRef.current = index
       setDailyHistoryProjects(filterProjectsByName(index.normalizedProjects, projectFilter, excludeFilter))
       let target = periodRef.current
-      if (
-        !autoFallbackAppliedRef.current
-        && autoFallbackFromEmptyToday
-        && target === 'today'
-        && index.readyThrough === 'week'
-        && !initialProjects.some(project => project.sessions.length > 0)
-      ) {
+      if (shouldAutoFallbackToWeek(
+        autoFallbackFromEmptyToday,
+        autoFallbackAppliedRef.current,
+        target,
+        index,
+        initialProjects,
+      )) {
         autoFallbackAppliedRef.current = true
         target = 'week'
         setPeriod('week')
@@ -1951,9 +1951,11 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
       setProjects([])
       setDurable(undefined)
       setLoading(true)
-      setIndexing(true)
       if (debounceRef.current) clearTimeout(debounceRef.current)
-      if (dayDate) void reloadData(period, next, dayDate)
+      // Custom ranges and day views do not run the progressive history effect,
+      // so provider cycling must always own and finish its reload. Setting the
+      // global indexing flag here stranded --from/--to on a permanent skeleton.
+      void reloadData(period, next, dayDate)
       return
     }
     // Period switches reload the underlying data. Disable them while the
@@ -2207,6 +2209,35 @@ function dashboardIndexScanRange(readyThrough: Period): DateRange {
 export function dashboardIndexSupportsPeriod(index: DashboardHistoryIndex, period: Period): boolean {
   const readyThrough = index.readyThrough ?? 'lifetime'
   return PERIODS.indexOf(period) <= PERIODS.indexOf(readyThrough)
+}
+
+/** The unset interactive default moves to 7D only when Today is truly all-zero.
+ * A warm lifetime index follows the same rule as a week-ready cold index. */
+export function shouldAutoFallbackToWeek(
+  enabled: boolean,
+  alreadyApplied: boolean,
+  visiblePeriod: Period,
+  index: DashboardHistoryIndex,
+  todayProjects: ProjectSummary[],
+): boolean {
+  const todayHasUsage = todayProjects.some(project => (
+    project.totalApiCalls > 0
+    || project.totalCostUSD !== 0
+    || (project.totalSavingsUSD ?? 0) !== 0
+    || project.sessions.some(session => (
+      session.apiCalls > 0
+      || session.totalCostUSD !== 0
+      || session.totalInputTokens > 0
+      || session.totalOutputTokens > 0
+      || session.totalCacheReadTokens > 0
+      || session.totalCacheWriteTokens > 0
+    ))
+  ))
+  return enabled
+    && !alreadyApplied
+    && visiblePeriod === 'today'
+    && dashboardIndexSupportsPeriod(index, 'week')
+    && !todayHasUsage
 }
 
 type DashboardHistoryIndexBuildOptions = {

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -6,8 +6,7 @@ import { render, Box, Text, measureElement, useInput, useApp, useWindowSize, typ
 import { CATEGORY_LABELS, type DateRange, type ProjectSummary, type TaskCategory } from './types.js'
 import { formatCost, formatTokens, markEstimated, carriedCostNote } from './format.js'
 import { aggregateModelEfficiency } from './model-efficiency.js'
-import { parseAllSessions, filterProjectsByDateRange, filterProjectsByName, setInteractiveScanUI, withSinglePassParse, withColdFirstPaintFloor, filesParsedFromSourceCount } from './parser.js'
-import { isColdCacheOnDisk } from './session-cache.js'
+import { parseAllSessions, filterProjectsByDateRange, filterProjectsByName, setInteractiveScanUI, withSinglePassParse, withColdFirstPaintFloor, filesParsedFromSourceCount, isCompleteSessionSnapshotAvailable } from './parser.js'
 import { findUnpricedModels, isExpectedFreeModel, loadPricing } from './models.js'
 import { aggregateModelTotals } from './model-breakdown.js'
 import { buildDurableOverviewFromNormalizedIndex, buildDurablePeriod, hydrateDailyCacheFromNormalizedProjects } from './usage-aggregator.js'
@@ -33,10 +32,13 @@ export type DailyActivityRow = {
   calls: number
 }
 
+type DashboardIndexPhase = Period | 'cached' | 'refreshing'
+
 export const DAILY_ACTIVITY_PAGE_SIZE = 10
 export const INDEX_PROGRESS_TICK_MS = 1000
+export const BACKGROUND_INDEX_INPUT_GRACE_MS = 2000
 export const LARGE_HISTORY_FILE_THRESHOLD = 1000
-export const INTERACTIVE_RENDER_OPTIONS = { alternateScreen: true } as const
+export const INTERACTIVE_RENDER_OPTIONS = { alternateScreen: true, interactive: true } as const
 export const RESIZE_DEBOUNCE_MS = 150
 
 export type TerminalSize = { columns: number; rows: number }
@@ -1480,7 +1482,7 @@ function ScrollableViewport({ children, width, lineScroll = true }: { children: 
   )
 }
 
-export function InteractiveDashboard({ initialProjects, initialDailyHistoryProjects, initialPeriod, initialProvider, initialPlanUsages, initialDurable, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel, initialDay, windowColumns, initialIndexPendingFiles, initialHistoryIndexing = false, initialCacheWasCold = false, initialHistoryIndex }: {
+export function InteractiveDashboard({ initialProjects, initialDailyHistoryProjects, initialPeriod, initialProvider, initialPlanUsages, initialDurable, refreshSeconds, projectFilter, excludeFilter, customRange, customRangeLabel, initialDay, windowColumns, initialIndexPendingFiles, initialHistoryIndexing = false, initialCacheWasCold = false, initialHistoryIndex, autoFallbackFromEmptyToday = false, terminateProcess }: {
   initialProjects: ProjectSummary[]
   initialDailyHistoryProjects?: ProjectSummary[]
   initialPeriod: Period
@@ -1500,6 +1502,10 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   initialHistoryIndexing?: boolean
   initialCacheWasCold?: boolean
   initialHistoryIndex?: DashboardHistoryIndex
+  autoFallbackFromEmptyToday?: boolean
+  /// CLI-only hard stop after Ink has been asked to restore the terminal.
+  /// Component tests and embedders omit it and receive ordinary Ink exit.
+  terminateProcess?: () => void
 }) {
   const { exit } = useApp()
   const [period, setPeriod] = useState<Period>(initialPeriod)
@@ -1525,9 +1531,16 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   // whole set rotates through without demanding attention.
   const [noteTick, setNoteTick] = useState(0)
   const indexPendingFiles = initialIndexPendingFiles ?? 0
-  const [indexing, setIndexing] = useState((initialHistoryIndexing || indexPendingFiles > 0) && initialHistoryIndex == null)
+  const [indexing, setIndexing] = useState(
+    (initialHistoryIndexing || indexPendingFiles > 0)
+    && (initialHistoryIndex == null || !dashboardIndexSupportsPeriod(initialHistoryIndex, 'lifetime')),
+  )
   const [indexedFiles, setIndexedFiles] = useState(0)
+  const [indexCold, setIndexCold] = useState(initialCacheWasCold)
+  const [indexPhase, setIndexPhase] = useState<DashboardIndexPhase>(initialCacheWasCold ? 'week' : 'cached')
   const historyIndexRef = useRef<DashboardHistoryIndex | null>(initialHistoryIndex ?? null)
+  const autoFallbackAppliedRef = useRef(false)
+  const quitArmedRef = useRef(false)
   // #1143: first q during the cold-start fill arms a confirmation so the user
   // sees feedback instead of a silent ~16.5s drain. The second q (or any
   // Ctrl+C) takes the abrupt path; #1109 already made abrupt exit kill-safe.
@@ -1580,6 +1593,7 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   }, [coachingNotes.length])
 
   useEffect(() => {
+    if (indexing) return
     let cancelled = false
     async function detect() {
       const found: string[] = []
@@ -1588,7 +1602,7 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
     }
     detect()
     return () => { cancelled = true }
-  }, [])
+  }, [indexing])
 
   useEffect(() => {
     let cancelled = false
@@ -1700,59 +1714,124 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
     }
   }, [optimizeAvailable, projects, currentRange, optimizeLoading, optimizeResult, activeProvider])
 
+  // Warm launch: load the complete normalized snapshot once, make every tab
+  // available, then reconcile sources exactly once and atomically replace it.
+  // Cold launch: widen through the user-visible readiness order; cached files
+  // from an earlier phase are never parsed from source again.
   useEffect(() => {
-    const refreshIntervalMs = getRefreshIntervalMs(refreshSeconds ?? 0)
-    if (refreshIntervalMs === 0) return
-    if (view !== 'dashboard') return
-    if (!dayDate && isHeavyPeriod(period)) return
-    const id = setInterval(() => { void reloadData(period, activeProvider, dayDate, true) }, refreshIntervalMs)
-    return () => clearInterval(id)
-  }, [refreshSeconds, period, activeProvider, dayDate, reloadData, view])
-
-  // One background lifetime index for this provider. The first paint deliberately
-  // skipped every file too old to show in Today; this pass normalizes them through
-  // the existing session cache and completes the existing durable day cache. All
-  // period tabs then project from this one result instead of reparsing the corpus.
-  // Mount-only: one index for the launch provider; provider changes retain the
-  // existing explicit reload path.
-  useEffect(() => {
-    if (!initialHistoryIndexing || initialHistoryIndex) return
+    if (!initialHistoryIndexing || initialHistoryIndex || isCustomRange || isDayMode) return
+    let cancelled = false
+    const provider = activeProvider
     const parsedBefore = filesParsedFromSourceCount()
-    const id = setInterval(() => setIndexedFiles(filesParsedFromSourceCount() - parsedBefore), INDEX_PROGRESS_TICK_MS)
-    void buildDashboardHistoryIndex(initialProvider, projectFilter, excludeFilter)
-      .then(async index => {
-        historyIndexRef.current = index
-        if (providerRef.current !== index.provider || dayRef.current != null || customRange != null) return
-        const selected = selectDashboardHistoryIndex(index, periodRef.current)
-        setDailyHistoryProjects(filterProjectsByName(index.normalizedProjects, projectFilter, excludeFilter))
+    const progressId = setInterval(() => setIndexedFiles(filesParsedFromSourceCount() - parsedBefore), INDEX_PROGRESS_TICK_MS)
+
+    const publish = async (index: DashboardHistoryIndex): Promise<void> => {
+      if (cancelled || providerRef.current !== index.provider) return
+      historyIndexRef.current = index
+      setDailyHistoryProjects(filterProjectsByName(index.normalizedProjects, projectFilter, excludeFilter))
+      let target = periodRef.current
+      if (
+        !autoFallbackAppliedRef.current
+        && autoFallbackFromEmptyToday
+        && target === 'today'
+        && index.readyThrough === 'week'
+        && !initialProjects.some(project => project.sessions.length > 0)
+      ) {
+        autoFallbackAppliedRef.current = true
+        target = 'week'
+        setPeriod('week')
+      }
+      if (dayRef.current == null && dashboardIndexSupportsPeriod(index, target)) {
+        const selected = selectDashboardHistoryIndex(index, target)
         setProjects(selected.projects)
         setDurable(selected.durable)
-        setPlanUsages(index.planUsages)
         setLoading(false)
-        setIndexedFiles(indexPendingFiles)
-        await nextTick()
-      })
-      .catch(error => {
-        console.error(error)
-        if (providerRef.current === initialProvider && dayRef.current == null && customRange == null) {
-          void reloadData(periodRef.current, initialProvider, null)
+      }
+      if (index.planUsages.length > 0) setPlanUsages(index.planUsages)
+      await nextTick()
+    }
+
+    const run = async (): Promise<void> => {
+      // Let Ink flush the truthful Today frame before any cache expansion or
+      // provider discovery can compete for the event loop, and leave a short
+      // window for immediate q/q input before synchronous provider discovery.
+      await nextTick()
+      await new Promise<void>(resolve => setTimeout(resolve, BACKGROUND_INDEX_INPUT_GRACE_MS))
+      if (cancelled) return
+      const snapshotAvailable = await isCompleteSessionSnapshotAvailable(getPeriodRange('today'), provider)
+      if (cancelled) return
+      setIndexCold(!snapshotAvailable)
+      setIndexing(true)
+      setIndexedFiles(0)
+
+      if (snapshotAvailable) {
+        setIndexPhase('cached')
+        await publish(await buildDashboardHistoryIndex(provider, projectFilter, excludeFilter, {
+          readyThrough: 'lifetime',
+          preferCompleteSnapshot: true,
+        }))
+        if (cancelled) return
+        setIndexPhase('refreshing')
+        await publish(await buildDashboardHistoryIndex(provider, projectFilter, excludeFilter))
+      } else {
+        for (const readyThrough of DASHBOARD_COLD_INDEX_PHASES) {
+          if (cancelled) return
+          setIndexPhase(readyThrough)
+          await publish(await buildDashboardHistoryIndex(provider, projectFilter, excludeFilter, {
+            readyThrough,
+            progressiveSource: true,
+          }))
         }
-      })
-      .finally(() => {
-        clearInterval(id)
-        setIndexing(false)
-      })
-    return () => clearInterval(id)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+      }
+    }
+
+    void run().catch(error => {
+      if (!cancelled) console.error(error)
+    }).finally(() => {
+      clearInterval(progressId)
+      if (!cancelled) setIndexing(false)
+    })
+    return () => {
+      cancelled = true
+      clearInterval(progressId)
+    }
+  }, [activeProvider, autoFallbackFromEmptyToday, customRange, excludeFilter, initialHistoryIndex, initialHistoryIndexing, initialProjects, isCustomRange, isDayMode, projectFilter])
 
   useEffect(() => {
-    if (!indexing && quitArmed) setQuitArmed(false)
+    const refreshIntervalMs = getRefreshIntervalMs(refreshSeconds ?? 0)
+    if (refreshIntervalMs === 0 || indexing) return
+    if (view !== 'dashboard') return
+    if (!dayDate && isHeavyPeriod(period)) return
+    const id = setInterval(() => {
+      const index = historyIndexRef.current
+      if (!dayDate && index?.provider === activeProvider && dashboardIndexSupportsPeriod(index, 'lifetime')) {
+        void buildDashboardHistoryIndex(activeProvider, projectFilter, excludeFilter).then(refreshed => {
+          if (providerRef.current !== refreshed.provider || dayRef.current != null) return
+          historyIndexRef.current = refreshed
+          const selected = selectDashboardHistoryIndex(refreshed, periodRef.current)
+          setDailyHistoryProjects(filterProjectsByName(refreshed.normalizedProjects, projectFilter, excludeFilter))
+          setProjects(selected.projects)
+          setDurable(selected.durable)
+          setPlanUsages(refreshed.planUsages)
+          setOptimizeResult(null)
+        }).catch(console.error)
+        return
+      }
+      void reloadData(period, activeProvider, dayDate, true)
+    }, refreshIntervalMs)
+    return () => clearInterval(id)
+  }, [refreshSeconds, indexing, view, dayDate, period, activeProvider, projectFilter, excludeFilter, reloadData])
+
+  useEffect(() => {
+    if (!indexing && quitArmed) {
+      quitArmedRef.current = false
+      setQuitArmed(false)
+    }
   }, [indexing, quitArmed])
 
   const selectIndexedPeriod = useCallback((np: Period): boolean => {
     const index = historyIndexRef.current
-    if (!index || index.provider !== activeProvider) return false
+    if (!index || index.provider !== activeProvider || !dashboardIndexSupportsPeriod(index, np)) return false
     const selected = selectDashboardHistoryIndex(index, np)
     setPeriod(np)
     setDailyHistoryCursor(0)
@@ -1815,20 +1894,27 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   }, [switchDay])
 
   useInput((input, key) => {
+    const quitNow = (): void => {
+      exit()
+      terminateProcess?.()
+    }
     // #1143: Ctrl+C always exits immediately, regardless of fill state. The
     // #1109 abrupt path is kill-safe (nothing marked seen without being
     // parsed, resume converges), so this is the unconditional escape hatch.
-    if (key.ctrl && input === 'c') { exit(); return }
+    if (key.ctrl && input === 'c') { quitNow(); return }
     // First q during an active fill: arm confirmation, do not exit. The fill
     // keeps running so the next launch starts warm. A second q takes the
     // abrupt path; q with no fill active exits immediately (no flicker).
     if (input === 'q') {
       if (indexing) {
-        if (quitArmed) { exit(); return }
+        // A ref makes two q bytes decisive even when the background scan keeps
+        // React from committing the confirmation state between them.
+        if (quitArmedRef.current) { quitNow(); return }
+        quitArmedRef.current = true
         setQuitArmed(true)
         return
       }
-      exit()
+      quitNow()
       return
     }
     if (input === 'o' && view === 'dashboard' && optimizeAvailable) { void loadOptimizeResult(); return }
@@ -1854,8 +1940,14 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
       const opts = ['all', ...detectedProviders]; const next = opts[(opts.indexOf(activeProvider) + 1) % opts.length]
       setActiveProvider(next); setView('dashboard')
       setDailyHistoryCursor(0)
+      historyIndexRef.current = null
+      setProjects([])
+      setDurable(undefined)
+      setLoading(true)
+      setIndexing(true)
       if (debounceRef.current) clearTimeout(debounceRef.current)
-      reloadData(period, next, dayDate); return
+      if (dayDate) void reloadData(period, next, dayDate)
+      return
     }
     // Period switches reload the underlying data. Disable them while the
     // compare view is mounted; the compare view re-aggregates from
@@ -1910,7 +2002,7 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
         {!isCustomRange && !isDayMode && <PeriodTabs active={period} providerName={activeProvider} showProvider={view !== 'compare' && multipleProviders} />}
         {isDayMode && <DayBanner label={headerLabel} width={dashWidth} />}
         {isCustomRange && <CustomRangeBanner label={headerLabel} width={dashWidth} />}
-        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} cold={initialCacheWasCold} />}
+        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} cold={indexCold} phase={indexPhase} />}
         {view === 'compare'
           ? <Box flexDirection="column" paddingX={2} paddingY={1}>
               <Box flexDirection="column" borderStyle="round" borderColor={ORANGE} paddingX={1}>
@@ -1931,7 +2023,7 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
         {!isCustomRange && !isDayMode && <PeriodTabs active={period} providerName={activeProvider} showProvider={multipleProviders && view !== 'compare'} />}
         {isDayMode && <DayBanner label={headerLabel} width={dashWidth} />}
         {isCustomRange && <CustomRangeBanner label={headerLabel} width={dashWidth} />}
-        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} cold={initialCacheWasCold} />}
+        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} cold={indexCold} phase={indexPhase} />}
         {view === 'compare'
           ? <CompareView projects={projects} onBack={() => setView('dashboard')} />
           : view === 'optimize' && optimizeResult
@@ -1960,14 +2052,24 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
 
 /// Honest phase and file-count state while Today remains usable and older
 /// periods wait for the shared normalized index.
-function IndexingBanner({ width, done, total, cold }: { width: number; done: number; total: number; cold: boolean }) {
+function IndexingBanner({ width, done, total, cold, phase }: { width: number; done: number; total: number; cold: boolean; phase: DashboardIndexPhase }) {
   const largeFirstIndex = cold && total >= LARGE_HISTORY_FILE_THRESHOLD
+  const readyLabel = phase === 'cached'
+    ? 'loading normalized cache · cached Today ready; source refresh pending'
+    : phase === 'refreshing'
+      ? 'cached periods ready; refreshing changed source files'
+      : phase === 'week'
+        ? 'Today ready; loading 7 Days'
+        : `${PERIOD_LABELS[DASHBOARD_COLD_INDEX_PHASES[Math.max(0, DASHBOARD_COLD_INDEX_PHASES.indexOf(phase) - 1)]!]} ready; loading ${PERIOD_LABELS[phase]}`
+  const count = cold && total > 0
+    ? ` · ${Math.min(done, total)} source files parsed · ${total} deferred at first paint`
+    : ''
   return (
     <Box width={width} paddingX={1} flexDirection="column">
       <Text wrap="truncate-end">
-        <Text color={ORANGE} bold>{cold ? 'indexing ' : 'loading '}</Text>
+        <Text color={ORANGE} bold>{phase === 'refreshing' ? 'refreshing ' : phase === 'cached' ? 'cached ' : 'indexing '}</Text>
         <Text dimColor>
-          {cold ? 'source history' : 'normalized history'} · {Math.min(done, total)}/{total} files · Today is ready; older periods fill from this index
+          {readyLabel}{count}
         </Text>
       </Text>
       {largeFirstIndex && <Text color={ORANGE}>large first index · may take a few minutes</Text>}
@@ -2077,25 +2179,60 @@ export type DashboardHistoryIndex = {
   normalizedProjects: ProjectSummary[]
   cache: DailyCache
   planUsages: PlanUsage[]
+  readyThrough?: Period
   projectFilter?: string[]
   excludeFilter?: string[]
 }
 
-/** Build the one normalized lifetime result every standard period tab shares. */
+export const DASHBOARD_COLD_INDEX_PHASES: Period[] = ['week', '30days', 'month', 'all', 'lifetime']
+
+function dashboardIndexScanRange(readyThrough: Period): DateRange {
+  const range = getPeriodRange(readyThrough)
+  if (readyThrough !== 'month') return range
+  const thirtyDays = getPeriodRange('30days')
+  return {
+    start: new Date(Math.min(range.start.getTime(), thirtyDays.start.getTime())),
+    end: new Date(Math.max(range.end.getTime(), thirtyDays.end.getTime())),
+  }
+}
+
+export function dashboardIndexSupportsPeriod(index: DashboardHistoryIndex, period: Period): boolean {
+  const readyThrough = index.readyThrough ?? 'lifetime'
+  return PERIODS.indexOf(period) <= PERIODS.indexOf(readyThrough)
+}
+
+type DashboardHistoryIndexBuildOptions = {
+  readyThrough?: Period
+  preferCompleteSnapshot?: boolean
+  progressiveSource?: boolean
+}
+
+/** Build one widening normalized index; cached files are never source-parsed twice. */
 export async function buildDashboardHistoryIndex(
   provider: string,
   projectFilter: string[] | undefined,
   excludeFilter: string[] | undefined,
+  options: DashboardHistoryIndexBuildOptions = {},
 ): Promise<DashboardHistoryIndex> {
-  const normalizedProjects = await parseAllSessions(getPeriodRange('lifetime'), provider)
+  const readyThrough = options.readyThrough ?? 'lifetime'
+  const range = dashboardIndexScanRange(readyThrough)
+  const parse = () => parseAllSessions(range, provider)
+  const normalizedProjects = options.preferCompleteSnapshot || options.progressiveSource
+    ? (await withColdFirstPaintFloor(
+        range.start,
+        parse,
+        false,
+        options.preferCompleteSnapshot === true,
+      )).result
+    : await parse()
   // The durable cache is all-provider state. Only an all-provider normalized
   // index can safely advance it; a provider-scoped index reads but never
   // rewrites that shared history.
   const cache = provider === 'all'
-    ? await hydrateDailyCacheFromNormalizedProjects(normalizedProjects)
+    ? await hydrateDailyCacheFromNormalizedProjects(normalizedProjects, readyThrough === 'lifetime')
     : await loadDailyCache()
-  const planUsages = await getPlanUsages()
-  return { provider, normalizedProjects, cache, planUsages, projectFilter, excludeFilter }
+  const planUsages = readyThrough === 'lifetime' && !options.preferCompleteSnapshot ? await getPlanUsages() : []
+  return { provider, normalizedProjects, cache, planUsages, readyThrough, projectFilter, excludeFilter }
 }
 
 /** Pure period projection: no discovery, transcript reads, or parser calls. */
@@ -2149,6 +2286,7 @@ export async function assembleDashboardFirstPaint(
       false,
     ),
     true,
+    true,
   )
   let paint = await run(period, autoFallback)
   if (paint.result.period !== period) paint = await run(paint.result.period, false)
@@ -2164,7 +2302,9 @@ export async function renderDashboard(period: Period = 'week', provider: string 
   // lifetime (initial scan and every enabled auto-refresh, including the
   // getPlanUsages → parseAllSessions path). Plain CLI commands are unaffected.
   setInteractiveScanUI()
+  const startupStarted = performance.now()
   await loadPricing()
+  if (process.env['CODEBURN_VERBOSE'] === '1') process.stderr.write(`codeburn: startup timing pricing=${(performance.now() - startupStarted).toFixed(1)}ms\n`)
   const dayRange = initialDay ? getDayRange(initialDay) : null
   const isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY)
   const scrollableDailyHistory = isTTY && dayRange == null && customRange == null
@@ -2175,31 +2315,48 @@ export async function renderDashboard(period: Period = 'week', provider: string 
   // (json/csv/markdown, report, sessions, the app and menubar payloads) keeps
   // the full parse and can never return a partial total.
   const progressive = isTTY && dayRange == null && customRange == null
-  const cacheWasCold = progressive ? await isColdCacheOnDisk() : false
+  const snapshotAvailable = progressive
+    ? await isCompleteSessionSnapshotAvailable(getPeriodRange('today'), provider)
+    : false
+  const cacheWasCold = progressive && !snapshotAvailable
   // #1111: with no explicit period the interactive dashboard opens on Today and
   // falls back to 7 days only when today holds nothing yet. Explicit -p/--day/
   // --from/--to and the non-interactive render keep the 7-day default.
   const auto = autoPeriod && isTTY && dayRange == null && customRange == null
   const openPeriod: Period = auto ? 'today' : period
   const paint = progressive
-    ? await assembleDashboardFirstPaint(openPeriod, provider, projectFilter, excludeFilter, customRange, initialDay ?? null, auto)
+    ? await assembleDashboardFirstPaint(openPeriod, provider, projectFilter, excludeFilter, customRange, initialDay ?? null, false)
     : {
         result: await assembleDashboardData(openPeriod, provider, projectFilter, excludeFilter, customRange, initialDay ?? null, scrollableDailyHistory, auto),
         deferredFiles: 0,
       }
   if (process.env['CODEBURN_VERBOSE'] === '1') {
+    process.stderr.write(`codeburn: startup timing pre-ink=${(performance.now() - startupStarted).toFixed(1)}ms\n`)
     process.stderr.write(`codeburn: progressive startup ${progressive ? 'on' : 'off'}, ${paint.deferredFiles} files deferred to the background index\n`)
   }
   const { period: opened, scannedProjects, filteredProjects, planUsages, initialDurable } = paint.result
   const label = initialDay ? formatDayRangeLabel(initialDay) : customRangeLabel
   patchStdoutForWindows()
   if (isTTY) {
+    let lastQuitByteAt = 0
+    const hardQuitGuard = (chunk: string | Buffer): void => {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      for (const byte of bytes) {
+        if (byte === 3) setImmediate(() => process.exit(0))
+        if (byte !== 113) continue
+        const now = Date.now()
+        if (now - lastQuitByteAt <= 2000) setImmediate(() => process.exit(0))
+        lastQuitByteAt = now
+      }
+    }
+    process.stdin.on('data', hardQuitGuard)
     const app = renderDebouncedInteractive(process.stdout, ({ columns }) => (
-      <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={opened} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} windowColumns={columns} initialIndexPendingFiles={paint.deferredFiles} initialHistoryIndexing={progressive} initialCacheWasCold={cacheWasCold} />
+      <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={opened} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} windowColumns={columns} initialIndexPendingFiles={paint.deferredFiles} initialHistoryIndexing={progressive} initialCacheWasCold={cacheWasCold} autoFallbackFromEmptyToday={auto} terminateProcess={() => { setImmediate(() => process.exit(0)) }} />
     ))
     try {
       await app.waitUntilExit()
     } finally {
+      process.stdin.off('data', hardQuitGuard)
       app.dispose()
     }
   } else {

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1832,6 +1832,13 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   const selectIndexedPeriod = useCallback((np: Period): boolean => {
     const index = historyIndexRef.current
     if (!index || index.provider !== activeProvider || !dashboardIndexSupportsPeriod(index, np)) return false
+    // Indexed selection publishes synchronously, so it must also supersede any
+    // async day/period reload already in flight. Otherwise that older request
+    // can pass its generation checks later and paint day-only data under this
+    // newly selected period label.
+    reloadGenerationRef.current++
+    pendingReloadRef.current = null
+    if (debounceRef.current) clearTimeout(debounceRef.current)
     const selected = selectDashboardHistoryIndex(index, np)
     setPeriod(np)
     setDailyHistoryCursor(0)

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -2009,7 +2009,7 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
         {!isCustomRange && !isDayMode && <PeriodTabs active={period} providerName={activeProvider} showProvider={view !== 'compare' && multipleProviders} />}
         {isDayMode && <DayBanner label={headerLabel} width={dashWidth} />}
         {isCustomRange && <CustomRangeBanner label={headerLabel} width={dashWidth} />}
-        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} cold={indexCold} phase={indexPhase} />}
+        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} cold={indexCold} phase={indexPhase} visiblePeriod={period} />}
         {view === 'compare'
           ? <Box flexDirection="column" paddingX={2} paddingY={1}>
               <Box flexDirection="column" borderStyle="round" borderColor={ORANGE} paddingX={1}>
@@ -2030,7 +2030,7 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
         {!isCustomRange && !isDayMode && <PeriodTabs active={period} providerName={activeProvider} showProvider={multipleProviders && view !== 'compare'} />}
         {isDayMode && <DayBanner label={headerLabel} width={dashWidth} />}
         {isCustomRange && <CustomRangeBanner label={headerLabel} width={dashWidth} />}
-        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} cold={indexCold} phase={indexPhase} />}
+        {indexing && <IndexingBanner width={dashWidth} done={indexedFiles} total={indexPendingFiles} cold={indexCold} phase={indexPhase} visiblePeriod={period} />}
         {view === 'compare'
           ? <CompareView projects={projects} onBack={() => setView('dashboard')} />
           : view === 'optimize' && optimizeResult
@@ -2057,17 +2057,18 @@ export function InteractiveDashboard({ initialProjects, initialDailyHistoryProje
   )
 }
 
-/// Honest phase and file-count state while Today remains usable and older
-/// periods wait for the shared normalized index.
-function IndexingBanner({ width, done, total, cold, phase }: { width: number; done: number; total: number; cold: boolean; phase: DashboardIndexPhase }) {
+/// Honest phase and file-count state while the selected period remains usable
+/// and the shared normalized index widens in the background.
+function IndexingBanner({ width, done, total, cold, phase, visiblePeriod }: { width: number; done: number; total: number; cold: boolean; phase: DashboardIndexPhase; visiblePeriod: Period }) {
   const largeFirstIndex = cold && total >= LARGE_HISTORY_FILE_THRESHOLD
-  const readyLabel = phase === 'cached'
-    ? 'loading normalized cache · cached Today ready; source refresh pending'
+  const sharedIndexLabel = phase === 'cached'
+    ? 'loading normalized cache; source refresh pending'
     : phase === 'refreshing'
       ? 'cached periods ready; refreshing changed source files'
       : phase === 'week'
         ? 'Today ready; loading 7 Days'
         : `${PERIOD_LABELS[DASHBOARD_COLD_INDEX_PHASES[Math.max(0, DASHBOARD_COLD_INDEX_PHASES.indexOf(phase) - 1)]!]} ready; loading ${PERIOD_LABELS[phase]}`
+  const readyLabel = `${PERIOD_LABELS[visiblePeriod]} visible · shared index: ${sharedIndexLabel}`
   const count = cold && total > 0
     ? ` · ${Math.min(done, total)} source files parsed · ${total} deferred at first paint`
     : ''

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2006,11 +2006,12 @@ async function scanProjectDirs(
 
     const cached = section.files[filePath]
     const action = reconcileFile(fp, cached)
-    if (cached && (readOnly || action.action === 'unchanged')) {
+    if (!readOnly && deferToBackgroundFill(filePath, fp, cached)) {
+      continue
+    } else if (cached && (readOnly || action.action === 'unchanged')) {
       if (readOnly && action.action !== 'unchanged') readOnlyServedStale = true
       unchangedFiles.push({ filePath, dirName, source, cached: section.files[filePath]! })
     } else if (!readOnly) {
-      if (deferToBackgroundFill(filePath, fp, cached)) continue
       if (action.action === 'appended') {
         changedFiles.push({
           filePath,
@@ -3374,11 +3375,12 @@ export async function parseProviderSources(
     // A cached parse failure at this same fingerprint stays skipped — don't
     // re-read a file that already threw and hasn't changed. It re-parses only
     // when the file changes (then `reconcileFile` reports non-'unchanged').
-    if (cached && (readOnly || (action.action === 'unchanged' && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))))) {
+    if (!readOnly && deferToBackgroundFill(source.path, fp, cached)) {
+      continue
+    } else if (cached && (readOnly || (action.action === 'unchanged' && (cached.failed || !cachedFileNeedsProviderReparse(providerName, source.path, cached))))) {
       if (readOnly && action.action !== 'unchanged') readOnlyServedStale = true
       unchangedSources.push({ source, cached })
     } else if (!readOnly) {
-      if (deferToBackgroundFill(source.path, fp, cached)) continue
       changedSources.push({ source, fp })
     } else {
       // Read-only with no cache entry at all — see scanProjectDirs.
@@ -5073,6 +5075,11 @@ function singlePassParse(dateRange: DateRange | undefined, providerFilter: strin
 export const FIRST_PAINT_MTIME_MARGIN_MS = 48 * 60 * 60 * 1000
 
 let firstPaintFloorMs: number | null = null
+// The TUI's Today-first paint also defers older entries already normalized in
+// a complete cache. Reading/aggregating those cached turns before Ink renders
+// is precisely the warm-start latency this mode removes. Other progressive
+// consumers keep the historical cold-only rule unless they opt in.
+let firstPaintIncludesCachedFiles = false
 // Files this scope deferred, as a SET of paths: one first paint runs several
 // parses (the scan, the plan window, the durable backfill) and each defers the
 // same old files, so a running count would report a multiple of the real work.
@@ -5118,17 +5125,21 @@ export function sessionHydrationSnapshot(): {
 export async function withColdFirstPaintFloor<T>(
   rangeStart: Date,
   fn: () => Promise<T>,
+  includeCachedFiles = false,
 ): Promise<{ result: T; deferredFiles: number }> {
   const outer = firstPaintFloorMs
   const outerPaths = firstPaintDeferredPaths
+  const outerIncludeCached = firstPaintIncludesCachedFiles
   firstPaintFloorMs = rangeStart.getTime() - FIRST_PAINT_MTIME_MARGIN_MS
   firstPaintDeferredPaths = new Set()
+  firstPaintIncludesCachedFiles = includeCachedFiles
   try {
     const result = await fn()
     return { result, deferredFiles: firstPaintDeferredPaths.size }
   } finally {
     firstPaintFloorMs = outer
     firstPaintDeferredPaths = outerPaths
+    firstPaintIncludesCachedFiles = outerIncludeCached
   }
 }
 
@@ -5140,12 +5151,13 @@ export function shouldDeferToBackgroundFill(
   fp: { mtimeMs: number },
   cached: unknown,
   floorMs: number | null,
+  includeCachedFiles = false,
 ): boolean {
-  return floorMs !== null && cached === undefined && fp.mtimeMs < floorMs
+  return floorMs !== null && (includeCachedFiles || cached === undefined) && fp.mtimeMs < floorMs
 }
 
 function deferToBackgroundFill(path: string, fp: { mtimeMs: number }, cached: unknown): boolean {
-  if (!shouldDeferToBackgroundFill(fp, cached, firstPaintFloorMs)) return false
+  if (!shouldDeferToBackgroundFill(fp, cached, firstPaintFloorMs, firstPaintIncludesCachedFiles)) return false
   firstPaintDeferredPaths?.add(path)
   firstPaintDeferredThisRun++
   return true

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5080,6 +5080,10 @@ let firstPaintFloorMs: number | null = null
 // is precisely the warm-start latency this mode removes. Other progressive
 // consumers keep the historical cold-only rule unless they opt in.
 let firstPaintIncludesCachedFiles = false
+// A complete, environment-compatible normalized cache can paint an honestly
+// labelled cached Today without waiting for source discovery/reconciliation.
+// The mounted dashboard immediately refreshes sources in the background.
+let firstPaintPrefersCompleteSnapshot = false
 // Files this scope deferred, as a SET of paths: one first paint runs several
 // parses (the scan, the plan window, the durable backfill) and each defers the
 // same old files, so a running count would report a multiple of the real work.
@@ -5126,13 +5130,16 @@ export async function withColdFirstPaintFloor<T>(
   rangeStart: Date,
   fn: () => Promise<T>,
   includeCachedFiles = false,
+  preferCompleteSnapshot = false,
 ): Promise<{ result: T; deferredFiles: number }> {
   const outer = firstPaintFloorMs
   const outerPaths = firstPaintDeferredPaths
   const outerIncludeCached = firstPaintIncludesCachedFiles
+  const outerPreferSnapshot = firstPaintPrefersCompleteSnapshot
   firstPaintFloorMs = rangeStart.getTime() - FIRST_PAINT_MTIME_MARGIN_MS
   firstPaintDeferredPaths = new Set()
   firstPaintIncludesCachedFiles = includeCachedFiles
+  firstPaintPrefersCompleteSnapshot = preferCompleteSnapshot
   try {
     const result = await fn()
     return { result, deferredFiles: firstPaintDeferredPaths.size }
@@ -5140,6 +5147,7 @@ export async function withColdFirstPaintFloor<T>(
     firstPaintFloorMs = outer
     firstPaintDeferredPaths = outerPaths
     firstPaintIncludesCachedFiles = outerIncludeCached
+    firstPaintPrefersCompleteSnapshot = outerPreferSnapshot
   }
 }
 
@@ -5171,6 +5179,20 @@ export function parseAllSessions(dateRange?: DateRange, providerFilter?: string)
   // directory even if an embedding host changes the process env mid-parse.
   const codexCacheDir = getCodeburnCacheDir()
   return withCodexCacheDirectory(codexCacheDir, () => parseAllSessionsInCacheScope(dateRange, providerFilter))
+}
+
+function canServeCompleteSnapshot(cache: SessionCache, providerFilter?: string): boolean {
+  if (!isCacheComplete(cache)) return false
+  const sections = providerFilter && providerFilter !== 'all'
+    ? ([[providerFilter, cache.providers[providerFilter]]] as const).filter((entry): entry is readonly [string, ProviderSection] => entry[1] != null)
+    : Object.entries(cache.providers)
+  return sections.some(([, section]) => Object.keys(section.files).length > 0)
+    && sections.every(([name, section]) => section.envFingerprint === computeEnvFingerprint(name))
+}
+
+export async function isCompleteSessionSnapshotAvailable(dateRange: DateRange, providerFilter?: string): Promise<boolean> {
+  const diskCache = await loadCache(monthScopeForRange(dateRange.start, dateRange.end))
+  return canServeCompleteSnapshot(diskCache, providerFilter)
 }
 
 async function parseAllSessionsInCacheScope(dateRange?: DateRange, providerFilter?: string): Promise<ProjectSummary[]> {
@@ -5218,8 +5240,12 @@ async function parseAllSessionsInCacheScope(dateRange?: DateRange, providerFilte
   // a proxied key emitted under two providers the attribution can land on a
   // different provider than a full load would pick.
   const loadScope = dateRange ? monthScopeForRange(dateRange.start, dateRange.end) : undefined
+  const cacheLoadStarted = performance.now()
   let diskCache = await loadCache(loadScope)
   await cleanupOrphanedTempFiles()
+  if (process.env['CODEBURN_VERBOSE'] === '1') {
+    process.stderr.write(`codeburn: startup timing cache-load=${(performance.now() - cacheLoadStarted).toFixed(1)}ms complete=${isCacheComplete(diskCache)}\n`)
+  }
 
   // Cold-hydration coordination (advisory, cross-process). Engages whenever the
   // on-disk cache is not COMPLETE — an empty cache OR a partial one an interrupted
@@ -5240,6 +5266,15 @@ async function parseAllSessionsInCacheScope(dateRange?: DateRange, providerFilte
     }
   }
 
+  if (firstPaintPrefersCompleteSnapshot && canServeCompleteSnapshot(diskCache, providerFilter)) {
+    return runParse(key, diskCache, dateRange, providerFilter, {
+      readOnly: true,
+      snapshotOnly: true,
+      burstSig,
+      parseStartedAt,
+    })
+  }
+
   // A complete cache refresh is a strict read/reconcile/parse/save transaction.
   // Keep the snapshot loaded before acquisition: timeout/unavailable paths serve
   // exactly this complete snapshot and never mutate or invalidate the holder.
@@ -5251,10 +5286,14 @@ async function parseAllSessionsInCacheScope(dateRange?: DateRange, providerFilte
   // lock (#1117). runParse arms its own keepalive; this covers the gap before it.
   startProgressKeepalive()
   let refresh: RefreshLockOutcome
+  const refreshWaitStarted = performance.now()
   try {
     refresh = await acquireCacheRefreshLock()
   } finally {
     stopProgressKeepalive()
+  }
+  if (process.env['CODEBURN_VERBOSE'] === '1') {
+    process.stderr.write(`codeburn: startup timing refresh-lock=${(performance.now() - refreshWaitStarted).toFixed(1)}ms outcome=${refresh.outcome}\n`)
   }
   if (refresh.outcome === 'timed-out' || refresh.outcome === 'unavailable') {
     return runParse(key, priorSnapshot, dateRange, providerFilter, { readOnly: true, burstSig, parseStartedAt })
@@ -5282,6 +5321,7 @@ class RefreshPublicationUnavailableError extends Error {}
 type RunParseOptions = {
   isCold?: boolean
   readOnly?: boolean
+  snapshotOnly?: boolean
   refreshLock?: RefreshLockHandle
   burstSig: string
   parseStartedAt: number
@@ -5311,13 +5351,22 @@ async function runParseInner(
   providerFilter: string | undefined,
   options: RunParseOptions,
 ): Promise<ProjectSummary[]> {
-  const { isCold = false, readOnly = false, refreshLock } = options
+  const { isCold = false, readOnly = false, snapshotOnly = false, refreshLock } = options
+  const timingStarted = performance.now()
+  let timingPrevious = timingStarted
+  const traceTiming = (stage: string, extra = ''): void => {
+    if (process.env['CODEBURN_VERBOSE'] !== '1') return
+    const now = performance.now()
+    process.stderr.write(`codeburn: startup timing ${stage}=${(now - timingPrevious).toFixed(1)}ms total=${(now - timingStarted).toFixed(1)}ms${extra}\n`)
+    timingPrevious = now
+  }
   readOnlyServedStale = false
   deferredRetryableSource = false
   firstPaintDeferredThisRun = 0
   const seenMsgIds = new Set<string>()
   const seenKeys = new Set<string>()
-  const allSources = await discoverAllSessions(providerFilter)
+  const allSources = snapshotOnly ? [] : await discoverAllSessions(providerFilter)
+  traceTiming('discovery', ` sources=${allSources.length}`)
 
   const claudeSources = allSources.filter(s => s.provider === 'claude')
   const nonClaudeSources = allSources.filter(s => s.provider !== 'claude')
@@ -5382,6 +5431,7 @@ async function runParseInner(
       emitScanProgress({ kind: 'provider', provider: 'claude', state: 'skipped' })
     }
   }
+  traceTiming('claude')
 
   const otherProjects: ProjectSummary[] = []
   for (const [providerName, sources] of providerGroups) {
@@ -5399,12 +5449,14 @@ async function runParseInner(
     }
     await saveProgress()
   }
+  traceTiming('other-providers', ` providers=${providerGroups.size}`)
 
   // Durable providers with cached data but NO discovered sources (all files pruned
   // by VS Code / the external tool) still need their orphan pass to run so the
   // monthly total never drops. Call parseProviderSources with empty sources for
   // any such provider found in the disk cache.
   const processedProviders = new Set(providerGroups.keys())
+  if (claudeInScope) processedProviders.add('claude')
   for (const providerName of Object.keys(diskCache.providers)) {
     if (processedProviders.has(providerName)) continue
     // Skip if filtered to a different provider
@@ -5415,7 +5467,7 @@ async function runParseInner(
     // processes a durableSources provider) OR the static DURABLE_PROVIDER_NAMES
     // constant — both checks are O(1) and avoid a getProvider() dynamic-import
     // round-trip for every unprocessed provider in the disk cache.
-    if (!section.durable && !DURABLE_PROVIDER_NAMES.has(providerName)) continue
+    if (!snapshotOnly && !section.durable && !DURABLE_PROVIDER_NAMES.has(providerName)) continue
     const projects = await parseProviderSources(providerName, [], seenKeys, diskCache, dateRange, saveProgress, readOnly)
     otherProjects.push(...projects)
   }
@@ -5490,5 +5542,6 @@ async function runParseInner(
   correlateCrossProviderPrSessions(result)
   if (dateRange) setCachePutMeta({ startMs: dateRange.start.getTime(), endMs: dateRange.end.getTime(), sig: options.burstSig })
   cachePut(key, result, options.parseStartedAt)
+  traceTiming('aggregate', ` projects=${result.length}`)
   return result
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4353,7 +4353,13 @@ export function clearSessionCache(): void {
   singlePassScope?.parses.clear()
 }
 
+let sessionMemoPublications = 0
+export function sessionMemoPublicationCount(): number {
+  return sessionMemoPublications
+}
+
 function cachePut(key: string, data: ProjectSummary[], parseStartedAt: number) {
+  sessionMemoPublications++
   const now = Date.now()
   for (const [k, v] of sessionCache) {
     if (now - v.createdAt > CACHE_TTL_MS) sessionCache.delete(k)
@@ -5540,8 +5546,13 @@ async function runParseInner(
 
   const result = Array.from(mergedMap.values()).sort((a, b) => b.totalCostUSD - a.totalCostUSD)
   correlateCrossProviderPrSessions(result)
-  if (dateRange) setCachePutMeta({ startMs: dateRange.start.getTime(), endMs: dateRange.end.getTime(), sig: options.burstSig })
-  cachePut(key, result, options.parseStartedAt)
+  // A snapshot is an explicitly stale, source-unvalidated view. Publishing it
+  // into either exact-key or burst reuse can suppress the reconciliation that
+  // the mounted dashboard starts immediately afterward for the full TTL.
+  if (!snapshotOnly) {
+    if (dateRange) setCachePutMeta({ startMs: dateRange.start.getTime(), endMs: dateRange.end.getTime(), sig: options.burstSig })
+    cachePut(key, result, options.parseStartedAt)
+  }
   traceTiming('aggregate', ` projects=${result.length}`)
   return result
 }

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -1448,7 +1448,13 @@ async function fingerprintSqliteFile(dbPath: string): Promise<FileFingerprint | 
   }
 }
 
+let fingerprintCalls = 0
+export function fingerprintFileCount(): number {
+  return fingerprintCalls
+}
+
 export async function fingerprintFile(filePath: string): Promise<FileFingerprint | null> {
+  fingerprintCalls++
   try {
     const s = await stat(filePath)
     // A source path that IS a SQLite database (copilot OTel's agent-traces.db)

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -456,7 +456,19 @@ export function buildDurableOverviewFromNormalizedIndex(
       )
     : []
   const allDays = [...cachedAllDays, ...normalizedHistoricalDays].sort((a, b) => a.date.localeCompare(b.date))
-  const days = pf === 'all' ? allDays : allDays.map(day => sliceDayToProvider(day, pf))
+  const normalizedByDate = new Map(normalizedDays.map(day => [day.date, day]))
+  const days = pf === 'all' ? allDays : allDays.map(day => {
+    if (Object.hasOwn(day.providers, pf)) return sliceDayToProvider(day, pf)
+    const normalized = normalizedByDate.get(day.date)
+    // The shared cache can be complete for a date while lacking this selected
+    // provider's slice (for example, Claude was cached before Codex appeared).
+    // Fill only that absent slice from the provider-scoped normalized index.
+    // An existing slice remains authoritative, retaining carried/expired money
+    // and preventing the surviving source from being counted twice.
+    return normalized && Object.hasOwn(normalized.providers, pf)
+      ? sliceDayToProvider(normalized, pf)
+      : sliceDayToProvider(day, pf)
+  })
   const data = buildPeriodDataFromDays(days, periodInfo.label)
 
   // Fields whose durable day rows cannot project under a project filter come

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -122,12 +122,12 @@ async function hydrateCache(): Promise<DailyCache> {
  * session index. The parser callback is only a range projection of `projects`:
  * no source discovery, transcript read, or session-cache parse is repeated.
  */
-export async function hydrateDailyCacheFromNormalizedProjects(projects: ProjectSummary[]): Promise<DailyCache> {
+export async function hydrateDailyCacheFromNormalizedProjects(projects: ProjectSummary[], complete = true): Promise<DailyCache> {
   return ensureCacheHydrated(
     (range) => Promise.resolve(filterProjectsByDateRange(projects, range)),
     aggregateProjectsIntoDays,
     getDailyCacheConfigHash(),
-    () => true,
+    () => complete,
     (rangeProjects, tz) => aggregateProjectsIntoDays(rangeProjects, (iso) => dateKeyInTz(iso, tz)),
   )
 }
@@ -432,12 +432,30 @@ export function buildDurableOverviewFromNormalizedIndex(
   const scanProjects = filterProjectsByDateRange(filteredProjects, periodInfo.range)
   const now = new Date()
   const todayStr = toDateString(now)
-  const todayDays = aggregateProjectsIntoDays(filterProjectsByDays(filteredProjects, new Set([todayStr])))
+  const normalizedDays = aggregateProjectsIntoDays(filteredProjects)
+  const todayDays = normalizedDays
     .filter(day => day.date === todayStr)
   const historicalSlice = hasProjectFilter
     ? (day: DailyEntry): DailyEntry => sliceDayToProject(day, include, exclude)
     : undefined
-  const allDays = unionDaysForPeriod(cache, todayDays, periodInfo, null, historicalSlice)
+  const cachedAllDays = unionDaysForPeriod(cache, todayDays, periodInfo, null, historicalSlice)
+  const cachedDates = new Set(cache.days.map(day => day.date))
+  const rangeStartStr = toDateString(periodInfo.range.start)
+  const rangeEndStr = toDateString(periodInfo.range.end)
+  // A provider-scoped index deliberately does not rewrite the shared all-
+  // provider durable cache. When that cache has no row for a surviving
+  // historical source, fill the missing date from this same normalized index;
+  // existing durable rows stay authoritative so expired history is preserved.
+  const canFillMissingDates = cache.complete !== true || cache.days.length === 0
+  const normalizedHistoricalDays = canFillMissingDates
+    ? normalizedDays.filter(day =>
+        day.date !== todayStr
+        && day.date >= rangeStartStr
+        && day.date <= rangeEndStr
+        && !cachedDates.has(day.date)
+      )
+    : []
+  const allDays = [...cachedAllDays, ...normalizedHistoricalDays].sort((a, b) => a.date.localeCompare(b.date))
   const days = pf === 'all' ? allDays : allDays.map(day => sliceDayToProvider(day, pf))
   const data = buildPeriodDataFromDays(days, periodInfo.label)
 

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -2,7 +2,7 @@ import { homedir } from 'node:os'
 import { CATEGORY_LABELS, type ProjectSummary, type TaskCategory, type DateRange } from './types.js'
 import { isBehavioralCall } from './behavioral-weight.js'
 import { type PeriodData, type ProviderCost, type BreakdownArrays, type MenubarPayload, type ClaudeConfigSelector, type HydrationState, buildMenubarPayload } from './menubar-json.js'
-import { parseAllSessions, filterProjectsByName, filterProjectsByDays, filterProjectsByClaudeConfigSource, isSessionHydrationComplete, sessionHydrationSnapshot } from './parser.js'
+import { parseAllSessions, filterProjectsByName, filterProjectsByDays, filterProjectsByClaudeConfigSource, filterProjectsByDateRange, isSessionHydrationComplete, sessionHydrationSnapshot } from './parser.js'
 import { findUnpricedModels, getFlatRateModelsConfigHash, getLocalModelSavingsConfigHash, getPriceOverridesConfigHash, getShortModelName, isExpectedFreeModel } from './models.js'
 import { getAllProviders, safeDiscoverSessions } from './providers/index.js'
 import { claude, getClaudeConfigDirs, getDesktopSessionsDirs } from './providers/claude.js'
@@ -115,6 +115,21 @@ async function hydrateCache(): Promise<DailyCache> {
     )
     return emptyCache()
   }
+}
+
+/**
+ * Finish the existing durable day cache from an already-normalized lifetime
+ * session index. The parser callback is only a range projection of `projects`:
+ * no source discovery, transcript read, or session-cache parse is repeated.
+ */
+export async function hydrateDailyCacheFromNormalizedProjects(projects: ProjectSummary[]): Promise<DailyCache> {
+  return ensureCacheHydrated(
+    (range) => Promise.resolve(filterProjectsByDateRange(projects, range)),
+    aggregateProjectsIntoDays,
+    getDailyCacheConfigHash(),
+    () => true,
+    (rangeProjects, tz) => aggregateProjectsIntoDays(rangeProjects, (iso) => dateKeyInTz(iso, tz)),
+  )
 }
 
 /// The `hydration` block is emitted ONLY inside the resident serve child, which
@@ -382,6 +397,72 @@ function unionDaysForPeriod(
   const todayInRange = todayAllDays.filter(d => d.date >= rangeStartStr && d.date <= rangeEndStr)
   const unfiltered = [...historicalDays, ...todayInRange].sort((a, b) => a.date.localeCompare(b.date))
   return daysSelection ? unfiltered.filter(d => daysSelection.has(d.date)) : unfiltered
+}
+
+export type IndexedDurableOverview = {
+  cost: number
+  savingsUSD: number
+  calls: number
+  sessions: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  carriedCostUSD: number
+}
+
+/**
+ * Project a dashboard headline from one normalized lifetime index. Existing
+ * durable cache days remain authoritative (so expired transcripts do not
+ * disappear); normalized days fill only dates the durable cache does not yet
+ * contain, which is the cold first-index case. Today always comes from the
+ * live normalized index. No parser is called here.
+ */
+export function buildDurableOverviewFromNormalizedIndex(
+  periodInfo: PeriodInfo,
+  normalizedProjects: ProjectSummary[],
+  cache: DailyCache,
+  opts: AggregateOpts = {},
+): IndexedDurableOverview {
+  const pf = opts.provider ?? 'all'
+  const include = (opts.project ?? []).map(value => value.toLowerCase())
+  const exclude = (opts.exclude ?? []).map(value => value.toLowerCase())
+  const hasProjectFilter = include.length > 0 || exclude.length > 0
+  const filteredProjects = filterProjectsByName(normalizedProjects, opts.project ?? [], opts.exclude ?? [])
+  const scanProjects = filterProjectsByDateRange(filteredProjects, periodInfo.range)
+  const now = new Date()
+  const todayStr = toDateString(now)
+  const todayDays = aggregateProjectsIntoDays(filterProjectsByDays(filteredProjects, new Set([todayStr])))
+    .filter(day => day.date === todayStr)
+  const historicalSlice = hasProjectFilter
+    ? (day: DailyEntry): DailyEntry => sliceDayToProject(day, include, exclude)
+    : undefined
+  const allDays = unionDaysForPeriod(cache, todayDays, periodInfo, null, historicalSlice)
+  const days = pf === 'all' ? allDays : allDays.map(day => sliceDayToProvider(day, pf))
+  const data = buildPeriodDataFromDays(days, periodInfo.label)
+
+  // Fields whose durable day rows cannot project under a project filter come
+  // from the same normalized period slice that feeds the visible detail panels.
+  const scan = buildPeriodData(periodInfo.label, scanProjects)
+  data.sessions = Math.max(data.sessions, scan.sessions)
+  if (hasProjectFilter) {
+    data.inputTokens = scan.inputTokens
+    data.outputTokens = scan.outputTokens
+    data.cacheReadTokens = scan.cacheReadTokens
+    data.cacheWriteTokens = scan.cacheWriteTokens
+  }
+
+  return {
+    cost: data.cost,
+    savingsUSD: data.savingsUSD,
+    calls: data.calls,
+    sessions: data.sessions,
+    inputTokens: data.inputTokens,
+    outputTokens: data.outputTokens,
+    cacheReadTokens: data.cacheReadTokens,
+    cacheWriteTokens: data.cacheWriteTokens,
+    carriedCostUSD: days.reduce((sum, day) => sum + (day.carried ? day.cost : 0), 0),
+  }
 }
 
 /// The single durable-totals builder every CLI/TUI surface and the menubar share.

--- a/tests/dashboard-custom-range-provider.test.ts
+++ b/tests/dashboard-custom-range-provider.test.ts
@@ -1,0 +1,130 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { render } from 'ink'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, it, onTestFinished, vi } from 'vitest'
+
+import type { ProjectSummary, SessionSummary } from '../src/types.js'
+
+const { parseAllSessionsMock } = vi.hoisted(() => ({
+  parseAllSessionsMock: vi.fn<
+    Parameters<typeof import('../src/parser.js').parseAllSessions>,
+    ReturnType<typeof import('../src/parser.js').parseAllSessions>
+  >(),
+}))
+
+vi.mock('../src/parser.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/parser.js')>()
+  return { ...actual, parseAllSessions: parseAllSessionsMock }
+})
+
+vi.mock('../src/providers/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/providers/index.js')>()
+  const provider = (name: string) => ({
+    name,
+    displayName: name,
+    modelDisplayName: (model: string) => model,
+    toolDisplayName: (tool: string) => tool,
+    discoverSessions: async () => [{ provider: name, project: name, path: `/tmp/${name}` }],
+    createSessionParser: () => ({ async *parse() {} }),
+  })
+  return { ...actual, getAllProviders: async () => [provider('beta'), provider('gamma')] }
+})
+
+vi.mock('../src/usage-aggregator.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/usage-aggregator.js')>()
+  return {
+    ...actual,
+    buildDurablePeriod: vi.fn(async () => ({
+      data: { cost: 7, savingsUSD: 0, calls: 1, sessions: 1, inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      carriedCostUSD: 0,
+    })),
+  }
+})
+
+vi.mock('../src/plan-usage.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/plan-usage.js')>()
+  return { ...actual, getPlanUsages: vi.fn(async () => []) }
+})
+
+const BREAKDOWN = {
+  coding: { turns: 1, costUSD: 7, savingsUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+} as SessionSummary['categoryBreakdown']
+
+function project(name: string, provider: string, cost: number): ProjectSummary {
+  const timestamp = new Date().toISOString()
+  const call = {
+    provider, model: `${provider}-model`,
+    usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0, webSearchRequests: 0 },
+    costUSD: cost, tools: [], mcpTools: [], skills: [], subagentTypes: [], hasAgentSpawn: false,
+    hasPlanMode: false, speed: 'standard' as const, timestamp, bashCommands: [], deduplicationKey: `${provider}:${name}`,
+  }
+  const session: SessionSummary = {
+    sessionId: `${provider}-session`, project: name, firstTimestamp: timestamp, lastTimestamp: timestamp,
+    totalCostUSD: cost, totalSavingsUSD: 0, totalInputTokens: 10, totalOutputTokens: 5,
+    totalReasoningTokens: 0, totalCacheReadTokens: 0, totalCacheWriteTokens: 0, apiCalls: 1,
+    turns: [{ userMessage: 'hi', assistantCalls: [call], timestamp, sessionId: `${provider}-session`, category: 'coding', retries: 0, hasEdits: false }],
+    modelBreakdown: { [`${provider}-model`]: { calls: 1, costUSD: cost, savingsUSD: 0, tokens: call.usage } },
+    toolBreakdown: {}, mcpBreakdown: {}, bashBreakdown: {}, categoryBreakdown: BREAKDOWN,
+    skillBreakdown: {}, subagentBreakdown: {},
+  }
+  return {
+    project: name,
+    projectPath: `/repo/${name}`,
+    sessions: [session],
+    totalCostUSD: cost,
+    totalSavingsUSD: 0,
+    totalApiCalls: 1,
+    totalProxiedCostUSD: 0,
+  }
+}
+
+function tui() {
+  const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream
+  const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream
+  stdin.isTTY = true
+  stdin.setRawMode = () => stdin
+  stdin.ref = () => stdin
+  stdin.unref = () => stdin
+  stdout.isTTY = true
+  stdout.columns = 140
+  stdout.rows = 50
+  return { stdin, stdout }
+}
+
+describe('InteractiveDashboard custom-range provider switching', () => {
+  it('finishes the provider reload instead of stranding a loading skeleton', async () => {
+    const { InteractiveDashboard } = await import('../src/dashboard.js')
+    const beta = project('beta-visible', 'beta', 7)
+    const gamma = project('gamma-visible', 'gamma', 3)
+    parseAllSessionsMock.mockResolvedValue([beta])
+    const { stdin, stdout } = tui()
+    const frames: string[] = []
+    stdout.on('data', chunk => frames.push(stripAnsi(String(chunk))))
+    const app = render(React.createElement(InteractiveDashboard, {
+      initialProjects: [beta, gamma],
+      initialPeriod: 'week',
+      initialProvider: 'all',
+      refreshSeconds: 0,
+      windowColumns: 140,
+      customRange: { start: new Date(Date.now() - 7 * 86_400_000), end: new Date() },
+      customRangeLabel: 'custom test range',
+    }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
+    onTestFinished(() => app.unmount())
+    await app.waitUntilRenderFlush()
+    await new Promise(resolve => setTimeout(resolve, 20))
+    await app.waitUntilRenderFlush()
+
+    frames.length = 0
+    stdin.write('p')
+    await vi.waitFor(async () => {
+      await app.waitUntilRenderFlush()
+      const latest = frames.filter(frame => frame.trim()).at(-1) ?? ''
+      expect(latest).toContain('$7.00 cost')
+      expect(latest).not.toContain('Loading custom test range')
+    })
+
+    expect(parseAllSessionsMock).toHaveBeenCalledWith(expect.anything(), 'beta')
+  })
+})

--- a/tests/dashboard-exit.test.ts
+++ b/tests/dashboard-exit.test.ts
@@ -5,7 +5,7 @@ import { render } from 'ink'
 import stripAnsi from 'strip-ansi'
 import { describe, expect, it, onTestFinished, vi } from 'vitest'
 
-import { InteractiveDashboard } from '../src/dashboard.js'
+import { InteractiveDashboard, type DashboardHistoryIndex } from '../src/dashboard.js'
 
 // #1143: the quit-confirmation path runs only while a cold-start fill is
 // active, so the parser mock below holds the fill in flight (parseAllSessions
@@ -14,12 +14,16 @@ import { InteractiveDashboard } from '../src/dashboard.js'
 // test. The other exports are kept stable so the rest of the dashboard
 // (provider detection, the budget effect, the q-without-fill handler) still
 // works with the mock in place - the existing #1141 tests rely on that.
-const { parseAllSessionsMock, filesParsedFromSourceCountMock } = vi.hoisted(() => ({
+const { parseAllSessionsMock, filesParsedFromSourceCountMock, resolveNextParse } = vi.hoisted(() => {
+  const pending: Array<(projects: unknown[]) => void> = []
+  return {
   parseAllSessionsMock: vi.fn<Parameters<typeof import('../src/parser.js').parseAllSessions>, ReturnType<typeof import('../src/parser.js').parseAllSessions>>(
-    () => new Promise(() => {}),
+    () => new Promise(resolve => pending.push(resolve as (projects: unknown[]) => void)),
   ),
   filesParsedFromSourceCountMock: vi.fn(() => 0),
-}))
+  resolveNextParse: (projects: unknown[]) => pending.shift()?.(projects),
+  }
+})
 
 vi.mock('../src/parser.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/parser.js')>()
@@ -28,6 +32,22 @@ vi.mock('../src/parser.js', async (importOriginal) => {
     parseAllSessions: parseAllSessionsMock,
     filesParsedFromSourceCount: filesParsedFromSourceCountMock,
   }
+})
+
+vi.mock('../src/usage-aggregator.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/usage-aggregator.js')>()
+  return {
+    ...actual,
+    buildDurablePeriod: vi.fn(async () => ({
+      data: { cost: 99, savingsUSD: 0, calls: 1, sessions: 1, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      carriedCostUSD: 0,
+    })),
+  }
+})
+
+vi.mock('../src/plan-usage.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/plan-usage.js')>()
+  return { ...actual, getPlanUsages: vi.fn(async () => []) }
 })
 
 const EMPTY_CATEGORY_BREAKDOWN = {
@@ -67,6 +87,20 @@ function makeSession(id: string) {
     categoryBreakdown: { ...EMPTY_CATEGORY_BREAKDOWN },
     skillBreakdown: {},
     subagentBreakdown: {},
+  }
+}
+
+function makeSessionWithCall(id: string, timestamp: string, cost: number) {
+  const call = {
+    provider: 'claude', model: 'claude-test',
+    usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0, webSearchRequests: 0 },
+    costUSD: cost, tools: [], mcpTools: [], skills: [], subagentTypes: [], hasAgentSpawn: false,
+    hasPlanMode: false, speed: 'standard' as const, timestamp, bashCommands: [], deduplicationKey: id,
+  }
+  return {
+    ...makeSession(id), firstTimestamp: timestamp, lastTimestamp: timestamp,
+    totalCostUSD: cost, totalInputTokens: 10, totalOutputTokens: 5,
+    turns: [{ userMessage: 'hi', assistantCalls: [call], timestamp, sessionId: id, category: 'coding' as const, retries: 0, hasEdits: false }],
   }
 }
 
@@ -128,6 +162,43 @@ describe('InteractiveDashboard exit keystrokes (#1141)', () => {
     // parser surfaces it as { input: 'c', key: { ctrl: true } }.
     stdin.write('\x03')
     await expect(exited).resolves.toBeUndefined()
+  })
+})
+
+describe('InteractiveDashboard indexed-period reload races', () => {
+  it('does not let an in-flight day reload overwrite a synchronous indexed period', async () => {
+    const { stdin, stdout } = makeTui()
+    const chunks: string[] = []
+    stdout.on('data', chunk => chunks.push(stripAnsi(String(chunk))))
+    const now = new Date().toISOString()
+    const indexed = makeProject('indexed-week', [makeSessionWithCall('indexed', now, 7)])
+    const history: DashboardHistoryIndex = {
+      provider: 'all', normalizedProjects: [indexed],
+      cache: { version: 29, savingsConfigHash: '', lastComputedDate: null, days: [], complete: true },
+      planUsages: [], readyThrough: 'lifetime',
+    }
+    const app = render(React.createElement(InteractiveDashboard, {
+      initialProjects: [indexed], initialPeriod: 'today', initialProvider: 'all',
+      refreshSeconds: 0, windowColumns: 120, initialHistoryIndex: history,
+    }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
+    onTestFinished(() => app.unmount())
+    await app.waitUntilRenderFlush()
+
+    stdin.write('d')
+    await app.waitUntilRenderFlush()
+    chunks.length = 0
+    stdin.write('2')
+    await app.waitUntilRenderFlush()
+    expect(chunks.join('')).toContain('indexed-week')
+
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+    resolveNextParse([makeProject('stale-day', [makeSessionWithCall('stale', yesterday, 99)])])
+    await new Promise(resolve => setTimeout(resolve, 25))
+    await app.waitUntilRenderFlush()
+
+    const rendered = chunks.join('')
+    expect(rendered).toContain('indexed-week')
+    expect(rendered).not.toContain('stale-day')
   })
 })
 

--- a/tests/dashboard-period-truth.test.ts
+++ b/tests/dashboard-period-truth.test.ts
@@ -1,0 +1,132 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { render } from 'ink'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, it, onTestFinished } from 'vitest'
+
+import { InteractiveDashboard, type DashboardHistoryIndex } from '../src/dashboard.js'
+import type { DailyCache } from '../src/daily-cache.js'
+import type { ProjectSummary, SessionSummary } from '../src/types.js'
+
+const EMPTY_BREAKDOWN = {
+  coding: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  debugging: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  feature: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  refactoring: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  testing: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  exploration: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  planning: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  delegation: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  git: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  'build/deploy': { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  conversation: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  brainstorming: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+  general: { turns: 0, costUSD: 0, retries: 0, editTurns: 0, oneShotTurns: 0 },
+} as const
+
+function project(): ProjectSummary {
+  const timestamp = new Date().toISOString()
+  const session: SessionSummary = {
+    sessionId: 'today', project: 'p', firstTimestamp: timestamp, lastTimestamp: timestamp,
+    totalCostUSD: 1, totalSavingsUSD: 0, totalInputTokens: 0, totalOutputTokens: 0,
+    totalCacheReadTokens: 0, totalCacheWriteTokens: 0, apiCalls: 1,
+    turns: [], modelBreakdown: {}, toolBreakdown: {}, mcpBreakdown: {}, bashBreakdown: {},
+    categoryBreakdown: { ...EMPTY_BREAKDOWN }, skillBreakdown: {}, subagentBreakdown: {},
+  }
+  return { project: 'p', projectPath: '/tmp/p', sessions: [session], totalCostUSD: 1, totalApiCalls: 1 }
+}
+
+function emptyDailyCache(): DailyCache {
+  return { version: 29, savingsConfigHash: '', lastComputedDate: null, days: [], complete: true }
+}
+
+describe('interactive period truth', () => {
+  it('warns honestly before a large first history index', async () => {
+    const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream
+    const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream
+    stdin.isTTY = true
+    stdin.setRawMode = () => stdin
+    stdin.ref = () => stdin
+    stdin.unref = () => stdin
+    stdout.isTTY = true
+    stdout.columns = 140
+    stdout.rows = 50
+    const frames: string[] = []
+    stdout.on('data', chunk => frames.push(stripAnsi(String(chunk))))
+
+    const app = render(React.createElement(InteractiveDashboard, {
+      initialProjects: [project()], initialPeriod: 'today', initialProvider: 'all',
+      refreshSeconds: 0, windowColumns: 140, initialIndexPendingFiles: 1000, initialCacheWasCold: true,
+    }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
+    onTestFinished(() => app.unmount())
+    await app.waitUntilRenderFlush()
+
+    const frame = frames.filter(value => value.trim()).at(-1) ?? ''
+    expect(frame).toContain('indexing source history · 0/1000 files')
+    expect(frame).toContain('large first index · may take a few minutes')
+  })
+
+  it('never labels Today totals as Lifetime while the history index is unavailable', async () => {
+    const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream
+    const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream
+    stdin.isTTY = true
+    stdin.setRawMode = () => stdin
+    stdin.ref = () => stdin
+    stdin.unref = () => stdin
+    stdout.isTTY = true
+    stdout.columns = 120
+    stdout.rows = 50
+    const frames: string[] = []
+    stdout.on('data', chunk => frames.push(stripAnsi(String(chunk))))
+
+    const app = render(React.createElement(InteractiveDashboard, {
+      initialProjects: [project()], initialPeriod: 'today', initialProvider: 'all',
+      initialDurable: { cost: 1, savingsUSD: 0, calls: 1, sessions: 1, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, carriedCostUSD: 0 },
+      refreshSeconds: 0, windowColumns: 120, initialIndexPendingFiles: 1,
+    }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
+    onTestFinished(() => app.unmount())
+    await app.waitUntilRenderFlush()
+
+    frames.length = 0
+    stdin.write('6')
+    await app.waitUntilRenderFlush()
+    const frame = frames.filter(value => value.trim()).at(-1) ?? ''
+
+    expect(frame).toContain('Loading Lifetime')
+    expect(frame).not.toContain('$1.00 cost')
+  })
+
+  it('switches periods synchronously from the completed normalized index', async () => {
+    const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream
+    const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream
+    stdin.isTTY = true
+    stdin.setRawMode = () => stdin
+    stdin.ref = () => stdin
+    stdin.unref = () => stdin
+    stdout.isTTY = true
+    stdout.columns = 120
+    stdout.rows = 50
+    const frames: string[] = []
+    stdout.on('data', chunk => frames.push(stripAnsi(String(chunk))))
+    const history: DashboardHistoryIndex = { provider: 'all', normalizedProjects: [project()], cache: emptyDailyCache(), planUsages: [] }
+
+    const app = render(React.createElement(InteractiveDashboard, {
+      initialProjects: [project()], initialPeriod: 'today', initialProvider: 'all',
+      initialDurable: { cost: 1, savingsUSD: 0, calls: 1, sessions: 1, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, carriedCostUSD: 0 },
+      refreshSeconds: 0, windowColumns: 120, initialHistoryIndex: history,
+    }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
+    onTestFinished(() => app.unmount())
+    await app.waitUntilRenderFlush()
+
+    frames.length = 0
+    stdin.write('6')
+    await app.waitUntilRenderFlush()
+    const frame = frames.filter(value => value.trim()).at(-1) ?? ''
+
+    expect(frame).toContain('[ Lifetime ]')
+    expect(frame).toContain('$0.00 cost')
+    expect(frame).not.toContain('$1.00 cost')
+    expect(frame).not.toContain('Loading Lifetime')
+  })
+})

--- a/tests/dashboard-period-truth.test.ts
+++ b/tests/dashboard-period-truth.test.ts
@@ -5,7 +5,7 @@ import { render } from 'ink'
 import stripAnsi from 'strip-ansi'
 import { describe, expect, it, onTestFinished } from 'vitest'
 
-import { InteractiveDashboard, type DashboardHistoryIndex } from '../src/dashboard.js'
+import { InteractiveDashboard, selectDashboardHistoryIndex, type DashboardHistoryIndex } from '../src/dashboard.js'
 import type { DailyCache } from '../src/daily-cache.js'
 import type { ProjectSummary, SessionSummary } from '../src/types.js'
 
@@ -41,7 +41,40 @@ function emptyDailyCache(): DailyCache {
   return { version: 29, savingsConfigHash: '', lastComputedDate: null, days: [], complete: true }
 }
 
+function historicalProviderProject(): ProjectSummary {
+  const timestamp = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString()
+  const call = {
+    provider: 'claude', model: 'claude-sonnet-4-5', costUSD: 7, timestamp,
+    usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0, webSearchRequests: 0 },
+    tools: [], mcpTools: [], skills: [], subagentTypes: [], hasAgentSpawn: false,
+    hasPlanMode: false, speed: 'standard' as const, bashCommands: [], deduplicationKey: 'claude-historical',
+  }
+  return {
+    project: 'p', projectPath: '/tmp/p', totalCostUSD: 7, totalApiCalls: 1,
+    sessions: [{
+      sessionId: 'claude-historical', project: 'p', firstTimestamp: timestamp, lastTimestamp: timestamp,
+      totalCostUSD: 7, totalSavingsUSD: 0, totalInputTokens: 10, totalOutputTokens: 5,
+      totalCacheReadTokens: 0, totalCacheWriteTokens: 0, apiCalls: 1,
+      turns: [{ userMessage: 'hi', timestamp, sessionId: 'claude-historical', category: 'coding', retries: 0, hasEdits: false, assistantCalls: [call] }],
+      modelBreakdown: {}, toolBreakdown: {}, mcpBreakdown: {}, bashBreakdown: {},
+      categoryBreakdown: { ...EMPTY_BREAKDOWN }, skillBreakdown: {}, subagentBreakdown: {},
+    }],
+  } as ProjectSummary
+}
+
 describe('interactive period truth', () => {
+  it('keeps provider-filtered historical money when the durable day cache is empty', () => {
+    const history: DashboardHistoryIndex = {
+      provider: 'claude', normalizedProjects: [historicalProviderProject()], cache: emptyDailyCache(), planUsages: [], readyThrough: 'lifetime',
+    }
+
+    expect(selectDashboardHistoryIndex(history, 'lifetime').durable).toMatchObject({
+      cost: 7,
+      calls: 1,
+      sessions: 1,
+    })
+  })
+
   it('warns honestly before a large first history index', async () => {
     const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream
     const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream
@@ -63,7 +96,7 @@ describe('interactive period truth', () => {
     await app.waitUntilRenderFlush()
 
     const frame = frames.filter(value => value.trim()).at(-1) ?? ''
-    expect(frame).toContain('indexing source history · 0/1000 files')
+    expect(frame).toContain('indexing Today ready; loading 7 Days · 0 source files parsed · 1000 deferred at first paint')
     expect(frame).toContain('large first index · may take a few minutes')
   })
 
@@ -128,5 +161,68 @@ describe('interactive period truth', () => {
     expect(frame).toContain('$0.00 cost')
     expect(frame).not.toContain('$1.00 cost')
     expect(frame).not.toContain('Loading Lifetime')
+  })
+
+  it('makes 7 Days usable before Lifetime on a widening cold index', async () => {
+    const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream
+    const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream
+    stdin.isTTY = true
+    stdin.setRawMode = () => stdin
+    stdin.ref = () => stdin
+    stdin.unref = () => stdin
+    stdout.isTTY = true
+    stdout.columns = 120
+    stdout.rows = 50
+    const frames: string[] = []
+    stdout.on('data', chunk => frames.push(stripAnsi(String(chunk))))
+    const history: DashboardHistoryIndex = {
+      provider: 'all', normalizedProjects: [project()], cache: emptyDailyCache(), planUsages: [], readyThrough: 'week',
+    }
+
+    const app = render(React.createElement(InteractiveDashboard, {
+      initialProjects: [project()], initialPeriod: 'today', initialProvider: 'all',
+      refreshSeconds: 0, windowColumns: 120, initialHistoryIndex: history, initialHistoryIndexing: true,
+    }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
+    onTestFinished(() => app.unmount())
+    await app.waitUntilRenderFlush()
+
+    frames.length = 0
+    stdin.write('2')
+    await app.waitUntilRenderFlush()
+    let frame = frames.filter(value => value.trim()).at(-1) ?? ''
+    expect(frame).toContain('[ 7 Days ]')
+    expect(frame).not.toContain('Loading 7 Days')
+
+    frames.length = 0
+    stdin.write('6')
+    await app.waitUntilRenderFlush()
+    frame = frames.filter(value => value.trim()).at(-1) ?? ''
+    expect(frame).toContain('Loading Lifetime')
+    expect(frame).not.toContain('$1.00 cost')
+  })
+
+  it('labels a warm first frame as cached without a fake source-file fraction', async () => {
+    const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream
+    const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream
+    stdin.isTTY = true
+    stdin.setRawMode = () => stdin
+    stdin.ref = () => stdin
+    stdin.unref = () => stdin
+    stdout.isTTY = true
+    stdout.columns = 140
+    stdout.rows = 50
+    const frames: string[] = []
+    stdout.on('data', chunk => frames.push(stripAnsi(String(chunk))))
+
+    const app = render(React.createElement(InteractiveDashboard, {
+      initialProjects: [project()], initialPeriod: 'today', initialProvider: 'all',
+      refreshSeconds: 0, windowColumns: 140, initialIndexPendingFiles: 1, initialCacheWasCold: false,
+    }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
+    onTestFinished(() => app.unmount())
+    await app.waitUntilRenderFlush()
+
+    const frame = frames.filter(value => value.trim()).at(-1) ?? ''
+    expect(frame).toContain('cached loading normalized cache · cached Today ready; source refresh pending')
+    expect(frame).not.toContain('0/1 source files')
   })
 })

--- a/tests/dashboard-period-truth.test.ts
+++ b/tests/dashboard-period-truth.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, onTestFinished } from 'vitest'
 
 import { InteractiveDashboard, selectDashboardHistoryIndex, type DashboardHistoryIndex } from '../src/dashboard.js'
 import type { DailyCache } from '../src/daily-cache.js'
+import { aggregateProjectsIntoDays } from '../src/day-aggregator.js'
 import type { ProjectSummary, SessionSummary } from '../src/types.js'
 
 const EMPTY_BREAKDOWN = {
@@ -41,21 +42,25 @@ function emptyDailyCache(): DailyCache {
   return { version: 29, savingsConfigHash: '', lastComputedDate: null, days: [], complete: true }
 }
 
-function historicalProviderProject(): ProjectSummary {
-  const timestamp = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString()
+function historicalProviderProject(
+  provider = 'claude',
+  cost = 7,
+  timestamp = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+): ProjectSummary {
+  const id = `${provider}-historical-${cost}`
   const call = {
-    provider: 'claude', model: 'claude-sonnet-4-5', costUSD: 7, timestamp,
+    provider, model: `${provider}-model`, costUSD: cost, timestamp,
     usage: { inputTokens: 10, outputTokens: 5, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0, webSearchRequests: 0 },
     tools: [], mcpTools: [], skills: [], subagentTypes: [], hasAgentSpawn: false,
-    hasPlanMode: false, speed: 'standard' as const, bashCommands: [], deduplicationKey: 'claude-historical',
+    hasPlanMode: false, speed: 'standard' as const, bashCommands: [], deduplicationKey: id,
   }
   return {
-    project: 'p', projectPath: '/tmp/p', totalCostUSD: 7, totalApiCalls: 1,
+    project: 'p', projectPath: '/tmp/p', totalCostUSD: cost, totalApiCalls: 1,
     sessions: [{
-      sessionId: 'claude-historical', project: 'p', firstTimestamp: timestamp, lastTimestamp: timestamp,
-      totalCostUSD: 7, totalSavingsUSD: 0, totalInputTokens: 10, totalOutputTokens: 5,
+      sessionId: id, project: 'p', firstTimestamp: timestamp, lastTimestamp: timestamp,
+      totalCostUSD: cost, totalSavingsUSD: 0, totalInputTokens: 10, totalOutputTokens: 5,
       totalCacheReadTokens: 0, totalCacheWriteTokens: 0, apiCalls: 1,
-      turns: [{ userMessage: 'hi', timestamp, sessionId: 'claude-historical', category: 'coding', retries: 0, hasEdits: false, assistantCalls: [call] }],
+      turns: [{ userMessage: 'hi', timestamp, sessionId: id, category: 'coding', retries: 0, hasEdits: false, assistantCalls: [call] }],
       modelBreakdown: {}, toolBreakdown: {}, mcpBreakdown: {}, bashBreakdown: {},
       categoryBreakdown: { ...EMPTY_BREAKDOWN }, skillBreakdown: {}, subagentBreakdown: {},
     }],
@@ -73,6 +78,32 @@ describe('interactive period truth', () => {
       calls: 1,
       sessions: 1,
     })
+  })
+
+  it('fills only a missing provider slice on a complete shared historical day', () => {
+    const timestamp = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString()
+    const claude = historicalProviderProject('claude', 3, timestamp)
+    const codex = historicalProviderProject('codex', 7, timestamp)
+    const sharedCache: DailyCache = {
+      ...emptyDailyCache(),
+      days: aggregateProjectsIntoDays([claude]),
+    }
+
+    expect(selectDashboardHistoryIndex({
+      provider: 'codex', normalizedProjects: [codex], cache: sharedCache, planUsages: [], readyThrough: 'lifetime',
+    }, 'lifetime').durable).toMatchObject({ cost: 7, calls: 1, sessions: 1 })
+
+    const cachedCodex = historicalProviderProject('codex', 4, timestamp)
+    const cacheWithCodex: DailyCache = {
+      ...emptyDailyCache(),
+      days: aggregateProjectsIntoDays([claude, cachedCodex]),
+    }
+    expect(selectDashboardHistoryIndex({
+      provider: 'codex', normalizedProjects: [codex], cache: cacheWithCodex, planUsages: [], readyThrough: 'lifetime',
+    }, 'lifetime').durable).toMatchObject({ cost: 4, calls: 1, sessions: 1 })
+    expect(selectDashboardHistoryIndex({
+      provider: 'codex', normalizedProjects: [], cache: cacheWithCodex, planUsages: [], readyThrough: 'lifetime',
+    }, 'lifetime').durable).toMatchObject({ cost: 4, calls: 1, sessions: 1 })
   })
 
   it('warns honestly before a large first history index', async () => {

--- a/tests/dashboard-period-truth.test.ts
+++ b/tests/dashboard-period-truth.test.ts
@@ -106,7 +106,7 @@ describe('interactive period truth', () => {
     }, 'lifetime').durable).toMatchObject({ cost: 4, calls: 1, sessions: 1 })
   })
 
-  it('warns honestly before a large first history index', async () => {
+  it('names the visible explicit Month while a cold shared index widens in the background', async () => {
     const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream
     const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream
     stdin.isTTY = true
@@ -120,14 +120,14 @@ describe('interactive period truth', () => {
     stdout.on('data', chunk => frames.push(stripAnsi(String(chunk))))
 
     const app = render(React.createElement(InteractiveDashboard, {
-      initialProjects: [project()], initialPeriod: 'today', initialProvider: 'all',
+      initialProjects: [project()], initialPeriod: 'month', initialProvider: 'all',
       refreshSeconds: 0, windowColumns: 140, initialIndexPendingFiles: 1000, initialCacheWasCold: true,
     }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
     onTestFinished(() => app.unmount())
     await app.waitUntilRenderFlush()
 
     const frame = frames.filter(value => value.trim()).at(-1) ?? ''
-    expect(frame).toContain('indexing Today ready; loading 7 Days · 0 source files parsed · 1000 deferred at first paint')
+    expect(frame).toContain('indexing This Month visible · shared index: Today ready; loading 7 Days · 0 source files parsed · 1000 deferred at first paint')
     expect(frame).toContain('large first index · may take a few minutes')
   })
 
@@ -232,7 +232,7 @@ describe('interactive period truth', () => {
     expect(frame).not.toContain('$1.00 cost')
   })
 
-  it('labels a warm first frame as cached without a fake source-file fraction', async () => {
+  it('names the visible explicit Month while a warm shared index loads in the background', async () => {
     const stdin = new PassThrough() as PassThrough & NodeJS.ReadStream
     const stdout = new PassThrough() as PassThrough & NodeJS.WriteStream
     stdin.isTTY = true
@@ -246,14 +246,14 @@ describe('interactive period truth', () => {
     stdout.on('data', chunk => frames.push(stripAnsi(String(chunk))))
 
     const app = render(React.createElement(InteractiveDashboard, {
-      initialProjects: [project()], initialPeriod: 'today', initialProvider: 'all',
+      initialProjects: [project()], initialPeriod: 'month', initialProvider: 'all',
       refreshSeconds: 0, windowColumns: 140, initialIndexPendingFiles: 1, initialCacheWasCold: false,
     }), { stdin, stdout, debug: true, interactive: true, patchConsole: false })
     onTestFinished(() => app.unmount())
     await app.waitUntilRenderFlush()
 
     const frame = frames.filter(value => value.trim()).at(-1) ?? ''
-    expect(frame).toContain('cached loading normalized cache · cached Today ready; source refresh pending')
+    expect(frame).toContain('cached This Month visible · shared index: loading normalized cache; source refresh pending')
     expect(frame).not.toContain('0/1 source files')
   })
 })

--- a/tests/dashboard-progressive-startup.test.ts
+++ b/tests/dashboard-progressive-startup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -11,7 +11,7 @@ import {
   selectDashboardHistoryIndex,
 } from '../src/dashboard.js'
 import { getDateRange, type Period } from '../src/cli-date.js'
-import { clearSessionCache, filesParsedFromSourceCount, isCompleteSessionSnapshotAvailable, parseAllSessions } from '../src/parser.js'
+import { clearSessionCache, filesParsedFromSourceCount, isCompleteSessionSnapshotAvailable, parseAllSessions, sessionMemoPublicationCount } from '../src/parser.js'
 import { clearLoadCacheMemo, fingerprintFileCount, isColdCacheOnDisk } from '../src/session-cache.js'
 import { buildDurablePeriod } from '../src/usage-aggregator.js'
 
@@ -41,7 +41,7 @@ afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true })
 })
 
-async function writeSession(name: string, ageDays: number): Promise<void> {
+async function writeSession(name: string, ageDays: number, outputTokens = 50): Promise<void> {
   const dir = join(tmpDir, 'projects', 'proj')
   await mkdir(dir, { recursive: true })
   const at = new Date(Date.now() - ageDays * DAY_MS)
@@ -57,10 +57,28 @@ async function writeSession(name: string, ageDays: number): Promise<void> {
       role: 'assistant',
       model: 'claude-sonnet-4-5',
       content: [],
-      usage: { input_tokens: 100, output_tokens: 50 },
+      usage: { input_tokens: 100, output_tokens: outputTokens },
     },
   })}\n`)
   await utimes(path, at, at)
+}
+
+async function appendSessionCall(name: string, outputTokens: number): Promise<void> {
+  const timestamp = new Date().toISOString()
+  await appendFile(join(tmpDir, 'projects', 'proj', `${name}.jsonl`), `${JSON.stringify({
+    type: 'assistant',
+    sessionId: name,
+    timestamp,
+    cwd: '/tmp/proj',
+    message: {
+      id: `msg-${name}-appended`,
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [],
+      usage: { input_tokens: 100, output_tokens: outputTokens },
+    },
+  })}\n`)
 }
 
 describe('interactive dashboard progressive startup', () => {
@@ -168,17 +186,27 @@ describe('interactive dashboard progressive startup', () => {
     await parseAllSessions(getDateRange('lifetime').range, 'all')
     clearSessionCache()
     clearLoadCacheMemo()
+    // The source changes before launch, with no resident watcher available to
+    // invalidate an in-process memo. Cached first paint may show the old value;
+    // its immediately-following source reconciliation must replace it.
+    await appendSessionCall('today', 450)
 
     const beforeSnapshot = fingerprintFileCount()
-    await buildDashboardHistoryIndex('all', undefined, undefined, {
+    const memoPublicationsBefore = sessionMemoPublicationCount()
+    const snapshot = await buildDashboardHistoryIndex('all', undefined, undefined, {
       readyThrough: 'lifetime',
       preferCompleteSnapshot: true,
     })
     const afterSnapshot = fingerprintFileCount()
     expect(afterSnapshot).toBe(beforeSnapshot)
+    expect(sessionMemoPublicationCount()).toBe(memoPublicationsBefore)
+    expect(snapshot.normalizedProjects.flatMap(project => project.sessions)
+      .find(session => session.sessionId === 'today')?.totalOutputTokens).toBe(50)
 
-    await buildDashboardHistoryIndex('all', undefined, undefined)
+    const refreshed = await buildDashboardHistoryIndex('all', undefined, undefined)
     expect(fingerprintFileCount()).toBeGreaterThan(afterSnapshot)
+    expect(refreshed.normalizedProjects.flatMap(project => project.sessions)
+      .find(session => session.sessionId === 'today')?.totalOutputTokens).toBe(500)
   })
 
   it('widens a cold index in readiness order without parsing a source twice', async () => {

--- a/tests/dashboard-progressive-startup.test.ts
+++ b/tests/dashboard-progressive-startup.test.ts
@@ -3,10 +3,16 @@ import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { assembleDashboardFirstPaint, buildDashboardHistoryIndex, selectDashboardHistoryIndex } from '../src/dashboard.js'
+import {
+  assembleDashboardFirstPaint,
+  buildDashboardHistoryIndex,
+  DASHBOARD_COLD_INDEX_PHASES,
+  dashboardIndexSupportsPeriod,
+  selectDashboardHistoryIndex,
+} from '../src/dashboard.js'
 import { getDateRange, type Period } from '../src/cli-date.js'
-import { clearSessionCache, filesParsedFromSourceCount, parseAllSessions } from '../src/parser.js'
-import { clearLoadCacheMemo, isColdCacheOnDisk } from '../src/session-cache.js'
+import { clearSessionCache, filesParsedFromSourceCount, isCompleteSessionSnapshotAvailable, parseAllSessions } from '../src/parser.js'
+import { clearLoadCacheMemo, fingerprintFileCount, isColdCacheOnDisk } from '../src/session-cache.js'
 import { buildDurablePeriod } from '../src/usage-aggregator.js'
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -58,6 +64,35 @@ async function writeSession(name: string, ageDays: number): Promise<void> {
 }
 
 describe('interactive dashboard progressive startup', () => {
+  it('does not treat an empty cache as a usable complete snapshot', async () => {
+    expect(await isCompleteSessionSnapshotAvailable(getDateRange('today').range, 'all')).toBe(false)
+    await parseAllSessions(getDateRange('today').range, 'all')
+    clearSessionCache()
+    clearLoadCacheMemo()
+    expect(await isCompleteSessionSnapshotAvailable(getDateRange('today').range, 'all')).toBe(false)
+    await writeSession('arrived-after-empty-cache', 0)
+    const paint = await assembleDashboardFirstPaint(
+      'today', 'all', undefined, undefined, null, null, false,
+    )
+    expect(paint.result.filteredProjects.flatMap(project => project.sessions).map(session => session.sessionId))
+      .toEqual(['arrived-after-empty-cache'])
+    clearSessionCache()
+    clearLoadCacheMemo()
+    expect(await isCompleteSessionSnapshotAvailable(getDateRange('today').range, 'codex')).toBe(false)
+  })
+
+  it('discovers current source files when the normalized cache is cold', async () => {
+    await writeSession('today', 0)
+
+    const paint = await assembleDashboardFirstPaint(
+      'today', 'all', undefined, undefined, null, null, false,
+    )
+
+    expect(paint.result.filteredProjects.flatMap(project => project.sessions).map(session => session.sessionId))
+      .toEqual(['today'])
+    expect(filesParsedFromSourceCount()).toBeGreaterThan(0)
+  })
+
   it('paints Today first even when the normalized session cache is already complete', async () => {
     await writeSession('today', 0)
     await writeSession('old', 90)
@@ -74,15 +109,17 @@ describe('interactive dashboard progressive startup', () => {
     clearLoadCacheMemo()
 
     const parsedBefore = filesParsedFromSourceCount()
+    const fingerprintsBefore = fingerprintFileCount()
     const paint = await assembleDashboardFirstPaint(
       'today', 'all', undefined, undefined, null, null, false,
     )
 
     expect(paint.result.period).toBe('today')
-    expect(paint.result.scannedProjects.flatMap(project => project.sessions).map(session => session.sessionId)).toEqual(['today'])
+    expect(paint.result.filteredProjects.flatMap(project => project.sessions).map(session => session.sessionId)).toEqual(['today'])
     expect(paint.result.planUsages).toEqual([])
-    expect(paint.deferredFiles).toBe(1)
+    expect(paint.deferredFiles).toBe(0)
     expect(filesParsedFromSourceCount() - parsedBefore).toBe(0)
+    expect(fingerprintFileCount() - fingerprintsBefore).toBe(0)
   })
 
   it('projects every period from one normalized lifetime index without returning to source files', async () => {
@@ -123,5 +160,53 @@ describe('interactive dashboard progressive startup', () => {
         .toEqual(expected.liveProjects.flatMap(project => project.sessions).map(session => session.sessionId).sort())
     }
     expect(filesParsedFromSourceCount()).toBe(parsedAfterIndex)
+  })
+
+  it('does not let the fast cached snapshot suppress source reconciliation', async () => {
+    await writeSession('today', 0)
+    await writeSession('old', 90)
+    await parseAllSessions(getDateRange('lifetime').range, 'all')
+    clearSessionCache()
+    clearLoadCacheMemo()
+
+    const beforeSnapshot = fingerprintFileCount()
+    await buildDashboardHistoryIndex('all', undefined, undefined, {
+      readyThrough: 'lifetime',
+      preferCompleteSnapshot: true,
+    })
+    const afterSnapshot = fingerprintFileCount()
+    expect(afterSnapshot).toBe(beforeSnapshot)
+
+    await buildDashboardHistoryIndex('all', undefined, undefined)
+    expect(fingerprintFileCount()).toBeGreaterThan(afterSnapshot)
+  })
+
+  it('widens a cold index in readiness order without parsing a source twice', async () => {
+    const periods: Period[] = ['today', ...DASHBOARD_COLD_INDEX_PHASES]
+    await Promise.all([
+      writeSession('today', 0),
+      writeSession('week', 5),
+      writeSession('month', 20),
+      writeSession('older', 45),
+      writeSession('six-months', 120),
+      writeSession('lifetime', 500),
+    ])
+
+    const parsedBefore = filesParsedFromSourceCount()
+    let previousParsed = parsedBefore
+    for (const [position, readyThrough] of DASHBOARD_COLD_INDEX_PHASES.entries()) {
+      const index = await buildDashboardHistoryIndex('all', undefined, undefined, {
+        readyThrough,
+        progressiveSource: true,
+      })
+      for (const [periodPosition, period] of periods.entries()) {
+        expect(dashboardIndexSupportsPeriod(index, period)).toBe(periodPosition <= position + 1)
+      }
+      const parsed = filesParsedFromSourceCount()
+      expect(parsed).toBeGreaterThanOrEqual(previousParsed)
+      previousParsed = parsed
+    }
+
+    expect(filesParsedFromSourceCount() - parsedBefore).toBe(6)
   })
 })

--- a/tests/dashboard-progressive-startup.test.ts
+++ b/tests/dashboard-progressive-startup.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { assembleDashboardFirstPaint, buildDashboardHistoryIndex, selectDashboardHistoryIndex } from '../src/dashboard.js'
+import { getDateRange, type Period } from '../src/cli-date.js'
+import { clearSessionCache, filesParsedFromSourceCount, parseAllSessions } from '../src/parser.js'
+import { clearLoadCacheMemo, isColdCacheOnDisk } from '../src/session-cache.js'
+import { buildDurablePeriod } from '../src/usage-aggregator.js'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+let tmpDir: string
+const originalHome = process.env['HOME']
+
+beforeEach(async () => {
+  clearSessionCache()
+  clearLoadCacheMemo()
+  tmpDir = await mkdtemp(join(tmpdir(), 'dashboard-progressive-'))
+  process.env['HOME'] = tmpDir
+  process.env['CLAUDE_CONFIG_DIR'] = tmpDir
+  process.env['CODEBURN_CACHE_DIR'] = join(tmpDir, 'cache')
+  process.env['CODEBURN_DESKTOP_SESSIONS_DIR'] = join(tmpDir, 'desktop-sessions')
+})
+
+afterEach(async () => {
+  clearSessionCache()
+  clearLoadCacheMemo()
+  delete process.env['CLAUDE_CONFIG_DIR']
+  delete process.env['CODEBURN_CACHE_DIR']
+  delete process.env['CODEBURN_DESKTOP_SESSIONS_DIR']
+  if (originalHome == null) delete process.env['HOME']
+  else process.env['HOME'] = originalHome
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+async function writeSession(name: string, ageDays: number): Promise<void> {
+  const dir = join(tmpDir, 'projects', 'proj')
+  await mkdir(dir, { recursive: true })
+  const at = new Date(Date.now() - ageDays * DAY_MS)
+  const path = join(dir, `${name}.jsonl`)
+  await writeFile(path, `${JSON.stringify({
+    type: 'assistant',
+    sessionId: name,
+    timestamp: at.toISOString(),
+    cwd: '/tmp/proj',
+    message: {
+      id: `msg-${name}`,
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-sonnet-4-5',
+      content: [],
+      usage: { input_tokens: 100, output_tokens: 50 },
+    },
+  })}\n`)
+  await utimes(path, at, at)
+}
+
+describe('interactive dashboard progressive startup', () => {
+  it('paints Today first even when the normalized session cache is already complete', async () => {
+    await writeSession('today', 0)
+    await writeSession('old', 90)
+    const configDir = join(tmpDir, '.config', 'codeburn')
+    await mkdir(configDir, { recursive: true })
+    await writeFile(join(configDir, 'config.json'), JSON.stringify({
+      plans: { claude: { id: 'claude-max', monthlyUsd: 200, resetDay: 1 } },
+    }))
+
+    await parseAllSessions(getDateRange('lifetime').range, 'all')
+    await buildDurablePeriod(getDateRange('lifetime'), { provider: 'all' })
+    expect(await isColdCacheOnDisk()).toBe(false)
+    clearSessionCache()
+    clearLoadCacheMemo()
+
+    const parsedBefore = filesParsedFromSourceCount()
+    const paint = await assembleDashboardFirstPaint(
+      'today', 'all', undefined, undefined, null, null, false,
+    )
+
+    expect(paint.result.period).toBe('today')
+    expect(paint.result.scannedProjects.flatMap(project => project.sessions).map(session => session.sessionId)).toEqual(['today'])
+    expect(paint.result.planUsages).toEqual([])
+    expect(paint.deferredFiles).toBe(1)
+    expect(filesParsedFromSourceCount() - parsedBefore).toBe(0)
+  })
+
+  it('projects every period from one normalized lifetime index without returning to source files', async () => {
+    const periods: Period[] = ['today', 'week', '30days', 'month', 'all', 'lifetime']
+    await Promise.all([
+      writeSession('today', 0),
+      writeSession('week', 5),
+      writeSession('month', 20),
+      writeSession('older', 45),
+      writeSession('six-months', 120),
+      writeSession('lifetime', 500),
+    ])
+
+    const baseline = new Map<Period, Awaited<ReturnType<typeof buildDurablePeriod>>>()
+    for (const period of periods) {
+      baseline.set(period, await buildDurablePeriod(getDateRange(period), { provider: 'all' }))
+    }
+
+    const index = await buildDashboardHistoryIndex('all', undefined, undefined)
+    const parsedAfterIndex = filesParsedFromSourceCount()
+    await rm(join(tmpDir, 'projects'), { recursive: true, force: true })
+
+    for (const period of periods) {
+      const selected = selectDashboardHistoryIndex(index, period)
+      const expected = baseline.get(period)!
+      expect(selected.durable).toEqual({
+        cost: expected.data.cost,
+        savingsUSD: expected.data.savingsUSD,
+        calls: expected.data.calls,
+        sessions: expected.data.sessions,
+        inputTokens: expected.data.inputTokens,
+        outputTokens: expected.data.outputTokens,
+        cacheReadTokens: expected.data.cacheReadTokens,
+        cacheWriteTokens: expected.data.cacheWriteTokens,
+        carriedCostUSD: expected.carriedCostUSD,
+      })
+      expect(selected.projects.flatMap(project => project.sessions).map(session => session.sessionId).sort())
+        .toEqual(expected.liveProjects.flatMap(project => project.sessions).map(session => session.sessionId).sort())
+    }
+    expect(filesParsedFromSourceCount()).toBe(parsedAfterIndex)
+  })
+})

--- a/tests/dashboard-progressive-startup.test.ts
+++ b/tests/dashboard-progressive-startup.test.ts
@@ -9,11 +9,13 @@ import {
   DASHBOARD_COLD_INDEX_PHASES,
   dashboardIndexSupportsPeriod,
   selectDashboardHistoryIndex,
+  shouldAutoFallbackToWeek,
 } from '../src/dashboard.js'
 import { getDateRange, type Period } from '../src/cli-date.js'
 import { clearSessionCache, filesParsedFromSourceCount, isCompleteSessionSnapshotAvailable, parseAllSessions, sessionMemoPublicationCount } from '../src/parser.js'
 import { clearLoadCacheMemo, fingerprintFileCount, isColdCacheOnDisk } from '../src/session-cache.js'
 import { buildDurablePeriod } from '../src/usage-aggregator.js'
+import type { ProjectSummary } from '../src/types.js'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -82,6 +84,26 @@ async function appendSessionCall(name: string, outputTokens: number): Promise<vo
 }
 
 describe('interactive dashboard progressive startup', () => {
+  it('falls back from an all-zero Today on cold and warm indexes, but keeps real usage on Today', () => {
+    const cache = { version: 29, savingsConfigHash: '', lastComputedDate: null, days: [], complete: true } as const
+    const coldWeek = { provider: 'all', normalizedProjects: [], cache, planUsages: [], readyThrough: 'week' as const }
+    const warmLifetime = { ...coldWeek, readyThrough: 'lifetime' as const }
+    const zeroSessionProject = {
+      project: 'zero', projectPath: '/tmp/zero', sessions: [{
+        sessionId: 'zero', project: 'zero', firstTimestamp: '', lastTimestamp: '', totalCostUSD: 0,
+        totalSavingsUSD: 0, totalInputTokens: 0, totalOutputTokens: 0, totalCacheReadTokens: 0,
+        totalCacheWriteTokens: 0, apiCalls: 0, turns: [], modelBreakdown: {}, toolBreakdown: {},
+        mcpBreakdown: {}, bashBreakdown: {}, categoryBreakdown: {}, skillBreakdown: {}, subagentBreakdown: {},
+      }], totalCostUSD: 0, totalSavingsUSD: 0, totalApiCalls: 0,
+    } as ProjectSummary
+    const realUsage = { ...zeroSessionProject, totalApiCalls: 1 }
+
+    expect(shouldAutoFallbackToWeek(true, false, 'today', coldWeek, [])).toBe(true)
+    expect(shouldAutoFallbackToWeek(true, false, 'today', warmLifetime, [zeroSessionProject])).toBe(true)
+    expect(shouldAutoFallbackToWeek(true, false, 'today', coldWeek, [realUsage])).toBe(false)
+    expect(shouldAutoFallbackToWeek(true, false, 'today', warmLifetime, [realUsage])).toBe(false)
+  })
+
   it('does not treat an empty cache as a usable complete snapshot', async () => {
     expect(await isCompleteSessionSnapshotAvailable(getDateRange('today').range, 'all')).toBe(false)
     await parseAllSessions(getDateRange('today').range, 'all')

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -418,7 +418,7 @@ describe('getRefreshIntervalMs', () => {
 
 describe('interactive terminal rendering', () => {
   it('isolates resize reflow from stale primary-screen frames', () => {
-    expect(INTERACTIVE_RENDER_OPTIONS).toMatchObject({ alternateScreen: true })
+    expect(INTERACTIVE_RENDER_OPTIONS).toMatchObject({ alternateScreen: true, interactive: true })
   })
 
   it.each([


### PR DESCRIPTION
## Outcome

Makes the interactive TUI useful before a large local corpus has been fully re-indexed.

- paints an exact cached period first, clearly labelled as cached while source refresh continues
- makes Today, 7D, 30D, Month, 6M, and Lifetime immediately selectable from one normalized cached index
- stages cold-cache readiness in that order while parsing source contents once
- falls back from Today to 7D only when Today is exactly empty across calls, cost, savings, and tokens; unpriced/token-only activity remains on Today
- preserves provider and period truth across rapid navigation, custom ranges, day mode, and in-flight reloads
- keeps cached snapshots out of the parse memo, then atomically replaces the index after reconciliation
- preserves real q and Ctrl-C process termination

This is deliberately limited to the interactive TUI path. It does not change CLI JSON/CSV, Desktop, web, pricing, sync, or Teams semantics.

## Exact provenance

- base: `b79cf40169e4cde931aae10f50bf20cbe8aff49e`
- head: `c8c3f60af9607437fe885e13daa38d555819d282`

## Heavy-corpus evidence

Independent same-HOME Expect/PTTY first-visible comparison against exact built artifacts:

- base: 20,953.2 ms
- original progressive candidate: 1,891.5 ms

An alternating implementation check observed base runs of 27,260.4 / 25,010.3 ms and candidate runs of 2,283.3 / 3,893.7 ms (median 26.14 s -> 3.09 s, about 88% faster). These are acceptance observations on one Mac and corpus, not a general benchmark distribution.

## Verification

- exact-zero Today fallback and provider/day/custom-range regressions: 13/13 passed
- full suite: 253 files passed, 2 skipped; 3,381 tests passed, 5 skipped
- cache-lock family: 34/34
- TypeScript: clean
- production build: clean
- all required GitHub checks: passed
- diff check and worktree: clean

## Review notes / follow-ups

These are intentionally left out of this reviewable slice:

- provider switching still rebuilds a provider-correct index; it needs its own real-corpus speed proof before claiming instant switching
- heavy detail tabs suppress automatic refresh and may age until navigation/manual refresh
- cold tiering repeats discovery/fingerprinting per readiness phase; preserve per-phase timing artifacts before optimizing this further
- the snapshot memo guard is defensive hardening; it is not presented as a reproduced user-facing stale-refresh fix

The larger provider-cache prototype is separately held: a 109.6 MiB shard made `JSON.parse` alone exceed the 250 ms interaction budget and independent review found filter-parity gaps. None of that unaccepted WIP is in this PR.

No issue or PR is auto-closed by this draft.

---
Part of #1160.
