### PR TITLE
fix(windows): let Quit actually exit and enforce a single tray instance

### DIFF
--- a/windows/src-tauri/Cargo.lock
+++ b/windows/src-tauri/Cargo.lock
@@ -490,6 +490,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "thiserror 1.0.69",
  "tokio",
  "windows-sys 0.59.0",
@@ -4210,6 +4211,22 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0cb5c412a5071b69bab6a6df1583cbb89460d4a83b6a24769b08d15b6b1e1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/windows/src-tauri/Cargo.toml
+++ b/windows/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
 tauri-plugin-shell = "2"
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["process", "io-util", "rt-multi-thread", "macros", "time", "sync"] }

--- a/windows/src-tauri/src/lib.rs
+++ b/windows/src-tauri/src/lib.rs
@@ -52,6 +52,10 @@ pub struct AppState {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        // Must be registered before any other plugin so it can intercept a second launch.
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            show_popover(app, None);
+        }))
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_opener::init())
         .setup(|app| {
@@ -108,8 +112,13 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while running tauri application")
         .run(|_app, event| {
-            if let tauri::RunEvent::ExitRequested { api, .. } = event {
-                api.prevent_exit();
+            // `code` is `None` only when the last window closed on its own; an explicit
+            // `app.exit(..)` (tray Quit, `commands::quit_app`) always carries `Some(_)` and
+            // must be allowed through, or Quit does nothing.
+            if let tauri::RunEvent::ExitRequested { api, code, .. } = event {
+                if code.is_none() {
+                    api.prevent_exit();
+                }
             }
         });
 }


### PR DESCRIPTION
## Bugs, as observed on a Windows 11 VM

**1. Quit does nothing.** Right-click the tray icon > Quit CodeBurn and the app just keeps running. The Tauri run loop's `RunEvent::ExitRequested` handler unconditionally called `api.prevent_exit()`, which also swallowed the explicit `app.exit(0)` fired by the tray "quit" menu item and `commands::quit_app`. In Tauri 2, `ExitRequested` carries `code: Option<i32>`: `None` when the last window closes on its own, `Some(_)` for an explicit `app.exit(..)`. Fixed by only preventing exit when `code.is_none()`, so the popover window closing still keeps the app resident in the tray, but Quit actually quits.

**2. Launching twice gives four tray icons.** Each running instance registers two tray icons by design (the flame logo plus a spend badge icon next to it). Launching the app a second time (e.g. double-clicking the shortcut again) starts a second process instead of reusing the first, so the notification area ends up with two flame icons and two badge icons for what looks like one app. Fixed by adding `tauri-plugin-single-instance`, registered first in the builder chain per its docs; a second launch now just calls the existing `show_popover` to bring the running instance's popover forward instead of spawning a duplicate process.

## Changes
- `windows/src-tauri/src/lib.rs`: guard `ExitRequested` on `code.is_none()`; register `tauri_plugin_single_instance::init` as the first plugin, focusing the popover on relaunch.
- `windows/src-tauri/Cargo.toml`: add `tauri-plugin-single-instance = "2"` (resolves to 2.4.4 against the pinned tauri 2.10.3).
- `windows/src-tauri/Cargo.lock`: minimal lockfile addition for the new dependency (17 lines).

## Test plan
- [x] `cargo check` passes on macOS host (compiles the non-Linux tray code path)
- [ ] CI nsis/appx Windows build jobs
- [ ] Manual: Windows 11 VM, right-click tray > Quit exits the process
- [ ] Manual: Windows 11 VM, launch app twice, only one flame + one badge icon remain, second launch focuses the popover