### PR TITLE
fix(mac): map Z.ai body authentication errors

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Data/ZaiSubscriptionService.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/ZaiSubscriptionService.swift
@@ -110,6 +110,10 @@ enum ZaiSubscriptionService {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw FetchError.parseFailure
         }
+        let bodyCode = jsonNumber(root["code"]).map(Int.init)
+        if bodyCode == 401 || bodyCode == 403 { throw FetchError.authenticationRejected }
+        if root["success"] as? Bool == false { throw FetchError.parseFailure }
+
         let payload = (root["data"] as? [String: Any]) ?? root
         guard let limits = payload["limits"] as? [Any] else { throw FetchError.parseFailure }
 

--- a/mac/Tests/CodeBurnMenubarTests/ZaiQuotaTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/ZaiQuotaTests.swift
@@ -123,10 +123,28 @@ struct ZaiQuotaTests {
         }
     }
 
+    @Test("HTTP 200 body authentication failures are terminal")
+    func bodyAuthenticationFailure() async throws {
+        for code in [401, 403] {
+            let recorder = RequestRecorder()
+            let body = #"{"code":\#(code),"msg":"token expired or incorrect","success":false}"#
+            do {
+                _ = try await ZaiSubscriptionService.refresh(
+                    apiKey: Self.syntheticKey,
+                    deps: Self.deps(recorder: recorder, body: body)
+                )
+                Issue.record("Expected body code \(code) to reject authentication")
+            } catch let error as ZaiSubscriptionService.FetchError {
+                #expect(error == .authenticationRejected)
+            }
+        }
+    }
+
     @Test("malformed or empty quota fails")
     func malformedQuota() throws {
         for body in [
             "not json",
+            #"{"code":500,"success":false}"#,
             #"{"data":{}}"#,
             #"{"data":{"limits":[]}}"#,
             #"{"data":{"limits":[{"type":"CREDIT_LIMIT","unit":3,"number":5}]}}"#,


### PR DESCRIPTION
## Summary

- inspect Z.ai's body-level `code` and `success` fields before parsing quota limits
- map body codes 401 and 403 to `authenticationRejected`, even when HTTP status is 200
- keep other unsuccessful or malformed bodies classified as parse failures

Follow-up to #1202 and the maintainer's second live-test finding.

## Testing

- [x] red/green Swift harness reproduced HTTP 200 + body 401 returning `parseFailure`, then verified `authenticationRejected`
- [x] regression coverage for body codes 401 and 403
- [x] `SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX26.5.sdk swift build --package-path mac --scratch-path /tmp/codeburn-zai-followup-build -c release --arch arm64`
- [x] `swiftc -parse mac/Sources/CodeBurnMenubar/Data/ZaiSubscriptionService.swift mac/Tests/CodeBurnMenubarTests/ZaiQuotaTests.swift`

The local Command Line Tools install still lacks the XCTest/Testing macro plugins required by the full Swift test target; macOS CI has that toolchain.
