### PR TITLE
feat(cli): codeburn quota command reading provider capacity from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,8 @@ Sync sends token counts, costs, models, and projects, never prompts or code. Thi
 
 | Command | What it does |
 |---------|--------------|
+| `codeburn quota` | Live provider capacity: quota windows for each signed-in coding tool |
+| `codeburn quota --format json` | The same capacity readings as JSON |
 | `codeburn doctor` | Per-provider detection status: paths probed, sessions found, parse health (`--json`, `--provider`) |
 | `codeburn audit` | Per provider-model token source table: where every number comes from |
 | `codeburn context` | What fills a session's context window: interactive browser (Claude Code and Codex) |
@@ -664,6 +666,31 @@ codeburn doctor --json              # machine-readable, pipe to jq
 ```
 
 For each provider it shows the exact directories or databases probed (with any env override such as `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, or `OPENCODE_DATA_DIR` and whether the path exists), how many session files were found, how many of a bounded sample parsed cleanly, the cached file count, and a one-line verdict: `OK (n sessions)`, `NOTHING FOUND` with the likely cause (directory missing, override points at an empty dir, or the tool is not installed), or `ERRORS (n parse failures)`. A provider that throws is caught and reported as its own error row, never crashing the rest of the report.
+
+### Provider quota
+
+`codeburn quota` reads how much of each provider's plan you have already spent, from the credentials the tools themselves keep on this machine. Claude, Codex, Gemini, GitHub Copilot and Kimi are read from their own signed-in sessions; Antigravity is read from its local language server.
+
+```bash
+codeburn quota               # table of every provider and its windows
+codeburn quota --format json # machine-readable, pipe to jq
+```
+
+Providers you are not signed in to are listed with `available: false` and no error. Reads run in parallel with a short per-provider timeout, and the command always exits 0 so a status bar or tray can poll it safely.
+
+```json
+{
+  "providers": [
+    {
+      "id": "claude",
+      "name": "Claude",
+      "available": true,
+      "plan": "Max 20x",
+      "windows": [{ "label": "Weekly", "usedPct": 42.5, "resetsAt": "2026-09-08T12:00:00.000Z" }]
+    }
+  ]
+}
+```
 
 ### JSON Output
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2609,6 +2609,23 @@ program
     process.stdout.write(renderDoctorTable(report, { color: opts.color }))
   })
 
+program
+  .command('quota')
+  .description('Live provider capacity: quota windows for each signed-in coding tool on this machine')
+  .option('--format <format>', 'Output format: table, json', 'table')
+  .option('--no-color', 'Disable ANSI colors')
+  .action(async (opts) => {
+    const { collectQuota, renderQuotaTable } = await import('./quota/index.js')
+    const report = await collectQuota()
+    const out = opts.format === 'json'
+      ? JSON.stringify(report, null, 2) + '\n'
+      : renderQuotaTable(report, { color: opts.color }) + '\n'
+    // A keychain lookup or local-server probe abandoned by the per-provider
+    // timeout keeps its child alive long past the output, so leave on purpose
+    // once the write has flushed.
+    process.stdout.write(out, () => process.exit(0))
+  })
+
 registerActCommands(program)
 registerGuardCommands(program)
 registerSyncCommands(program)

--- a/src/quota/antigravity.ts
+++ b/src/quota/antigravity.ts
@@ -1,0 +1,239 @@
+// Live Antigravity quota from LOCAL surfaces only - the Antigravity app's own
+// language server or a signed-in `agy` CLI's embedded server. The local
+// Antigravity language-server protocol is undocumented and
+// experimental). No Google OAuth fallback in v1: when no local server answers,
+// the provider reports disconnected and the UI shows its Connect affordance.
+//
+// Endpoints (localhost only, Connect-RPC JSON):
+// - POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary
+//     (preferred; falls back to)
+// - POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetUserStatus
+//
+// Discovery uses `ps` to find candidate processes (app language
+// servers need their `--csrf_token`; the `agy` CLI needs none), then `lsof`
+// lists each pid's listening TCP ports. Local HTTPS uses a self-signed cert,
+// so TLS verification is relaxed ONLY for the 127.0.0.1 loopback probes.
+import { execFile } from 'node:child_process'
+import http from 'node:http'
+import https from 'node:https'
+import { promisify } from 'node:util'
+
+import { fraction, sanitizeError } from './security.js'
+import type { QuotaProvider, QuotaWindow } from './types.js'
+
+const SUMMARY_PATH = '/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary'
+const STATUS_PATH = '/exa.language_server_pb.LanguageServerService/GetUserStatus'
+const LOCAL_TIMEOUT_MS = 3_000
+
+export type ExecFileFn = (file: string, args: string[]) => Promise<{ stdout: string }>
+export type LocalRequestFn = (
+  port: number,
+  tls: boolean,
+  pathName: string,
+  body: string,
+  csrf?: string,
+) => Promise<{ status: number; text: string } | null>
+
+export type AntigravityDeps = {
+  execFile: ExecFileFn
+  request: LocalRequestFn
+}
+
+const execFileAsync: ExecFileFn = promisify(execFile)
+
+function postLocal(port: number, tls: boolean, pathName: string, body: string, csrf?: string): Promise<{ status: number; text: string } | null> {
+  return new Promise(resolve => {
+    const request = (tls ? https : http).request({
+      host: '127.0.0.1',
+      port,
+      method: 'POST',
+      path: pathName,
+      ...(tls ? { rejectUnauthorized: false } : {}),
+      headers: {
+        'Content-Type': 'application/json',
+        'Connect-Protocol-Version': '1',
+        ...(csrf ? { 'X-Codeium-Csrf-Token': csrf } : {}),
+      },
+      timeout: LOCAL_TIMEOUT_MS,
+    }, response => {
+      let text = ''
+      response.setEncoding('utf8')
+      response.on('data', chunk => { text += chunk })
+      response.on('end', () => resolve({ status: response.statusCode ?? 0, text }))
+    })
+    request.on('timeout', () => { request.destroy(); resolve(null) })
+    request.on('error', () => resolve(null))
+    request.end(body)
+  })
+}
+
+const defaults: AntigravityDeps = {
+  execFile: execFileAsync,
+  request: postLocal,
+}
+
+function empty(connection: QuotaProvider['connection']): QuotaProvider {
+  return { provider: 'antigravity', connection, primary: null, details: [], planLabel: null, footerLines: [] }
+}
+
+// Process kinds distinguish the app language server from standalone processes.
+// carries richer quota data than the IDE variant, so IDE matches are skipped;
+// a CLI (`agy`) match is accepted because its tokenless server exposes the
+// same summary payload.
+const LANGUAGE_SERVER = /language[_-]server(_macos)?(_arm)?/
+const IDE_MARKER = /antigravity[-_]ide/i
+const CLI_MARKER = /antigravity[-_]cli/i
+const AGY_BINARY = /(^|\/|\s)agy(\s|$)/
+const APP_MARKER = /--app_data_dir[= ]"?antigravity(?![\w-])|\/antigravity\//i
+
+type Candidate = { pid: string; cli: boolean; csrf?: string; extPort?: number }
+
+function flagValue(line: string, flag: string): string | undefined {
+  const match = line.match(new RegExp(`${flag}[= ]([^\\s]+)`))
+  return match?.[1]
+}
+
+export function classifyProcessLine(line: string): Candidate | null {
+  const isServer = LANGUAGE_SERVER.test(line)
+  const isCli = !isServer && (CLI_MARKER.test(line) || AGY_BINARY.test(line))
+  if (!isServer && !isCli) return null
+  const pid = line.trim().match(/^(\d+)/)?.[1]
+  if (!pid) return null
+  // A tokenless desktop language-server match is skipped so a later, valid
+  // server can be found; the CLI exposes no CSRF flag and needs none. IDE
+  // language servers are excluded too - their payloads lack the weekly groups.
+  if (!isCli && (!APP_MARKER.test(line) || IDE_MARKER.test(line))) return null
+  const csrf = flagValue(line, '--csrf_token')
+  if (!isCli && !csrf) return null
+  const extPort = Number(flagValue(line, '--extension_server_port'))
+  return { pid, cli: isCli, csrf, extPort: Number.isFinite(extPort) && extPort > 0 ? extPort : undefined }
+}
+
+async function discoverCandidates(deps: AntigravityDeps): Promise<Candidate[]> {
+  const { stdout } = await deps.execFile('ps', ['-ax', '-o', 'pid=,command='])
+  const seen = new Set<string>()
+  const candidates: Candidate[] = []
+  for (const line of stdout.split('\n')) {
+    const candidate = classifyProcessLine(line)
+    if (!candidate || seen.has(candidate.pid)) continue
+    seen.add(candidate.pid)
+    candidates.push(candidate)
+  }
+  // The app source ranks above the CLI: richer quota data beats availability.
+  return candidates.sort((a, b) => Number(a.cli) - Number(b.cli))
+}
+
+async function listeningPorts(deps: AntigravityDeps, pid: string): Promise<number[]> {
+  try {
+    const { stdout } = await deps.execFile('lsof', ['-nP', '-iTCP', '-sTCP:LISTEN', '-a', '-p', pid])
+    const ports = [...stdout.matchAll(/:(\d+)\s/g)].map(match => Number(match[1]))
+    return [...new Set(ports)].filter(port => Number.isFinite(port) && port > 0)
+  } catch {
+    return []
+  }
+}
+
+function resetTimeOf(value: unknown): string | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return new Date(value > 1e12 ? value : value * 1000).toISOString()
+  }
+  if (typeof value === 'string' && !Number.isNaN(Date.parse(value))) return new Date(value).toISOString()
+  return null
+}
+
+function windowOf(label: string, remainingFraction: unknown, resetTime?: unknown): QuotaWindow | null {
+  const remaining = fraction(typeof remainingFraction === 'number' ? (1 - remainingFraction) * 100 : NaN)
+  if (remaining === null) return null
+  return { label, percent: remaining, resetsAt: resetTimeOf(resetTime ?? null) }
+}
+
+/** Preferred payload: two named quota groups of model buckets. */
+export function decodeAntigravitySummary(body: unknown): QuotaWindow[] {
+  const data = body && typeof body === 'object' ? body as Record<string, any> : {}
+  const windows: QuotaWindow[] = []
+  for (const group of Array.isArray(data.groups) ? data.groups : []) {
+    const groupName = typeof group?.displayName === 'string' ? group.displayName : ''
+    for (const bucket of Array.isArray(group?.buckets) ? group.buckets : []) {
+      const name = [groupName, typeof bucket?.displayName === 'string' ? bucket.displayName : bucket?.bucketId]
+        .filter(Boolean).join(' · ')
+      if (!name) continue
+      const window = windowOf(name, bucket?.remaining?.remainingFraction)
+      if (window) windows.push(window)
+    }
+  }
+  return windows
+}
+
+/** Legacy payload: flat per-model quota rows under GetUserStatus. */
+export function decodeAntigravityStatus(body: unknown): QuotaWindow[] {
+  const data = body && typeof body === 'object' ? body as Record<string, any> : {}
+  const configs = data.userStatus?.cascadeModelConfigData?.clientModelConfigs
+  const windows: QuotaWindow[] = []
+  for (const config of Array.isArray(configs) ? configs : []) {
+    const name = typeof config?.modelName === 'string' ? config.modelName : ''
+    if (!name) continue
+    const window = windowOf(name, config?.quotaInfo?.remainingFraction, config?.quotaInfo?.resetTime)
+    if (window) windows.push(window)
+  }
+  return windows
+}
+
+function planFromStatus(body: unknown): string | null {
+  const data = body && typeof body === 'object' ? body as Record<string, any> : {}
+  const plan = data.planName ?? data.userStatus?.planName ?? data.account_plan
+  return typeof plan === 'string' && plan.trim() ? plan.trim() : null
+}
+
+async function probePort(deps: AntigravityDeps, port: number, csrf?: string): Promise<{ windows: QuotaWindow[]; planLabel: string | null } | null> {
+  const body = JSON.stringify({})
+  for (const tls of [true, false]) {
+    const summary = await deps.request(port, tls, SUMMARY_PATH, body, csrf)
+    if (summary?.status === 200) {
+      const windows = decodeAntigravitySummary(parseJson(summary.text))
+      if (windows.length > 0) return { windows, planLabel: null }
+    }
+    const status = await deps.request(port, tls, STATUS_PATH, body, csrf)
+    if (status?.status === 200) {
+      const parsed = parseJson(status.text)
+      const windows = decodeAntigravityStatus(parsed)
+      if (windows.length > 0) return { windows, planLabel: planFromStatus(parsed) }
+    }
+  }
+  return null
+}
+
+function parseJson(text: string): unknown {
+  try { return JSON.parse(text) } catch { return null }
+}
+
+export async function fetchAntigravityQuota(deps: Partial<AntigravityDeps> = {}): Promise<QuotaProvider> {
+  const resolved = { ...defaults, ...deps }
+  // Discovery leans on `ps` and `lsof`, which Windows has no equivalent of, so
+  // report a clean disconnected rather than a spawn failure.
+  if (process.platform === 'win32' && !deps.execFile) return empty('disconnected')
+  try {
+    const candidates = await discoverCandidates(resolved)
+    if (candidates.length === 0) return empty('disconnected')
+    for (const candidate of candidates) {
+      const ports = await listeningPorts(resolved, candidate.pid)
+      if (candidate.extPort !== undefined && !ports.includes(candidate.extPort)) ports.push(candidate.extPort)
+      for (const port of ports) {
+        const found = await probePort(resolved, port, candidate.csrf)
+        if (found) {
+          const windows = [...found.windows].sort((a, b) => b.percent - a.percent)
+          return {
+            provider: 'antigravity', connection: 'connected',
+            primary: windows[0] ?? null,
+            details: windows,
+            planLabel: found.planLabel,
+            footerLines: [],
+          }
+        }
+      }
+    }
+    return empty('disconnected')
+  } catch (error) {
+    console.warn(`Antigravity quota unavailable: ${sanitizeError(error)}`)
+    return empty('transientFailure')
+  }
+}

