### PR TITLE
fix(menubar): launch the Windows tray exe by its real binary name

### DIFF
--- a/src/menubar-installer.ts
+++ b/src/menubar-installer.ts
@@ -27,6 +27,8 @@ const SUPPORTED_OS = 'darwin'
 /// rewrites the spaces in the bundle name to dots when it stores the asset, so both the asset
 /// name and its download URL carry `CodeBurn.Menubar_...`.
 const WINDOWS_PRODUCT_NAME = 'CodeBurn Menubar'
+/// Tauri names the binary after the crate (windows/src-tauri/Cargo.toml), not the product.
+const WINDOWS_EXE_NAME = 'codeburn-menubar.exe'
 const WINDOWS_ASSET_PATTERN = /^CodeBurn\.Menubar_.+_x64_en-US\.msi$/
 const MIN_MACOS_MAJOR = 14
 const PERSISTED_CLI_PATH = join(homedir(), 'Library', 'Application Support', 'CodeBurn', 'codeburn-cli-path.v1')
@@ -563,7 +565,7 @@ export function parseInstalledWindowsMenubar(regOutput: string): InstalledWindow
     // InstallLocation to join onto.
     const icon = values.get('DisplayIcon')?.split(',')[0]?.trim()
     const exePath = location
-      ? `${location.replace(/[\\/]+$/, '')}\\${WINDOWS_PRODUCT_NAME}.exe`
+      ? `${location.replace(/[\\/]+$/, '')}\\${WINDOWS_EXE_NAME}`
       : icon
     if (!exePath) continue
     return { version: values.get('DisplayVersion') ?? '', exePath }

--- a/tests/menubar-installer-windows.test.ts
+++ b/tests/menubar-installer-windows.test.ts
@@ -106,7 +106,7 @@ describe('parseInstalledWindowsMenubar', () => {
   it('reads the version and joins the exe onto InstallLocation', () => {
     expect(parseInstalledWindowsMenubar(INSTALLED_0_9_20)).toEqual({
       version: '0.9.20',
-      exePath: 'C:\\Program Files\\CodeBurn Menubar\\CodeBurn Menubar.exe',
+      exePath: 'C:\\Program Files\\CodeBurn Menubar\\codeburn-menubar.exe',
     })
   })
 
@@ -114,10 +114,10 @@ describe('parseInstalledWindowsMenubar', () => {
     const output = regBlock({
       DisplayName: 'CodeBurn Menubar',
       DisplayVersion: '0.9.20',
-      DisplayIcon: 'C:\\Program Files\\CodeBurn Menubar\\CodeBurn Menubar.exe,0',
+      DisplayIcon: 'C:\\Program Files\\CodeBurn Menubar\\codeburn-menubar.exe,0',
     })
 
-    expect(parseInstalledWindowsMenubar(output)?.exePath).toBe('C:\\Program Files\\CodeBurn Menubar\\CodeBurn Menubar.exe')
+    expect(parseInstalledWindowsMenubar(output)?.exePath).toBe('C:\\Program Files\\CodeBurn Menubar\\codeburn-menubar.exe')
   })
 
   it('returns undefined when the product is not installed', () => {
@@ -171,8 +171,8 @@ describe('installMenubarApp on windows', () => {
 
     expect(fetches).toBe(0)
     expect(installerCalls).toEqual([])
-    expect(launched).toEqual(['C:\\Program Files\\CodeBurn Menubar\\CodeBurn Menubar.exe'])
-    expect(result).toEqual({ installedPath: 'C:\\Program Files\\CodeBurn Menubar\\CodeBurn Menubar.exe', launched: true })
+    expect(launched).toEqual(['C:\\Program Files\\CodeBurn Menubar\\codeburn-menubar.exe'])
+    expect(result).toEqual({ installedPath: 'C:\\Program Files\\CodeBurn Menubar\\codeburn-menubar.exe', launched: true })
   })
 
   it('downloads, verifies, runs msiexec from System32 and launches the installed app', async () => {
@@ -189,7 +189,7 @@ describe('installMenubarApp on windows', () => {
       exe: 'C:\\Windows\\System32\\msiexec.exe',
       args: ['/i', join(sandbox, 'CodeBurn.Menubar_0.9.20_x64_en-US.msi'), '/passive', '/norestart'],
     }])
-    expect(launched).toEqual(['C:\\Program Files\\CodeBurn Menubar\\CodeBurn Menubar.exe'])
+    expect(launched).toEqual(['C:\\Program Files\\CodeBurn Menubar\\codeburn-menubar.exe'])
     expect(result.launched).toBe(true)
     expect(logs).toContain('Downloading CodeBurn.Menubar_0.9.20_x64_en-US.msi...')
     expect(logs).toContain('Verifying checksum...')


### PR DESCRIPTION
First run of `codeburn menubar` on a real Windows 11 install: the MSI installs fine, but the launch step fails with spawn ENOENT.

Cause: `parseInstalledWindowsMenubar` builds the exe path as `InstallLocation + 'CodeBurn Menubar.exe'` (the product name), while Tauri names the binary after the crate: `codeburn-menubar.exe` (windows/src-tauri/Cargo.toml). Verified in the guest: `C:\Program Files\CodeBurn Menubar\codeburn-menubar.exe` is the only exe the MSI ships, and launching it directly works.

Fix: join with a `WINDOWS_EXE_NAME` constant instead. The DisplayIcon fallback path is unchanged. Test fixtures updated to the real name.