### PR TITLE
fix(menubar): stop rendering the closed popover around the clock

### DIFF
--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -49,6 +49,10 @@ final class AppStore {
     var selectedScope: MenubarScope = MenubarScope.savedMenubarScope()
     var selectedClaudeConfigSourceId: String?
     var selectedDays: Set<String> = []
+    /// True while the status-item popover is on screen. The popover's hosting
+    /// view is created once and lives forever, so repeat-forever animations
+    /// must gate on this or they render at display cadence around the clock.
+    var menuPopoverVisible = false
     var activeScope: MenubarScope { effectiveSelectedScope }
 
     private var effectiveSelectedScope: MenubarScope {

--- a/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
+++ b/mac/Sources/CodeBurnMenubar/CodeBurnApp.swift
@@ -1427,6 +1427,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSM
             // closes. The popover's window takes keyboard focus on its own
             // via makeKeyAndOrderFront, which is enough for keystrokes to
             // reach the SwiftUI content.
+            store.menuPopoverVisible = true
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             if let window = popover.contentViewController?.view.window {
                 // Pin the popover's window above the status-bar layer but tag
@@ -1640,6 +1641,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSM
     }
 
     func popoverDidClose(_ notification: Notification) {
+        store.menuPopoverVisible = false
         // Catch up on any menubar title updates that were skipped while the
         // popover was anchored.
         refreshStatusButton()

--- a/mac/Sources/CodeBurnMenubar/Views/FlameWordmark.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/FlameWordmark.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// The "CodeBurn" wordmark filled with the website's animated flame gradient.
 struct FlameWordmark: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(AppStore.self) private var store
     @State private var sweeping = false
 
     // CSS parity: the site's `.flame-text` uses background-size: 300% with
@@ -38,13 +39,21 @@ struct FlameWordmark: View {
                     .frame(width: geo.size.width * 3, height: geo.size.height)
                     .offset(x: sweeping ? -geo.size.width * 2 : 0)
                     .animation(
-                        reduceMotion ? nil : .easeInOut(duration: 1.5).repeatForever(autoreverses: true),
+                        reduceMotion || !store.menuPopoverVisible
+                            ? nil
+                            : .easeInOut(duration: 1.5).repeatForever(autoreverses: true),
                         value: sweeping
                     )
                 }
                 .mask(wordmark)
             }
-            .onAppear { sweeping = true }
+            .onAppear { sweeping = store.menuPopoverVisible }
+            // The hosting view outlives every popover appearance, so the sweep
+            // starts and stops with visibility instead of running forever in a
+            // closed popover (5 to 7 percent idle CPU before this gate).
+            .onChange(of: store.menuPopoverVisible) { _, visible in
+                sweeping = visible
+            }
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("CodeBurn")
     }

--- a/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/MenuBarContent.swift
@@ -302,6 +302,7 @@ private struct FetchErrorOverlay: View {
 /// yellow→orange→red, looping.
 private struct BurnLoadingOverlay: View {
     let periodLabel: String
+    @Environment(AppStore.self) private var store
     @State private var fillProgress: CGFloat = 0
     @State private var glowing: Bool = false
 
@@ -320,13 +321,27 @@ private struct BurnLoadingOverlay: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .onAppear {
-            withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
-                fillProgress = 1.0
+        .onAppear { setPulsing(store.menuPopoverVisible) }
+        .onChange(of: store.menuPopoverVisible) { _, visible in
+            setPulsing(visible)
+        }
+    }
+
+    private func setPulsing(_ on: Bool) {
+        guard on else {
+            var stop = Transaction()
+            stop.disablesAnimations = true
+            withTransaction(stop) {
+                fillProgress = 0
+                glowing = false
             }
-            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
-                glowing = true
-            }
+            return
+        }
+        withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
+            fillProgress = 1.0
+        }
+        withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+            glowing = true
         }
     }
 }


### PR DESCRIPTION
## Problem
Activity Monitor showed CodeBurn Menubar at 5.6 Energy Impact with a 12-hour figure of 70.9, about two thirds of Chrome's daily energy on the same machine. Measured idle: 5 to 7 percent CPU and roughly 650 wakeups a second with nothing on screen.

## Root cause
`sample` traced the busy stacks to display-cycle layout: `NSHostingView.layout` and SwiftUI `ViewGraph` rendering on every frame. The status-item popover's `NSHostingController` is created once in `setupPopover()` and lives for the app's lifetime, and `FlameWordmark` inside it runs a `repeatForever` gradient sweep, so the closed, invisible popover re-rendered at display cadence around the clock. The loading flame pulse (`BurnLoadingOverlay`) has the same shape while a first load is pending.

## Fix
A `menuPopoverVisible` flag on `AppStore`, set by the existing popover show call and `popoverDidClose` delegate. The wordmark sweep and the loading pulse start when the popover appears and stop (without animation) when it closes. No visual change while the popover is open.

## Verification
- Before, idle with popover closed: 5 to 7 percent CPU, ~650 wakeups/s, top POWER 5 to 7.
- After, same conditions, same machine: **0.1 percent CPU, ~20 wakeups/s, top POWER 0.2**.
- `swift build` clean; `swift test` 348 tests in 44 suites pass.