--- a/src/quota/claude.ts
+++ b/src/quota/claude.ts
@@ -1,0 +1,152 @@
+import os from 'node:os'
+import path from 'node:path'
+
+import { fraction, quotaRequestSignal, readKeychainPassword, readSecureFile, sanitizeError } from './security.js'
+import type { KeychainOutcome } from './security.js'
+import type { QuotaProvider, QuotaWindow } from './types.js'
+
+const ENDPOINT = 'https://api.anthropic.com/api/oauth/usage'
+const KEYCHAIN_SERVICE = 'Claude Code-credentials'
+
+type ClaudeCredential = { accessToken: string; expiresAt?: number; rateLimitTier?: string }
+export type ClaudeDeps = {
+  fetch: typeof fetch
+  credentialPath: string
+  readFile: typeof readSecureFile
+  now: () => number
+  keychain?: () => Promise<KeychainOutcome>
+}
+
+const defaults: ClaudeDeps = {
+  fetch: globalThis.fetch,
+  credentialPath: path.join(os.homedir(), '.claude', '.credentials.json'),
+  readFile: readSecureFile,
+  now: Date.now,
+}
+
+function empty(connection: QuotaProvider['connection']): QuotaProvider {
+  return { provider: 'claude', connection, primary: null, details: [], planLabel: null, footerLines: [] }
+}
+
+function parseCredential(raw: string): ClaudeCredential | null {
+  const clean = raw.replace(/\r/g, '').replace(/\n[ \t]*/g, '')
+  const oauth = (JSON.parse(clean) as { claudeAiOauth?: Record<string, unknown> }).claudeAiOauth
+  if (!oauth || typeof oauth.accessToken !== 'string' || oauth.accessToken.length === 0) return null
+  return {
+    accessToken: oauth.accessToken,
+    expiresAt: typeof oauth.expiresAt === 'number' ? oauth.expiresAt : undefined,
+    rateLimitTier: typeof oauth.rateLimitTier === 'string' ? oauth.rateLimitTier : undefined,
+  }
+}
+
+async function credentialFromFile(deps: ClaudeDeps): Promise<ClaudeCredential | null> {
+  const raw = await deps.readFile(deps.credentialPath, 64 * 1024)
+  return raw ? parseCredential(raw) : null
+}
+
+export async function readClaudeKeychain(): Promise<KeychainOutcome> {
+  // Claude Code has written the item under both `$USER` (2.1.x) and the older
+  // hardcoded "agentseal" account; a user-scoped miss must fall through to the
+  // service-only lookup rather than reporting disconnected.
+  const user = process.env.USER
+  return readKeychainPassword(KEYCHAIN_SERVICE, user ? [user, null] : [null])
+}
+
+function windowOf(label: string, value: unknown): QuotaWindow | null {
+  if (!value || typeof value !== 'object') return null
+  const row = value as Record<string, unknown>
+  const percent = fraction(row.utilization)
+  if (percent === null) return null
+  const resetsAt = typeof row.resets_at === 'string' && !Number.isNaN(Date.parse(row.resets_at))
+    ? new Date(row.resets_at).toISOString() : null
+  return { label, percent, resetsAt }
+}
+
+function tierLabel(raw: string | undefined): string {
+  const value = raw?.toLowerCase() ?? ''
+  if (value.includes('max_20x') || value.includes('max20x') || value.includes('max-20x')) return 'Max 20x'
+  if (value.includes('max_5x') || value.includes('max5x') || value.includes('max-5x') || value.includes('max')) return 'Max 5x'
+  if (value.includes('pro')) return 'Pro'
+  if (value.includes('team')) return 'Team'
+  if (value.includes('enterprise')) return 'Enterprise'
+  return 'Subscription'
+}
+
+export function decodeClaudeUsage(body: unknown, credential: ClaudeCredential): QuotaProvider {
+  const data = body && typeof body === 'object' ? body as Record<string, unknown> : {}
+  const five = windowOf('5-hour', data.five_hour)
+  const weekly = windowOf('Weekly', data.seven_day)
+  const opus = windowOf('Weekly · Opus', data.seven_day_opus)
+  const sonnet = windowOf('Weekly · Sonnet', data.seven_day_sonnet)
+  const scoped: QuotaWindow[] = []
+  if (Array.isArray(data.limits)) {
+    for (const item of data.limits) {
+      if (!item || typeof item !== 'object') continue
+      const row = item as Record<string, any>
+      const display = row.scope?.model?.display_name
+      const percent = fraction(row.percent)
+      if (row.kind !== 'weekly_scoped' || typeof display !== 'string' || percent === null) continue
+      const resetsAt = typeof row.resets_at === 'string' && !Number.isNaN(Date.parse(row.resets_at))
+        ? new Date(row.resets_at).toISOString() : null
+      scoped.push({ label: `Weekly · ${display}`, percent, resetsAt })
+    }
+  }
+  return {
+    provider: 'claude', connection: 'connected', primary: weekly,
+    details: [five, weekly, opus, sonnet].filter((row): row is QuotaWindow => row !== null).concat(scoped),
+    planLabel: tierLabel(credential.rateLimitTier), footerLines: [],
+  }
+}
+
+async function request(token: string, deps: ClaudeDeps, parent?: AbortSignal): Promise<Response> {
+  return deps.fetch(ENDPOINT, {
+    method: 'GET', signal: quotaRequestSignal(parent),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+      'anthropic-beta': 'oauth-2025-04-20',
+      'User-Agent': 'claude-code/2.1.0',
+    },
+  })
+}
+
+export type ClaudeResult = { quota: QuotaProvider; retryAfterSeconds?: number }
+
+export async function fetchClaudeQuota(options: Partial<ClaudeDeps> & { signal?: AbortSignal; allowKeychain?: boolean } = {}): Promise<ClaudeResult> {
+  const deps = { ...defaults, ...options }
+  try {
+    let credential = await credentialFromFile(deps)
+    if (!credential && options.allowKeychain && process.platform === 'darwin') {
+      const outcome = await (deps.keychain ?? readClaudeKeychain)()
+      if (outcome.status === 'accessDenied') return { quota: empty('accessDenied') }
+      credential = outcome.status === 'found' ? parseCredential(outcome.value) : null
+    }
+    if (!credential) return { quota: empty('disconnected') }
+
+    let response: Response
+    if (credential.expiresAt !== undefined && credential.expiresAt - deps.now() <= 5 * 60_000) {
+      const reread = await credentialFromFile(deps)
+      if (!reread || reread.accessToken === credential.accessToken) return { quota: empty('transientFailure') }
+      credential = reread
+    }
+    response = await request(credential.accessToken, deps, options.signal)
+    if (response.status === 401) {
+      const reread = await credentialFromFile(deps)
+      if (!reread || reread.accessToken === credential.accessToken) return { quota: empty('transientFailure') }
+      credential = reread
+      response = await request(credential.accessToken, deps, options.signal)
+    }
+    if (response.status === 429) {
+      let hint: unknown
+      try { hint = (await response.json() as Record<string, unknown>).retry_after } catch { hint = undefined }
+      const parsed = typeof hint === 'number' ? hint : typeof hint === 'string' ? Number(hint) : NaN
+      return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(parsed) ? parsed : 300, 60) }
+    }
+    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure') }
+    return { quota: decodeClaudeUsage(await response.json(), credential) }
+  } catch (error) {
+    // Deliberately sanitize before the only diagnostic sink. Tokens are never returned.
+    console.warn(`Claude quota unavailable: ${sanitizeError(error)}`)
+    return { quota: empty('transientFailure') }
+  }
+}

