### PR TITLE
docs: sync provider registry, test inventory, and Gemini page with the tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ There is no separate build step required to run the dev CLI. `npm run dev` runs 
 
 | Command | What it does |
 |---|---|
-| `npm test` | Runs the vitest suite under `tests/` (189 of the 192 files, 2,494 tests). |
-| `npm run test:locks` | Runs the three parallelism-sensitive `cache-refresh-lock` suites serially. |
+| `npm test` | Runs the vitest suite under `tests/`, excluding the four serial lock suites. |
+| `npm run test:locks` | Runs the four parallelism-sensitive `cache-refresh-lock` suites serially. |
 | `npm run test:watch` | Same scope as `npm test`, in watch mode. |
 | `npm run dev -- status` | Runs the CLI in dev mode against your real data. |
 | `npm run build` | Bundles the litellm pricing snapshot, then runs `tsup` to produce `dist/cli.js`. |
@@ -83,7 +83,7 @@ See `docs/architecture.md` for a fuller map.
 
 ### The full suite is the gate
 
-Before opening or updating a PR, run `npx vitest run` on your branch and on `main`, and compare. Your branch must introduce zero new failures. Listing only your own new tests as verification is not verification; the regressions we catch are almost always in tests the author never ran. For `mac/` changes the same applies to `swift test`.
+Before opening or updating a PR, run `npm test` on your branch and on `main`, and compare (`cd app && npm test` if your change touches the Electron app). Your branch must introduce zero new failures. Listing only your own new tests as verification is not verification; the regressions we catch are almost always in tests the author never ran. For `mac/` changes the same applies to `swift test` run from `mac/`.
 
 ## Commit Message Format
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,7 +193,7 @@ type Provider = {
 
 `src/providers/index.ts` registers providers across two tiers:
 
-- **Eager**: `claude`, `cline`, `codewhale`, `codebuff`, `codex`, `copilot`, `devin`, `droid`, `dsh`, `gemini`, `hermes`, `ibm-bob`, `kilo-code`, `kiro`, `kimi`, `lingtai-tui`, `mistral-vibe`, `mux`, `openclaw`, `open-design`, `pi`, `omp`, `qwen`, `roo-code`, `zerostack`, `grok`. Imported at module load.
+- **Eager**: `claude`, `cline`, `cline-cli`, `codewhale`, `codebuff`, `codex`, `copilot`, `devin`, `droid`, `dsh`, `gemini`, `hermes`, `ibm-bob`, `kilo-code`, `kiro`, `kimi`, `kimicode`, `lingtai-tui`, `mistral-vibe`, `mux`, `openclaw`, `openclaude`, `open-design`, `pi`, `omp`, `qwen`, `quickdesk`, `roo-code`, `zerostack`, `grok`. Imported at module load.
 - **Lazy**: `antigravity`, `forge`, `goose`, `cursor`, `opencode`, `cursor-agent`, `crush`, `warp`, `vercel-gateway`, `zcode`, `zed`. Imported via dynamic `import()` so the heavy dependencies (SQLite, protobuf, network clients) do not touch users who do not have those tools installed.
 
 Both lists hit the same `getAllProviders()` aggregator. A failed lazy import is silent and excludes that provider from the run.
@@ -254,18 +254,18 @@ The `prepublishOnly` hook in `package.json` runs `npm run build` so `npm publish
 
 ## Tests
 
-`npm test` runs vitest, scoped to `tests/`. 192 test files live there:
+`npm test` runs vitest, scoped to `tests/`. 266 test files live there:
 
-- `tests/` root (141 files) covers CLI, parser, optimize, cache, format, models, plans.
+- `tests/` root (209 files) covers CLI, parser, optimize, cache, format, models, plans.
 - `tests/security/` (1 file) covers prototype-pollution guards.
-- `tests/providers/` (44 files) covers per-provider parsing.
-- `tests/sharing/` (6 files) covers the share/export surface.
+- `tests/providers/` (49 files) covers per-provider parsing.
+- `tests/sharing/` (7 files) covers the share/export surface.
 - `tests/setup/` holds the env-isolation setup file, not specs.
 - `tests/fixtures/` holds redacted real-world session data.
 
 The scope is deliberate: the Electron app under `app/` has its own vitest config and its
 own `jsdom` dependency, so vitest's default glob must not reach it from a root install.
-The three `cache-refresh-lock` suites are excluded from `npm test` and run serially via
+The four `cache-refresh-lock` suites are excluded from `npm test` and run serially via
 `npm run test:locks`, because they exercise a cross-process file lock and fail under full
 worker pressure.
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -14,12 +14,13 @@ For the architectural picture, see `../architecture.md`.
 | [Cline](cline.md) | JSON | `src/providers/cline.ts` | `tests/providers/cline.test.ts` |
 | [Cline CLI](cline-cli.md) | JSON | `src/providers/cline-cli.ts` | `tests/providers/cline-cli.test.ts` |
 | [CodeWhale](codewhale.md) | JSON | `src/providers/codewhale.ts` | `tests/providers/codewhale.test.ts` |
+| [Codebuff](codebuff.md) | JSON | `src/providers/codebuff.ts` | `tests/providers/codebuff.test.ts` |
 | [Codex](codex.md) | JSONL | `src/providers/codex.ts` | `tests/providers/codex.test.ts` |
 | [Copilot](copilot.md) | JSONL + SQLite (OTel) + Nitrite .db (JetBrains) | `src/providers/copilot.ts` | `tests/providers/copilot.test.ts` |
 | [Devin](devin.md) | JSON + SQLite enrichment | `src/providers/devin.ts` | `tests/providers/devin.test.ts` |
 | [Droid](droid.md) | JSONL | `src/providers/droid.ts` | `tests/providers/droid.test.ts` |
 | [DeepSeek Harness](dsh.md) | JSONL (zstd frames) | `src/providers/dsh.ts` | `tests/providers/dsh.test.ts` |
-| [Gemini](gemini.md) | JSON / JSONL | `src/providers/gemini.ts` | none |
+| [Gemini](gemini.md) | JSON / JSONL | `src/providers/gemini.ts` | `tests/providers/gemini.test.ts` |
 | [Hermes Agent](hermes.md) | SQLite | `src/providers/hermes.ts` | `tests/providers/hermes.test.ts` |
 | [IBM Bob](ibm-bob.md) | JSON | `src/providers/ibm-bob.ts` | `tests/providers/ibm-bob.test.ts` |
 | [KiloCode](kilo-code.md) | JSON | `src/providers/kilo-code.ts` | `tests/providers/kilo-code.test.ts` |
@@ -28,8 +29,10 @@ For the architectural picture, see `../architecture.md`.
 | [Kimi Code](kimicode.md) | JSONL | `src/providers/kimicode.ts` | `tests/providers/kimicode.test.ts` |
 | [LingTai TUI](lingtai-tui.md) | JSONL | `src/providers/lingtai-tui.ts` | `tests/providers/lingtai-tui.test.ts` |
 | [Mistral Vibe](mistral-vibe.md) | JSON / JSONL | `src/providers/mistral-vibe.ts` | `tests/providers/mistral-vibe.test.ts` |
+| [Mux](mux.md) | JSONL | `src/providers/mux.ts` | `tests/providers/mux.test.ts` |
 | [OpenClaw](openclaw.md) | JSONL | `src/providers/openclaw.ts` | `tests/providers/openclaw.test.ts` |
 | [OpenClaude](openclaude.md) | JSONL | `src/providers/openclaude.ts` | `tests/providers/openclaude.test.ts` |
+| [Open Design](open-design.md) | JSONL | `src/providers/open-design.ts` | `tests/providers/open-design.test.ts` |
 | [Pi](pi.md) | JSONL | `src/providers/pi.ts` | `tests/providers/pi.test.ts` |
 | [OMP](omp.md) | JSONL | `src/providers/pi.ts` | `tests/providers/omp.test.ts` |
 | [Qwen](qwen.md) | JSONL | `src/providers/qwen.ts` | none |
@@ -42,7 +45,7 @@ For the architectural picture, see `../architecture.md`.
 
 | Provider | Storage | Source | Test |
 |---|---|---|---|
-| [Antigravity](antigravity.md) | protobuf over RPC | `src/providers/antigravity.ts` | none |
+| [Antigravity](antigravity.md) | protobuf over RPC | `src/providers/antigravity.ts` | `tests/providers/antigravity.test.ts` |
 | [Crush](crush.md) | SQLite (per-project) | `src/providers/crush.ts` | `tests/providers/crush.test.ts` |
 | [Forge](forge.md) | SQLite | `src/providers/forge.ts` | `tests/providers/forge.test.ts` |
 | [Cursor](cursor.md) | SQLite | `src/providers/cursor.ts` | `tests/providers/cursor.test.ts` |
@@ -52,6 +55,7 @@ For the architectural picture, see `../architecture.md`.
 | [Warp](warp.md) | SQLite | `src/providers/warp.ts` | `tests/providers/warp.test.ts` |
 | [Vercel AI Gateway](vercel-gateway.md) | REST API | `src/providers/vercel-gateway.ts` | `tests/providers/vercel-gateway.test.ts` |
 | [ZCode](zcode.md) | SQLite | `src/providers/zcode.ts` | `tests/providers/zcode.test.ts` |
+| [Zed](zed.md) | SQLite | `src/providers/zed.ts` | `tests/providers/zed.test.ts` |
 
 ### Shared
 

--- a/docs/providers/codebuff.md
+++ b/docs/providers/codebuff.md
@@ -1,0 +1,48 @@
+# Codebuff
+
+Codebuff (formerly Manicode) CLI coding agent. Codebuff bills in credits rather than a flat per-token rate, so the parser prices from tokens when they are present and falls back to a credit-based estimate otherwise.
+
+- **Source:** `src/providers/codebuff.ts`
+- **Loading:** eager (`src/providers/index.ts`)
+- **Test:** `tests/providers/codebuff.test.ts` (22 tests, fixture-based)
+
+## Where it reads from
+
+Codebuff's chat history lives on disk under its legacy product name, plus separate dev/staging channels:
+
+| Channel | Path |
+|---|---|
+| Stable | `~/.config/manicode` |
+| Dev | `~/.config/manicode-dev` |
+| Staging | `~/.config/manicode-staging` |
+
+`$CODEBUFF_DATA_DIR` overrides all three with a single root. Each channel root is walked as `<root>/projects/<project>/chats/<chatId>/chat-messages.json`, with a sibling `run-state.json` used to resolve the session's real working directory (the chat folder name itself is often the same across unrelated projects).
+
+## Storage format
+
+A JSON array of chat messages in `chat-messages.json`. Each message has a `variant` (`user`, `ai`, `agent`, or `assistant`), optional `credits`, optional tool-call `blocks` (including nested sub-agent blocks), and `metadata` that may carry usage directly or bury it inside `runState.sessionState.mainAgentState.messageHistory`.
+
+## Pricing
+
+The parser tries `calculateCost` on the message's token usage first. If that resolves to `0` and the message reports non-zero `credits`, it falls back to `credits * $0.01`, Codebuff's public pay-as-you-go rate, so subscription users still see a conservative cost estimate instead of `$0`.
+
+## Caching
+
+None at the provider level.
+
+## Deduplication
+
+Per `codebuff:<chatDir>:<messageId>`, falling back to the message's array index when it has no `id`.
+
+## Quirks
+
+- **Session ids are channel-qualified.** Chat folder names are ISO timestamps, so the same folder name can legitimately exist under `manicode`, `manicode-dev`, and `manicode-staging`. The parser prefixes the session id with the channel it came from (derived from the on-disk path), joined with `/` rather than `:` because `src/parser.ts` splits its aggregation key on colons.
+- **Usage can be stashed, not direct.** Some messages carry `metadata.usage` (or `metadata.codebuff.usage`) directly; others only record usage on the last assistant entry inside `metadata.runState.sessionState.mainAgentState.messageHistory`. The parser checks the direct field first and falls back to the stashed history, including for the model name.
+- **Zero-signal messages are skipped.** A message with no credits and no tokens (mode dividers, empty framing blocks) is dropped before it reaches dedup.
+- **Tool names are collected recursively.** Blocks of type `agent` nest their own `blocks`, so sub-agent tool calls roll up into the parent message's tool list.
+
+## When fixing a bug here
+
+1. Confirm which channel the session came from; `CODEBUFF_DATA_DIR` overrides all three channels at once, which is a common source of "wrong project" reports.
+2. If costs look off, check whether the message had real token usage priced via `calculateCost`, or fell back to the credit-based rate.
+3. New fixtures go in `tests/providers/codebuff.test.ts`; it builds `chat-messages.json` fixtures inline rather than from files under `tests/fixtures/`.

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -3,8 +3,8 @@
 Google Gemini CLI.
 
 - **Source:** `src/providers/gemini.ts`
-- **Loading:** eager (`src/providers/index.ts:5`)
-- **Test:** none. Adding a fixture-based test is a known good first issue.
+- **Loading:** eager (`src/providers/index.ts`)
+- **Test:** `tests/providers/gemini.test.ts`
 
 ## Where it reads from
 
@@ -12,7 +12,7 @@ Google Gemini CLI.
 
 ## Storage format
 
-Either a single JSON document per session or JSONL, depending on Gemini CLI version. The parser sniffs the first non-whitespace character to decide (`gemini.ts:197-206`).
+Either a single JSON document per session or JSONL, depending on Gemini CLI version. The parser tries `JSON.parse` on the whole file first (single-JSON, Gemini CLI <=0.38); if that throws or the result doesn't look like a session, it falls back to parsing the file line by line as JSONL (`gemini.ts:194-204`).
 
 ## Caching
 
@@ -20,16 +20,16 @@ None.
 
 ## Deduplication
 
-Per `sessionId` (`gemini.ts:72`). Gemini sessions are aggregated to a single call per session.
+Per session and message: the key is `gemini:<sessionId>:<messageId>`, where `messageId` falls back to a per-message ordinal when the message has no `id` (`gemini.ts:97`).
 
 ## Quirks
 
 - **Cached tokens are a subset of input.** Gemini reports cached tokens included inside `promptTokenCount`. The parser subtracts them so callers see Anthropic semantics (cached are separate).
 - **Thoughts are billed at output rate** (`gemini.ts:125`).
-- Each session collapses to one `ParsedProviderCall`. If you need per-turn data, the upstream format does not support it without re-parsing the prompt history.
+- One call per assistant message that carries usage. `parseSession` walks every `gemini`-type message with `tokens` and `model` set and emits one `ParsedProviderCall` per message, not one per session.
 
 ## When fixing a bug here
 
-1. The lack of a test file is a hazard. **Add a fixture and a test before changing parsing logic** so future regressions are caught.
-2. If the bug involves a new Gemini version's schema, sniff with the same first-character heuristic; do not call `JSON.parse` on the whole file.
+1. Add a fixture-based regression test alongside any parsing change; `tests/providers/gemini.test.ts` is the place for it.
+2. If the bug involves a new Gemini version's schema, keep the same try-JSON-then-JSONL fallback; do not assume one format based on a byte sniff.
 3. If the bug is "Gemini sessions report less than expected", check whether the cached-token subtraction is over-correcting.

--- a/docs/providers/open-design.md
+++ b/docs/providers/open-design.md
@@ -1,0 +1,45 @@
+# Open Design
+
+Open Design coding agent. Records an event-stream JSONL log per run, with token usage attached to periodic `usage` events rather than one entry per turn.
+
+- **Source:** `src/providers/open-design.ts`
+- **Loading:** eager (`src/providers/index.ts`)
+- **Test:** `tests/providers/open-design.test.ts` (7 tests, fixture-based)
+
+## Where it reads from
+
+| OS | Default path |
+|---|---|
+| macOS | `~/Library/Application Support/Open Design` |
+| Windows | `%APPDATA%/Open Design` |
+| Linux | `~/.config/Open Design` |
+
+`$CODEBURN_OPEN_DESIGN_DIR` overrides the default. Discovery accepts several base-directory shapes and normalizes them all down to `<namespace>/data/runs/<runId>/events.jsonl`: a `namespaces` root (`<base>/namespaces/<ns>/data/runs`), a `data` dir, a `runs` dir, or a plain root, tried at both `<base>/data/runs` and `<base>/runs`. Results are deduplicated by resolved path so an ambiguous root does not double-count a run.
+
+## Storage format
+
+JSONL, one event object per line: `{ id, event, data, timestamp }`. A `start` event, or an `agent` event with `data.type === 'status'`, carries the current model in `data.model`. An `agent` event with `data.type === 'usage'` carries `data.usage.{input_tokens, output_tokens, cached_read_tokens, thought_tokens}`.
+
+## Pricing
+
+Recomputed locally via `calculateCost`. `input_tokens` is inclusive of cached reads, so the parser subtracts `cached_read_tokens` before pricing fresh input; `thought_tokens` (reasoning) bills at the output rate and is folded into the output argument passed to `calculateCost`.
+
+## Caching
+
+None at the provider level.
+
+## Deduplication
+
+Per `open-design:<sessionId>:<eventId>`, where `sessionId` is the run's directory name and `eventId` is the event's own `id`, falling back to a per-line counter when the event has none.
+
+## Quirks
+
+- **A usage event needs a model first.** Usage is only recorded once a `start` or status event has set `currentModel`; a `usage` event that arrives before any model is known is dropped rather than attributed to `unknown`.
+- **No tool or bash-command tracking.** `tools` and `bashCommands` are always empty; the event stream does not expose per-call tool names today.
+- **Only two models have display-name overrides**: `openai-codex:gpt-5.5` maps to `GPT-5.5`, and `glm-5.2` / `GLM-5.2` both map to `GLM-5.2`. Any other model string displays as-is.
+
+## When fixing a bug here
+
+1. Confirm which base-directory shape the install actually uses; `CODEBURN_OPEN_DESIGN_DIR` is the fastest way to point discovery at a specific `data`, `runs`, or `namespaces` root while testing.
+2. If costs are `$0`, check whether a `start` or status event ever set the model before the `usage` event arrived for that run.
+3. New fixtures go under `tests/fixtures/open-design/` and `tests/providers/open-design.test.ts`.


### PR DESCRIPTION
Maintainer docs pass, written from the code on main.

- docs/providers/README.md: add the missing Codebuff, Mux, Open Design and Zed rows; Gemini and Antigravity now point at their real test files instead of none.
- docs/architecture.md: eager provider list gains cline-cli, kimicode, openclaude, quickdesk; test inventory and lock-suite count corrected (four cache-refresh-lock suites).
- CONTRIBUTING.md: the npm test row no longer hard-codes a case count that rots on every PR, and the full-suite gate now says npm test (plus cd app and npm test for app changes, swift test under mac/) instead of the unsupported whole-repo npx vitest run that sweeps app/ and fails on jsdom.
- docs/providers/gemini.md: one call per assistant message with usage (not per session), JSON.parse then JSONL fallback (not a first-character sniff), dedup key per session and message, stale line citations dropped.
- New pages docs/providers/codebuff.md and docs/providers/open-design.md derived from their parsers.

Verification: npm test in a fresh worktree, 260 passed, 2 skipped, 0 failed; every cited path checked with ls; no em-dashes added.