### PR TITLE
fix(hermes): don't trust a $0 estimated cost — calculate from tokens

### DIFF
--- a/src/providers/hermes.ts
+++ b/src/providers/hermes.ts
@@ -463,11 +463,16 @@ function resolveHermesCost(
     tokens.cacheReadTokens,
     0,
   )
-  // This slice treats explicit $0 as recorded. null still falls through.
+  // actual is a recorded invoice amount; explicit $0 still counts as recorded.
   if (row && row.actual_cost_usd != null) {
     return { costUSD: row.actual_cost_usd, costIsEstimated: false, costBasis: 'actual' }
   }
-  if (row && row.estimated_cost_usd != null) {
+  // estimated_cost_usd = 0.0 is not a measurement: Hermes writes it when cost_status
+  // is 'unknown' (no pricing data) or 'included' (flat subscription), so trusting it
+  // would zero out every subscription session. Only positive estimates are trusted;
+  // anything else falls through to the token-based calculation. A genuinely free
+  // model still lands on $0 either way, since litellm prices it at 0.
+  if (row && row.estimated_cost_usd != null && row.estimated_cost_usd > 0) {
     return { costUSD: row.estimated_cost_usd, costIsEstimated: false, costBasis: 'estimated' }
   }
   return { costUSD: calculatedCost, costIsEstimated: true, costBasis: 'calculated' }

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -373,7 +373,7 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   // replays (double-counted before), takes the model from the reporting
   // assistant/message, and keeps agent-injected context out of the preview.
   dsh: 'seed-aware-v1',
-  hermes: 'reasoning-output-accounting-v1-est-cost-routed-ids-workspace-pr-v5',
+  hermes: 'reasoning-output-accounting-v1-est-cost-routed-ids-workspace-pr-v5-zero-estimate-fallback-v1',
   'lingtai-tui': 'token-ledger-registry-activity-v3',
   'ibm-bob': 'worktree-project-grouping-v1',
   // project-path-v1: the parser now records the session's full working

--- a/tests/hermes-cost-fallback.test.ts
+++ b/tests/hermes-cost-fallback.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdir, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { createRequire } from 'node:module'
+
+import { clearSessionCache, parseAllSessions } from '../src/parser.js'
+import { isSqliteAvailable } from '../src/sqlite.js'
+
+// The exported Hermes provider resolves HERMES_HOME when its singleton is
+// created, at import time. Point it at the fixture during module hoisting so the
+// provider reads the temp DB instead of the real ~/.hermes.
+const testRoot = vi.hoisted(() => {
+  const root = `${process.env['TMPDIR'] || '/tmp'}/hermes-cost-fallback-${process.pid}-${Date.now()}`
+  process.env['HERMES_HOME'] = `${root}/hermes`
+  return root
+})
+const HERMES_HOME = join(testRoot, 'hermes')
+const CACHE_DIR = join(testRoot, 'cache')
+
+const requireForTest = createRequire(import.meta.url)
+
+function seedDb(): void {
+  const { DatabaseSync: Database } = requireForTest('node:sqlite')
+  const db = new Database(join(HERMES_HOME, 'state.db'))
+  db.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, source TEXT, model TEXT, cwd TEXT, git_repo_root TEXT,
+      input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,
+      cache_read_tokens INTEGER DEFAULT 0, cache_write_tokens INTEGER DEFAULT 0,
+      reasoning_tokens INTEGER DEFAULT 0, estimated_cost_usd REAL, actual_cost_usd REAL,
+      api_call_count INTEGER DEFAULT 0, tool_call_count INTEGER DEFAULT 0,
+      started_at REAL, title TEXT
+    )
+  `)
+  db.exec(`
+    CREATE TABLE messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL, role TEXT NOT NULL,
+      content TEXT, tool_calls TEXT, timestamp REAL NOT NULL
+    )
+  `)
+  const startedAt = Date.now() / 1000 - 3600
+  const insert = db.prepare(
+    `INSERT INTO sessions (id, source, model, input_tokens, output_tokens,
+      estimated_cost_usd, actual_cost_usd, api_call_count, started_at)
+     VALUES (?, 'cli', ?, ?, ?, ?, ?, 1, ?)`,
+  )
+  // Hermes writes estimated 0.0 when cost_status is 'unknown' or 'included'
+  // (subscription). CodeBurn must not trust that $0: the tokens are real, so
+  // cost falls through to the token-based calculation.
+  insert.run('zero-estimate', 'claude-opus-4-6', 100000, 10000, 0.0, null, startedAt)
+  // A positive recorded estimate stays authoritative.
+  insert.run('positive-estimate', 'claude-opus-4-6', 100000, 10000, 0.5, null, startedAt)
+  // An explicit $0 *actual* invoice amount is recorded fact and stays $0.
+  insert.run('zero-actual', 'claude-opus-4-6', 100000, 10000, null, 0.0, startedAt)
+  for (const id of ['zero-estimate', 'positive-estimate', 'zero-actual']) {
+    db.prepare('INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)')
+      .run(id, 'user', `session ${id}`, startedAt)
+    db.prepare('INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)')
+      .run(id, 'assistant', 'ok', startedAt + 1)
+  }
+  db.close()
+}
+
+beforeEach(async () => {
+  clearSessionCache()
+  await rm(testRoot, { recursive: true, force: true })
+  await mkdir(HERMES_HOME, { recursive: true })
+  process.env['HERMES_HOME'] = HERMES_HOME
+  process.env['CODEBURN_CACHE_DIR'] = CACHE_DIR
+})
+
+afterEach(async () => {
+  clearSessionCache()
+  await rm(testRoot, { recursive: true, force: true })
+})
+
+const skipUnlessSqlite = isSqliteAvailable() ? describe : describe.skip
+
+skipUnlessSqlite('hermes recorded-cost fallback', () => {
+  it('ignores a $0 estimated cost and calculates from tokens', async () => {
+    seedDb()
+    const projects = await parseAllSessions(undefined, 'hermes')
+    const sessions = projects.flatMap(project => project.sessions)
+    const byId = new Map(sessions.map(s => [s.sessionId, s]))
+
+    const zeroEstimate = byId.get('zero-estimate')!
+    expect(zeroEstimate.totalCostUSD).toBeGreaterThan(0)
+
+    const positive = byId.get('positive-estimate')!
+    expect(positive.totalCostUSD).toBe(0.5)
+
+    const zeroActual = byId.get('zero-actual')!
+    expect(zeroActual.totalCostUSD).toBe(0)
+  })
+})


### PR DESCRIPTION
## Problem

Every Hermes session on a flat subscription (Codex plan, z.ai, Kimi) reports **$0.00** in CodeBurn despite real token usage.

Root cause: Hermes writes `estimated_cost_usd = 0.0` — not NULL — when its `cost_status` is `'unknown'` (no pricing data) or `'included'` (flat subscription, per Hermes's `usage_pricing.py`: "subscription-included; no provider invoice for usage"). `resolveHermesCost` treats any non-null estimate as a recorded amount, so the placeholder $0 wins over the token-based calculation forever.

I verified against a live `~/.hermes/state.db`: 17 sessions with full token counts, all `estimated_cost_usd = 0.0` with `cost_status` `'included'`/`'unknown'` and `cost_source = 'none'` — no measurement happened.

## Fix

Only trust **positive** recorded estimates; $0 falls through to `calculateCost`. Deliberately not keyed off `cost_status`: the `> 0` check also covers DBs from before the column existed, and matches the columns CodeBurn already reads.

Semantics preserved:
- `actual_cost_usd` non-null still wins — including explicit $0 (a real invoice amount is fact)
- genuinely free models still land on $0 — litellm prices them at 0, so the fallback calculation agrees

The ledger's cost-delta path makes existing sessions self-heal: on the next scan, calculated cost > lastSeen $0 emits a cost-only correction observation.

## Tests

- New `tests/hermes-cost-fallback.test.ts`: zero-estimate → calculated, positive estimate → trusted, zero actual → $0
- Existing hermes suites pass (12 tests total)