--- a/src/quota/codex.ts
+++ b/src/quota/codex.ts
@@ -1,0 +1,324 @@
+import os from 'node:os'
+import path from 'node:path'
+
+import { atomicWriteSecureFile, fraction, quotaRequestSignal, readKeychainPassword, readSecureFile, sanitizeError } from './security.js'
+import type { KeychainOutcome } from './security.js'
+import type { QuotaProvider, QuotaWindow } from './types.js'
+
+const USAGE_ENDPOINT = 'https://chatgpt.com/backend-api/wham/usage'
+const TOKEN_ENDPOINT = 'https://auth.openai.com/oauth/token'
+const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
+const EIGHT_DAYS = 8 * 24 * 60 * 60_000
+// The CodeBurn menubar caches its ChatGPT-mode Codex OAuth here as a
+// `CredentialRecord` JSON blob (accessToken/refreshToken/idToken/accountId/…),
+// account "default". Same brand, same machine, already consented - preferred
+// over any OpenAI-owned storage.
+const MENUBAR_KEYCHAIN_SERVICE = 'org.agentseal.codeburn.menubar.codex.oauth.v1'
+
+type AuthDoc = Record<string, any> & {
+  auth_mode?: string
+  tokens?: { access_token?: string; refresh_token?: string; id_token?: string; account_id?: string; [key: string]: unknown }
+  last_refresh?: string
+}
+
+export type CodexDeps = {
+  fetch: typeof fetch
+  authPath: string
+  openaiAuthPath: string
+  readFile: typeof readSecureFile
+  writeFile: typeof atomicWriteSecureFile
+  keychain: (service: string) => Promise<KeychainOutcome>
+  now: () => number
+}
+
+const defaults: CodexDeps = {
+  fetch: globalThis.fetch,
+  authPath: path.join(os.homedir(), '.codex', 'auth.json'),
+  openaiAuthPath: path.join(os.homedir(), 'Library', 'Application Support', 'com.openai.codex', 'auth.json'),
+  readFile: readSecureFile,
+  writeFile: atomicWriteSecureFile,
+  keychain: service => readKeychainPassword(service, ['default', null]),
+  now: Date.now,
+}
+
+/** A resolved Codex credential plus how much of its lifecycle we own. Only the
+ * Codex CLI's own auth.json is `writable` (we may rotate + write it back); the
+ * menubar keychain and OpenAI app-support copies are read-only. */
+type CodexSource = {
+  name: 'menubarKeychain' | 'authFile' | 'openaiAppSupport'
+  auth: AuthDoc
+  writable: boolean
+  reread: () => Promise<AuthDoc | null>
+}
+
+function empty(connection: QuotaProvider['connection']): QuotaProvider {
+  return { provider: 'codex', connection, primary: null, details: [], planLabel: null, footerLines: [] }
+}
+
+async function readAuth(deps: CodexDeps, filePath: string = deps.authPath): Promise<AuthDoc | null> {
+  const raw = await deps.readFile(filePath, 64 * 1024)
+  return raw ? JSON.parse(raw) as AuthDoc : null
+}
+
+// The menubar stores a Swift `CredentialRecord` (camelCase, Date fields as
+// numbers) rather than the CLI's snake_case auth.json. Normalize to AuthDoc and
+// mark it chatgpt-mode (the menubar only ever caches ChatGPT subscriptions).
+function authFromMenubarRecord(raw: string): AuthDoc | null {
+  let record: Record<string, unknown>
+  try { record = JSON.parse(raw) as Record<string, unknown> } catch { return null }
+  const access = typeof record.accessToken === 'string' ? record.accessToken : ''
+  if (!access) return null
+  return {
+    auth_mode: 'chatgpt',
+    tokens: {
+      access_token: access,
+      refresh_token: typeof record.refreshToken === 'string' ? record.refreshToken : undefined,
+      id_token: typeof record.idToken === 'string' ? record.idToken : undefined,
+      account_id: typeof record.accountId === 'string' ? record.accountId : undefined,
+    },
+  }
+}
+
+async function discoverSource(deps: CodexDeps, allowKeychain: boolean): Promise<CodexSource | 'accessDenied' | null> {
+  let denied = false
+  // (a) CodeBurn menubar's own cached Codex OAuth. Read-only: the menubar owns
+  // rotation, so we never write it back and never proactively refresh it.
+  if (allowKeychain && process.platform === 'darwin') {
+    const outcome = await deps.keychain(MENUBAR_KEYCHAIN_SERVICE)
+    if (outcome.status === 'accessDenied') denied = true
+    else if (outcome.status === 'found') {
+      const auth = authFromMenubarRecord(outcome.value)
+      if (auth) {
+        return {
+          name: 'menubarKeychain', auth, writable: false,
+          reread: async () => {
+            const next = await deps.keychain(MENUBAR_KEYCHAIN_SERVICE)
+            return next.status === 'found' ? authFromMenubarRecord(next.value) : null
+          },
+        }
+      }
+    }
+  }
+  // (b) The Codex CLI's own ~/.codex/auth.json. We own rotation + write-back.
+  const fileAuth = await readAuth(deps)
+  if (fileAuth) return { name: 'authFile', auth: fileAuth, writable: true, reread: () => readAuth(deps) }
+  // (c) com.openai.codex App Support, only if it holds a plaintext auth JSON
+  // with a usable token. Tokens encrypted via "Codex Safe Storage" have no
+  // plaintext access_token here, so they fall through - we never decrypt.
+  const openaiAuth = await readAuth(deps, deps.openaiAuthPath).catch(() => null)
+  if (openaiAuth?.tokens?.access_token) {
+    return { name: 'openaiAppSupport', auth: openaiAuth, writable: false, reread: () => readAuth(deps, deps.openaiAuthPath).catch(() => null) }
+  }
+  return denied ? 'accessDenied' : null
+}
+
+function labelForSeconds(value: unknown): string {
+  const seconds = typeof value === 'number' ? Math.max(0, Math.trunc(value)) : 0
+  if (seconds < 3600) return 'Hourly'
+  if (seconds < 7200) return 'Hour'
+  if (seconds >= 18_000 && seconds < 19_000) return '5-hour'
+  if (seconds >= 86_400 && seconds < 87_000) return 'Daily'
+  if (seconds >= 604_800 && seconds < 605_000) return 'Weekly'
+  const hours = Math.floor(seconds / 3600)
+  return hours < 24 ? `${hours}-hour` : `${Math.floor(hours / 24)}-day`
+}
+
+function windowOf(value: unknown, override?: string): QuotaWindow | null {
+  if (!value || typeof value !== 'object') return null
+  const row = value as Record<string, unknown>
+  const percent = fraction(row.used_percent)
+  if (percent === null) return null
+  const reset = typeof row.reset_at === 'number' && Number.isFinite(row.reset_at)
+    ? new Date(row.reset_at * 1000).toISOString() : null
+  return { label: override ?? labelForSeconds(row.limit_window_seconds), percent, resetsAt: reset }
+}
+
+// chatgpt.com mixes encodings inside one payload. `Number('')` is 0, not NaN,
+// so blank is rejected or an absent `used` decodes as a confident zero.
+function num(value: unknown): number | null {
+  if (typeof value === 'string' && !value.trim()) return null
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value.trim()) : NaN
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+// Credit-based-pricing tiers arrive composite (`enterprise_cbp_usage_based`).
+function normalizePlanType(value: string): string {
+  return value
+    .replace(/[_-]usage[_-]based$/, '')
+    .replace(/^self[_-]serve[_-]/, '')
+    .replace(/[_-]cbp$/, '')
+    .replace(/[_-]cbp[_-]/g, '_')
+}
+
+function planLabel(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null
+  const raw = value.trim()
+  const lower = normalizePlanType(raw.toLowerCase())
+  const known: Record<string, string> = {
+    guest: 'Guest', free: 'Free', go: 'Go', plus: 'Plus', pro: 'Pro',
+    prolite: 'Pro Lite', pro_lite: 'Pro Lite', 'pro-lite': 'Pro Lite',
+    free_workspace: 'Free Workspace', team: 'Team', business: 'Business',
+    education: 'Education', quorum: 'Quorum', k12: 'K-12', enterprise: 'Enterprise', edu: 'Edu',
+  }
+  return known[lower] ?? lower.replace(/(^|[_-])\w/g, match => match.replace(/[_-]/, ' ').toUpperCase())
+}
+
+// The admin-set monthly allowance, the only limit a credit-metered workspace
+// has. `spend_control` is the live position, the others forward-compat. `any`
+// because this walks six optional-chained hops, all validated by `num()`.
+function spendControlWindow(data: Record<string, any>): QuotaWindow | null {
+  // `find`/`num` per alias, not `??`: a non-null garbage value would stop `??`
+  // and mask a valid alias further down. Object-shaped garbage still wins the
+  // position, matching Swift, which likewise commits to the first that decodes.
+  const row = [
+    data.spend_control?.individual_limit,
+    data.spend_control?.individualLimit,
+    data.individual_limit,
+    data.individualLimit,
+    data.rate_limit?.individual_limit,
+    data.rate_limit?.individualLimit,
+  ].find(candidate => candidate && typeof candidate === 'object')
+  if (!row) return null
+  const limit = num(row.limit)
+  if (limit === null || limit <= 0) return null
+  const remainingPercent = num(row.remaining_percent) ?? num(row.remainingPercent)
+  const used = num(row.used)
+  const rawPercent = num(row.used_percent) ?? num(row.usedPercent)
+    ?? (remainingPercent === null ? null : 100 - remainingPercent)
+    ?? (used === null ? null : (used / limit) * 100)
+  if (rawPercent === null) return null
+  const percent = Math.min(1, Math.max(0, rawPercent / 100))
+  const resetRaw = num(row.reset_at) ?? num(row.resets_at) ?? num(row.resetsAt)
+  // Past 8.64e15 ms `toISOString()` throws RangeError.
+  const resetsAt = resetRaw !== null && resetRaw > 0 && resetRaw * 1000 <= 8.64e15
+    ? new Date(resetRaw * 1000).toISOString()
+    : null
+  // Unclamped percent, so a 120% draw still reports 12,000 of 10,000.
+  const spent = used ?? limit * Math.max(0, rawPercent) / 100
+  const round = (n: number) => Math.round(n).toLocaleString('en-US')
+  const reached = data.spend_control?.reached === true
+  const label = `Monthly usage limit · ${round(spent)} / ${round(limit)} credits`
+  return { label: reached ? `${label} · limit reached` : label, percent, resetsAt }
+}
+
+export function decodeCodexUsage(body: unknown): QuotaProvider {
+  const data = body && typeof body === 'object' ? body as Record<string, any> : {}
+  const primaryRaw = windowOf(data.rate_limit?.primary_window)
+  const secondaryRaw = windowOf(data.rate_limit?.secondary_window)
+  const primary = primaryRaw ?? secondaryRaw
+  const details: QuotaWindow[] = []
+  if (primaryRaw) details.push(primaryRaw)
+  if (secondaryRaw && secondaryRaw !== primary) details.push(secondaryRaw)
+  else if (!primaryRaw && secondaryRaw) details.push(secondaryRaw)
+  if (Array.isArray(data.additional_rate_limits)) {
+    for (const additional of data.additional_rate_limits) {
+      if (!additional || typeof additional !== 'object' || typeof additional.limit_name !== 'string') continue
+      for (const key of ['primary_window', 'secondary_window'] as const) {
+        const raw = additional.rate_limit?.[key]
+        const base = windowOf(raw)
+        if (base && base.percent > 0) details.push({ ...base, label: `${additional.limit_name} · ${base.label}` })
+      }
+    }
+  }
+  const credits = spendControlWindow(data)
+  if (credits) details.push(credits)
+  const balance = num(data.credits?.balance)
+  // Credit-settled accounts denominate in credits, so no currency symbol.
+  const hasCredits = data.credits?.has_credits === true
+  const footerLines: string[] = []
+  if (balance !== null && balance > 0) {
+    footerLines.push(`Credits remaining · ${hasCredits ? Math.round(balance).toLocaleString('en-US') : balance.toLocaleString('en-US', { style: 'currency', currency: 'USD' })}`)
+  }
+  // Uncapped on purpose, so a bar-less card does not read as a failed fetch.
+  if (!credits && data.credits?.unlimited === true) footerLines.push('Credits · Unlimited')
+  return {
+    provider: 'codex', connection: 'connected', primary: primary ?? credits, details,
+    planLabel: planLabel(data.plan_type),
+    footerLines,
+  }
+}
+
+async function refresh(auth: AuthDoc, deps: CodexDeps, signal?: AbortSignal): Promise<AuthDoc | null> {
+  const refreshToken = auth.tokens?.refresh_token
+  if (!refreshToken) return null
+  const response = await deps.fetch(TOKEN_ENDPOINT, {
+    method: 'POST', signal: quotaRequestSignal(signal),
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ client_id: CLIENT_ID, grant_type: 'refresh_token', refresh_token: refreshToken, scope: 'openid profile email' }),
+  })
+  if (!response.ok) return null
+  const next = await response.json() as Record<string, unknown>
+  if (typeof next.access_token !== 'string' || !next.access_token) return null
+  const latest = await readAuth(deps)
+  if (!latest || latest.auth_mode !== 'chatgpt') return null
+  latest.tokens = {
+    ...latest.tokens,
+    access_token: next.access_token,
+    ...(typeof next.refresh_token === 'string' ? { refresh_token: next.refresh_token } : {}),
+    ...(typeof next.id_token === 'string' ? { id_token: next.id_token } : {}),
+  }
+  latest.last_refresh = new Date(deps.now()).toISOString()
+  await deps.writeFile(deps.authPath, `${JSON.stringify(latest, null, 2)}\n`)
+  return latest
+}
+
+async function usage(auth: AuthDoc, deps: CodexDeps, signal?: AbortSignal): Promise<Response | null> {
+  const token = auth.tokens?.access_token
+  if (!token) return null
+  const headers: Record<string, string> = { Authorization: `Bearer ${token}`, Accept: 'application/json', 'User-Agent': 'CodeBurn' }
+  if (auth.tokens?.account_id) headers['ChatGPT-Account-Id'] = auth.tokens.account_id
+  return deps.fetch(USAGE_ENDPOINT, { method: 'GET', headers, signal: quotaRequestSignal(signal) })
+}
+
+export type CodexResult = { quota: QuotaProvider; retryAfterSeconds?: number }
+
+export async function fetchCodexQuota(options: Partial<CodexDeps> & { signal?: AbortSignal; allowKeychain?: boolean } = {}): Promise<CodexResult> {
+  const deps = { ...defaults, ...options }
+  try {
+    const discovered = await discoverSource(deps, Boolean(options.allowKeychain))
+    if (discovered === 'accessDenied') return { quota: empty('accessDenied') }
+    if (!discovered) return { quota: empty('disconnected') }
+    const source = discovered
+    let auth = source.auth
+    if (auth.auth_mode !== 'chatgpt') return { quota: empty('terminalFailure') }
+    if (!auth.tokens?.access_token) return { quota: empty('disconnected') }
+
+    // Proactive staleness refresh only for the source whose rotation we own.
+    if (source.writable) {
+      const refreshedAt = typeof auth.last_refresh === 'string' ? Date.parse(auth.last_refresh) : NaN
+      if (!Number.isFinite(refreshedAt) || deps.now() - refreshedAt > EIGHT_DAYS) {
+        const next = await refresh(auth, deps, options.signal)
+        if (next) auth = next
+      }
+    }
+    let response = await usage(auth, deps, options.signal)
+    if (!response) return { quota: empty('disconnected') }
+    if (response.status === 401) {
+      const reread = await source.reread()
+      if (reread?.tokens?.access_token && reread.tokens.access_token !== auth.tokens?.access_token) {
+        auth = reread
+      } else if (source.writable) {
+        const next = await refresh(reread ?? auth, deps, options.signal)
+        if (!next) return { quota: empty('transientFailure') }
+        auth = next
+      } else {
+        // Read-only source: the owner (menubar) rotates tokens on its own
+        // cadence, so re-read once and otherwise wait for the next poll.
+        return { quota: empty('transientFailure') }
+      }
+      response = await usage(auth, deps, options.signal)
+      if (!response) return { quota: empty('transientFailure') }
+    }
+    if (response.status === 429) {
+      const raw = response.headers.get('Retry-After')
+      let seconds = raw === null ? NaN : Number(raw)
+      if (!Number.isFinite(seconds) && raw) seconds = (Date.parse(raw) - deps.now()) / 1000
+      return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(seconds) ? Math.ceil(seconds) : 300, 60) }
+    }
+    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure') }
+    return { quota: decodeCodexUsage(await response.json()) }
+  } catch (error) {
+    console.warn(`Codex quota unavailable: ${sanitizeError(error)}`)
+    return { quota: empty('transientFailure') }
+  }
+}

