### PR TITLE
feat: standardize model capability tiers

### DIFF
--- a/app/renderer/components/StackedBars.tsx
+++ b/app/renderer/components/StackedBars.tsx
@@ -6,7 +6,7 @@ import { SERIES_LABELS, type SeriesKey, seriesClassForKey, seriesClassForModel, 
 import { formatChartDate } from '../lib/period'
 import type { DailyHistoryEntry } from '../lib/types'
 
-const SERIES_ORDER: readonly SeriesKey[] = ['opus', 'fable', 'haiku', 'gpt', 'sonnet', 'other']
+const SERIES_ORDER: readonly SeriesKey[] = ['flagship', 'premium', 'balanced', 'fast', 'other']
 
 function modelSpend(day: DailyHistoryEntry): number {
   return day.topModels.reduce((sum, model) => sum + Math.max(0, model.cost), 0)

--- a/app/renderer/lib/modelSeries.test.ts
+++ b/app/renderer/lib/modelSeries.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { SERIES_LABELS, seriesClassForModel, seriesColorForModel, seriesKeyForModel } from './modelSeries'
+
+describe('model series', () => {
+  it('uses provider-neutral capability labels', () => {
+    expect(SERIES_LABELS).toEqual({
+      flagship: 'Flagship',
+      premium: 'Premium',
+      balanced: 'Balanced',
+      fast: 'Fast',
+      other: 'Other',
+    })
+  })
+
+  it.each([
+    ['Claude Opus 4.8', 'flagship'],
+    ['claude-fable-1', 'premium'],
+    ['claude-sonnet-4.6', 'balanced'],
+    ['claude-haiku-4.5', 'fast'],
+    ['GPT-5.6 Sol', 'flagship'],
+    ['gpt-5.6-terra', 'balanced'],
+    ['gpt-5.6-luna', 'fast'],
+    ['gpt-5.5-codex', 'balanced'],
+    ['codex-auto-review', 'balanced'],
+    ['gemini-3.1-pro-preview', 'balanced'],
+    ['Gemini 3.5 Flash', 'fast'],
+    ['gemini-3.1-flash-lite-preview', 'fast'],
+    ['mystery-model', 'other'],
+    [undefined, 'other'],
+  ] as const)('classifies %s as %s', (model, series) => {
+    expect(seriesKeyForModel(model)).toBe(series)
+  })
+
+  it('assigns every tier an existing neutral color and class', () => {
+    expect(seriesColorForModel('gpt-5.6-sol')).toBe('var(--s-flagship)')
+    expect(seriesClassForModel('claude-fable-1')).toBe('s-premium')
+    expect(seriesColorForModel('gemini-3.1-pro')).toBe('var(--s-balanced)')
+    expect(seriesClassForModel('gemini-3.5-flash')).toBe('s-fast')
+  })
+})

--- a/app/renderer/lib/modelSeries.ts
+++ b/app/renderer/lib/modelSeries.ts
@@ -1,39 +1,43 @@
-export type SeriesKey = 'opus' | 'fable' | 'sonnet' | 'haiku' | 'gpt' | 'other'
+export type SeriesKey = 'flagship' | 'premium' | 'balanced' | 'fast' | 'other'
 
 export const SERIES_LABELS: Record<SeriesKey, string> = {
-  opus: 'Opus',
-  fable: 'Fable',
-  sonnet: 'Sonnet',
-  haiku: 'Haiku',
-  gpt: 'GPT / Codex',
+  flagship: 'Flagship',
+  premium: 'Premium',
+  balanced: 'Balanced',
+  fast: 'Fast',
   other: 'Other',
 }
 
 const SERIES_CSS_VAR: Record<SeriesKey, string> = {
-  opus: 'var(--s-opus)',
-  fable: 'var(--s-fable)',
-  sonnet: 'var(--s-sonnet)',
-  haiku: 'var(--s-haiku)',
-  gpt: 'var(--s-gpt)',
+  flagship: 'var(--s-flagship)',
+  premium: 'var(--s-premium)',
+  balanced: 'var(--s-balanced)',
+  fast: 'var(--s-fast)',
   other: 'var(--s-other)',
 }
 
 const SERIES_CLASS: Record<SeriesKey, string> = {
-  opus: 's-opus',
-  fable: 's-fable',
-  sonnet: 's-son',
-  haiku: 's-hai',
-  gpt: 's-gpt',
+  flagship: 's-flagship',
+  premium: 's-premium',
+  balanced: 's-balanced',
+  fast: 's-fast',
   other: 's-other',
 }
 
 export function seriesKeyForModel(model?: string): SeriesKey {
   const m = (model ?? '').toLowerCase()
-  if (m.includes('opus')) return 'opus'
-  if (m.includes('fable')) return 'fable'
-  if (m.includes('sonnet')) return 'sonnet'
-  if (m.includes('haiku')) return 'haiku'
-  if (m.includes('gpt') || m.includes('codex')) return 'gpt'
+  if (/\bgpt[-\s]?5\.6[-\s]?sol\b/.test(m)) return 'flagship'
+  if (/\bgpt[-\s]?5\.6[-\s]?luna\b/.test(m)) return 'fast'
+  if (/\bgpt[-\s]?5\.6[-\s]?terra\b/.test(m)) return 'balanced'
+  if (m.includes('gemini')) {
+    if (m.includes('flash')) return 'fast'
+    if (m.includes('pro')) return 'balanced'
+  }
+  if (m.includes('opus')) return 'flagship'
+  if (m.includes('fable')) return 'premium'
+  if (m.includes('sonnet')) return 'balanced'
+  if (m.includes('haiku')) return 'fast'
+  if (m.includes('gpt') || m.includes('codex')) return 'balanced'
   return 'other'
 }
 

--- a/app/renderer/sections/Models.test.tsx
+++ b/app/renderer/sections/Models.test.tsx
@@ -164,8 +164,8 @@ describe('Models', () => {
     expect(screen.getByText('$35.10')).toHaveClass('pos')
 
     const dots = [...container.querySelectorAll('.mdot')]
-    expect(dots[0]).toHaveAttribute('style', expect.stringContaining('var(--s-opus)'))
-    expect(dots[1]).toHaveAttribute('style', expect.stringContaining('var(--s-gpt)'))
+    expect(dots[0]).toHaveAttribute('style', expect.stringContaining('var(--s-flagship)'))
+    expect(dots[1]).toHaveAttribute('style', expect.stringContaining('var(--s-balanced)'))
   })
 
   it('names the provider on each model row so duplicate model names stay distinguishable', async () => {

--- a/app/renderer/sections/Spend.test.tsx
+++ b/app/renderer/sections/Spend.test.tsx
@@ -286,11 +286,16 @@ describe('Spend', () => {
   it('maps stacked segments to the expected model series classes', async () => {
     const payload = makePayload(new Date())
     payload.history.daily = [
-      daily('2026-07-10', 25, [
+      daily('2026-07-10', 50, [
         { name: 'claude-opus-4', cost: 5 },
+        { name: 'claude-fable-1', cost: 5 },
         { name: 'claude-sonnet-5', cost: 5 },
         { name: 'claude-haiku-4', cost: 5 },
-        { name: 'gpt-5.5-codex', cost: 5 },
+        { name: 'gpt-5.6-sol', cost: 5 },
+        { name: 'gpt-5.6-terra', cost: 5 },
+        { name: 'gpt-5.6-luna', cost: 5 },
+        { name: 'gemini-3.1-pro-preview', cost: 5 },
+        { name: 'gemini-3.5-flash', cost: 5 },
         { name: 'mystery-model', cost: 5 },
       ]),
     ]
@@ -301,15 +306,15 @@ describe('Spend', () => {
     const { container } = render(<Spend period="week" provider="all" />)
     expect(await screen.findByLabelText('Daily spend by model')).toBeInTheDocument()
 
-    expect(container.querySelector('.sbars .s-opus')).toBeInTheDocument()
-    expect(container.querySelector('.sbars .s-son')).toBeInTheDocument()
-    expect(container.querySelector('.sbars .s-hai')).toBeInTheDocument()
-    expect(container.querySelector('.sbars .s-gpt')).toBeInTheDocument()
+    expect(container.querySelector('.sbars .s-flagship')).toBeInTheDocument()
+    expect(container.querySelector('.sbars .s-premium')).toBeInTheDocument()
+    expect(container.querySelector('.sbars .s-balanced')).toBeInTheDocument()
+    expect(container.querySelector('.sbars .s-fast')).toBeInTheDocument()
     expect(container.querySelector('.sbars .s-other')).toBeInTheDocument()
-    expect(screen.getByText('Opus')).toBeInTheDocument()
-    expect(screen.getByText('Sonnet')).toBeInTheDocument()
-    expect(screen.getByText('Haiku')).toBeInTheDocument()
-    expect(screen.getByText('GPT / Codex')).toBeInTheDocument()
+    expect(screen.getByText('Flagship')).toBeInTheDocument()
+    expect(screen.getByText('Premium')).toBeInTheDocument()
+    expect(screen.getByText('Balanced')).toBeInTheDocument()
+    expect(screen.getByText('Fast')).toBeInTheDocument()
     expect(screen.getByText('Other')).toBeInTheDocument()
     expect(screen.queryByText('Opus 4.8')).not.toBeInTheDocument()
     expect(screen.queryByText('Sonnet 5')).not.toBeInTheDocument()
@@ -334,7 +339,7 @@ describe('Spend', () => {
     const opusRibbon = container.querySelector('[data-testid="sankey-ribbon"][data-model="claude-opus-4-20260701"]')
     expect(opusRibbon?.getAttribute('stroke')).toBe('url(#sankey-claude-opus-4-20260701)')
     const opusStop = container.querySelector('linearGradient[id="sankey-claude-opus-4-20260701"] stop')
-    expect(opusStop?.getAttribute('stop-color')).toBe('var(--s-opus)')
+    expect(opusStop?.getAttribute('stop-color')).toBe('var(--s-flagship)')
     const otherNode = container.querySelector('[data-testid="sankey-node"][data-node-id="__other__"]')
     expect(otherNode?.getAttribute('fill')).toBe('var(--s-other)')
   })

--- a/app/renderer/styles/indigo.css
+++ b/app/renderer/styles/indigo.css
@@ -97,10 +97,10 @@ h2 { font-size: 20px; font-weight: 650; letter-spacing: -.015em; margin: 0 0 6px
 .sbars .s:first-child { border-radius: 0 0 2px 2px; }
 .sbars .s:last-child { border-radius: 2px 2px 0 0; }
 .sbars .s:only-child { border-radius: 2px; }
-.s-opus { background: var(--s-opus); }
-.s-son { background: var(--s-sonnet); }
-.s-hai { background: var(--s-haiku); }
-.s-gpt { background: var(--s-gpt); }
+.s-flagship { background: var(--s-flagship); }
+.s-premium { background: var(--s-premium); }
+.s-balanced { background: var(--s-balanced); }
+.s-fast { background: var(--s-fast); }
 .s-other { background: var(--s-other); }
 .legend { display: flex; gap: 16px; padding: 9px 4px 0; font-size: 10.5px; color: var(--mut); flex-wrap: wrap; }
 .legend i { width: 8px; height: 8px; border-radius: 2.5px; display: inline-block; margin-right: 6px; vertical-align: -1px; }

--- a/app/renderer/styles/plain.css
+++ b/app/renderer/styles/plain.css
@@ -4,11 +4,10 @@
   --side: #ffffff;
   --panel: #ffffff;
   --phead: #fafbfc;
-  --s-opus: #2a78d6;
-  --s-fable: #1baf7a;
-  --s-sonnet: #e87ba4;
-  --s-haiku: #eda100;
-  --s-gpt: #008300;
+  --s-flagship: #2a78d6;
+  --s-premium: #1baf7a;
+  --s-balanced: #e87ba4;
+  --s-fast: #eda100;
   --s-other: #8b93a1;
   --card-shadow: 0 1px 2px rgba(20,24,33,.05), 0 1px 3px rgba(20,24,33,.06);
   --accent: #e8590c;
@@ -48,11 +47,10 @@
     --side: #131519;
     --panel: #16181d;
     --phead: #1a1d22;
-    --s-opus: #3987e5;
-    --s-fable: #199e70;
-    --s-sonnet: #d55181;
-    --s-haiku: #c98500;
-    --s-gpt: #008300;
+    --s-flagship: #3987e5;
+    --s-premium: #199e70;
+    --s-balanced: #d55181;
+    --s-fast: #c98500;
     --s-other: #6b7280;
     --card-shadow: 0 1px 2px rgba(0,0,0,.24), 0 1px 3px rgba(0,0,0,.30);
     --accent: #f2701c;
@@ -80,7 +78,7 @@
 :root[data-theme='dark'] {
   color-scheme: dark;
   --canvas: #0e1013; --side: #131519; --panel: #16181d; --phead: #1a1d22;
-  --s-opus: #3987e5; --s-fable: #199e70; --s-sonnet: #d55181; --s-haiku: #c98500; --s-gpt: #008300; --s-other: #6b7280;
+  --s-flagship: #3987e5; --s-premium: #199e70; --s-balanced: #d55181; --s-fast: #c98500; --s-other: #6b7280;
   --card-shadow: 0 1px 2px rgba(0,0,0,.24), 0 1px 3px rgba(0,0,0,.30);
   --accent: #f2701c; --accent-text: #f2701c; --bg: #0e1013; --line: #282c33; --line2: #20242a;
   --ink: #e8eaee; --mut: #959ca8; --mut2: #8b93a1; --ok: #3ecf8e;
@@ -94,7 +92,7 @@
 :root[data-theme='light'] {
   color-scheme: light;
   --canvas: #f5f6f8; --side: #ffffff; --panel: #ffffff; --phead: #fafbfc;
-  --s-opus: #2a78d6; --s-fable: #1baf7a; --s-sonnet: #e87ba4; --s-haiku: #eda100; --s-gpt: #008300; --s-other: #8b93a1;
+  --s-flagship: #2a78d6; --s-premium: #1baf7a; --s-balanced: #e87ba4; --s-fast: #eda100; --s-other: #8b93a1;
   --card-shadow: 0 1px 2px rgba(20,24,33,.05), 0 1px 3px rgba(20,24,33,.06);
   --accent: #e8590c; --accent-text: #bf4808; --bg: #f5f6f8; --line: #e6e8ec; --line2: #eef0f3;
   --ink: #181b20; --mut: #697181; --mut2: #68707c; --ok: #12805c;
@@ -440,12 +438,11 @@ td:first-child { font-size: var(--fs-body); font-weight: var(--fw-body); }
 .models-by-task .model-task-row td:first-child { padding-left: 24px; font-weight: 500; }
 .models-by-task .model-task-row td:first-child::before { left: 22px; }
 .models-by-task .model-task-row td:last-child::before { right: 2px; }
-.s-opus  { background: var(--s-opus); }
-.s-fable { background: var(--s-fable); }
-.s-son   { background: var(--s-sonnet); }
-.s-hai   { background: var(--s-haiku); }
-.s-gpt   { background: var(--s-gpt); }
-.s-other { background: var(--s-other); }
+.s-flagship { background: var(--s-flagship); }
+.s-premium  { background: var(--s-premium); }
+.s-balanced { background: var(--s-balanced); }
+.s-fast     { background: var(--s-fast); }
+.s-other    { background: var(--s-other); }
 .track i, .tglon { background: var(--accent); box-shadow: none; }
 .track i.over { background: var(--bad); }
 .track i.mut { background: var(--bar); }


### PR DESCRIPTION
## Summary

Fixes #1162

Standardize model visualization into provider-neutral capability tiers across the desktop dashboard.

Adds Flagship, Premium, Balanced, Fast, and Other tiers.
Classifies GPT-5.6 Sol/Terra/Luna and Gemini Pro/Flash models.
Applies consistent colors across Spend charts, Sankey flows, and Models tables.
Adds regression and integration coverage.

## Testing

- [ ] I have tested this locally against real data (not just unit tests)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds

### For new providers only:

- [ ] I installed the tool and generated real sessions by using it
- [ ] `npm run dev -- today` shows correct costs and session counts for this provider
- [ ] `npm run dev -- models --provider <name>` shows correct model names and pricing
- [ ] Screenshot or terminal output attached below proving it works with real data

<!-- Paste screenshot / terminal output here -->
