### PR TITLE
fix(menubar): keep Capacity Dock hover alive after app deactivation

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CapacityDockController.swift
+++ b/mac/Sources/CodeBurnMenubar/CapacityDockController.swift
@@ -20,6 +20,8 @@ final class CapacityDockController {
     private var detailWork: DispatchWorkItem?
     private var detailExitWork: DispatchWorkItem?
     private var pointerInsideRail = false
+    private var pointerInsideDetail = false
+    private var hoveredRowProvider: CapacityDockProvider?
     private var dragStartFrame: CGRect?
     private var dragVisibleFrame: CGRect?
     private var dragScreenFrame: CGRect?
@@ -114,6 +116,9 @@ final class CapacityDockController {
             self.accessibilityObserver = nil
         }
         stopEventMonitoring()
+        pointerInsideRail = false
+        pointerInsideDetail = false
+        hoveredRowProvider = nil
 
         detailPanel?.orderOut(nil)
         railPanel?.orderOut(nil)
@@ -161,6 +166,9 @@ final class CapacityDockController {
 
         guard snapshot.isEnabled else {
             stopEventMonitoring()
+            pointerInsideRail = false
+            pointerInsideDetail = false
+            hoveredRowProvider = nil
             model.interaction.dismiss()
             hideDetail(animated: false)
             stopRailMotion()
@@ -184,12 +192,6 @@ final class CapacityDockController {
             model: model,
             quota: { [weak self] provider in
                 self?.store.capacityDockQuotaSummary(for: provider)
-            },
-            onRailHover: { [weak self] hovering in
-                self?.railHoverChanged(hovering)
-            },
-            onProviderHover: { [weak self] provider, hovering in
-                self?.providerHoverChanged(provider, hovering: hovering)
             },
             onProviderClick: { [weak self] provider in
                 self?.providerClicked(provider)
@@ -242,9 +244,6 @@ final class CapacityDockController {
             quota: { [weak self] provider in
                 self?.store.capacityDockQuotaSummary(for: provider)
             },
-            onHover: { [weak self] hovering in
-                self?.detailHoverChanged(hovering)
-            },
             onConnect: { [weak self] provider in
                 self?.connect(provider)
             }
@@ -277,7 +276,9 @@ final class CapacityDockController {
         ) { [weak self] event in
             guard let self else { return event }
             if event.type == .mouseMoved {
-                self.updateMouseEventPassthrough(at: NSEvent.mouseLocation)
+                let point = NSEvent.mouseLocation
+                self.updateMouseEventPassthrough(at: point)
+                self.syncPointerHover(at: point)
             } else if event.type == .keyDown, event.keyCode == 53 {
                 if self.model.interaction.handleEscape() {
                     self.hideDetail(animated: false)
@@ -295,7 +296,9 @@ final class CapacityDockController {
                 guard let self else { return }
                 let point = NSEvent.mouseLocation
                 self.updateMouseEventPassthrough(at: point)
-                if event.type != .mouseMoved {
+                if event.type == .mouseMoved {
+                    self.syncPointerHover(at: point)
+                } else {
                     self.dismissIfOutside(point: point)
                 }
             }
@@ -342,6 +345,57 @@ final class CapacityDockController {
         }
     }
 
+    /// SwiftUI's onHover rides on NSTrackingAreas that only deliver while the
+    /// app is active. An accessory app behind a nonactivating panel loses
+    /// activation on the first outside click and can never win it back, so
+    /// hover enter/exit is synthesized here from the event monitors, which
+    /// observe the pointer regardless of activation.
+    private func syncPointerHover(at point: CGPoint = NSEvent.mouseLocation) {
+        guard model.preferences.isEnabled,
+              model.interaction.acceptsHoverTransitions,
+              railPanel != nil else { return }
+        let insideRail = railContains(screenPoint: point)
+        let insideDetail = detailPanel?.isVisible == true && detailContains(screenPoint: point)
+        let row = insideRail ? providerRow(at: point) : nil
+
+        if insideDetail != pointerInsideDetail {
+            pointerInsideDetail = insideDetail
+            detailHoverChanged(insideDetail)
+        }
+        if insideRail != pointerInsideRail {
+            railHoverChanged(insideRail)
+        }
+        if row != hoveredRowProvider {
+            let previous = hoveredRowProvider
+            hoveredRowProvider = row
+            if let previous { providerHoverChanged(previous, hovering: false) }
+            if let row { providerHoverChanged(row, hovering: true) }
+        }
+    }
+
+    private func providerRow(at screenPoint: CGPoint) -> CapacityDockProvider? {
+        guard let railPanel else { return nil }
+        let frame = railPanel.frame
+        let alongOffset: CGFloat = if model.isVertical {
+            model.expansionAnchor == .start
+                ? frame.maxY - model.railTopPadding - screenPoint.y
+                : screenPoint.y - frame.minY - model.railBottomPadding
+        } else {
+            model.expansionAnchor == .start
+                ? screenPoint.x - frame.minX - model.railTopPadding
+                : frame.maxX - model.railBottomPadding - screenPoint.x
+        }
+        let providers = model.displayedProviders
+        guard let index = CapacityDockPlacement.providerRowIndex(
+            alongOffset: alongOffset,
+            rowHeight: model.rowHeight,
+            rowSpacing: model.rowSpacing,
+            rowCount: providers.count,
+            expansionAnchor: model.expansionAnchor
+        ) else { return nil }
+        return providers[index]
+    }
+
     private func railHoverChanged(_ hovering: Bool) {
         pointerInsideRail = hovering
         guard model.interaction.acceptsHoverTransitions else { return }
@@ -369,9 +423,12 @@ final class CapacityDockController {
         guard model.interaction.acceptsHoverTransitions else { return }
         detailWork?.cancel()
         detailExitWork?.cancel()
-        collapseWork?.cancel()
 
         if hovering {
+            // Re-entering a row aborts a pending collapse; a row exit must NOT
+            // touch collapseWork, or it clobbers the collapse the rail exit
+            // just scheduled and strands the rail expanded.
+            collapseWork?.cancel()
             let work = DispatchWorkItem { [weak self] in
                 guard let self else { return }
                 self.showDetail(for: provider)
@@ -534,6 +591,8 @@ final class CapacityDockController {
             model.interaction.beginDragging()
             railPanel.ignoresMouseEvents = false
             hideDetail(animated: false)
+            hoveredRowProvider = nil
+            pointerInsideDetail = false
             dragStartFrame = railPanel.frame
             dragVisibleFrame = screen.visibleFrame
             dragScreenFrame = screen.frame
@@ -733,6 +792,9 @@ final class CapacityDockController {
             model.interaction.beginRailExitGrace()
             scheduleCollapse()
         }
+        // The drag cleared the row cache; a pointer resting on a row at drop
+        // gets no further mouseMoved event, so re-derive the row hover here.
+        syncPointerHover()
     }
 
     private func layoutRail(preserveCurrentTop: Bool = true, animate: Bool = true) {
@@ -823,6 +885,9 @@ final class CapacityDockController {
         if !detailIsDismissing, let provider = model.hoveredProvider {
             layoutDetail(for: provider)
         }
+        // A stationary pointer gets no mouseMoved event when the rail resizes
+        // or moves beneath it; re-derive hover from the settled geometry.
+        syncPointerHover()
     }
 
     private func layoutDetail(
@@ -1003,6 +1068,7 @@ final class CapacityDockController {
                 if !self.detailIsDismissing, let provider = self.model.hoveredProvider {
                     self.layoutDetail(for: provider, transaction: .detailFollow)
                 }
+                self.syncPointerHover()
             }
         )
         railMotion?.start()
@@ -1048,6 +1114,7 @@ final class CapacityDockController {
                     self.detailPanel?.alphaValue = 1
                 }
                 self.updateMouseEventPassthrough()
+                self.syncPointerHover()
             }
         )
         detailMotion?.start()

--- a/mac/Sources/CodeBurnMenubar/CapacityDockPlacement.swift
+++ b/mac/Sources/CodeBurnMenubar/CapacityDockPlacement.swift
@@ -303,6 +303,25 @@ enum CapacityDockPlacement {
         )
     }
 
+    /// Inverse of the controller's row-midpoint layout: which provider row band
+    /// contains a pointer, given its along-axis distance from the anchor-side
+    /// content start (padding already subtracted). Returns nil in the spacing
+    /// gaps and outside the row run.
+    static func providerRowIndex(
+        alongOffset: CGFloat,
+        rowHeight: CGFloat,
+        rowSpacing: CGFloat,
+        rowCount: Int,
+        expansionAnchor: CapacityDockExpansionAnchor
+    ) -> Int? {
+        guard rowCount > 0, rowHeight > 0, alongOffset >= 0 else { return nil }
+        let period = rowHeight + rowSpacing
+        let slot = Int(alongOffset / period)
+        guard slot < rowCount,
+              alongOffset - CGFloat(slot) * period <= rowHeight else { return nil }
+        return expansionAnchor == .start ? slot : rowCount - 1 - slot
+    }
+
     static func preferredDetailSide(
         railFrame: CGRect,
         visibleFrame: CGRect,

--- a/mac/Sources/CodeBurnMenubar/Views/CapacityDockView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/CapacityDockView.swift
@@ -176,8 +176,6 @@ final class CapacityDockViewModel {
 struct CapacityDockView: View {
     let model: CapacityDockViewModel
     let quota: (CapacityDockProvider) -> QuotaSummary?
-    let onRailHover: (Bool) -> Void
-    let onProviderHover: (CapacityDockProvider, Bool) -> Void
     let onProviderClick: (CapacityDockProvider) -> Void
     let onHide: () -> Void
     let onDock: (CapacityDockEdge) -> Void
@@ -202,7 +200,6 @@ struct CapacityDockView: View {
                     quota: quota(provider),
                     scale: model.scale,
                     gaugeShape: model.preferences.gaugeShape,
-                    onHover: { onProviderHover(provider, $0) },
                     onClick: { onProviderClick(provider) }
                 )
                 .frame(
@@ -260,7 +257,6 @@ struct CapacityDockView: View {
         }
         .clipShape(railShape)
         .contentShape(railShape)
-        .onHover(perform: onRailHover)
         .contextMenu {
             Menu("Dock to Edge") {
                 Button("Left") { onDock(.left) }
@@ -301,7 +297,6 @@ private struct CapacityDockProviderRow: View {
     let quota: QuotaSummary?
     let scale: CGFloat
     let gaugeShape: CapacityDockGaugeShape
-    let onHover: (Bool) -> Void
     let onClick: () -> Void
 
     private var headline: QuotaSummary.Window? { quota?.headlineWindow }
@@ -359,7 +354,6 @@ private struct CapacityDockProviderRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .onHover(perform: onHover)
         .accessibilityLabel("\(provider.displayName) usage")
         .accessibilityValue(headline?.percentLabel ?? "Unknown")
         .accessibilityHint("Click to keep Capacity Dock expanded")
@@ -481,7 +475,6 @@ enum CapacityDockQuotaPresentation {
 struct CapacityDockDetailView: View {
     let model: CapacityDockViewModel
     let quota: (CapacityDockProvider) -> QuotaSummary?
-    let onHover: (Bool) -> Void
     let onConnect: (CapacityDockProvider) -> Void
 
     var body: some View {
@@ -508,7 +501,6 @@ struct CapacityDockDetailView: View {
             }
         }
         .contentShape(bubbleShape)
-        .onHover(perform: onHover)
         .accessibilityElement(children: .contain)
     }
 

--- a/mac/Tests/CodeBurnMenubarTests/CapacityDockPlacementTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CapacityDockPlacementTests.swift
@@ -494,4 +494,38 @@ struct CapacityDockPlacementTests {
             preferredEdge: .left
         ) == .right)
     }
+
+    @Test("provider row hit test resolves bands, gaps, and both anchors")
+    func providerRowHitTest() {
+        func index(_ offset: CGFloat, anchor: CapacityDockExpansionAnchor = .start) -> Int? {
+            CapacityDockPlacement.providerRowIndex(
+                alongOffset: offset,
+                rowHeight: 84,
+                rowSpacing: 12,
+                rowCount: 3,
+                expansionAnchor: anchor
+            )
+        }
+
+        #expect(index(0) == 0)
+        #expect(index(84) == 0)
+        #expect(index(90) == nil)
+        #expect(index(96) == 1)
+        #expect(index(240) == 2)
+        #expect(index(276) == 2)
+        #expect(index(277) == nil)
+        #expect(index(-1) == nil)
+
+        #expect(index(0, anchor: .end) == 2)
+        #expect(index(96, anchor: .end) == 1)
+        #expect(index(240, anchor: .end) == 0)
+
+        #expect(CapacityDockPlacement.providerRowIndex(
+            alongOffset: 10,
+            rowHeight: 84,
+            rowSpacing: 12,
+            rowCount: 0,
+            expansionAnchor: .start
+        ) == nil)
+    }
 }


### PR DESCRIPTION
## Problem

The Capacity Dock's hover interactions (rail expansion, provider detail bubble) only worked right after a fresh launch. SwiftUI onHover is backed by NSTrackingAreas that deliver only while the app is active; the dock lives in a borderless nonactivating panel inside an accessory app, so the first click into any other app deactivated CodeBurn permanently and every hover died until relaunch.

## Fix

- Hover enter/exit is synthesized in CapacityDockController from the existing local and global mouse monitors, which observe the pointer regardless of activation. Transitions are edge-triggered against cached containment state and drive the pre-existing handlers unchanged.
- Provider row hit-testing inverts the layoutDetail row-midpoint math via the new pure CapacityDockPlacement.providerRowIndex (all four orientation x anchor combinations, unit-tested).
- SwiftUI onHover plumbing is removed from the rail, row, and detail views so the controller is the single hover source.
- Hover is re-derived when geometry settles under a stationary pointer (layout completion, animation completions, drag drop).
- Row exits no longer cancel the rail's pending collapse; previously a fast hover-and-leave could strand the rail expanded and leave stale interaction state that later re-inflated it.

## Verification

- swift build clean; all 93 Capacity Dock tests pass, plus new providerRowIndex coverage. The 24 CredentialKeychainContinuityTests failures are pre-existing on b23dbf96 (verified on a clean worktree) and unrelated.
- Adversarial review traced the four coordinate branches numerically and the hover state machine interleavings; the two findings it raised (stranded expansion on quick sweep, stale collapse-grace after Escape) are fixed here and were re-verified by trigger-sequence trace.
- Verified live on device: hover works after the app loses activation, quick sweep collapses the rail, Escape does not corrupt state, drop with a stationary pointer opens the bubble.