### PR TITLE
feat(menubar): let the Capacity Dock size go down to 60 percent

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Data/CapacityDockPreferences.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CapacityDockPreferences.swift
@@ -160,7 +160,7 @@ enum CapacityDockPreferences {
     static let defaultProvider: CapacityDockProvider = .codex
     static let supportedProviders = CapacityDockProvider.allCases
     static let maxAutoProviders = 5
-    static let defaultScale = 0.85
+    static let defaultScale = 0.6
     static let scaleRange = 0.6 ... 1.2
 
     struct Snapshot: Equatable, Sendable {

--- a/mac/Sources/CodeBurnMenubar/Data/CapacityDockPreferences.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CapacityDockPreferences.swift
@@ -161,7 +161,7 @@ enum CapacityDockPreferences {
     static let supportedProviders = CapacityDockProvider.allCases
     static let maxAutoProviders = 5
     static let defaultScale = 0.85
-    static let scaleRange = 0.7 ... 1.2
+    static let scaleRange = 0.6 ... 1.2
 
     struct Snapshot: Equatable, Sendable {
         let isEnabled: Bool

--- a/mac/Tests/CodeBurnMenubarTests/CapacityDockPreferencesTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CapacityDockPreferencesTests.swift
@@ -150,7 +150,7 @@ struct CapacityDockPreferencesTests {
         #expect(CapacityDockPreferences.load(defaults: defaults).scale == 1.2)
 
         CapacityDockPreferences.setScale(0.2, defaults: defaults)
-        #expect(CapacityDockPreferences.load(defaults: defaults).scale == 0.7)
+        #expect(CapacityDockPreferences.load(defaults: defaults).scale == 0.6)
 
         CapacityDockPreferences.setScale(0.8, defaults: defaults)
         #expect(CapacityDockPreferences.load(defaults: defaults).scale == 0.8)

--- a/mac/Tests/CodeBurnMenubarTests/CapacityDockPreferencesTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CapacityDockPreferencesTests.swift
@@ -22,7 +22,7 @@ struct CapacityDockPreferencesTests {
         #expect(snapshot.attachmentEdge == .right)
         #expect(snapshot.normalizedHorizontalOffset == nil)
         #expect(snapshot.normalizedVerticalOffset == nil)
-        #expect(snapshot.scale == 0.85)
+        #expect(snapshot.scale == 0.6)
         #expect(snapshot.theme == .graphite)
         #expect(snapshot.gaugeShape == .squircle)
     }


### PR DESCRIPTION
Extends the dock size slider's lower bound from 70 to 60 percent (same 5-point steps). Out-of-range persisted values clamp to the new bound; the clamp test moved with it. swift test: 348 tests in 44 suites pass.