--- a/src/quota/copilot.ts
+++ b/src/quota/copilot.ts
@@ -1,0 +1,145 @@
+// Live GitHub Copilot quota via the editor plugins' internal usage endpoint.
+//
+// - GET https://api.github.com/copilot_internal/user
+//     Headers mirror observed GitHub Copilot client traffic (Editor-Version /
+//     Editor-Plugin-Version / X-Github-Api-Version). This is an INTERNAL, UNDOCUMENTED
+//     API that may drift without notice; every failure must degrade to the
+//     normal connection states and never crash the panel.
+//
+// Credential: the GitHub OAuth token already on disk from a signed-in Copilot
+// plugin - ~/.config/github-copilot/hosts.json (keyed by host) falling back to
+// apps.json (keyed by app name). Read-only; no new storage.
+import os from 'node:os'
+import path from 'node:path'
+
+import { fraction, quotaRequestSignal, readSecureFile, sanitizeError } from './security.js'
+import type { QuotaProvider, QuotaWindow } from './types.js'
+
+const USAGE_ENDPOINT = 'https://api.github.com/copilot_internal/user'
+const HEADERS = {
+  Accept: 'application/json',
+  'Editor-Version': 'vscode/1.96.2',
+  'Editor-Plugin-Version': 'copilot-chat/0.26.7',
+  'User-Agent': 'GitHubCopilotChat/0.26.7',
+  'X-Github-Api-Version': '2025-04-01',
+} as const
+
+type HostRecord = Record<string, any> & { oauth_token?: unknown }
+
+export type CopilotDeps = {
+  fetch: typeof fetch
+  hostsPath: string
+  appsPath: string
+  readFile: typeof readSecureFile
+}
+
+const defaults: CopilotDeps = {
+  fetch: globalThis.fetch,
+  hostsPath: path.join(os.homedir(), '.config', 'github-copilot', 'hosts.json'),
+  appsPath: path.join(os.homedir(), '.config', 'github-copilot', 'apps.json'),
+  readFile: readSecureFile,
+}
+
+function empty(connection: QuotaProvider['connection']): QuotaProvider {
+  return { provider: 'copilot', connection, primary: null, details: [], planLabel: null, footerLines: [] }
+}
+
+function tokenFromMap(raw: string): string | null {
+  const map = JSON.parse(raw) as Record<string, HostRecord>
+  // hosts.json keys by host - prefer github.com; apps.json has no canonical
+  // key, so its first entry wins. Both store the token as `oauth_token`.
+  const preferred = map['github.com'] ?? Object.values(map)[0]
+  const token = preferred?.oauth_token
+  return typeof token === 'string' && token ? token : null
+}
+
+async function credentialFromFiles(deps: CopilotDeps): Promise<string | null> {
+  for (const filePath of [deps.hostsPath, deps.appsPath]) {
+    try {
+      const raw = await deps.readFile(filePath, 64 * 1024)
+      if (!raw) continue
+      const token = tokenFromMap(raw)
+      if (token) return token
+    } catch {
+      // A malformed or unreadable file falls through to the next candidate.
+    }
+  }
+  return null
+}
+
+function windowOf(label: string, snapshot: unknown): QuotaWindow | null {
+  if (!snapshot || typeof snapshot !== 'object') return null
+  const row = snapshot as Record<string, unknown>
+  // The API reports percent REMAINING (0..100); windows render percent USED.
+  const rawRemaining = row.percent_remaining ?? row.percentRemaining
+  const remaining = fraction(typeof rawRemaining === 'number' ? rawRemaining : NaN)
+  if (remaining === null) return null
+  // A plan without this quota reports entitlement 0 and 0% remaining, which
+  // would render as 100% used; unlimited windows have no meaningful percent.
+  if (row.entitlement === 0 || row.unlimited === true) return null
+  // Round away float dust from the 1-remaining subtraction (1-0.7 !== 0.3).
+  return { label, percent: Number((1 - remaining).toFixed(6)), resetsAt: null }
+}
+
+function planLabel(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null
+  const lower = value.trim().toLowerCase()
+  const known: Record<string, string> = {
+    free: 'Free', individual: 'Individual', pro: 'Pro', business: 'Business',
+    enterprise: 'Enterprise', for_educators: 'Educators', 'for-educators': 'Educators',
+  }
+  return known[lower] ?? lower.replace(/(^|[_-])\w/g, match => match.replace(/[_-]/, ' ').toUpperCase())
+}
+
+export function decodeCopilotUsage(body: unknown): QuotaProvider {
+  const data = body && typeof body === 'object' ? body as Record<string, any> : {}
+  // Field names have shipped both camelCase and snake_case; read each alias
+  // rather than trusting one spelling.
+  const snapshots = data.quota_snapshots ?? data.quotaSnapshots
+  const premium = windowOf('Premium requests', snapshots?.premium_interactions ?? snapshots?.premiumInteractions)
+  const chat = windowOf('Chat', snapshots?.chat)
+  const details = [premium, chat].filter((row): row is QuotaWindow => row !== null)
+  return {
+    provider: 'copilot', connection: 'connected', primary: premium ?? chat,
+    details,
+    planLabel: planLabel(data.copilot_plan ?? data.copilotPlan),
+    footerLines: [],
+  }
+}
+
+async function request(token: string, deps: CopilotDeps, parent?: AbortSignal): Promise<Response> {
+  return deps.fetch(USAGE_ENDPOINT, {
+    method: 'GET', signal: quotaRequestSignal(parent),
+    headers: { ...HEADERS, Authorization: `token ${token}` },
+  })
+}
+
+export type CopilotResult = { quota: QuotaProvider; retryAfterSeconds?: number }
+
+export async function fetchCopilotQuota(options: Partial<CopilotDeps> & { signal?: AbortSignal } = {}): Promise<CopilotResult> {
+  const deps = { ...defaults, ...options }
+  try {
+    let token = await credentialFromFiles(deps)
+    if (!token) return { quota: empty('disconnected') }
+
+    let response = await request(token, deps, options.signal)
+    if (response.status === 401) {
+      // An active editor session rotates this token; re-read once before
+      // giving up so we don't report a failure the disk already fixed.
+      const reread = await credentialFromFiles(deps)
+      if (!reread || reread === token) return { quota: empty('transientFailure') }
+      token = reread
+      response = await request(token, deps, options.signal)
+    }
+    if (response.status === 429) {
+      const raw = response.headers.get('Retry-After')
+      const seconds = raw === null ? NaN : Number(raw)
+      return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(seconds) ? Math.ceil(seconds) : 300, 60) }
+    }
+    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure') }
+    return { quota: decodeCopilotUsage(await response.json()) }
+  } catch (error) {
+    console.warn(`Copilot quota unavailable: ${sanitizeError(error)}`)
+    return { quota: empty('transientFailure') }
+  }
+}

