### PR TITLE
Sync provider and test documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ There is no separate build step required to run the dev CLI. `npm run dev` runs 
 
 | Command | What it does |
 |---|---|
-| `npm test` | Runs the vitest suite under `tests/` (189 of the 192 files, 2,494 tests). |
-| `npm run test:locks` | Runs the three parallelism-sensitive `cache-refresh-lock` suites serially. |
+| `npm test` | Runs the vitest suite under `tests/` (261 of the 265 files, 3,495 tests). |
+| `npm run test:locks` | Runs the four parallelism-sensitive `cache-refresh-lock` suites serially. |
 | `npm run test:watch` | Same scope as `npm test`, in watch mode. |
 | `npm run dev -- status` | Runs the CLI in dev mode against your real data. |
 | `npm run build` | Bundles the litellm pricing snapshot, then runs `tsup` to produce `dist/cli.js`. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,7 +193,7 @@ type Provider = {
 
 `src/providers/index.ts` registers providers across two tiers:
 
-- **Eager**: `claude`, `cline`, `codewhale`, `codebuff`, `codex`, `copilot`, `devin`, `droid`, `dsh`, `gemini`, `hermes`, `ibm-bob`, `kilo-code`, `kiro`, `kimi`, `lingtai-tui`, `mistral-vibe`, `mux`, `openclaw`, `open-design`, `pi`, `omp`, `qwen`, `roo-code`, `zerostack`, `grok`. Imported at module load.
+- **Eager**: `claude`, `cline`, `cline-cli`, `codewhale`, `codebuff`, `codex`, `copilot`, `devin`, `droid`, `dsh`, `gemini`, `hermes`, `ibm-bob`, `kilo-code`, `kiro`, `kimi`, `kimicode`, `lingtai-tui`, `mistral-vibe`, `mux`, `openclaw`, `openclaude`, `open-design`, `pi`, `omp`, `qwen`, `quickdesk`, `roo-code`, `zerostack`, `grok`. Imported at module load.
 - **Lazy**: `antigravity`, `forge`, `goose`, `cursor`, `opencode`, `cursor-agent`, `crush`, `warp`, `vercel-gateway`, `zcode`, `zed`. Imported via dynamic `import()` so the heavy dependencies (SQLite, protobuf, network clients) do not touch users who do not have those tools installed.
 
 Both lists hit the same `getAllProviders()` aggregator. A failed lazy import is silent and excludes that provider from the run.
@@ -254,18 +254,18 @@ The `prepublishOnly` hook in `package.json` runs `npm run build` so `npm publish
 
 ## Tests
 
-`npm test` runs vitest, scoped to `tests/`. 192 test files live there:
+`npm test` runs vitest, scoped to `tests/`. 265 test files live there:
 
-- `tests/` root (141 files) covers CLI, parser, optimize, cache, format, models, plans.
+- `tests/` root (208 files) covers CLI, parser, optimize, cache, format, models, plans.
 - `tests/security/` (1 file) covers prototype-pollution guards.
-- `tests/providers/` (44 files) covers per-provider parsing.
-- `tests/sharing/` (6 files) covers the share/export surface.
+- `tests/providers/` (49 files) covers per-provider parsing.
+- `tests/sharing/` (7 files) covers the share/export surface.
 - `tests/setup/` holds the env-isolation setup file, not specs.
 - `tests/fixtures/` holds redacted real-world session data.
 
 The scope is deliberate: the Electron app under `app/` has its own vitest config and its
 own `jsdom` dependency, so vitest's default glob must not reach it from a root install.
-The three `cache-refresh-lock` suites are excluded from `npm test` and run serially via
+The four `cache-refresh-lock` suites are excluded from `npm test` and run serially via
 `npm run test:locks`, because they exercise a cross-process file lock and fail under full
 worker pressure.
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -13,13 +13,14 @@ For the architectural picture, see `../architecture.md`.
 | [Claude](claude.md) | JSONL (no parser) | `src/providers/claude.ts` | none (covered indirectly) |
 | [Cline](cline.md) | JSON | `src/providers/cline.ts` | `tests/providers/cline.test.ts` |
 | [Cline CLI](cline-cli.md) | JSON | `src/providers/cline-cli.ts` | `tests/providers/cline-cli.test.ts` |
+| [Codebuff](codebuff.md) | JSON | `src/providers/codebuff.ts` | `tests/providers/codebuff.test.ts` |
 | [CodeWhale](codewhale.md) | JSON | `src/providers/codewhale.ts` | `tests/providers/codewhale.test.ts` |
 | [Codex](codex.md) | JSONL | `src/providers/codex.ts` | `tests/providers/codex.test.ts` |
 | [Copilot](copilot.md) | JSONL + SQLite (OTel) + Nitrite .db (JetBrains) | `src/providers/copilot.ts` | `tests/providers/copilot.test.ts` |
 | [Devin](devin.md) | JSON + SQLite enrichment | `src/providers/devin.ts` | `tests/providers/devin.test.ts` |
 | [Droid](droid.md) | JSONL | `src/providers/droid.ts` | `tests/providers/droid.test.ts` |
 | [DeepSeek Harness](dsh.md) | JSONL (zstd frames) | `src/providers/dsh.ts` | `tests/providers/dsh.test.ts` |
-| [Gemini](gemini.md) | JSON / JSONL | `src/providers/gemini.ts` | none |
+| [Gemini](gemini.md) | JSON / JSONL | `src/providers/gemini.ts` | `tests/providers/gemini.test.ts` |
 | [Hermes Agent](hermes.md) | SQLite | `src/providers/hermes.ts` | `tests/providers/hermes.test.ts` |
 | [IBM Bob](ibm-bob.md) | JSON | `src/providers/ibm-bob.ts` | `tests/providers/ibm-bob.test.ts` |
 | [KiloCode](kilo-code.md) | JSON | `src/providers/kilo-code.ts` | `tests/providers/kilo-code.test.ts` |
@@ -28,8 +29,10 @@ For the architectural picture, see `../architecture.md`.
 | [Kimi Code](kimicode.md) | JSONL | `src/providers/kimicode.ts` | `tests/providers/kimicode.test.ts` |
 | [LingTai TUI](lingtai-tui.md) | JSONL | `src/providers/lingtai-tui.ts` | `tests/providers/lingtai-tui.test.ts` |
 | [Mistral Vibe](mistral-vibe.md) | JSON / JSONL | `src/providers/mistral-vibe.ts` | `tests/providers/mistral-vibe.test.ts` |
+| [Mux](mux.md) | JSONL | `src/providers/mux.ts` | `tests/providers/mux.test.ts` |
 | [OpenClaw](openclaw.md) | JSONL | `src/providers/openclaw.ts` | `tests/providers/openclaw.test.ts` |
 | [OpenClaude](openclaude.md) | JSONL | `src/providers/openclaude.ts` | `tests/providers/openclaude.test.ts` |
+| [Open Design](open-design.md) | JSONL | `src/providers/open-design.ts` | `tests/providers/open-design.test.ts` |
 | [Pi](pi.md) | JSONL | `src/providers/pi.ts` | `tests/providers/pi.test.ts` |
 | [OMP](omp.md) | JSONL | `src/providers/pi.ts` | `tests/providers/omp.test.ts` |
 | [Qwen](qwen.md) | JSONL | `src/providers/qwen.ts` | none |
@@ -42,7 +45,7 @@ For the architectural picture, see `../architecture.md`.
 
 | Provider | Storage | Source | Test |
 |---|---|---|---|
-| [Antigravity](antigravity.md) | protobuf over RPC | `src/providers/antigravity.ts` | none |
+| [Antigravity](antigravity.md) | protobuf over RPC | `src/providers/antigravity.ts` | `tests/providers/antigravity.test.ts` |
 | [Crush](crush.md) | SQLite (per-project) | `src/providers/crush.ts` | `tests/providers/crush.test.ts` |
 | [Forge](forge.md) | SQLite | `src/providers/forge.ts` | `tests/providers/forge.test.ts` |
 | [Cursor](cursor.md) | SQLite | `src/providers/cursor.ts` | `tests/providers/cursor.test.ts` |
@@ -52,6 +55,7 @@ For the architectural picture, see `../architecture.md`.
 | [Warp](warp.md) | SQLite | `src/providers/warp.ts` | `tests/providers/warp.test.ts` |
 | [Vercel AI Gateway](vercel-gateway.md) | REST API | `src/providers/vercel-gateway.ts` | `tests/providers/vercel-gateway.test.ts` |
 | [ZCode](zcode.md) | SQLite | `src/providers/zcode.ts` | `tests/providers/zcode.test.ts` |
+| [Zed](zed.md) | SQLite | `src/providers/zed.ts` | `tests/providers/zed.test.ts` |
 
 ### Shared
 

--- a/docs/providers/codebuff.md
+++ b/docs/providers/codebuff.md
@@ -1,0 +1,44 @@
+# Codebuff
+
+Codebuff (formerly Manicode) local chat history and usage.
+
+- **Source:** `src/providers/codebuff.ts`
+- **Loading:** eager (`src/providers/index.ts`)
+- **Test:** `tests/providers/codebuff.test.ts`
+
+## Where it reads from
+
+`$CODEBUFF_DATA_DIR` when set, otherwise all three local channels:
+
+```text
+~/.config/manicode/projects/<project>/chats/<chat-id>/
+~/.config/manicode-dev/projects/<project>/chats/<chat-id>/
+~/.config/manicode-staging/projects/<project>/chats/<chat-id>/
+```
+
+Each chat directory must contain `chat-messages.json`. When present, `run-state.json` supplies the real working directory used for project grouping.
+
+## Storage format
+
+`chat-messages.json` is an array of user and assistant messages. Completed assistant messages can carry token usage in their metadata, credit usage, model information, nested tool blocks, and timestamps. CodeBurn prefers recorded token usage and LiteLLM pricing; when only credits are available, it uses Codebuff's public pay-as-you-go rate as a conservative cost estimate.
+
+## Caching
+
+No provider-specific cache. The shared session cache fingerprints the discovered chat data.
+
+## Deduplication
+
+Per chat directory and message id: `codebuff:<chat-dir>:<message-id>`. Session ids include the channel name so identical timestamp-based chat ids in stable, development, and staging stores stay distinct.
+
+## Quirks
+
+- The legacy `manicode` name remains in the on-disk paths.
+- Tool names are normalized to CodeBurn's canonical tool set; nested agent blocks are traversed recursively.
+- A message with neither tokens nor credits is treated as framing or in-progress data and skipped.
+- The project folder name is only a fallback. `run-state.json` is preferred because sanitized folder names do not reliably identify the original worktree.
+
+## When fixing a bug here
+
+1. Reproduce the exact `chat-messages.json` and optional `run-state.json` shape with a sanitized fixture in `tests/providers/codebuff.test.ts`.
+2. Exercise stable, development, and staging roots together when changing discovery or deduplication.
+3. Preserve the token-first, credit-fallback cost behavior and recursive tool extraction.

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -4,7 +4,7 @@ Google Gemini CLI.
 
 - **Source:** `src/providers/gemini.ts`
 - **Loading:** eager (`src/providers/index.ts:5`)
-- **Test:** none. Adding a fixture-based test is a known good first issue.
+- **Test:** `tests/providers/gemini.test.ts`
 
 ## Where it reads from
 
@@ -30,6 +30,6 @@ Per `sessionId` (`gemini.ts:72`). Gemini sessions are aggregated to a single cal
 
 ## When fixing a bug here
 
-1. The lack of a test file is a hazard. **Add a fixture and a test before changing parsing logic** so future regressions are caught.
+1. Add a fixture and a focused case to `tests/providers/gemini.test.ts` before changing parsing logic.
 2. If the bug involves a new Gemini version's schema, sniff with the same first-character heuristic; do not call `JSON.parse` on the whole file.
 3. If the bug is "Gemini sessions report less than expected", check whether the cached-token subtraction is over-correcting.

--- a/docs/providers/open-design.md
+++ b/docs/providers/open-design.md
@@ -1,0 +1,44 @@
+# Open Design
+
+Open Design agent runs and per-model token usage.
+
+- **Source:** `src/providers/open-design.ts`
+- **Loading:** eager (`src/providers/index.ts`)
+- **Test:** `tests/providers/open-design.test.ts`
+
+## Where it reads from
+
+`$CODEBURN_OPEN_DESIGN_DIR` when set. Otherwise CodeBurn uses the platform application-data directory:
+
+| Platform | Path |
+|---|---|
+| macOS | `~/Library/Application Support/Open Design` |
+| Windows | `%APPDATA%/Open Design` |
+| Linux | `~/.config/Open Design` |
+
+Discovery accepts a `runs/` or `data/` directory directly and also scans `namespaces/<namespace>/data/runs/`. Each run is represented by `<run-id>/events.jsonl`.
+
+## Storage format
+
+`events.jsonl` contains start, status, and usage events. Start and status events select the active model. Agent usage events provide input, output, cache-read, and reasoning-token counts. Malformed and unrelated lines are skipped independently.
+
+## Caching
+
+No provider-specific cache. The shared session cache applies to parsed sources.
+
+## Deduplication
+
+Per run and event id: `open-design:<run-id>:<event-id>`. Entries without an id receive a stable line-order fallback within the parse.
+
+## Quirks
+
+- Usage is emitted only after a model has been observed from a start or status event.
+- Cached reads are included in `input_tokens`; CodeBurn subtracts them before pricing fresh input.
+- Reasoning tokens are reported separately and priced at the output rate.
+- Open Design records no tools or shell-command detail in this event shape.
+
+## When fixing a bug here
+
+1. Add a sanitized run under `tests/fixtures/open-design/` and a focused case in `tests/providers/open-design.test.ts`.
+2. Preserve mixed-model runs: each usage event must use the model active at that point in the stream.
+3. Test direct data directories and namespaced layouts when changing discovery.


### PR DESCRIPTION
## Summary

- update contributor and architecture test inventories to the current 265-file tree and four serial lock suites
- make the provider index match the 41-provider registry, including current Gemini and Antigravity tests
- add the missing Codebuff and Open Design provider maintenance pages

Fixes #1206.

## Testing

- [ ] I have tested this locally against real data (not just unit tests)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds

Documentation-focused validation performed:

- `npx tsc --noEmit`
- 77 Markdown files / 64 local Markdown targets checked, with 0 broken targets
- provider registry/index consistency check: 41 providers, no undocumented registered provider (OMP intentionally shares `pi.ts`)
- tracked test inventory check: 265 total, 261 parallel, 4 lock suites
- `npx vitest run tests/providers/codebuff.test.ts tests/providers/gemini.test.ts` (26 passed)
- Electron app typecheck, Electron compile, and renderer build
- dashboard typecheck and production build
- Windows menubar TypeScript/Vite build
- `git diff --check`

The full root and Electron suites are green in the upstream CI for the exact base commit. On this native Windows host, the root suite and four Open Design cases hit existing POSIX-path assumptions, while Electron process-spawn cases hit native Windows `EFTYPE`; no runtime or test code is changed here.

### For new providers only:

- [ ] I installed the tool and generated real sessions by using it
- [ ] `npm run dev -- today` shows correct costs and session counts for this provider
- [ ] `npm run dev -- models --provider <name>` shows correct model names and pricing
- [ ] Screenshot or terminal output attached below proving it works with real data

Not applicable: this PR documents existing providers and does not add or change a provider implementation.
