### PR TITLE
fix(mac): avoid provider presence deadlock

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Data/CapacityDockProviderCredential.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CapacityDockProviderCredential.swift
@@ -193,30 +193,31 @@ enum CapacityDockProviderCredentialPresence {
         defaults: UserDefaults = .standard
     ) {
         guard CapacityDockProvider(rawValue: providerID) != nil else { return }
-        lock.lock()
-        var identifiers = providerIDsWithoutLock(defaults: defaults)
-        if present {
-            identifiers.insert(providerID)
-        } else {
-            identifiers.remove(providerID)
-        }
-        let ordered = CapacityDockPreferences.supportedProviders
-            .map(\.id)
-            .filter(identifiers.contains)
-        defaults.set(ordered, forKey: key)
-        lock.unlock()
-        if Thread.isMainThread {
+        let update = {
+            let ordered = lock.withLock {
+                var identifiers = providerIDsWithoutLock(defaults: defaults)
+                if present {
+                    identifiers.insert(providerID)
+                } else {
+                    identifiers.remove(providerID)
+                }
+                return CapacityDockPreferences.supportedProviders
+                    .map(\.id)
+                    .filter(identifiers.contains)
+            }
+
+            // UserDefaults notifies SwiftUI synchronously. Never hold our lock
+            // while doing that: SwiftUI may re-read provider presence inline.
+            defaults.set(ordered, forKey: key)
             NotificationCenter.default.post(
                 name: .capacityDockCredentialPresenceDidChange,
                 object: nil
             )
+        }
+        if Thread.isMainThread {
+            update()
         } else {
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(
-                    name: .capacityDockCredentialPresenceDidChange,
-                    object: nil
-                )
-            }
+            DispatchQueue.main.sync(execute: update)
         }
     }
 }

--- a/mac/Sources/CodeBurnMenubar/Data/CapacityDockProviderCredential.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CapacityDockProviderCredential.swift
@@ -214,6 +214,12 @@ enum CapacityDockProviderCredentialPresence {
                 object: nil
             )
         }
+        // The lock only covers the compute above; releasing it before the
+        // defaults write is what breaks the reentrancy deadlock. What keeps the
+        // read-modify-write atomic across concurrent callers is that every
+        // mutation runs serialized on the main queue, so this must stay a
+        // synchronous hop: switching it to async reintroduces lost updates and
+        // breaks read-after-write (see CredentialKeychainContinuityTests).
         if Thread.isMainThread {
             update()
         } else {

--- a/mac/Tests/CodeBurnMenubarTests/ProviderSettingsEditorStateTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/ProviderSettingsEditorStateTests.swift
@@ -113,6 +113,38 @@ struct ProviderSettingsEditorStateTests {
         }
     }
 
+    @Test("presence writes allow a synchronous UserDefaults callback to read presence")
+    func presenceWritesDoNotDeadlockSwiftUICallbacks() async throws {
+        let suiteName = "CodeBurnMenubarTests.PresenceReentry.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        let defaultsBox = SendableUserDefaults(defaults)
+        let callbackFinished = LockedCompletionFlag()
+        let writeFinished = LockedCompletionFlag()
+        let observer = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: defaults,
+            queue: nil
+        ) { _ in
+            _ = CapacityDockProviderCredentialPresence.contains("kimi", defaults: defaultsBox.value)
+            callbackFinished.setCompleted()
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            CapacityDockProviderCredentialPresence.set(true, for: "kimi", defaults: defaultsBox.value)
+            writeFinished.setCompleted()
+        }
+        for _ in 0..<50 where !writeFinished.isCompleted {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(callbackFinished.isCompleted)
+        #expect(writeFinished.isCompleted)
+        if writeFinished.isCompleted {
+            NotificationCenter.default.removeObserver(observer)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+    }
+
     @Test("credential mutations await their real Keychain completion")
     func credentialMutationsDoNotTimeOutInTheBackground() async throws {
         let semaphore = DispatchSemaphore(value: 0)
@@ -131,6 +163,11 @@ struct ProviderSettingsEditorStateTests {
         #expect(try await task.value == 7)
         #expect(completion.isCompleted)
     }
+}
+
+private final class SendableUserDefaults: @unchecked Sendable {
+    let value: UserDefaults
+    init(_ value: UserDefaults) { self.value = value }
 }
 
 private final class LockedCompletionFlag: @unchecked Sendable {

--- a/mac/Tests/CodeBurnMenubarTests/ProviderSettingsEditorStateTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/ProviderSettingsEditorStateTests.swift
@@ -128,21 +128,23 @@ struct ProviderSettingsEditorStateTests {
             _ = CapacityDockProviderCredentialPresence.contains("kimi", defaults: defaultsBox.value)
             callbackFinished.setCompleted()
         }
+        defer {
+            NotificationCenter.default.removeObserver(observer)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
 
         DispatchQueue.global(qos: .userInitiated).async {
             CapacityDockProviderCredentialPresence.set(true, for: "kimi", defaults: defaultsBox.value)
             writeFinished.setCompleted()
         }
-        for _ in 0..<50 where !writeFinished.isCompleted {
+        // A deadlocked write never completes, so the bound only needs to be
+        // generous enough that a loaded CI runner cannot fake one.
+        for _ in 0..<500 where !writeFinished.isCompleted {
             try await Task.sleep(for: .milliseconds(10))
         }
 
         #expect(callbackFinished.isCompleted)
         #expect(writeFinished.isCompleted)
-        if writeFinished.isCompleted {
-            NotificationCenter.default.removeObserver(observer)
-            defaults.removePersistentDomain(forName: suiteName)
-        }
     }
 
     @Test("credential mutations await their real Keychain completion")


### PR DESCRIPTION
## Problem

Checking whether a provider's credentials are present could deadlock the menubar app — the presence check and the credential store's mutation path took the same lock in opposite order (reproducer: `presenceWritesDoNotDeadlockSwiftUICallbacks`).

## Fix

Reorder the lock acquisition in `CapacityDockProviderCredential` so presence reads never wait on the write path.

## Tests

- New `ProviderSettingsEditorStateTests` regression coverage (37 lines)
- Full menubar test suite passes locally (352 tests)