### PR TITLE
fix(menubar): map Z.ai body-level auth rejections to real errors

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Data/ZaiSubscriptionService.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/ZaiSubscriptionService.swift
@@ -110,6 +110,17 @@ enum ZaiSubscriptionService {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw FetchError.parseFailure
         }
+        // Z.ai rejects bad auth inside an HTTP 200 body
+        // ({"code":401,"msg":"token expired or incorrect","success":false}),
+        // so map the body code before the shape check or a bad key reads as
+        // an unrecognized response instead of a rejected one.
+        if let success = root["success"] as? Bool, !success {
+            switch jsonNumber(root["code"]).map(Int.init) {
+            case 401, 403: throw FetchError.authenticationRejected
+            case 429: throw FetchError.rateLimited
+            default: throw FetchError.providerUnavailable
+            }
+        }
         let payload = (root["data"] as? [String: Any]) ?? root
         guard let limits = payload["limits"] as? [Any] else { throw FetchError.parseFailure }
 

--- a/mac/Tests/CodeBurnMenubarTests/ZaiQuotaTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/ZaiQuotaTests.swift
@@ -123,6 +123,24 @@ struct ZaiQuotaTests {
         }
     }
 
+    @Test("body-level rejections map to real errors, not parse failures")
+    func bodyLevelRejection() throws {
+        for (body, expected) in [
+            (#"{"code":401,"msg":"token expired or incorrect","success":false}"#,
+             ZaiSubscriptionService.FetchError.authenticationRejected),
+            (#"{"code":403,"msg":"forbidden","success":false}"#, .authenticationRejected),
+            (#"{"code":429,"msg":"slow down","success":false}"#, .rateLimited),
+            (#"{"code":500,"msg":"boom","success":false}"#, .providerUnavailable),
+        ] {
+            do {
+                _ = try ZaiSubscriptionService.decode(Data(body.utf8))
+                Issue.record("Expected body-level rejection to fail")
+            } catch let error as ZaiSubscriptionService.FetchError {
+                #expect(error == expected)
+            }
+        }
+    }
+
     @Test("malformed or empty quota fails")
     func malformedQuota() throws {
         for body in [


### PR DESCRIPTION
Follow-up to #1202, as noted in review there.

Z.ai signals bad auth inside an HTTP 200 body:

```json
{"code": 401, "msg": "token expired or incorrect", "success": false}
```

The adapter only classified the HTTP status, so a body-level rejection fell through to "Z.ai returned an unrecognized quota response" (observed in a live test with a bad key). The decoder now reads the body envelope first: `success: false` with code 401/403 maps to authenticationRejected, 429 to rateLimited, anything else to providerUnavailable.

Verification: `swift build` clean, `swift test` 348 tests in 44 suites pass (4-case body-rejection test added).