--- a/src/quota/gemini.ts
+++ b/src/quota/gemini.ts
@@ -1,0 +1,206 @@
+// Live Gemini quota via the OAuth-backed Code Assist APIs the Gemini CLI
+// itself calls, derived from the Google Code Assist client flow and the CLI's
+// own traffic:
+//
+// - POST https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist
+//     body { metadata: { ideType: 'GEMINI_CLI', pluginType: 'GEMINI' } }
+//     → tier (plan label), cloudaicompanionProject (quota project)
+// - POST https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota
+//     body { project } (or {} when unknown) → per-model quota buckets
+// - POST https://oauth2.googleapis.com/token (only when the stored token is
+//     stale and GEMINI_OAUTH_CLIENT_ID/GEMINI_OAUTH_CLIENT_SECRET are set;
+//     the refreshed token stays in memory - the Gemini CLI owns its file)
+//
+// Credential: the Gemini CLI's own ~/.gemini/oauth_creds.json, read-only.
+import os from 'node:os'
+import path from 'node:path'
+
+import { fraction, quotaRequestSignal, readSecureFile, sanitizeError } from './security.js'
+import type { QuotaProvider, QuotaWindow } from './types.js'
+
+const CODE_ASSIST_ENDPOINT = 'https://cloudcode-pa.googleapis.com/v1internal'
+const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token'
+
+type GeminiCredential = {
+  access_token?: string
+  refresh_token?: string
+  id_token?: string
+  expiry_date?: number
+}
+
+export type GeminiDeps = {
+  fetch: typeof fetch
+  credentialPath: string
+  readFile: typeof readSecureFile
+  now: () => number
+}
+
+const defaults: GeminiDeps = {
+  fetch: globalThis.fetch,
+  credentialPath: path.join(os.homedir(), '.gemini', 'oauth_creds.json'),
+  readFile: readSecureFile,
+  now: Date.now,
+}
+
+function empty(connection: QuotaProvider['connection'], footerLines: string[] = []): QuotaProvider {
+  return { provider: 'gemini', connection, primary: null, details: [], planLabel: null, footerLines }
+}
+
+function parseCredential(raw: string): GeminiCredential | null {
+  const parsed = JSON.parse(raw) as GeminiCredential
+  if (!parsed || typeof parsed.access_token !== 'string' || parsed.access_token.length === 0) return null
+  return parsed
+}
+
+async function credentialFromFile(deps: GeminiDeps): Promise<GeminiCredential | null> {
+  const raw = await deps.readFile(deps.credentialPath, 64 * 1024)
+  return raw ? parseCredential(raw) : null
+}
+
+// Client credentials live inside the installed Gemini CLI bundle; scanning the
+// install is out of scope here, so only the CLI's documented env overrides are
+// honored. Without them an expired token is used as-is and a 401 degrades.
+function clientCredentials(): { clientId: string; clientSecret: string } | null {
+  const clientId = process.env['GEMINI_OAUTH_CLIENT_ID']
+  const clientSecret = process.env['GEMINI_OAUTH_CLIENT_SECRET']
+  return clientId && clientSecret ? { clientId, clientSecret } : null
+}
+
+async function refresh(credential: GeminiCredential, deps: GeminiDeps, signal?: AbortSignal): Promise<string | null> {
+  const client = clientCredentials()
+  const refreshToken = credential.refresh_token
+  if (!client || !refreshToken) return null
+  const body = new URLSearchParams({
+    client_id: client.clientId,
+    client_secret: client.clientSecret,
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token',
+  })
+  const response = await deps.fetch(TOKEN_ENDPOINT, { method: 'POST', signal: quotaRequestSignal(signal), body })
+  if (!response.ok) return null
+  const next = await response.json() as Record<string, unknown>
+  return typeof next.access_token === 'string' && next.access_token ? next.access_token : null
+}
+
+// The `hd` claim (hosted domain) separates Google Workspace logins from
+// personal ones, matching the provider's tier labels.
+function workspaceClaim(idToken: string | undefined): boolean {
+  if (!idToken) return false
+  const [, payload] = idToken.split('.')
+  if (!payload) return false
+  try {
+    const json = JSON.parse(Buffer.from(payload.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8')) as Record<string, unknown>
+    return typeof json.hd === 'string' && json.hd.length > 0
+  } catch {
+    return false
+  }
+}
+
+function tierLabel(body: Record<string, any>, credential: GeminiCredential): string | null {
+  // paidTier wins whenever present; otherwise whatever tier the account sits on.
+  const raw = body.paidTier?.name ?? body.currentTier?.name ?? body.currentTier?.id
+  if (typeof raw !== 'string' || !raw.trim()) return null
+  const lower = raw.trim().toLowerCase()
+  if (lower === 'standard-tier') return 'Paid'
+  if (lower === 'legacy-tier') return 'Legacy'
+  if (lower.includes('free') && workspaceClaim(credential.id_token)) return 'Workspace'
+  if (lower.includes('free')) return 'Free'
+  return raw.trim()
+}
+
+function windowOf(bucket: Record<string, unknown>): QuotaWindow | null {
+  const modelId = bucket.modelId
+  const remaining = fraction(typeof bucket.remainingFraction === 'number' ? bucket.remainingFraction * 100 : NaN)
+  if (typeof modelId !== 'string' || !modelId || remaining === null) return null
+  const resetTime = bucket.resetTime
+  const resetsAt = typeof resetTime === 'string' && !Number.isNaN(Date.parse(resetTime))
+    ? new Date(resetTime).toISOString() : null
+  return { label: modelId, percent: 1 - remaining, resetsAt }
+}
+
+export function decodeGeminiUsage(body: unknown): QuotaProvider {
+  const data = body && typeof body === 'object' ? body as Record<string, unknown> : {}
+  const buckets = Array.isArray(data.buckets) ? data.buckets : []
+  const details = buckets
+    .filter((bucket): bucket is Record<string, unknown> => Boolean(bucket) && typeof bucket === 'object')
+    .map(windowOf)
+    .filter((window): window is QuotaWindow => window !== null)
+    .sort((a, b) => b.percent - a.percent)
+  return {
+    provider: 'gemini', connection: 'connected',
+    primary: details[0] ?? null,
+    details,
+    planLabel: null,
+    footerLines: [],
+  }
+}
+
+async function post(token: string, path: string, payload: Record<string, unknown>, deps: GeminiDeps, parent?: AbortSignal): Promise<Response> {
+  return deps.fetch(`${CODE_ASSIST_ENDPOINT}:${path}`, {
+    method: 'POST', signal: quotaRequestSignal(parent),
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': 'CodeBurn' },
+    body: JSON.stringify(payload),
+  })
+}
+
+// Google flags retired consumer tiers (June 2026 shutdown of individual/AI
+// Pro/Ultra OAuth access) with these sentinels instead of ordinary errors.
+function migrationFooter(body: unknown): string[] {
+  const error = body && typeof body === 'object' ? (body as Record<string, any>).error : null
+  const status = typeof error?.status === 'string' ? error.status : ''
+  const message = typeof error?.message === 'string' ? error.message : ''
+  const deprecated = status === 'UNSUPPORTED_CLIENT' || message.includes('IneligibleTierError')
+  return deprecated ? ['Google retired Gemini CLI OAuth for this account tier. Use Antigravity.'] : []
+}
+
+export type GeminiResult = { quota: QuotaProvider; retryAfterSeconds?: number }
+
+export async function fetchGeminiQuota(options: Partial<GeminiDeps> & { signal?: AbortSignal } = {}): Promise<GeminiResult> {
+  const deps = { ...defaults, ...options }
+  try {
+    let credential = await credentialFromFile(deps)
+    if (!credential) return { quota: empty('disconnected') }
+
+    if ((credential.expiry_date ?? Infinity) - deps.now() <= 5 * 60_000) {
+      const accessToken = await refresh(credential, deps, options.signal)
+      if (accessToken) credential = { ...credential, access_token: accessToken }
+    }
+    const token = credential.access_token!
+    let response = await post(token, 'loadCodeAssist', { metadata: { ideType: 'GEMINI_CLI', pluginType: 'GEMINI' } }, deps, options.signal)
+    if (response.status === 401) {
+      const reread = await credentialFromFile(deps)
+      if (!reread || reread.access_token === credential.access_token) return { quota: empty('transientFailure') }
+      credential = reread
+      response = await post(credential.access_token!, 'loadCodeAssist', { metadata: { ideType: 'GEMINI_CLI', pluginType: 'GEMINI' } }, deps, options.signal)
+    }
+    if (response.status === 429) {
+      const raw = response.headers.get('Retry-After')
+      const seconds = raw === null ? NaN : Number(raw)
+      return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(seconds) ? Math.ceil(seconds) : 300, 60) }
+    }
+    // Retired-tier sentinels ride inside the JSON error body of a non-200
+    // response, so parse before branching on status.
+    const assist = await response.json().catch(() => ({})) as Record<string, any>
+    const migration = migrationFooter(assist)
+    if (migration.length > 0) return { quota: empty('terminalFailure', migration) }
+    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure') }
+
+    const project = typeof assist.cloudaicompanionProject === 'string' && assist.cloudaicompanionProject
+      ? assist.cloudaicompanionProject : undefined
+    const quotaResponse = await post(credential.access_token!, 'retrieveUserQuota', project ? { project } : {}, deps, options.signal)
+    if (quotaResponse.status === 429) {
+      const raw = quotaResponse.headers.get('Retry-After')
+      const seconds = raw === null ? NaN : Number(raw)
+      return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(seconds) ? Math.ceil(seconds) : 300, 60) }
+    }
+    if (!quotaResponse.ok) {
+      return { quota: empty(quotaResponse.status >= 400 && quotaResponse.status < 500 ? 'terminalFailure' : 'transientFailure') }
+    }
+    const quota = decodeGeminiUsage(await quotaResponse.json())
+    quota.planLabel = tierLabel(assist, credential)
+    return { quota }
+  } catch (error) {
+    console.warn(`Gemini quota unavailable: ${sanitizeError(error)}`)
+    return { quota: empty('transientFailure') }
+  }
+}

