### PR TITLE
fix(snap): separate Claude credentials plug, narrow cline grant

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -164,10 +164,9 @@
             "interface": "personal-files",
             "read": [
               "$HOME/.claude/projects",
-              "$HOME/.claude/.credentials.json",
               "$HOME/.codex/sessions",
               "$HOME/.codex/archived_sessions",
-              "$HOME/.cline/data",
+              "$HOME/.cline/data/tasks",
               "$HOME/.codewhale/sessions",
               "$HOME/.copilot/session-state",
               "$HOME/.cursor/projects",
@@ -227,6 +226,14 @@
               "$HOME/.local/share/crush",
               "$HOME/.local/share/goose/sessions",
               "$HOME/.local/share/kilo"
+            ]
+          }
+        },
+        {
+          "claude-quota-credentials": {
+            "interface": "personal-files",
+            "read": [
+              "$HOME/.claude/.credentials.json"
             ]
           }
         }

--- a/app/scripts/snap-grants.test.ts
+++ b/app/scripts/snap-grants.test.ts
@@ -17,10 +17,16 @@ const ROOT_GRANTS_WITH_NO_NARROWER_FORM = new Set([
 
 const XDG_PARENTS = ['.config', '.local']
 
-function readGrants(): string[] {
+function readPlug(name: string): Record<string, unknown> {
   const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'))
-  const plug = pkg.build.snap.plugs.find((p: unknown) => typeof p === 'object')
-  return plug['ai-agent-session-logs'].read
+  const plug = pkg.build.snap.plugs.find(
+    (p: unknown) => typeof p === 'object' && p !== null && name in (p as object),
+  )
+  return (plug as Record<string, Record<string, unknown>>)[name]
+}
+
+function readGrants(): string[] {
+  return readPlug('ai-agent-session-logs').read as string[]
 }
 
 describe('snap personal-files declaration', () => {
@@ -35,11 +41,20 @@ describe('snap personal-files declaration', () => {
     expect(bare).toEqual([])
   })
 
-  it('requests read only, and one credential file explicitly', () => {
-    const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'))
-    const plug = pkg.build.snap.plugs.find((p: unknown) => typeof p === 'object')['ai-agent-session-logs']
+  it('requests read only and never a credential file', () => {
+    // Snap Store review (forum topic 52615): credentials must not ride along
+    // with the auto-connected session-log plug.
+    const plug = readPlug('ai-agent-session-logs')
     expect(Object.keys(plug).sort()).toEqual(['interface', 'read'])
     expect(readGrants().filter(e => e.includes('credential') || e.includes('auth.json')))
-      .toEqual(['$HOME/.claude/.credentials.json'])
+      .toEqual([])
+  })
+
+  it('keeps the Claude credential file in its own manually-connected plug', () => {
+    const plug = readPlug('claude-quota-credentials')
+    expect(plug).toBeDefined()
+    expect(Object.keys(plug).sort()).toEqual(['interface', 'read'])
+    expect(plug.interface).toBe('personal-files')
+    expect(plug.read).toEqual(['$HOME/.claude/.credentials.json'])
   })
 })


### PR DESCRIPTION
Implements the two changes from the Snap Store personal-files review (https://forum.snapcraft.io/t/auto-connect-request-codeburn-personal-files-ai-agent-session-logs/52615):

- `$HOME/.claude/.credentials.json` leaves the auto-connect `ai-agent-session-logs` plug and becomes its own `claude-quota-credentials` plug (personal-files, read-only, single file, no auto-connect requested). It only powers the optional Claude plan/quota tile (`app/electron/quota/claude.ts`), which already degrades gracefully when unreadable; users who want it run `snap connect codeburn:claude-quota-credentials` once.
- `$HOME/.cline/data` narrows to `$HOME/.cline/data/tasks`: the parser reads only `tasks/<taskId>/ui_messages.json` and `api_conversation_history.json` (Cline stores these under `tasks/`, not `sessions/`).

`app/scripts/snap-grants.test.ts` updated to enforce the new shape: no credential path may appear in the auto-connect plug, and the credential plug must stay a single read-only file. 3/3 pass.