### PR TITLE
fix(menubar): round Capacity Dock metrics to whole points to stop perpetual relayout

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Views/CapacityDockView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/CapacityDockView.swift
@@ -27,20 +27,29 @@ enum CapacityDockMetrics {
     private static let basePercentageTextSize: CGFloat = 17
     private static let baseDetailWidth: CGFloat = 350
 
-    static func railWidth(scale: CGFloat) -> CGFloat { baseRailWidth * scale }
-    static func horizontalRailWidth(scale: CGFloat) -> CGFloat { baseHorizontalRailWidth * scale }
-    static func edgeFlareWidth(scale: CGFloat) -> CGFloat { baseEdgeFlareWidth * scale }
-    static func edgeShoulderDepth(scale: CGFloat) -> CGFloat { baseEdgeShoulderDepth * scale }
-    static func rowHeight(scale: CGFloat) -> CGFloat { baseRowHeight * scale }
-    static func rowSpacing(scale: CGFloat) -> CGFloat { baseRowSpacing * scale }
-    static func railAlongPad(scale: CGFloat) -> CGFloat { baseRailAlongPad * scale }
-    static func railCrossPad(scale: CGFloat) -> CGFloat { baseRailCrossPad * scale }
-    static func ringSize(scale: CGFloat) -> CGFloat { baseRingSize * scale }
-    static func ringStrokeWidth(scale: CGFloat) -> CGFloat { baseRingStrokeWidth * scale }
-    static func ringLabelSpacing(scale: CGFloat) -> CGFloat { baseRingLabelSpacing * scale }
-    static func providerIconSize(scale: CGFloat) -> CGFloat { baseProviderIconSize * scale }
-    static func percentageTextSize(scale: CGFloat) -> CGFloat { basePercentageTextSize * scale }
-    static func detailWidth(scale: CGFloat) -> CGFloat { baseDetailWidth * scale }
+    /// Every dock dimension lands on a whole point. Fractional sizes (85%
+    /// of 88 is 74.8) made SwiftUI's fitted content disagree with the
+    /// pixel-aligned panel frame on every layout pass, so the hosting view
+    /// re-laid itself out at display cadence forever: 5 to 7 percent idle CPU
+    /// at any scale except 100%.
+    private static func points(_ base: CGFloat, _ scale: CGFloat) -> CGFloat {
+        max(1, (base * scale).rounded())
+    }
+
+    static func railWidth(scale: CGFloat) -> CGFloat { points(baseRailWidth, scale) }
+    static func horizontalRailWidth(scale: CGFloat) -> CGFloat { points(baseHorizontalRailWidth, scale) }
+    static func edgeFlareWidth(scale: CGFloat) -> CGFloat { points(baseEdgeFlareWidth, scale) }
+    static func edgeShoulderDepth(scale: CGFloat) -> CGFloat { points(baseEdgeShoulderDepth, scale) }
+    static func rowHeight(scale: CGFloat) -> CGFloat { points(baseRowHeight, scale) }
+    static func rowSpacing(scale: CGFloat) -> CGFloat { points(baseRowSpacing, scale) }
+    static func railAlongPad(scale: CGFloat) -> CGFloat { points(baseRailAlongPad, scale) }
+    static func railCrossPad(scale: CGFloat) -> CGFloat { points(baseRailCrossPad, scale) }
+    static func ringSize(scale: CGFloat) -> CGFloat { points(baseRingSize, scale) }
+    static func ringStrokeWidth(scale: CGFloat) -> CGFloat { points(baseRingStrokeWidth, scale) }
+    static func ringLabelSpacing(scale: CGFloat) -> CGFloat { points(baseRingLabelSpacing, scale) }
+    static func providerIconSize(scale: CGFloat) -> CGFloat { points(baseProviderIconSize, scale) }
+    static func percentageTextSize(scale: CGFloat) -> CGFloat { points(basePercentageTextSize, scale) }
+    static func detailWidth(scale: CGFloat) -> CGFloat { points(baseDetailWidth, scale) }
 
     static func railHeight(providerCount: Int, alongPad: CGFloat, scale: CGFloat) -> CGFloat {
         let count = max(providerCount, 1)


### PR DESCRIPTION
## Problem
Once quota data exists, the menubar app idles at 5 to 7 percent CPU with hundreds of wakeups a second (Activity Monitor 12-hour energy figure comparable to Chrome). Present on every release since the Capacity Dock shipped; reproduced on the original 0.9.23 commit.

## Root cause
At any dock scale except 100 percent the dock's dimensions are fractional (85 percent of 88 is 74.8 points; 60 percent is 52.8). The panel frame is pixel-aligned, so SwiftUI's fitted content never agrees with the frame it is given, and `NSHostingView.layout` re-runs at display cadence forever (`sample` shows the entire busy budget under `NSDisplayCycleFlush -> NSHostingView.layout -> ViewGraph render`, no timers). Disabling the dock removes all idle wakeups; setting the scale to 100 percent (integral sizes) removes the CPU cost without any code change, which isolated it.

## Fix
Every scaled `CapacityDockMetrics` value is rounded to a whole point, so all scales behave like 100 percent. Layout and the synthesized hover math read the same metrics, so they stay consistent.

## Measurements (same machine, minute-by-minute logs after the first data load)
| Build | Scale | Idle CPU | Wakeups |
|---|---|---|---|
| main (before) | 60% | 5 to 6 percent for 60 minutes | ~600/s |
| original 0.9.23 | 85% | 5.8 percent | ~770/s |
| main, scale forced to 100% | 100% | 0.1 to 0.2 percent for 10 minutes | ~30/s |
| **this fix** | **60%** | **0.1 percent for 12 minutes** (one refresh blip) | ~30/s |

## Verification
`swift build` clean; `swift test` 348 tests in 44 suites pass.