--- a/src/quota/index.ts
+++ b/src/quota/index.ts
@@ -1,0 +1,122 @@
+// Provider capacity readers for `codeburn quota`.
+//
+// These adapters were ported from the Electron desktop app's copies under
+// `app/electron/quota/*.ts`, which remain the origin and are still what the
+// desktop app runs. They are deliberately left untouched by this change; the
+// two trees will be deduped in a follow-up once every surface reads the CLI.
+
+import { renderTable } from '../text-table.js'
+import { fetchAntigravityQuota } from './antigravity.js'
+import { fetchClaudeQuota } from './claude.js'
+import { fetchCodexQuota } from './codex.js'
+import { fetchCopilotQuota } from './copilot.js'
+import { fetchGeminiQuota } from './gemini.js'
+import { fetchKimiQuota } from './kimi.js'
+import type { ProviderName, QuotaProvider } from './types.js'
+
+export type QuotaCommandWindow = { label: string; usedPct: number; resetsAt?: string }
+
+export type QuotaCommandProvider = {
+  id: ProviderName
+  name: string
+  available: boolean
+  plan?: string
+  windows: QuotaCommandWindow[]
+  error?: string
+}
+
+export type QuotaReport = { providers: QuotaCommandProvider[] }
+
+export type ProviderReader = (signal: AbortSignal) => Promise<QuotaProvider>
+
+const READERS: { id: ProviderName; name: string; read: ProviderReader }[] = [
+  { id: 'claude', name: 'Claude', read: async signal => (await fetchClaudeQuota({ signal, allowKeychain: true })).quota },
+  // No keychain for Codex: it would prefer the menubar's read-only cached token
+  // over `~/.codex/auth.json`, which this process may refresh and write back.
+  { id: 'codex', name: 'Codex', read: async signal => (await fetchCodexQuota({ signal })).quota },
+  { id: 'gemini', name: 'Gemini', read: async signal => (await fetchGeminiQuota({ signal })).quota },
+  { id: 'copilot', name: 'GitHub Copilot', read: async signal => (await fetchCopilotQuota({ signal })).quota },
+  { id: 'antigravity', name: 'Antigravity', read: () => fetchAntigravityQuota() },
+  { id: 'kimi', name: 'Kimi', read: async signal => (await fetchKimiQuota({ signal })).quota },
+]
+
+const DEFAULT_TIMEOUT_MS = 5_000
+
+function errorFor(quota: QuotaProvider): string | undefined {
+  switch (quota.connection) {
+    case 'accessDenied':
+      return quota.footerLines[0] ?? 'Access to the stored credential was denied.'
+    case 'terminalFailure':
+      return quota.footerLines[0] ?? 'The provider rejected the request.'
+    case 'transientFailure':
+      return quota.footerLines[0] ?? 'Temporarily unavailable.'
+    default:
+      return undefined
+  }
+}
+
+function toWindows(quota: QuotaProvider): QuotaCommandWindow[] {
+  const rows = quota.details.length > 0 ? quota.details : quota.primary ? [quota.primary] : []
+  return rows.map(row => ({
+    label: row.label,
+    usedPct: Math.round(row.percent * 1000) / 10,
+    ...(row.resetsAt ? { resetsAt: row.resetsAt } : {}),
+  }))
+}
+
+export function toCommandProvider(id: ProviderName, name: string, quota: QuotaProvider): QuotaCommandProvider {
+  const error = errorFor(quota)
+  return {
+    id,
+    name,
+    available: quota.connection === 'connected',
+    ...(quota.planLabel ? { plan: quota.planLabel } : {}),
+    windows: toWindows(quota),
+    ...(error ? { error } : {}),
+  }
+}
+
+export async function collectQuota(options: {
+  readers?: { id: ProviderName; name: string; read: ProviderReader }[]
+  timeoutMs?: number
+} = {}): Promise<QuotaReport> {
+  const readers = options.readers ?? READERS
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const providers = await Promise.all(readers.map(async entry => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    const timedOut = new Promise<'timeout'>(resolve => { controller.signal.addEventListener('abort', () => resolve('timeout')) })
+    try {
+      const quota = await Promise.race([entry.read(controller.signal), timedOut])
+      if (quota === 'timeout') {
+        return { id: entry.id, name: entry.name, available: false, windows: [], error: 'Timed out.' }
+      }
+      return toCommandProvider(entry.id, entry.name, quota)
+    } finally {
+      clearTimeout(timer)
+    }
+  }))
+  return { providers }
+}
+
+function resetLabel(iso: string | undefined): string {
+  if (!iso) return ''
+  const at = new Date(iso)
+  return Number.isNaN(at.getTime()) ? '' : at.toLocaleString()
+}
+
+export function renderQuotaTable(report: QuotaReport, opts: { color?: boolean } = {}): string {
+  const rows: string[][] = []
+  for (const provider of report.providers) {
+    const title = provider.plan ? `${provider.name} (${provider.plan})` : provider.name
+    if (provider.windows.length === 0) {
+      rows.push([title, provider.error ?? 'Not connected', '', ''])
+      continue
+    }
+    provider.windows.forEach((window, index) => {
+      rows.push([index === 0 ? title : '', window.label, `${window.usedPct}%`, resetLabel(window.resetsAt)])
+    })
+  }
+  const columns = [{ header: 'Provider' }, { header: 'Window' }, { header: 'Used', right: true }, { header: 'Resets' }]
+  return renderTable(columns, rows, { color: opts.color })
+}

--- a/src/quota/kimi.ts
+++ b/src/quota/kimi.ts
@@ -1,0 +1,184 @@
+// Live Kimi Code quota via the CLI's own usage endpoint (ported from the
+// menubar's KimiSubscriptionService.swift):
+//
+// - GET https://api.kimi.com/coding/v1/usages
+//     Headers mirror observed Kimi Code client responses (X-Msh-Platform /
+//     X-Msh-Device-Id). Numeric fields have shipped as both JSON numbers and
+//     strings, and the reset stamp under several spellings, so decode leniently.
+//
+// Credential: the Kimi CLI's own ~/.kimi-code/credentials/kimi-code.json,
+// read-only. Access tokens live ~15 minutes and ONLY the Kimi CLI refreshes
+// them - we never refresh and never write, so an expired or rejected token is a
+// terminal state whose footer tells the user to run the Kimi CLI once.
+import os from 'node:os'
+import path from 'node:path'
+
+import { fraction, quotaRequestSignal, readSecureFile, sanitizeError } from './security.js'
+import type { QuotaProvider, QuotaWindow } from './types.js'
+
+const USAGE_ENDPOINT = 'https://api.kimi.com/coding/v1/usages'
+const EXPIRED_FOOTER = ['Login expired. Run the Kimi CLI once, then refresh.']
+
+const kimiHome = process.env['KIMI_CODE_HOME'] ?? path.join(os.homedir(), '.kimi-code')
+
+export type KimiDeps = {
+  fetch: typeof fetch
+  credentialPath: string
+  deviceIdPath: string
+  readFile: typeof readSecureFile
+  now: () => number
+}
+
+const defaults: KimiDeps = {
+  fetch: globalThis.fetch,
+  credentialPath: path.join(kimiHome, 'credentials', 'kimi-code.json'),
+  deviceIdPath: path.join(kimiHome, 'device_id'),
+  readFile: readSecureFile,
+  now: Date.now,
+}
+
+function empty(connection: QuotaProvider['connection'], footerLines: string[] = []): QuotaProvider {
+  return { provider: 'kimi', connection, primary: null, details: [], planLabel: null, footerLines }
+}
+
+function num(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+/** `null` = no usable credential; `'expired'` = present but past its life. */
+async function freshToken(deps: KimiDeps): Promise<string | null | 'expired'> {
+  const raw = await deps.readFile(deps.credentialPath, 64 * 1024)
+  if (!raw) return null
+  const parsed = JSON.parse(raw) as Record<string, unknown>
+  const token = parsed.access_token
+  if (typeof token !== 'string' || !token) return null
+  const expiresAt = num(parsed.expires_at)
+  // 60s skew, matching the menubar: a token about to die is already useless.
+  if (expiresAt === null || expiresAt <= deps.now() / 1000 + 60) return 'expired'
+  return token
+}
+
+async function deviceId(deps: KimiDeps): Promise<string | null> {
+  try {
+    const raw = await deps.readFile(deps.deviceIdPath, 4 * 1024)
+    return raw?.trim() || null
+  } catch {
+    return null
+  }
+}
+
+/** Reset stamps arrive as ISO-8601 or as epoch seconds (string or number). */
+function resetsAt(value: unknown): string | null {
+  const raw = typeof value === 'number' ? String(value) : typeof value === 'string' ? value.trim() : null
+  if (!raw) return null
+  // Bare digits are epoch seconds; Date.parse would misread them as a year.
+  if (/^\d+(\.\d+)?$/.test(raw)) return new Date(Number(raw) * 1000).toISOString()
+  const iso = Date.parse(raw)
+  return Number.isFinite(iso) ? new Date(iso).toISOString() : null
+}
+
+function windowOf(label: string, detail: unknown): QuotaWindow | null {
+  if (!detail || typeof detail !== 'object') return null
+  const row = detail as Record<string, unknown>
+  const limit = num(row.limit)
+  if (limit === null || limit <= 0) return null
+  const remaining = num(row.remaining)
+  // Rate-limit windows report only limit + remaining - derive used.
+  const used = num(row.used) ?? Math.max(0, limit - (remaining ?? limit))
+  return {
+    label,
+    // Over-limit usage clamps to 100% rather than overflowing the bar.
+    percent: fraction(used / limit * 100)!,
+    resetsAt: resetsAt(row.resetTime ?? row.resetAt ?? row.reset_time ?? row.reset_at),
+  }
+}
+
+/** Window size → human label. The API sends enum-style units
+ *  ("TIME_UNIT_MINUTE", duration 300) as well as plain ones ("hour"), so
+ *  normalize first; exact sub-day durations roll up (300 minutes → 5-hour). */
+function windowLabel(duration: unknown, timeUnit: unknown): string {
+  let value = num(duration)
+  if (value === null || typeof timeUnit !== 'string' || !timeUnit) return 'Rate Limit'
+  let unit = timeUnit.toLowerCase().replace(/^time_unit_/, '').replace(/s$/, '')
+  if (unit === 'minute' && value >= 60 && value % 60 === 0) { value /= 60; unit = 'hour' }
+  const count = Math.trunc(value)
+  switch (unit) {
+    case 'minute': return count === 1 ? 'Minutely' : `${count}-min`
+    case 'hour': return count === 1 ? 'Hourly' : `${count}-hour`
+    case 'day': return count === 1 ? 'Daily' : count === 7 ? 'Weekly' : `${count}-day`
+    case 'week': return count === 1 ? 'Weekly' : `${count}-week`
+    case 'month': return count === 1 ? 'Monthly' : `${count}-month`
+    default: return `${count} ${unit}`
+  }
+}
+
+/** "LEVEL_INTERMEDIATE" → "Intermediate"; unknown/missing → null so the UI
+ *  falls back to the plain "Kimi Code" title. */
+function planLabel(level: unknown): string | null {
+  if (typeof level !== 'string' || !level.trim()) return null
+  return level.trim().replace(/^LEVEL_/i, '').replace(/_/g, ' ').toLowerCase()
+    .replace(/(^|\s)\w/g, match => match.toUpperCase())
+}
+
+/** `null` when the payload carries no usable window at all. */
+export function decodeKimiUsage(body: unknown): QuotaProvider | null {
+  const data = body && typeof body === 'object' ? body as Record<string, any> : {}
+  // The top-level usage envelope is the account's weekly quota (its reset lands
+  // ~7 days out), so label it the way the menubar does.
+  const primary = windowOf('Weekly', data.usage)
+  const rest = (Array.isArray(data.limits) ? data.limits : [])
+    .map((limit: any) => windowOf(windowLabel(limit?.window?.duration, limit?.window?.timeUnit), limit?.detail))
+    .filter((window: QuotaWindow | null): window is QuotaWindow => window !== null)
+  const details = primary ? [primary, ...rest] : rest
+  if (details.length === 0) return null
+  const parallel = num(data.parallel?.limit)
+  return {
+    provider: 'kimi', connection: 'connected',
+    primary: primary ?? details[0]!,
+    details,
+    planLabel: planLabel(data.user?.membership?.level),
+    footerLines: parallel !== null && parallel > 0 ? [`Parallel sessions: ${Math.trunc(parallel)}`] : [],
+  }
+}
+
+export type KimiResult = { quota: QuotaProvider; retryAfterSeconds?: number }
+
+export async function fetchKimiQuota(options: Partial<KimiDeps> & { signal?: AbortSignal } = {}): Promise<KimiResult> {
+  const deps = { ...defaults, ...options }
+  try {
+    const token = await freshToken(deps)
+    if (token === null) return { quota: empty('disconnected') }
+    if (token === 'expired') return { quota: empty('terminalFailure', EXPIRED_FOOTER) }
+
+    const device = await deviceId(deps)
+    const response = await deps.fetch(USAGE_ENDPOINT, {
+      method: 'GET', signal: quotaRequestSignal(options.signal),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        'User-Agent': 'CodeBurn',
+        'X-Msh-Platform': 'kimi_code_cli',
+        ...(device ? { 'X-Msh-Device-Id': device } : {}),
+      },
+    })
+    // We never self-refresh, so a rejected token is terminal until the CLI runs.
+    if (response.status === 401 || response.status === 403) return { quota: empty('terminalFailure', EXPIRED_FOOTER) }
+    if (response.status === 429) {
+      const raw = response.headers.get('Retry-After')
+      const seconds = raw === null ? NaN : Number(raw)
+      return { quota: empty('transientFailure'), retryAfterSeconds: Math.max(Number.isFinite(seconds) ? Math.ceil(seconds) : 300, 60) }
+    }
+    if (!response.ok) return { quota: empty(response.status >= 400 && response.status < 500 ? 'terminalFailure' : 'transientFailure') }
+    // Never log the body - it carries account data.
+    const quota = decodeKimiUsage(await response.json())
+    return { quota: quota ?? empty('transientFailure') }
+  } catch (error) {
+    console.warn(`Kimi quota unavailable: ${sanitizeError(error)}`)
+    return { quota: empty('transientFailure') }
+  }
+}

