### PR TITLE
fix: isolate overridden Claude credential homes

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Data/ClaudeCredentialStore.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/ClaudeCredentialStore.swift
@@ -249,6 +249,10 @@ enum ClaudeCredentialStore {
 
     private static func readClaudeSourceSilently() -> CredentialRecord? {
         if let fromFile = try? readClaudeFile() { return fromFile }
+        // An overridden home is an isolation boundary (tests and explicit
+        // sandboxed probes). Falling through here would read the operator's
+        // login Keychain when the isolated fixture has no Claude file.
+        guard homeDirectoryOverride == nil else { return nil }
         if let fromKeychain = try? readClaudeKeychain(allowUI: false) { return fromKeychain }
         return nil
     }
@@ -261,6 +265,7 @@ enum ClaudeCredentialStore {
 
     private static func readClaudeSource() throws -> CredentialRecord {
         if let silent = readClaudeSourceSilently() { return silent }
+        guard homeDirectoryOverride == nil else { throw StoreError.bootstrapNoSource }
         if let fromKeychain = try readClaudeKeychain(allowUI: true) { return fromKeychain }
         throw StoreError.bootstrapNoSource
     }


### PR DESCRIPTION
## Summary
- treat an overridden Claude home directory as a strict credential-source boundary
- prevent isolated tests and sandboxed probes from falling through to the operator login Keychain
- preserve normal file-then-Keychain discovery when no override is active

## Verification
- `swift test --filter CredentialKeychainContinuityTests` (22 tests passed)