### PR TITLE
ci(snap): treat the store's manual-review queue as a successful upload

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -55,4 +55,7 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         run: |
           sudo snap install snapcraft --classic
-          snapcraft upload --release=stable app/release/codeburn_*.snap
+          # snapcraft exits 1 when the store queues the revision for manual review,
+          # which every personal-files snap does; the upload itself succeeded.
+          snapcraft upload --release=stable app/release/codeburn_*.snap 2>&1 | tee upload.log
+          test "${PIPESTATUS[0]}" -eq 0 || grep -q 'will need manual review' upload.log


### PR DESCRIPTION
snapcraft upload exits 1 whenever the store answers "Status: will need manual review", which every personal-files snap gets, so the publish run showed red even though the revision was uploaded (run 33535768611). The step now passes when snapcraft succeeds or when the output carries that line; any other failure still fails the job.