--- a/src/quota/security.ts
+++ b/src/quota/security.ts
@@ -1,0 +1,156 @@
+import { execFile } from 'node:child_process'
+import { constants, type Stats } from 'node:fs'
+import { chmod, lstat, mkdir, open, rename, unlink } from 'node:fs/promises'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const NOFOLLOW = constants.O_NOFOLLOW ?? 0
+const execFileAsync = promisify(execFile)
+
+// The macOS keychain prompt (first read of an item `security` is not yet trusted
+// for) blocks until the user answers. Give them time to click Allow before we
+// give up - the old 10s kill fired while the dialog was still open and got
+// misread as "disconnected".
+const KEYCHAIN_TIMEOUT_MS = 90_000
+
+/** Outcome of a keychain lookup. `accessDenied` means the item exists but macOS
+ * needs the user to grant access (dialog dismissed, denied, or not answered). */
+export type KeychainOutcome =
+  | { status: 'found'; value: string }
+  | { status: 'notFound' }
+  | { status: 'accessDenied' }
+
+export type KeychainExec = (
+  file: string,
+  args: string[],
+  options: { timeout: number; maxBuffer: number },
+) => Promise<{ stdout: string }>
+
+// `security -w` hex-encodes password data it can't hand back as a clean C-string
+// (Claude Code line-wraps its JSON blob, which triggers this). Real credential
+// JSON always contains non-hex characters like '{' and '"', so an all-hex,
+// even-length payload is unambiguously a hex dump we must decode.
+function decodeKeychainValue(raw: string): string {
+  const trimmed = raw.trim()
+  if (trimmed.length >= 2 && trimmed.length % 2 === 0 && /^[0-9a-fA-F]+$/.test(trimmed)) {
+    return Buffer.from(trimmed, 'hex').toString('utf8')
+  }
+  return raw
+}
+
+// exit 44 / "could not be found" is a genuine miss; anything else non-zero
+// (interaction not allowed, user canceled/denied, or a timeout kill while the
+// dialog waited) means the item is there but access wasn't granted.
+function classifyKeychainError(error: unknown): 'notFound' | 'accessDenied' {
+  const err = error as { code?: number | string; stderr?: string; message?: string }
+  const code = typeof err.code === 'number' ? err.code : undefined
+  const text = `${err.stderr ?? ''} ${err.message ?? ''}`.toLowerCase()
+  if (code === 44 || text.includes('could not be found') || text.includes('specified item could not be found')) {
+    return 'notFound'
+  }
+  return 'accessDenied'
+}
+
+/**
+ * Reads a generic-password keychain item via the Apple-signed `/usr/bin/security`
+ * (which the item's `apple-tool:` partition trusts, avoiding the partition-list
+ * prompt on already-consented items). Tries each account candidate in order
+ * (`null` = service-only). Never returns or logs the secret to any caller but
+ * the direct one.
+ */
+export async function readKeychainPassword(
+  service: string,
+  accounts: (string | null)[] = [null],
+  exec: KeychainExec = execFileAsync,
+): Promise<KeychainOutcome> {
+  if (process.platform !== 'darwin') return { status: 'notFound' }
+  let denied = false
+  for (const account of accounts) {
+    const args = ['find-generic-password', '-s', service, ...(account ? ['-a', account] : []), '-w']
+    try {
+      const { stdout } = await exec('/usr/bin/security', args, { timeout: KEYCHAIN_TIMEOUT_MS, maxBuffer: 64 * 1024 })
+      if (stdout && stdout.trim()) return { status: 'found', value: decodeKeychainValue(stdout) }
+    } catch (error) {
+      if (classifyKeychainError(error) === 'accessDenied') denied = true
+    }
+  }
+  return denied ? { status: 'accessDenied' } : { status: 'notFound' }
+}
+
+export function sanitizeError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error)
+  return raw
+    .replace(/\0/g, '')
+    .replace(/Bearer\s+[^\s,;"']+/gi, '[REDACTED]')
+    .replace(/sk-ant-[A-Za-z0-9_-]+/gi, '[REDACTED]')
+    .replace(/sk-[A-Za-z0-9_-]+/gi, '[REDACTED]')
+    // Google (ya29.) and GitHub (gho_/ghu_/ghp_) OAuth token shapes used by
+    // the Gemini/Copilot quota providers.
+    .replace(/ya29\.[A-Za-z0-9._-]+/g, '[REDACTED]')
+    .replace(/gh[opusr]_[A-Za-z0-9_]+/g, '[REDACTED]')
+    .replace(/eyJ[A-Za-z0-9._-]+/g, '[REDACTED]')
+    .slice(0, 240)
+}
+
+function assertSafeMode(stats: Stats, filePath: string): void {
+  if (!stats.isFile()) throw new Error(`Credential path is not a regular file: ${filePath}`)
+  // POSIX mode bits are meaningless for Windows ACLs, where stats.mode would
+  // otherwise reject every credential file.
+  if (process.platform !== 'win32' && (stats.mode & 0o077) !== 0) throw new Error(`Credential file permissions are too broad: ${filePath}`)
+}
+
+export async function readSecureFile(filePath: string, maxBytes = 64 * 1024): Promise<string | null> {
+  let before: Stats
+  try {
+    before = await lstat(filePath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+  if (before.isSymbolicLink()) throw new Error(`Refusing symbolic link: ${filePath}`)
+  assertSafeMode(before, filePath)
+  if (before.size > maxBytes) throw new Error(`Credential file exceeds ${maxBytes} bytes: ${filePath}`)
+
+  const handle = await open(filePath, constants.O_RDONLY | NOFOLLOW)
+  try {
+    const after = await handle.stat()
+    assertSafeMode(after, filePath)
+    if (after.dev !== before.dev || after.ino !== before.ino) throw new Error(`Credential file changed while opening: ${filePath}`)
+    if (after.size > maxBytes) throw new Error(`Credential file exceeds ${maxBytes} bytes: ${filePath}`)
+    return await handle.readFile({ encoding: 'utf8' })
+  } finally {
+    await handle.close()
+  }
+}
+
+export async function atomicWriteSecureFile(filePath: string, contents: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 })
+  const tempPath = path.join(path.dirname(filePath), `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`)
+  const handle = await open(tempPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600)
+  try {
+    await handle.writeFile(contents, 'utf8')
+    await handle.sync()
+  } catch (error) {
+    await handle.close()
+    await unlink(tempPath).catch(() => undefined)
+    throw error
+  }
+  await handle.close()
+  await chmod(tempPath, 0o600)
+  try {
+    await rename(tempPath, filePath)
+  } catch (error) {
+    await unlink(tempPath).catch(() => undefined)
+    throw error
+  }
+}
+
+export function quotaRequestSignal(parent?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(30_000)
+  return parent ? AbortSignal.any([parent, timeout]) : timeout
+}
+
+export function fraction(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  return Math.min(1, Math.max(0, value / 100))
+}

--- a/src/quota/types.ts
+++ b/src/quota/types.ts
@@ -1,0 +1,21 @@
+export type QuotaWindow = {
+  label: string
+  percent: number
+  resetsAt: string | null
+}
+
+export type QuotaProvider = {
+  provider: 'claude' | 'codex' | 'gemini' | 'copilot' | 'antigravity' | 'kimi'
+  connection: 'connected' | 'disconnected' | 'accessDenied' | 'loading' | 'stale' | 'transientFailure' | 'terminalFailure'
+  primary: QuotaWindow | null
+  details: QuotaWindow[]
+  planLabel: string | null
+  footerLines: string[]
+  /** Set when the provider is in a 429 backoff window (rate limited by the
+   *  upstream quota endpoint), so the UI can say so honestly instead of the
+   *  generic "waiting" copy. */
+  rateLimited?: boolean
+}
+
+export type ProviderName = QuotaProvider['provider']
+

--- a/tests/quota-providers.test.ts
+++ b/tests/quota-providers.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { fetchAntigravityQuota, decodeAntigravitySummary } from '../src/quota/antigravity.js'
+import { decodeClaudeUsage, fetchClaudeQuota } from '../src/quota/claude.js'
+import { decodeCodexUsage, fetchCodexQuota } from '../src/quota/codex.js'
+import { decodeCopilotUsage, fetchCopilotQuota } from '../src/quota/copilot.js'
+import { decodeGeminiUsage, fetchGeminiQuota } from '../src/quota/gemini.js'
+import { collectQuota, renderQuotaTable } from '../src/quota/index.js'
+import { decodeKimiUsage, fetchKimiQuota } from '../src/quota/kimi.js'
+import type { QuotaProvider } from '../src/quota/types.js'
+
+const noFile = vi.fn(async () => null)
+const neverFetch = () => { throw new Error('the test must not reach the network') }
+
+describe('Claude quota', () => {
+  it('decodes the five-hour and weekly windows with the credential tier', () => {
+    const quota = decodeClaudeUsage({
+      five_hour: { utilization: 25, resets_at: '2026-07-12T12:00:00Z' },
+      seven_day: { utilization: 50, resets_at: '2026-07-19T12:00:00Z' },
+    }, { accessToken: 'hidden', rateLimitTier: 'max_20x' })
+    expect(quota.connection).toBe('connected')
+    expect(quota.planLabel).toBe('Max 20x')
+    expect(quota.details.map(row => row.label)).toEqual(['5-hour', 'Weekly'])
+    expect(quota.primary).toEqual({ label: 'Weekly', percent: 0.5, resetsAt: '2026-07-19T12:00:00.000Z' })
+  })
+
+  it('reports disconnected without a credential and never fetches', async () => {
+    const result = await fetchClaudeQuota({ fetch: neverFetch as unknown as typeof fetch, readFile: noFile })
+    expect(result.quota.connection).toBe('disconnected')
+  })
+})
+
+describe('Codex quota', () => {
+  it('decodes the primary and secondary rate-limit windows with the plan label', () => {
+    const quota = decodeCodexUsage({
+      plan_type: 'enterprise_cbp_usage_based',
+      rate_limit: {
+        primary_window: { used_percent: 12, limit_window_seconds: 18_000, reset_at: 1_760_000_000 },
+        secondary_window: { used_percent: 40, limit_window_seconds: 604_800 },
+      },
+    })
+    expect(quota.planLabel).toBe('Enterprise')
+    expect(quota.details.map(row => row.label)).toEqual(['5-hour', 'Weekly'])
+    expect(quota.primary?.percent).toBe(0.12)
+    expect(quota.primary?.resetsAt).toBe('2025-10-09T08:53:20.000Z')
+  })
+
+  it('reports disconnected when no auth file exists', async () => {
+    const result = await fetchCodexQuota({
+      fetch: neverFetch as unknown as typeof fetch,
+      readFile: noFile,
+      keychain: async () => ({ status: 'notFound' }),
+    })
+    expect(result.quota.connection).toBe('disconnected')
+  })
+})
+
+describe('Copilot quota', () => {
+  it('turns remaining-percent snapshots into used windows', () => {
+    const quota = decodeCopilotUsage({
+      copilot_plan: 'individual',
+      quota_snapshots: { premium_interactions: { percent_remaining: 70 }, chat: { percent_remaining: 100 } },
+    })
+    expect(quota.planLabel).toBe('Individual')
+    expect(quota.primary).toEqual({ label: 'Premium requests', percent: 0.3, resetsAt: null })
+    expect(quota.details.map(row => row.label)).toEqual(['Premium requests', 'Chat'])
+  })
+
+  it('reports disconnected when no plugin token is on disk', async () => {
+    const result = await fetchCopilotQuota({ fetch: neverFetch as unknown as typeof fetch, readFile: noFile })
+    expect(result.quota.connection).toBe('disconnected')
+  })
+})
+
+describe('Gemini quota', () => {
+  it('decodes per-model buckets into used windows ordered by pressure', () => {
+    const quota = decodeGeminiUsage({
+      buckets: [
+        { modelId: 'gemini-2.5-flash', remainingFraction: 0.9 },
+        { modelId: 'gemini-2.5-pro', remainingFraction: 0.25, resetTime: '2026-09-02T00:00:00Z' },
+      ],
+    })
+    expect(quota.details.map(row => row.label)).toEqual(['gemini-2.5-pro', 'gemini-2.5-flash'])
+    expect(quota.primary?.percent).toBeCloseTo(0.75, 6)
+    expect(quota.primary?.resetsAt).toBe('2026-09-02T00:00:00.000Z')
+  })
+
+  it('reports disconnected without the CLI oauth credential', async () => {
+    const result = await fetchGeminiQuota({ fetch: neverFetch as unknown as typeof fetch, readFile: noFile })
+    expect(result.quota.connection).toBe('disconnected')
+  })
+})
+
+describe('Kimi quota', () => {
+  it('decodes the weekly envelope plus the rate-limit windows', () => {
+    const quota = decodeKimiUsage({
+      usage: { limit: 100, used: 30 },
+      limits: [{ window: { duration: 300, timeUnit: 'TIME_UNIT_MINUTE' }, detail: { limit: 50, remaining: 10 } }],
+      user: { membership: { level: 'LEVEL_INTERMEDIATE' } },
+      parallel: { limit: 3 },
+    })
+    expect(quota?.planLabel).toBe('Intermediate')
+    expect(quota?.details.map(row => row.label)).toEqual(['Weekly', '5-hour'])
+    expect(quota?.details.map(row => row.percent)).toEqual([0.3, 0.8])
+    expect(quota?.footerLines).toEqual(['Parallel sessions: 3'])
+  })
+
+  it('reports disconnected without the Kimi CLI credential', async () => {
+    const result = await fetchKimiQuota({ fetch: neverFetch as unknown as typeof fetch, readFile: noFile })
+    expect(result.quota.connection).toBe('disconnected')
+  })
+})
+
+describe('Antigravity quota', () => {
+  it('decodes grouped model buckets into used windows', () => {
+    const windows = decodeAntigravitySummary({
+      groups: [{ displayName: 'Weekly', buckets: [{ displayName: 'Claude Sonnet 4.5', remaining: { remainingFraction: 0.4 } }] }],
+    })
+    expect(windows).toEqual([{ label: 'Weekly · Claude Sonnet 4.5', percent: 0.6, resetsAt: null }])
+  })
+
+  it('reports disconnected when no local language server is running', async () => {
+    const quota = await fetchAntigravityQuota({
+      execFile: async () => ({ stdout: '  501 /usr/bin/unrelated --flag\n' }),
+      request: async () => { throw new Error('the test must not probe a port') },
+    })
+    expect(quota.connection).toBe('disconnected')
+  })
+})
+
+describe('quota command envelope', () => {
+  const connected: QuotaProvider = {
+    provider: 'claude', connection: 'connected', planLabel: 'Max 20x', footerLines: [],
+    primary: { label: 'Weekly', percent: 0.5, resetsAt: '2026-07-19T12:00:00.000Z' },
+    details: [
+      { label: '5-hour', percent: 0.255, resetsAt: null },
+      { label: 'Weekly', percent: 0.5, resetsAt: '2026-07-19T12:00:00.000Z' },
+    ],
+  }
+  const missing: QuotaProvider = {
+    provider: 'kimi', connection: 'disconnected', primary: null, details: [], planLabel: null, footerLines: [],
+  }
+
+  it('renders providers, windows and the omitted-error contract', async () => {
+    const report = await collectQuota({
+      readers: [
+        { id: 'claude', name: 'Claude', read: async () => connected },
+        { id: 'kimi', name: 'Kimi', read: async () => missing },
+      ],
+    })
+    expect(report).toEqual({
+      providers: [
+        {
+          id: 'claude', name: 'Claude', available: true, plan: 'Max 20x',
+          windows: [
+            { label: '5-hour', usedPct: 25.5 },
+            { label: 'Weekly', usedPct: 50, resetsAt: '2026-07-19T12:00:00.000Z' },
+          ],
+        },
+        { id: 'kimi', name: 'Kimi', available: false, windows: [] },
+      ],
+    })
+    expect(renderQuotaTable(report, { color: false })).toContain('Claude (Max 20x)')
+  })
+
+  it('gives up on a provider that outlives its timeout', async () => {
+    const report = await collectQuota({
+      timeoutMs: 5,
+      readers: [{ id: 'gemini', name: 'Gemini', read: () => new Promise<QuotaProvider>(() => {}) }],
+    })
+    expect(report.providers).toEqual([{ id: 'gemini', name: 'Gemini', available: false, windows: [], error: 'Timed out.' }])
+  })
+})


### PR DESCRIPTION
First step of Windows menubar parity.

Provider quota/capacity reading lives only inside the Electron desktop app today (TypeScript adapters under `app/electron/quota/`) and inside the macOS menubar (native Swift). Non-Mac surfaces, starting with the Windows Tauri tray, have no way to show it. This moves the reading into the CLI so every surface can consume one payload.

## What this adds

`codeburn quota` reads the six providers in parallel, each with a short timeout, and always exits 0:

- `codeburn quota` prints a table of every provider and its windows
- `codeburn quota --format json` prints the machine payload

```json
{ "providers": [ { "id", "name", "available", "plan?", "windows": [ { "label", "usedPct", "resetsAt?" } ], "error?" } ] }
```

Add-only payload, per the CLI-app contract. A provider with no credentials on the machine is reported `available: false` with no `error` field, so an absent tool never reads as a failure.

Adapters ported: Claude, Codex, Gemini, GitHub Copilot, Antigravity, Kimi, plus the shared credential-reading and keychain helpers. Read logic and credential discovery are unchanged from the Electron originals.

Two deliberate differences, both aimed at non-Mac surfaces:

- Antigravity discovery uses `ps` and `lsof`, which Windows has no equivalent of, so it reports a clean disconnected there instead of a spawn failure.
- Codex reads `~/.codex/auth.json` directly rather than preferring the macOS menubar's cached OAuth. That cache is read-only to this process and goes stale, which degraded a perfectly good on-disk credential to "temporarily unavailable".

## Electron copies untouched

`app/electron/quota/` is unchanged and is still what the desktop app runs, so this PR carries no regression risk for the desktop. The new `src/quota/index.ts` names those files as the origin. The two trees get deduped in a follow-up once the surfaces read the CLI.

## Verification

- `npx vitest run tests/quota-providers.test.ts` green (14 tests): one decode plus one unavailable path per provider, the JSON envelope shape, and the per-provider timeout. No test touches the network; fetch and file reads are injected.
- `npx vitest run tests/quota.test.ts` still green (17 tests). That file covers the unrelated `src/quota.ts` pace model, which keeps its name.
- `npx tsc --noEmit` clean.
- `node dist/main.js quota --format json` on a Mac with real credentials returns in ~0.5s, exit 0, with Claude read from the keychain and Codex from disk.