### PR TITLE
fix(mac): stop Capacity Dock hover drift

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CapacityDockController.swift
+++ b/mac/Sources/CodeBurnMenubar/CapacityDockController.swift
@@ -213,6 +213,8 @@ final class CapacityDockController {
         )
         let panel = CapacityDockPanel()
         let hosting = CapacityDockHostingView(rootView: view.environment(store))
+        // Panel geometry has one owner; intrinsic resizing races the frame animator.
+        hosting.sizingOptions = []
         hosting.autoresizingMask = [.width, .height]
         // At the top edge the menu-bar/notch safe-area inset would push the rail
         // down, leaving a gap the bottom edge never shows. Opt the rail out of
@@ -252,6 +254,8 @@ final class CapacityDockController {
         )
         let panel = CapacityDockPanel()
         let hosting = CapacityDockHostingView(rootView: view.environment(store))
+        // Panel geometry has one owner; intrinsic resizing races the frame animator.
+        hosting.sizingOptions = []
         hosting.autoresizingMask = [.width, .height]
         hosting.interactiveShapeContains = { [weak model] point, bounds in
             guard let model else { return false }


### PR DESCRIPTION
## Summary

- make AppKit the sole owner of Capacity Dock panel geometry
- disable `NSHostingView` intrinsic window resizing for the rail and detail panels
- prevent SwiftUI content-size updates from racing hover frame animations and accumulating position drift

## Testing

- [x] focused AppKit/SwiftUI harness: changing hosted content size leaves the controller-owned panel frame unchanged
- [x] `swiftc -frontend -parse mac/Sources/CodeBurnMenubar/CapacityDockController.swift`
- [ ] full Swift tests (local Command Line Tools installation lacks `SwiftUIMacros`; macOS CI has the complete toolchain)
