### PR TITLE
fix(lock): atomic heartbeat rewrite ends the #904 torn-read flake

### DIFF
--- a/src/cache-refresh-lock.ts
+++ b/src/cache-refresh-lock.ts
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from 'crypto'
 import { existsSync, readFileSync, unlinkSync } from 'fs'
-import { mkdir, open, readFile, stat, unlink, utimes, writeFile } from 'fs/promises'
+import { mkdir, open, readFile, rename, stat, unlink, utimes, writeFile } from 'fs/promises'
 import { join } from 'path'
 
 import { getCodeburnCacheDir } from './cache-dir.js'
@@ -180,8 +180,10 @@ type ObservationResult = Observation | 'missing' | 'changing' | 'unavailable'
 
 async function observe(path: string): Promise<ObservationResult> {
   // Exclusive create exposes the directory entry just before its small body is
-  // written, and heartbeat rewrites briefly truncate it. Treat that bounded
-  // transition as contention, not broken infrastructure.
+  // written, and heartbeats of OLDER codeburn versions sharing this cache dir
+  // still rewrite the body in place (truncating it briefly); this version's
+  // heartbeat replaces atomically. Treat that bounded transition as
+  // contention, not broken infrastructure.
   let sawChange = false
   let corrupt: Observation | null = null
   for (let attempt = 0; attempt < 3; attempt++) {
@@ -393,7 +395,24 @@ export async function acquireCacheRefreshLock(options: RefreshLockOptions = {}):
           // recovers the lock one staleMs later through the age gate. Losing a
           // parse is the correct price for never having two owners.
           if (current.record === null || current.record.token !== token) return
-          await writeFile(lockPath, body(), { encoding: 'utf-8' })
+          // Atomic replace: a truncate-in-place rewrite here exposed every
+          // reader to an empty or partial body for the width of the write
+          // (#904). rename() swaps the directory entry whole, so a reader sees
+          // either the previous body or the next one, never a torn one. The
+          // temp name is deterministic per lock: there is one owner at a time,
+          // so a crash's leftover is simply overwritten by the next tick.
+          const nextPath = lockPath + '.hb-next'
+          await writeFile(nextPath, body(), { encoding: 'utf-8', mode: 0o600 })
+          try {
+            await rename(nextPath, lockPath)
+          } catch (err) {
+            // Windows can refuse the replace while an unrelated open handle
+            // lingers. Skipping the tick is safe: the mtime simply does not
+            // advance this round, and staleMs is nine heartbeats wide.
+            await unlink(nextPath).catch(() => {})
+            if (!isBusyError(err)) throw err
+            return
+          }
           const now = new Date(clock.wallNow())
           await utimes(lockPath, now, now)
         } catch { /* verify/release will turn displacement or I/O failure into a closed gate */ }

--- a/tests/cache-refresh-lock.test.ts
+++ b/tests/cache-refresh-lock.test.ts
@@ -280,6 +280,28 @@ describe('warm session-cache refresh lock', () => {
     }
   })
 
+  it('never exposes a torn lock body to a plain reader while heartbeating', async () => {
+    // Regression for #904: the heartbeat used to rewrite the body in place
+    // (truncate then write), so a concurrent reader could observe an empty or
+    // partial file. The rewrite is now an atomic rename, so every read below
+    // must parse, whichever side of a heartbeat it lands on.
+    const dir = await tempDir()
+    const clock = fakeClock(10_000)
+    const result = await acquireCacheRefreshLock({ cacheDir: dir, clock, heartbeatMs: 1 })
+    expect(result.outcome).toBe('acquired')
+    if (result.outcome !== 'acquired') return
+    try {
+      for (let i = 0; i < 400; i++) {
+        if (i % 20 === 0) clock.advance(100)
+        const record = JSON.parse(await readFile(lockPath(dir), 'utf-8'))
+        expect(record.token).toBe(result.handle.token)
+        if (i % 50 === 0) await new Promise(resolve => { setTimeout(resolve, 2) })
+      }
+    } finally {
+      await result.handle.release()
+    }
+  })
+
   it('takes over only after re-verifying a stale token and mtime', async () => {
     const dir = await tempDir()
     const clock = fakeClock(100_000)


### PR DESCRIPTION
The cache-refresh lock heartbeat rewrote the lock file in place (truncate then write), exposing every concurrent reader to an empty or partial JSON body. `observe()` papers over the window with stat-bracketed retries, but plain readers race it — that is the `Unexpected end of JSON input` flake that hit main and two PR runs today (#904 family).

**Fix:** the heartbeat writes the next body beside the lock and `rename()`s over it. POSIX rename is atomic and Node maps it to a replacing move on Windows, so a reader sees the old body or the new body, never a torn one. A refused replace (Windows busy handle) skips the tick and cleans its temp file; staleness is nine heartbeats wide, so a skipped tick is absorbed. `observe()` keeps its tolerance for the exclusive-create window and for older versions that still rewrite in place against the same cache dir.

**Evidence:**
- New regression test (400 plain reads against a 1ms heartbeat): **fails 5/5 runs on the old code**, passes with the fix.
- Serial lock suite (`npm run test:locks`): **10/10 consecutive green runs** (36 tests each).
- Full suite: 3,895 passed, 0 failed. `tsc` and `npm run build` clean.

Remaining #904 family member (the takeover-window `completed-by-other` misclassification in the process test) is a different race and stays tracked there.