### PR TITLE
fix(menubar): find Copilot credentials beyond the legacy plugin files (#1198)

### DIFF
--- a/app/electron/quota/copilot.test.ts
+++ b/app/electron/quota/copilot.test.ts
@@ -35,6 +35,20 @@ describe('Copilot usage decode', () => {
     expect(quota.primary?.percent).toBeCloseTo(0.45)
   })
 
+  it('skips zero-entitlement and unlimited windows instead of showing 100% used', () => {
+    const quota = decodeCopilotUsage({
+      copilot_plan: 'individual',
+      quota_snapshots: {
+        premium_interactions: { entitlement: 0, remaining: 0, percent_remaining: 0, unlimited: false },
+        chat: { entitlement: 200, remaining: 190, percent_remaining: 95, unlimited: false },
+        completions: { entitlement: 2000, remaining: 2000, percent_remaining: 100, unlimited: true },
+      },
+    })
+    expect(quota.details.map(row => row.label)).toEqual(['Chat'])
+    expect(quota.primary?.label).toBe('Chat')
+    expect(quota.primary?.percent).toBeCloseTo(0.05, 6)
+  })
+
   it('survives a malformed payload without usable snapshots', () => {
     const quota = decodeCopilotUsage({ quota_snapshots: { chat: 'garbage' }, extra: true })
     expect(quota.connection).toBe('connected')

--- a/app/electron/quota/copilot.ts
+++ b/app/electron/quota/copilot.ts
@@ -74,6 +74,9 @@ function windowOf(label: string, snapshot: unknown): QuotaWindow | null {
   const rawRemaining = row.percent_remaining ?? row.percentRemaining
   const remaining = fraction(typeof rawRemaining === 'number' ? rawRemaining : NaN)
   if (remaining === null) return null
+  // A plan without this quota reports entitlement 0 and 0% remaining, which
+  // would render as 100% used; unlimited windows have no meaningful percent.
+  if (row.entitlement === 0 || row.unlimited === true) return null
   // Round away float dust from the 1-remaining subtraction (1-0.7 !== 0.3).
   return { label, percent: Number((1 - remaining).toFixed(6)), resetsAt: null }
 }

--- a/docs/providers/copilot.md
+++ b/docs/providers/copilot.md
@@ -275,6 +275,48 @@ surfaces, add a reader with a captured fixture.)
   `chat-agent-sessions`.
 - **Override the root** with `CODEBURN_COPILOT_JETBRAINS_DIR`.
 
+## Live quota (Copilot subscription)
+
+Separate from the log parser above: the macOS menubar reads live quota from
+`GET https://api.github.com/copilot_internal/user` with a GitHub token. Usage
+tracking never needs this token; only the quota bars do.
+
+`mac/Sources/CodeBurnMenubar/Data/CopilotSubscriptionService.swift` walks an
+ordered, read-only chain and takes the first token it finds. Every rung
+tolerates an absent, locked, or malformed source and falls through:
+
+1. `~/.config/github-copilot/hosts.json` (`github.com` preferred), then
+   `apps.json`. Written only by the older editor plugins; modern VS Code keeps
+   its GitHub login in encrypted secret storage, which CodeBurn deliberately
+   does not touch.
+2. The GitHub Copilot CLI 1.0 keychain item, generic password service
+   `copilot-cli`. Read through `/usr/bin/security` (never the Security
+   framework) so a background read cannot raise the partition-list prompt. The
+   account name is not published, so the lookup is service-only, and a locked
+   keychain or a refused ACL reads as absent.
+3. `~/.copilot/config.json`, then `~/.copilot/settings.json` (the CLI moved
+   settings there in 1.0.35). The key holding the token is not documented and
+   has moved between releases, so instead of guessing key names the parser
+   takes the first string value carrying a GitHub access-token prefix
+   (`gho_`, `ghu_`, `ghp_`, `ghs_`, `github_pat_`). `ghr_` refresh tokens are
+   skipped: the usage endpoint rejects them.
+4. `COPILOT_GITHUB_TOKEN`, then `GH_TOKEN`, then `GITHUB_TOKEN`, matching the
+   Copilot CLI's own order. A GUI-launched app rarely inherits these.
+5. `gh auth token`, which resolves keyring vs `~/.config/gh/hosts.yml` itself.
+   The binary is located the same way `CodeburnCLI` locates codeburn.
+6. A token the user pastes into Settings, stored in CodeBurn's own
+   provider-scoped keychain item. A fine-grained personal access token with the
+   `Plan: Read-only` permission is enough.
+
+Rungs 2 and 5 each cost a process spawn, so their answers are cached for
+`probeCacheTTL` (5 minutes) and dropped on disconnect and before the one 401
+re-read. `hasCredential` is the cheap eligibility answer and never spawns: it
+approximates rung 2 with the existence of `~/.copilot` and rung 5 with an
+installed `gh` binary.
+
+The Electron surface (`app/electron/quota/copilot.ts`) still implements only
+rung 1.
+
 ## Caching
 
 None for the JSONL sources. The OTel and session-store sources use the durable cache (see above).

--- a/docs/providers/copilot.md
+++ b/docs/providers/copilot.md
@@ -289,30 +289,31 @@ tolerates an absent, locked, or malformed source and falls through:
    `apps.json`. Written only by the older editor plugins; modern VS Code keeps
    its GitHub login in encrypted secret storage, which CodeBurn deliberately
    does not touch.
-2. The GitHub Copilot CLI 1.0 keychain item, generic password service
-   `copilot-cli`. Read through `/usr/bin/security` (never the Security
-   framework) so a background read cannot raise the partition-list prompt. The
-   account name is not published, so the lookup is service-only, and a locked
-   keychain or a refused ACL reads as absent.
-3. `~/.copilot/config.json`, then `~/.copilot/settings.json` (the CLI moved
+2. `~/.copilot/config.json`, then `~/.copilot/settings.json` (the CLI moved
    settings there in 1.0.35). The key holding the token is not documented and
    has moved between releases, so instead of guessing key names the parser
    takes the first string value carrying a GitHub access-token prefix
    (`gho_`, `ghu_`, `ghp_`, `ghs_`, `github_pat_`). `ghr_` refresh tokens are
    skipped: the usage endpoint rejects them.
-4. `COPILOT_GITHUB_TOKEN`, then `GH_TOKEN`, then `GITHUB_TOKEN`, matching the
+3. `COPILOT_GITHUB_TOKEN`, then `GH_TOKEN`, then `GITHUB_TOKEN`, matching the
    Copilot CLI's own order. A GUI-launched app rarely inherits these.
-5. `gh auth token`, which resolves keyring vs `~/.config/gh/hosts.yml` itself.
+4. `gh auth token`, which resolves keyring vs `~/.config/gh/hosts.yml` itself.
    The binary is located the same way `CodeburnCLI` locates codeburn.
-6. A token the user pastes into Settings, stored in CodeBurn's own
+5. A token the user pastes into Settings, stored in CodeBurn's own
    provider-scoped keychain item. A fine-grained personal access token with the
    `Plan: Read-only` permission is enough.
 
-Rungs 2 and 5 each cost a process spawn, so their answers are cached for
-`probeCacheTTL` (5 minutes) and dropped on disconnect and before the one 401
-re-read. `hasCredential` is the cheap eligibility answer and never spawns: it
-approximates rung 2 with the existence of `~/.copilot` and rung 5 with an
-installed `gh` binary.
+The Copilot CLI's own keychain item (generic password service `copilot-cli`)
+is deliberately **not** read. It is written by a Node keyring library, so
+`/usr/bin/security` is not in its partition list and every read would raise the
+macOS "allow access?" dialog; a user who clicks Deny would see it again on each
+refresh. Rung 4 reaches the same users anyway, because the Copilot CLI itself
+falls back to gh.
+
+Rung 4 costs a process spawn, so its answer is cached for `probeCacheTTL`
+(5 minutes) and dropped on disconnect and before the one 401 re-read.
+`hasCredential` is the cheap eligibility answer and never spawns: it
+approximates rung 4 with an installed `gh` binary.
 
 The Electron surface (`app/electron/quota/copilot.ts`) still implements only
 rung 1.

--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -157,7 +157,7 @@ final class AppStore {
     var copilotUsage: CopilotUsage?
     var copilotError: String?
     // Same file-based activation as Kimi/Gemini — reading
-    // ~/.config/github-copilot is prompt-free, so we start dormant and
+    // Copilot discovery never raises a keychain prompt, so we start dormant and
     // auto-activate on the first refresh tick.
     var copilotLoadState: SubscriptionLoadState = CopilotSubscriptionService.hasCredential ? .dormant : .notBootstrapped
 
@@ -1393,9 +1393,8 @@ final class AppStore {
 
     // MARK: - Copilot
 
-    /// Same prompt-free activation as Kimi/Gemini: reading the editor plugins'
-    /// credential files needs no keychain, so the first refresh tick activates
-    /// dormant state.
+    /// Same prompt-free activation as Kimi/Gemini: the whole Copilot discovery
+    /// chain is prompt-free, so the first refresh tick activates dormant state.
     func bootstrapCopilot() async {
         // Capture the generation before the await so a disconnect that lands
         // mid-fetch cannot be resurrected into .loaded when the fetch returns.

--- a/mac/Sources/CodeBurnMenubar/Data/CopilotQuotaPresentation.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CopilotQuotaPresentation.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Pure display-decision helpers for the Copilot quota surfaces.
 ///
-/// Copilot tokens are read straight from the editor plugins' on-disk files
-/// with no refresh path, so a revoked token sits in `.terminalFailure` until
-/// the user signs in via an editor's Copilot plugin again. Like Kimi and
+/// Copilot tokens are read straight from whichever signed-in client already
+/// holds one, with no refresh path, so a revoked token sits in
+/// `.terminalFailure` until the user signs in again. Like Kimi and
 /// Gemini, the always-visible surfaces keep showing the last good snapshot
 /// with a quiet caption instead of flapping to a reconnect screen; the
 /// reconnect screen is reserved for the no-data case, where there is

--- a/mac/Sources/CodeBurnMenubar/Data/CopilotSubscriptionService.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CopilotSubscriptionService.swift
@@ -417,6 +417,11 @@ enum CopilotSubscriptionService {
     private static func window(label: String, snapshot: Any?) -> CopilotUsage.Window? {
         guard let row = snapshot as? [String: Any],
               let remaining = fraction(row["percent_remaining"] ?? row["percentRemaining"]) else { return nil }
+        // A plan without this quota reports entitlement 0 and 0% remaining,
+        // which would render as a full 100% used; unlimited windows have no
+        // meaningful percent either. Neither is a window to show.
+        if let entitlement = row["entitlement"] as? NSNumber, entitlement.doubleValue == 0 { return nil }
+        if let unlimited = row["unlimited"] as? Bool, unlimited { return nil }
         // Round away float dust from the 1-remaining subtraction
         // (1-0.7 != 0.3), mirroring the desktop decoder's toFixed(6) before
         // scaling to 0..100.

--- a/mac/Sources/CodeBurnMenubar/Data/CopilotSubscriptionService.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CopilotSubscriptionService.swift
@@ -167,7 +167,7 @@ enum CopilotSubscriptionService {
     /// 4. `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`
     /// 5. `gh auth token`
     /// 6. a token pasted into CodeBurn's Copilot settings
-    static func readToken(deps: Deps) -> String? {
+    private static func readToken(deps: Deps) -> String? {
         for url in [deps.hostsURL, deps.appsURL] {
             if let data = deps.readFile(url), let token = tokenFromMap(data) { return token }
         }

--- a/mac/Sources/CodeBurnMenubar/Data/CopilotSubscriptionService.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CopilotSubscriptionService.swift
@@ -31,21 +31,29 @@ struct CopilotUsage: Sendable, Equatable {
 /// failure must degrade to the normal connection states and never crash the
 /// panel.
 ///
-/// Credential: the GitHub OAuth token already on disk from a signed-in
-/// Copilot plugin — ~/.config/github-copilot/hosts.json (keyed by host,
-/// github.com preferred) falling back to apps.json. Read-only; nothing is
-/// copied or written, and there is no refresh path: an expired or revoked
-/// token stays dead until the user signs in via an editor's Copilot plugin
-/// again, which rewrites the file.
+/// Credential: any GitHub token already on the machine from a signed-in
+/// Copilot client. Modern clients no longer write the legacy plugin files, so
+/// discovery walks an ordered chain (see `readToken`). Read-only throughout;
+/// nothing is copied or written, and there is no refresh path: an expired or
+/// revoked token stays dead until the user signs in again with whichever
+/// client owns it.
 enum CopilotSubscriptionService {
     private static let usageURL = URL(string: "https://api.github.com/copilot_internal/user")!
     private static let usageBlockedUntilKey = "codeburn.copilot.usage.blockedUntil"
+    /// Capacity Dock provider id, used for the pasted-token rung.
+    static let providerID = "copilot"
+    /// Generic-password service the GitHub Copilot CLI 1.0 writes its OAuth
+    /// token under. The account name is not published, so lookups are
+    /// service-only.
+    static let copilotCLIKeychainService = "copilot-cli"
+    /// Honoured in the same order the Copilot CLI honours them.
+    static let environmentTokenNames = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
 
     enum FetchError: Error, LocalizedError {
         case noCredentials
-        /// 401 where re-reading the file yielded the same (or no) token. An
-        /// active editor session rotates this token, so this is transient —
-        /// the next refresh picks up the rotated token from disk.
+        /// 401 where re-reading the chain yielded the same (or no) token. An
+        /// active client session rotates this token, so this is transient: the
+        /// next refresh picks up the rotated one from whichever source holds it.
         case tokenRejected
         case rateLimited(retryAt: Date)
         case usageHTTPError(Int)
@@ -55,15 +63,17 @@ enum CopilotSubscriptionService {
         var errorDescription: String? {
             switch self {
             case .noCredentials:
-                return "No GitHub Copilot credentials found. Sign in via an editor's Copilot plugin first."
+                return "No GitHub Copilot credentials found. Usage tracking still works. "
+                    + "To show live quota, sign in with the Copilot CLI, run gh auth login, "
+                    + "or paste a GitHub token in Settings."
             case .tokenRejected:
-                return "GitHub rejected the stored Copilot token. It will be retried once an editor session refreshes it."
+                return "GitHub rejected the Copilot token found on this Mac. It will be retried once you sign in again."
             case let .rateLimited(retryAt):
                 let f = RelativeDateTimeFormatter()
                 f.unitsStyle = .short
                 return "GitHub rate-limited the Copilot quota endpoint. Retrying \(f.localizedString(for: retryAt, relativeTo: Date()))."
             case let .usageHTTPError(code):
-                return "Copilot quota fetch failed (HTTP \(code)). Sign in via an editor's Copilot plugin, then Reconnect."
+                return "Copilot quota fetch failed (HTTP \(code)). Sign in to Copilot again, then Reconnect."
             case .usageDecodeFailed:
                 return "Copilot quota response was malformed."
             case let .network(err):
@@ -96,6 +106,16 @@ enum CopilotSubscriptionService {
         var readFile: @Sendable (URL) -> Data?
         var hostsURL: URL
         var appsURL: URL
+        /// The Copilot CLI's config directory (~/.copilot).
+        var copilotDirURL: URL
+        /// Raw payload of the Copilot CLI's Keychain item. Uncached: the
+        /// service owns the caching so tests can drive the probe directly.
+        var keychainBlob: @Sendable () -> Data?
+        var environment: @Sendable (String) -> String?
+        /// `gh auth token`. Uncached, for the same reason as `keychainBlob`.
+        var ghAuthToken: @Sendable () -> String?
+        /// Token the user pasted into CodeBurn's own Copilot settings.
+        var savedToken: @Sendable () -> String?
         var now: @Sendable () -> Date
 
         static let live = Deps(
@@ -109,30 +129,62 @@ enum CopilotSubscriptionService {
             readFile: { url in FileManager.default.contents(atPath: url.path) },
             hostsURL: URL(fileURLWithPath: NSHomeDirectory() + "/.config/github-copilot/hosts.json"),
             appsURL: URL(fileURLWithPath: NSHomeDirectory() + "/.config/github-copilot/apps.json"),
+            copilotDirURL: URL(fileURLWithPath: NSHomeDirectory() + "/.copilot"),
+            keychainBlob: { readCopilotCLIKeychain() },
+            environment: { ProcessInfo.processInfo.environment[$0] },
+            ghAuthToken: { runGhAuthToken() },
+            savedToken: { savedCopilotToken() },
             now: { Date() }
         )
     }
 
-    // MARK: - Credential files
+    // MARK: - Credential discovery
 
-    private static var defaultHostsURL: URL { Deps.live.hostsURL }
-    private static var defaultAppsURL: URL { Deps.live.appsURL }
-
+    /// Cheap eligibility answer for the dock and the initial load state. It
+    /// must never spawn a subprocess, so the two subprocess rungs are
+    /// approximated: an existing ~/.copilot directory stands in for the
+    /// Copilot CLI, and an installed `gh` binary stands in for a `gh` login.
+    /// A false positive costs one probe inside `refresh`; a false negative
+    /// would silently never try at all.
     static var hasCredential: Bool {
-        FileManager.default.fileExists(atPath: defaultHostsURL.path)
-            || FileManager.default.fileExists(atPath: defaultAppsURL.path)
+        let deps = Deps.live
+        let manager = FileManager.default
+        for url in [deps.hostsURL, deps.appsURL, deps.copilotDirURL]
+        where manager.fileExists(atPath: url.path) {
+            return true
+        }
+        if environmentTokenNames.contains(where: { nonEmpty(deps.environment($0)) != nil }) { return true }
+        if CapacityDockProviderCredentialPresence.contains(providerID) { return true }
+        return ghExecutableURL() != nil
     }
 
-    /// hosts.json first, apps.json as fallback; a malformed or unreadable
-    /// file falls through to the next candidate. Throws noCredentials when
-    /// neither yields a token.
-    private static func readToken(deps: Deps) throws -> String {
+    /// Ordered, read-only credential chain; the first rung that yields a token
+    /// wins and every rung tolerates absent or malformed data:
+    ///
+    /// 1. legacy editor-plugin files: `hosts.json` then `apps.json`
+    /// 2. the Copilot CLI's Keychain item (service `copilot-cli`)
+    /// 3. `~/.copilot/config.json` then `~/.copilot/settings.json`
+    /// 4. `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`
+    /// 5. `gh auth token`
+    /// 6. a token pasted into CodeBurn's Copilot settings
+    static func readToken(deps: Deps) -> String? {
         for url in [deps.hostsURL, deps.appsURL] {
-            guard let data = deps.readFile(url),
-                  let token = tokenFromMap(data) else { continue }
-            return token
+            if let data = deps.readFile(url), let token = tokenFromMap(data) { return token }
         }
-        throw FetchError.noCredentials
+        if let token = cachedProbe("keychain", deps: deps, probe: {
+            deps.keychainBlob().flatMap(tokenFromBlob)
+        }) { return token }
+        for name in ["config.json", "settings.json"] {
+            if let data = deps.readFile(deps.copilotDirURL.appendingPathComponent(name)),
+               let token = tokenFromBlob(data) { return token }
+        }
+        for name in environmentTokenNames {
+            if let token = nonEmpty(deps.environment(name)) { return token }
+        }
+        if let token = cachedProbe("gh", deps: deps, probe: {
+            nonEmpty(deps.ghAuthToken())
+        }) { return token }
+        return nonEmpty(deps.savedToken())
     }
 
     /// hosts.json keys by host — prefer github.com; apps.json has no
@@ -145,19 +197,192 @@ enum CopilotSubscriptionService {
         return token
     }
 
+    /// GitHub access-token prefixes. `ghr_` (refresh) is deliberately absent:
+    /// the usage endpoint rejects it.
+    private static let tokenPrefixes = ["gho_", "ghu_", "ghp_", "ghs_", "github_pat_"]
+
+    static func looksLikeGitHubToken(_ value: String) -> Bool {
+        tokenPrefixes.contains { value.hasPrefix($0) && value.count > $0.count }
+    }
+
+    /// The Copilot CLI's Keychain payload and its ~/.copilot JSON are both
+    /// undocumented: the Keychain value may be the bare token or a JSON
+    /// envelope, and the JSON key holding the token has moved between
+    /// releases. Rather than guess key names, take the first value carrying a
+    /// GitHub access-token prefix.
+    private static func tokenFromBlob(_ data: Data) -> String? {
+        if let text = nonEmpty(String(data: data, encoding: .utf8)), looksLikeGitHubToken(text) {
+            return text
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data) else { return nil }
+        return firstGitHubToken(in: json)
+    }
+
+    /// Dictionary keys are visited in sorted order so the pick stays stable
+    /// when more than one field qualifies.
+    private static func firstGitHubToken(in value: Any) -> String? {
+        switch value {
+        case let text as String:
+            return looksLikeGitHubToken(text) ? text : nil
+        case let array as [Any]:
+            return array.lazy.compactMap { firstGitHubToken(in: $0) }.first
+        case let map as [String: Any]:
+            return map.keys.sorted().lazy.compactMap { firstGitHubToken(in: map[$0] as Any) }.first
+        default:
+            return nil
+        }
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    // MARK: - Subprocess probes
+
+    /// `security` and `gh` each cost a process spawn, and the panel re-checks
+    /// eligibility and refreshes far more often than a login changes, so both
+    /// answers are reused for this long.
+    static let probeCacheTTL: TimeInterval = 5 * 60
+
+    private final class ProbeCache: @unchecked Sendable {
+        private let lock = NSLock()
+        private var entries: [String: (value: String?, at: Date)] = [:]
+
+        func value(_ key: String, now: Date, ttl: TimeInterval, probe: () -> String?) -> String? {
+            lock.lock()
+            defer { lock.unlock() }
+            if let entry = entries[key], now.timeIntervalSince(entry.at) < ttl {
+                return entry.value
+            }
+            let value = probe()
+            entries[key] = (value, now)
+            return value
+        }
+
+        func reset() {
+            lock.lock()
+            defer { lock.unlock() }
+            entries.removeAll()
+        }
+    }
+
+    private static let probeCache = ProbeCache()
+
+    private static func cachedProbe(
+        _ key: String,
+        deps: Deps,
+        probe: () -> String?
+    ) -> String? {
+        probeCache.value(key, now: deps.now(), ttl: probeCacheTTL, probe: probe)
+    }
+
+    /// Drops the cached `security` / `gh` answers so the next read re-probes.
+    static func resetProbeCache() {
+        probeCache.reset()
+    }
+
+    /// `Process` is not Sendable; the watchdog only calls `terminate()`, which
+    /// is safe from another thread.
+    private final class ProcessBox: @unchecked Sendable {
+        let process: Process
+        init(_ process: Process) { self.process = process }
+    }
+
+    /// Runs a short-lived command and returns trimmed stdout, or nil on any
+    /// failure. stdin is /dev/null so a child can never block on a prompt, and
+    /// the deadline guarantees the caller's refresh cannot wedge.
+    private static func runCapturingStdout(
+        _ executable: URL,
+        _ arguments: [String],
+        timeout: TimeInterval = 5
+    ) -> String? {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        process.standardInput = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        let box = ProcessBox(process)
+        let watchdog = DispatchWorkItem {
+            if box.process.isRunning { box.process.terminate() }
+        }
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout, execute: watchdog)
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+        process.waitUntilExit()
+        watchdog.cancel()
+        guard process.terminationStatus == 0 else { return nil }
+        return nonEmpty(output)
+    }
+
+    /// Reads through `/usr/bin/security` for the same reason
+    /// `ClaudeCredentialStore` does: the Apple-signed binary sits in the item's
+    /// `apple-tool:` partition, so a background read never raises the
+    /// partition-list prompt. A locked keychain or a refused ACL yields nil,
+    /// which is indistinguishable from "not signed in" and falls through.
+    private static func readCopilotCLIKeychain() -> Data? {
+        runCapturingStdout(
+            URL(fileURLWithPath: "/usr/bin/security"),
+            ["find-generic-password", "-s", copilotCLIKeychainService, "-w"]
+        )?.data(using: .utf8)
+    }
+
+    /// `gh auth token` resolves keyring vs ~/.config/gh/hosts.yml itself, so we
+    /// only have to find the binary. A missing `gh` is simply absent.
+    private static func runGhAuthToken() -> String? {
+        guard let gh = ghExecutableURL() else { return nil }
+        return runCapturingStdout(gh, ["auth", "token"])
+    }
+
+    /// Spotlight-launched apps inherit a minimal PATH, so reuse the same PATH
+    /// augmentation that finds the codeburn CLI (Homebrew included).
+    private static func ghExecutableURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> URL? {
+        let path = CodeburnCLI.augmentedPath(
+            environment["PATH"] ?? "",
+            homeDirectory: NSHomeDirectory(),
+            environment: environment
+        )
+        for directory in path.split(separator: ":", omittingEmptySubsequences: true) {
+            let candidate = "\(directory)/gh"
+            if FileManager.default.isExecutableFile(atPath: candidate) {
+                return URL(fileURLWithPath: candidate)
+            }
+        }
+        return nil
+    }
+
+    /// Gated on the non-secret presence index so the common "nothing pasted"
+    /// case never touches Keychain at all.
+    private static func savedCopilotToken() -> String? {
+        guard CapacityDockProviderCredentialPresence.contains(providerID) else { return nil }
+        return (try? CapacityDockProviderCredentialStore.load(for: providerID))?.sanitizedOverride.apiKey
+    }
+
     // MARK: - Fetch
 
     static func refresh(deps: Deps = .live) async throws -> CopilotUsage {
         if let until = usageBlockedUntil(), until > deps.now() {
             throw FetchError.rateLimited(retryAt: until)
         }
-        var token = try readToken(deps: deps)
+        guard var token = readToken(deps: deps) else { throw FetchError.noCredentials }
 
         var (data, response) = try await send(request(token: token), deps: deps)
         if response.statusCode == 401 {
-            // An active editor session rotates this token; re-read once before
-            // giving up so we don't report a failure the disk already fixed.
-            guard let reread = try? readToken(deps: deps), reread != token else {
+            // An active client session rotates this token; re-read once before
+            // giving up so we don't report a failure the source already fixed.
+            // The subprocess rungs are cached, so drop those answers first.
+            resetProbeCache()
+            guard let reread = readToken(deps: deps), reread != token else {
                 throw FetchError.tokenRejected
             }
             token = reread
@@ -290,5 +515,6 @@ enum CopilotSubscriptionService {
 
     static func disconnect() {
         clearUsageBlock()
+        resetProbeCache()
     }
 }

--- a/mac/Sources/CodeBurnMenubar/Data/CopilotSubscriptionService.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CopilotSubscriptionService.swift
@@ -42,10 +42,6 @@ enum CopilotSubscriptionService {
     private static let usageBlockedUntilKey = "codeburn.copilot.usage.blockedUntil"
     /// Capacity Dock provider id, used for the pasted-token rung.
     static let providerID = "copilot"
-    /// Generic-password service the GitHub Copilot CLI 1.0 writes its OAuth
-    /// token under. The account name is not published, so lookups are
-    /// service-only.
-    static let copilotCLIKeychainService = "copilot-cli"
     /// Honoured in the same order the Copilot CLI honours them.
     static let environmentTokenNames = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]
 
@@ -108,11 +104,9 @@ enum CopilotSubscriptionService {
         var appsURL: URL
         /// The Copilot CLI's config directory (~/.copilot).
         var copilotDirURL: URL
-        /// Raw payload of the Copilot CLI's Keychain item. Uncached: the
-        /// service owns the caching so tests can drive the probe directly.
-        var keychainBlob: @Sendable () -> Data?
         var environment: @Sendable (String) -> String?
-        /// `gh auth token`. Uncached, for the same reason as `keychainBlob`.
+        /// `gh auth token`. Uncached: the service owns the caching so tests can
+        /// drive the probe directly.
         var ghAuthToken: @Sendable () -> String?
         /// Token the user pasted into CodeBurn's own Copilot settings.
         var savedToken: @Sendable () -> String?
@@ -130,7 +124,6 @@ enum CopilotSubscriptionService {
             hostsURL: URL(fileURLWithPath: NSHomeDirectory() + "/.config/github-copilot/hosts.json"),
             appsURL: URL(fileURLWithPath: NSHomeDirectory() + "/.config/github-copilot/apps.json"),
             copilotDirURL: URL(fileURLWithPath: NSHomeDirectory() + "/.copilot"),
-            keychainBlob: { readCopilotCLIKeychain() },
             environment: { ProcessInfo.processInfo.environment[$0] },
             ghAuthToken: { runGhAuthToken() },
             savedToken: { savedCopilotToken() },
@@ -141,11 +134,10 @@ enum CopilotSubscriptionService {
     // MARK: - Credential discovery
 
     /// Cheap eligibility answer for the dock and the initial load state. It
-    /// must never spawn a subprocess, so the two subprocess rungs are
-    /// approximated: an existing ~/.copilot directory stands in for the
-    /// Copilot CLI, and an installed `gh` binary stands in for a `gh` login.
-    /// A false positive costs one probe inside `refresh`; a false negative
-    /// would silently never try at all.
+    /// must never spawn a subprocess, so the `gh` rung is approximated by an
+    /// installed `gh` binary rather than an actual login probe. A false
+    /// positive costs one probe inside `refresh`; a false negative would
+    /// silently never try at all.
     static var hasCredential: Bool {
         let deps = Deps.live
         let manager = FileManager.default
@@ -162,28 +154,28 @@ enum CopilotSubscriptionService {
     /// wins and every rung tolerates absent or malformed data:
     ///
     /// 1. legacy editor-plugin files: `hosts.json` then `apps.json`
-    /// 2. the Copilot CLI's Keychain item (service `copilot-cli`)
-    /// 3. `~/.copilot/config.json` then `~/.copilot/settings.json`
-    /// 4. `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`
-    /// 5. `gh auth token`
-    /// 6. a token pasted into CodeBurn's Copilot settings
+    /// 2. `~/.copilot/config.json` then `~/.copilot/settings.json`
+    /// 3. `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`
+    /// 4. `gh auth token`
+    /// 5. a token pasted into CodeBurn's Copilot settings
+    ///
+    /// The Copilot CLI's own Keychain item (service `copilot-cli`) is
+    /// deliberately not read: it is written by a Node keyring library, so
+    /// `/usr/bin/security` is not in its partition list and every read would
+    /// raise the "allow access?" dialog. `gh auth token` reaches the same
+    /// users, because the Copilot CLI itself falls back to gh.
     private static func readToken(deps: Deps) -> String? {
         for url in [deps.hostsURL, deps.appsURL] {
             if let data = deps.readFile(url), let token = tokenFromMap(data) { return token }
         }
-        if let token = cachedProbe("keychain", deps: deps, probe: {
-            deps.keychainBlob().flatMap(tokenFromBlob)
-        }) { return token }
         for name in ["config.json", "settings.json"] {
             if let data = deps.readFile(deps.copilotDirURL.appendingPathComponent(name)),
-               let token = tokenFromBlob(data) { return token }
+               let token = tokenFromCopilotCLIJSON(data) { return token }
         }
         for name in environmentTokenNames {
             if let token = nonEmpty(deps.environment(name)) { return token }
         }
-        if let token = cachedProbe("gh", deps: deps, probe: {
-            nonEmpty(deps.ghAuthToken())
-        }) { return token }
+        if let token = cachedGhToken(deps: deps) { return token }
         return nonEmpty(deps.savedToken())
     }
 
@@ -205,15 +197,10 @@ enum CopilotSubscriptionService {
         tokenPrefixes.contains { value.hasPrefix($0) && value.count > $0.count }
     }
 
-    /// The Copilot CLI's Keychain payload and its ~/.copilot JSON are both
-    /// undocumented: the Keychain value may be the bare token or a JSON
-    /// envelope, and the JSON key holding the token has moved between
-    /// releases. Rather than guess key names, take the first value carrying a
-    /// GitHub access-token prefix.
-    private static func tokenFromBlob(_ data: Data) -> String? {
-        if let text = nonEmpty(String(data: data, encoding: .utf8)), looksLikeGitHubToken(text) {
-            return text
-        }
+    /// The ~/.copilot schema is undocumented and the key holding the token has
+    /// moved between releases, so rather than guess key names take the first
+    /// value carrying a GitHub access-token prefix.
+    private static func tokenFromCopilotCLIJSON(_ data: Data) -> String? {
         guard let json = try? JSONSerialization.jsonObject(with: data) else { return nil }
         return firstGitHubToken(in: json)
     }
@@ -242,44 +229,37 @@ enum CopilotSubscriptionService {
 
     // MARK: - Subprocess probes
 
-    /// `security` and `gh` each cost a process spawn, and the panel re-checks
-    /// eligibility and refreshes far more often than a login changes, so both
-    /// answers are reused for this long.
+    /// `gh auth token` costs a process spawn, and the panel refreshes far more
+    /// often than a login changes, so its answer is reused for this long.
     static let probeCacheTTL: TimeInterval = 5 * 60
 
     private final class ProbeCache: @unchecked Sendable {
         private let lock = NSLock()
-        private var entries: [String: (value: String?, at: Date)] = [:]
+        private var entry: (value: String?, at: Date)?
 
-        func value(_ key: String, now: Date, ttl: TimeInterval, probe: () -> String?) -> String? {
+        func value(now: Date, ttl: TimeInterval, probe: () -> String?) -> String? {
             lock.lock()
             defer { lock.unlock() }
-            if let entry = entries[key], now.timeIntervalSince(entry.at) < ttl {
-                return entry.value
-            }
+            if let entry, now.timeIntervalSince(entry.at) < ttl { return entry.value }
             let value = probe()
-            entries[key] = (value, now)
+            entry = (value, now)
             return value
         }
 
         func reset() {
             lock.lock()
             defer { lock.unlock() }
-            entries.removeAll()
+            entry = nil
         }
     }
 
     private static let probeCache = ProbeCache()
 
-    private static func cachedProbe(
-        _ key: String,
-        deps: Deps,
-        probe: () -> String?
-    ) -> String? {
-        probeCache.value(key, now: deps.now(), ttl: probeCacheTTL, probe: probe)
+    private static func cachedGhToken(deps: Deps) -> String? {
+        probeCache.value(now: deps.now(), ttl: probeCacheTTL) { nonEmpty(deps.ghAuthToken()) }
     }
 
-    /// Drops the cached `security` / `gh` answers so the next read re-probes.
+    /// Drops the cached `gh` answer so the next read re-probes.
     static func resetProbeCache() {
         probeCache.reset()
     }
@@ -321,18 +301,6 @@ enum CopilotSubscriptionService {
         watchdog.cancel()
         guard process.terminationStatus == 0 else { return nil }
         return nonEmpty(output)
-    }
-
-    /// Reads through `/usr/bin/security` for the same reason
-    /// `ClaudeCredentialStore` does: the Apple-signed binary sits in the item's
-    /// `apple-tool:` partition, so a background read never raises the
-    /// partition-list prompt. A locked keychain or a refused ACL yields nil,
-    /// which is indistinguishable from "not signed in" and falls through.
-    private static func readCopilotCLIKeychain() -> Data? {
-        runCapturingStdout(
-            URL(fileURLWithPath: "/usr/bin/security"),
-            ["find-generic-password", "-s", copilotCLIKeychainService, "-w"]
-        )?.data(using: .utf8)
     }
 
     /// `gh auth token` resolves keyring vs ~/.config/gh/hosts.yml itself, so we

--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -1368,8 +1368,9 @@ private struct CopilotSettingsTab: View {
             Section("Connection") {
                 CopilotConnectionRow()
             }
+            CopilotTokenSection()
             Section {
-                Text("Copilot live-quota tracking reads the GitHub Copilot editor sign-in token from `~/.config/github-copilot` read-only. Nothing is copied or stored. Sign in via an editor's Copilot plugin (VS Code, Xcode, etc.) first; if the connection shows as expired, sign in there again, then click Reconnect.")
+                Text("Copilot live-quota tracking reads a GitHub token that is already on this Mac, read-only. Nothing is copied or stored. CodeBurn looks at the editor plugin files in `~/.config/github-copilot`, the Copilot CLI's keychain item and `~/.copilot`, the COPILOT_GITHUB_TOKEN, GH_TOKEN and GITHUB_TOKEN variables, `gh auth token`, and finally a token you paste below. Usage tracking works without any of this; only the live quota bars need a token.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             } header: {
@@ -1378,6 +1379,60 @@ private struct CopilotSettingsTab: View {
         }
         .formStyle(.grouped)
         .padding()
+    }
+}
+
+/// Last rung of the credential chain: a token the user pastes here. Stored in
+/// CodeBurn's own provider-scoped Keychain item, the same one ClinePass uses.
+private struct CopilotTokenSection: View {
+    @Environment(AppStore.self) private var store
+    @State private var token = ""
+    @State private var isSaving = false
+    @State private var errorText: String?
+
+    var body: some View {
+        Section {
+            SecureField("GitHub token", text: $token)
+            HStack {
+                Button("Save & Connect") { save(token) }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isSaving || token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                Button("Clear Token") { save("") }
+                    .disabled(isSaving)
+                if isSaving {
+                    ProgressView().controlSize(.small)
+                }
+            }
+            if let errorText {
+                Text(errorText)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.red)
+            }
+        } header: {
+            Text("Paste a token")
+        } footer: {
+            Text("Optional, and only needed when nothing else on this Mac is signed in. A fine-grained personal access token with the \"Plan: Read-only\" permission is enough. The token is saved in CodeBurn's own Keychain item and is used only to read your Copilot quota.")
+                .font(.system(size: 11))
+        }
+    }
+
+    private func save(_ raw: String) {
+        isSaving = true
+        errorText = nil
+        Task {
+            defer { isSaving = false }
+            do {
+                try await CapacityDockProviderCredentialStore.saveAsync(
+                    CapacityDockProviderCredential(apiKey: raw),
+                    for: CopilotSubscriptionService.providerID
+                )
+                token = ""
+                CopilotSubscriptionService.resetProbeCache()
+                await store.bootstrapCopilot()
+            } catch {
+                errorText = error.localizedDescription
+            }
+        }
     }
 }
 
@@ -1446,13 +1501,13 @@ private struct CopilotConnectionRow: View {
             }
             return "Live quota tracked from api.github.com."
         case .terminalFailure:
-            return "Sign in via an editor's Copilot plugin to refresh your login, then click Reconnect."
+            return "Sign in again with the Copilot CLI, an editor's Copilot plugin, or gh auth login, then click Reconnect."
         case .transientFailure: return store.copilotError ?? "GitHub rate-limited; auto-retrying."
-        case .bootstrapping: return "Reading ~/.config/github-copilot credentials."
+        case .bootstrapping: return "Looking for a GitHub token on this Mac."
         case .loading: return "Background refresh in progress."
         case .dormant: return "Tap Load Quota to fetch live usage from api.github.com."
         case .notBootstrapped, .noCredentials:
-            return "Sign in via an editor's Copilot plugin first, then click Connect."
+            return "Usage tracking still works. For live quota, sign in with the Copilot CLI or gh auth login, or paste a token below, then click Connect."
         case .failed: return store.copilotError ?? ""
         }
     }
@@ -1471,7 +1526,7 @@ private struct CopilotConnectionRow: View {
                     }
                     Button("Cancel", role: .cancel) {}
                 } message: {
-                    Text("CodeBurn will stop tracking Copilot quota. Your ~/.config/github-copilot credentials are untouched. Your editor's Copilot plugin keeps working.")
+                    Text("CodeBurn will stop tracking Copilot quota. Every credential it read stays untouched, and your Copilot clients keep working.")
                 }
         case .terminalFailure, .noCredentials, .failed:
             Button("Reconnect") { Task { await store.bootstrapCopilot() } }

--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -1370,7 +1370,7 @@ private struct CopilotSettingsTab: View {
             }
             CopilotTokenSection()
             Section {
-                Text("Copilot live-quota tracking reads a GitHub token that is already on this Mac, read-only. Nothing is copied or stored. CodeBurn looks at the editor plugin files in `~/.config/github-copilot`, the Copilot CLI's keychain item and `~/.copilot`, the COPILOT_GITHUB_TOKEN, GH_TOKEN and GITHUB_TOKEN variables, `gh auth token`, and finally a token you paste below. Usage tracking works without any of this; only the live quota bars need a token.")
+                Text("Copilot live-quota tracking reads a GitHub token that is already on this Mac, read-only. Nothing is copied or stored. CodeBurn looks at the editor plugin files in `~/.config/github-copilot`, the Copilot CLI's `~/.copilot` files, the COPILOT_GITHUB_TOKEN, GH_TOKEN and GITHUB_TOKEN variables, `gh auth token`, and finally a token you paste below. Usage tracking works without any of this; only the live quota bars need a token.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             } header: {

--- a/mac/Tests/CodeBurnMenubarTests/CopilotQuotaTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CopilotQuotaTests.swift
@@ -131,6 +131,17 @@ final class CopilotQuotaTests: XCTestCase {
         XCTAssertEqual(usage.primary?.usedPercent ?? -1, 45, accuracy: 0.001)
     }
 
+    func testDecodeSkipsZeroEntitlementAndUnlimitedWindows() throws {
+        // A Free/Individual plan reports premium_interactions with entitlement
+        // 0 and 0% remaining, which must not render as 100% used.
+        let body = #"{"copilot_plan":"individual","quota_snapshots":{"premium_interactions":{"entitlement":0,"remaining":0,"percent_remaining":0.0,"unlimited":false},"chat":{"entitlement":200,"remaining":190,"percent_remaining":95.0,"unlimited":false},"completions":{"entitlement":2000,"remaining":2000,"percent_remaining":100.0,"unlimited":true}}}"#
+        let usage = try CopilotSubscriptionService.decodeUsage(
+            data: body.data(using: .utf8)!, now: Self.now)
+        XCTAssertEqual(usage.details.map(\.label), ["Chat"])
+        XCTAssertEqual(usage.primary?.label, "Chat")
+        XCTAssertEqual(usage.primary?.usedPercent ?? -1, 5, accuracy: 0.001)
+    }
+
     func testDecodeSurvivesMalformedSnapshots() throws {
         let body = #"{"quota_snapshots":{"chat":"garbage"},"extra":true}"#
         let usage = try CopilotSubscriptionService.decodeUsage(

--- a/mac/Tests/CodeBurnMenubarTests/CopilotQuotaTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CopilotQuotaTests.swift
@@ -46,7 +46,6 @@ final class CopilotQuotaTests: XCTestCase {
         apps: String? = nil,
         config: String? = nil,
         settings: String? = nil,
-        keychain: String? = nil,
         environment: [String: String] = [:],
         ghToken: String? = nil,
         savedToken: String? = nil,
@@ -73,7 +72,6 @@ final class CopilotQuotaTests: XCTestCase {
             hostsURL: URL(fileURLWithPath: "/tmp/codeburn-tests/.config/github-copilot/hosts.json"),
             appsURL: URL(fileURLWithPath: "/tmp/codeburn-tests/.config/github-copilot/apps.json"),
             copilotDirURL: URL(fileURLWithPath: "/tmp/codeburn-tests/.copilot"),
-            keychainBlob: { keychain?.data(using: .utf8) },
             environment: { environment[$0] },
             ghAuthToken: {
                 onGhProbe?()
@@ -86,7 +84,7 @@ final class CopilotQuotaTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        // The `security` / `gh` answers are cached process-wide.
+        // The `gh` answer is cached process-wide.
         CopilotSubscriptionService.resetProbeCache()
     }
 
@@ -329,36 +327,13 @@ final class CopilotQuotaTests: XCTestCase {
 
     // MARK: - Discovery chain (issue #1198)
 
-    func testKeychainRawTokenIsUsedWhenLegacyFilesAreAbsent() async throws {
-        let recorder = RequestRecorder()
-        let deps = Self.makeDeps(hosts: nil, keychain: "  gho_keychain-raw\n", recorder: recorder) { request in
-            Self.okJson(request, Self.usageBody)
-        }
-        _ = try await CopilotSubscriptionService.refresh(deps: deps)
-        XCTAssertEqual(authorization(recorder), "token gho_keychain-raw")
-    }
 
-    /// The Copilot CLI's keychain payload is undocumented, so a JSON envelope
-    /// has to work as well as a bare token, whatever the field is called.
-    func testKeychainJSONEnvelopeYieldsTheToken() async throws {
-        let recorder = RequestRecorder()
-        let deps = Self.makeDeps(
-            hosts: nil,
-            keychain: #"{"user":"octocat","nested":{"someFutureName":"ghu_keychain-json"}}"#,
-            recorder: recorder
-        ) { request in
-            Self.okJson(request, Self.usageBody)
-        }
-        _ = try await CopilotSubscriptionService.refresh(deps: deps)
-        XCTAssertEqual(authorization(recorder), "token ghu_keychain-json")
-    }
 
-    func testMalformedKeychainBlobFallsThroughToTheNextRung() async throws {
+    func testCopilotCLIConfigJSONIsUsedWhenLegacyFilesAreAbsent() async throws {
         let recorder = RequestRecorder()
         let deps = Self.makeDeps(
             hosts: nil,
             config: #"{"loggedInUsers":["octocat"],"github_token":"ghp_config-token"}"#,
-            keychain: "not json { and not a token",
             recorder: recorder
         ) { request in
             Self.okJson(request, Self.usageBody)
@@ -454,7 +429,6 @@ final class CopilotQuotaTests: XCTestCase {
             hosts: nil,
             config: "{}",
             settings: "not json {",
-            keychain: "",
             recorder: recorder
         ) { request in
             Self.okJson(request, Self.usageBody)
@@ -464,13 +438,12 @@ final class CopilotQuotaTests: XCTestCase {
     }
 
     /// Precedence over the whole chain: with every rung populated, the legacy
-    /// plugin file still wins, then keychain, then ~/.copilot, then env, then
-    /// gh, then the pasted token.
+    /// plugin file still wins, then ~/.copilot, then env, then gh, then the
+    /// pasted token.
     func testDiscoveryPrecedenceOrder() async throws {
         let rungs: [(String, [String: String])] = [
             ("gho_hosts", [:]),
-            ("gho_keychain", ["drop": "hosts"]),
-            ("gho_config", ["drop": "keychain"]),
+            ("gho_config", ["drop": "hosts"]),
             ("gho_settings", ["drop": "config"]),
             ("gho_env", ["drop": "settings"]),
             ("gho_gh", ["drop": "env"]),
@@ -485,7 +458,6 @@ final class CopilotQuotaTests: XCTestCase {
                 hosts: dropped.contains("hosts") ? nil : #"{"github.com":{"oauth_token":"gho_hosts"}}"#,
                 config: dropped.contains("config") ? nil : #"{"token":"gho_config"}"#,
                 settings: dropped.contains("settings") ? nil : #"{"token":"gho_settings"}"#,
-                keychain: dropped.contains("keychain") ? nil : "gho_keychain",
                 environment: dropped.contains("env") ? [:] : ["COPILOT_GITHUB_TOKEN": "gho_env"],
                 ghToken: dropped.contains("gh") ? nil : "gho_gh",
                 savedToken: "gho_saved",

--- a/mac/Tests/CodeBurnMenubarTests/CopilotQuotaTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CopilotQuotaTests.swift
@@ -44,8 +44,16 @@ final class CopilotQuotaTests: XCTestCase {
     private static func makeDeps(
         hosts: String?,
         apps: String? = nil,
+        config: String? = nil,
+        settings: String? = nil,
+        keychain: String? = nil,
+        environment: [String: String] = [:],
+        ghToken: String? = nil,
+        savedToken: String? = nil,
         recorder: RequestRecorder,
         readFile: (@Sendable (URL) -> Data?)? = nil,
+        now: (@Sendable () -> Date)? = nil,
+        onGhProbe: (@Sendable () -> Void)? = nil,
         respond: @escaping @Sendable (URLRequest) -> (Data, HTTPURLResponse)
     ) -> CopilotSubscriptionService.Deps {
         CopilotSubscriptionService.Deps(
@@ -54,14 +62,53 @@ final class CopilotQuotaTests: XCTestCase {
                 return respond(request)
             },
             readFile: readFile ?? { url in
-                if url.lastPathComponent == "hosts.json" { return hosts?.data(using: .utf8) }
-                if url.lastPathComponent == "apps.json" { return apps?.data(using: .utf8) }
-                return nil
+                switch url.lastPathComponent {
+                case "hosts.json": return hosts?.data(using: .utf8)
+                case "apps.json": return apps?.data(using: .utf8)
+                case "config.json": return config?.data(using: .utf8)
+                case "settings.json": return settings?.data(using: .utf8)
+                default: return nil
+                }
             },
             hostsURL: URL(fileURLWithPath: "/tmp/codeburn-tests/.config/github-copilot/hosts.json"),
             appsURL: URL(fileURLWithPath: "/tmp/codeburn-tests/.config/github-copilot/apps.json"),
-            now: { Self.now }
+            copilotDirURL: URL(fileURLWithPath: "/tmp/codeburn-tests/.copilot"),
+            keychainBlob: { keychain?.data(using: .utf8) },
+            environment: { environment[$0] },
+            ghAuthToken: {
+                onGhProbe?()
+                return ghToken
+            },
+            savedToken: { savedToken },
+            now: now ?? { Self.now }
         )
+    }
+
+    override func setUp() {
+        super.setUp()
+        // The `security` / `gh` answers are cached process-wide.
+        CopilotSubscriptionService.resetProbeCache()
+    }
+
+    private func authorization(_ recorder: RequestRecorder) -> String? {
+        recorder.requests.first?.value(forHTTPHeaderField: "Authorization")
+    }
+
+    private func expectNoCredentials(
+        _ deps: CopilotSubscriptionService.Deps,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await CopilotSubscriptionService.refresh(deps: deps)
+            XCTFail("expected noCredentials", file: file, line: line)
+        } catch let error as CopilotSubscriptionService.FetchError {
+            guard case .noCredentials = error else {
+                return XCTFail("expected noCredentials, got \(error)", file: file, line: line)
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)", file: file, line: line)
+        }
     }
 
     // MARK: - Decode
@@ -278,6 +325,214 @@ final class CopilotQuotaTests: XCTestCase {
         } catch {
             XCTFail("unexpected error: \(error)")
         }
+    }
+
+    // MARK: - Discovery chain (issue #1198)
+
+    func testKeychainRawTokenIsUsedWhenLegacyFilesAreAbsent() async throws {
+        let recorder = RequestRecorder()
+        let deps = Self.makeDeps(hosts: nil, keychain: "  gho_keychain-raw\n", recorder: recorder) { request in
+            Self.okJson(request, Self.usageBody)
+        }
+        _ = try await CopilotSubscriptionService.refresh(deps: deps)
+        XCTAssertEqual(authorization(recorder), "token gho_keychain-raw")
+    }
+
+    /// The Copilot CLI's keychain payload is undocumented, so a JSON envelope
+    /// has to work as well as a bare token, whatever the field is called.
+    func testKeychainJSONEnvelopeYieldsTheToken() async throws {
+        let recorder = RequestRecorder()
+        let deps = Self.makeDeps(
+            hosts: nil,
+            keychain: #"{"user":"octocat","nested":{"someFutureName":"ghu_keychain-json"}}"#,
+            recorder: recorder
+        ) { request in
+            Self.okJson(request, Self.usageBody)
+        }
+        _ = try await CopilotSubscriptionService.refresh(deps: deps)
+        XCTAssertEqual(authorization(recorder), "token ghu_keychain-json")
+    }
+
+    func testMalformedKeychainBlobFallsThroughToTheNextRung() async throws {
+        let recorder = RequestRecorder()
+        let deps = Self.makeDeps(
+            hosts: nil,
+            config: #"{"loggedInUsers":["octocat"],"github_token":"ghp_config-token"}"#,
+            keychain: "not json { and not a token",
+            recorder: recorder
+        ) { request in
+            Self.okJson(request, Self.usageBody)
+        }
+        _ = try await CopilotSubscriptionService.refresh(deps: deps)
+        XCTAssertEqual(authorization(recorder), "token ghp_config-token")
+    }
+
+    func testSettingsJSONIsReadWhenConfigJSONHasNoToken() async throws {
+        let recorder = RequestRecorder()
+        let deps = Self.makeDeps(
+            hosts: nil,
+            config: #"{"storeTokenPlaintext":false,"installedPlugins":[]}"#,
+            settings: #"{"auth":{"token":"gho_settings-token"}}"#,
+            recorder: recorder
+        ) { request in
+            Self.okJson(request, Self.usageBody)
+        }
+        _ = try await CopilotSubscriptionService.refresh(deps: deps)
+        XCTAssertEqual(authorization(recorder), "token gho_settings-token")
+    }
+
+    /// A refresh token is not a credential for this endpoint, so a file that
+    /// holds only one must read as absent.
+    func testRefreshTokenIsNotMistakenForAnAccessToken() async {
+        let recorder = RequestRecorder()
+        let deps = Self.makeDeps(
+            hosts: nil,
+            config: #"{"refresh":"ghr_refresh-only"}"#,
+            recorder: recorder
+        ) { request in
+            Self.okJson(request, Self.usageBody)
+        }
+        await expectNoCredentials(deps)
+        XCTAssertTrue(recorder.requests.isEmpty)
+    }
+
+    func testEnvironmentTokensAreHonouredInCopilotCLIOrder() async throws {
+        let recorder = RequestRecorder()
+        let deps = Self.makeDeps(
+            hosts: nil,
+            environment: [
+                "COPILOT_GITHUB_TOKEN": "gho_copilot-env",
+                "GH_TOKEN": "gho_gh-env",
+                "GITHUB_TOKEN": "gho_github-env",
+            ],
+            recorder: recorder
+        ) { request in
+            Self.okJson(request, Self.usageBody)
+        }
+        _ = try await CopilotSubscriptionService.refresh(deps: deps)
+        XCTAssertEqual(authorization(recorder), "token gho_copilot-env")
+
+        let fallback = RequestRecorder()
+        let ghOnly = Self.makeDeps(
+            hosts: nil,
+            environment: ["GITHUB_TOKEN": "gho_github-env"],
+            recorder: fallback
+        ) { request in
+            Self.okJson(request, Self.usageBody)
+        }
+        CopilotSubscriptionService.resetProbeCache()
+        _ = try await CopilotSubscriptionService.refresh(deps: ghOnly)
+        XCTAssertEqual(authorization(fallback), "token gho_github-env")
+    }
+
+    func testGhCLITokenIsUsedWhenNothingElseIsPresent() async throws {
+        let recorder = RequestRecorder()
+        let deps = Self.makeDeps(hosts: nil, ghToken: "gho_gh-cli", recorder: recorder) { request in
+            Self.okJson(request, Self.usageBody)
+        }
+        _ = try await CopilotSubscriptionService.refresh(deps: deps)
+        XCTAssertEqual(authorization(recorder), "token gho_gh-cli")
+    }
+
+    func testMissingGhCLIFallsThroughToThePastedToken() async throws {
+        let recorder = RequestRecorder()
+        let deps = Self.makeDeps(
+            hosts: nil,
+            ghToken: nil,
+            savedToken: "github_pat_pasted",
+            recorder: recorder
+        ) { request in
+            Self.okJson(request, Self.usageBody)
+        }
+        _ = try await CopilotSubscriptionService.refresh(deps: deps)
+        XCTAssertEqual(authorization(recorder), "token github_pat_pasted")
+    }
+
+    func testEveryRungAbsentStillReportsNoCredentialsWithoutFetching() async {
+        let recorder = RequestRecorder()
+        let deps = Self.makeDeps(
+            hosts: nil,
+            config: "{}",
+            settings: "not json {",
+            keychain: "",
+            recorder: recorder
+        ) { request in
+            Self.okJson(request, Self.usageBody)
+        }
+        await expectNoCredentials(deps)
+        XCTAssertTrue(recorder.requests.isEmpty)
+    }
+
+    /// Precedence over the whole chain: with every rung populated, the legacy
+    /// plugin file still wins, then keychain, then ~/.copilot, then env, then
+    /// gh, then the pasted token.
+    func testDiscoveryPrecedenceOrder() async throws {
+        let rungs: [(String, [String: String])] = [
+            ("gho_hosts", [:]),
+            ("gho_keychain", ["drop": "hosts"]),
+            ("gho_config", ["drop": "keychain"]),
+            ("gho_settings", ["drop": "config"]),
+            ("gho_env", ["drop": "settings"]),
+            ("gho_gh", ["drop": "env"]),
+            ("gho_saved", ["drop": "gh"]),
+        ]
+        var dropped: Set<String> = []
+        for (expected, step) in rungs {
+            if let drop = step["drop"] { dropped.insert(drop) }
+            let recorder = RequestRecorder()
+            CopilotSubscriptionService.resetProbeCache()
+            let deps = Self.makeDeps(
+                hosts: dropped.contains("hosts") ? nil : #"{"github.com":{"oauth_token":"gho_hosts"}}"#,
+                config: dropped.contains("config") ? nil : #"{"token":"gho_config"}"#,
+                settings: dropped.contains("settings") ? nil : #"{"token":"gho_settings"}"#,
+                keychain: dropped.contains("keychain") ? nil : "gho_keychain",
+                environment: dropped.contains("env") ? [:] : ["COPILOT_GITHUB_TOKEN": "gho_env"],
+                ghToken: dropped.contains("gh") ? nil : "gho_gh",
+                savedToken: "gho_saved",
+                recorder: recorder
+            ) { request in
+                Self.okJson(request, Self.usageBody)
+            }
+            _ = try await CopilotSubscriptionService.refresh(deps: deps)
+            XCTAssertEqual(authorization(recorder), "token \(expected)")
+        }
+    }
+
+    /// `gh auth token` is a process spawn, so repeated reads inside the TTL
+    /// must reuse the answer, and a read past it must probe again.
+    func testGhProbeIsCachedUntilTheTTLExpires() async throws {
+        final class Clock: @unchecked Sendable {
+            var probes = 0
+            var now = CopilotQuotaTests.now
+        }
+        let clock = Clock()
+        let recorder = RequestRecorder()
+        let deps = Self.makeDeps(
+            hosts: nil,
+            ghToken: "gho_gh-cli",
+            recorder: recorder,
+            now: { clock.now },
+            onGhProbe: { clock.probes += 1 }
+        ) { request in
+            Self.okJson(request, Self.usageBody)
+        }
+        _ = try await CopilotSubscriptionService.refresh(deps: deps)
+        _ = try await CopilotSubscriptionService.refresh(deps: deps)
+        XCTAssertEqual(clock.probes, 1)
+
+        clock.now = Self.now.addingTimeInterval(CopilotSubscriptionService.probeCacheTTL + 1)
+        _ = try await CopilotSubscriptionService.refresh(deps: deps)
+        XCTAssertEqual(clock.probes, 2)
+    }
+
+    func testNoCredentialsMessageOffersEveryConnectionRoute() {
+        let message = CopilotSubscriptionService.FetchError.noCredentials.localizedDescription
+        XCTAssertEqual(
+            message,
+            "No GitHub Copilot credentials found. Usage tracking still works. "
+                + "To show live quota, sign in with the Copilot CLI, run gh auth login, "
+                + "or paste a GitHub token in Settings.")
+        XCTAssertFalse(message.contains("—"))
     }
 
     func testMalformedSuccessBodyDegradesInsteadOfCrashing() async {


### PR DESCRIPTION
Fixes #1198.

## Problem
The Copilot quota ring only looked for `~/.config/github-copilot/hosts.json` / `apps.json`, which only the older editor plugins write. Modern VS Code keeps its GitHub login in encrypted secret storage and the Copilot CLI 1.0 uses `~/.copilot` plus the Keychain, so a fully signed-in user saw "No GitHub Copilot credentials found" with no hint that usage tracking was unaffected.

## Fix
Read-only discovery chain, first hit wins, every rung tolerant of absent or malformed data:
1. `hosts.json` then `apps.json` (unchanged)
2. `~/.copilot/config.json` then `settings.json`: the token key is undocumented and has moved between releases, so the parser takes the first value with a GitHub access-token prefix (`gho_`, `ghu_`, `ghp_`, `ghs_`, `github_pat_`); `ghr_` refresh tokens are skipped
3. `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`
4. `gh auth token` (verified: a gh login token gets HTTP 200 from `copilot_internal/user`); cached 5 minutes, 5 s deadline, stdin /dev/null, never on the main thread
5. A token pasted in Settings (fine-grained PAT with `Plan: Read-only` is enough), stored in CodeBurn's own provider-scoped keychain item like ClinePass

The Copilot CLI's own `copilot-cli` Keychain item is deliberately not read: it is written by a Node keyring library, so `/usr/bin/security` is outside its partition list and every read would raise the macOS access dialog. Rung 4 reaches the same users because the Copilot CLI itself falls back to gh.

VS Code's encrypted secret storage is out of scope by design.

## Messaging
`No GitHub Copilot credentials found. Usage tracking still works. To show live quota, sign in with the Copilot CLI, run gh auth login, or paste a GitHub token in Settings.` The existing Connect action opens the Copilot pane.

## Verification
- `swift build` clean; `swift test`: 341 swift-testing + 128 XCTest pass (10 net new tests: each rung present/absent/malformed, precedence, gh probe cache and TTL, refresh-token exclusion, message text)
- `docs/providers/copilot.md` documents the chain; the Electron surface still implements only rung 1 (noted, out of scope)

## Also in this PR
Verified against a live quota payload: a Free/Individual plan reports `premium_interactions` with entitlement 0 and 0% remaining, which both the menubar and the desktop decoder rendered as a 100% used ring. Windows with entitlement 0 or `unlimited: true` are now skipped in both readers (tests added; Swift 341 + 129, Electron 14, typecheck clean).