### PR TITLE
Repair provider usage and Hermes cost contracts

### DIFF
--- a/app/renderer/App.test.tsx
+++ b/app/renderer/App.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { App, overviewMemoKey, refreshedLabel, selectedReportMemoKeys, topCategoryByModel, usageSnapshotProps } from './App'
@@ -515,6 +515,34 @@ describe('App shortcuts', () => {
     expect(await screen.findByRole('option', { name: 'Claude' })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'Cursor' })).toBeInTheDocument()
     expect(screen.queryByRole('option', { name: 'Hermes' })).not.toBeInTheDocument()
+  })
+
+  it('does not carry another period provider catalog into a scoped period view', async () => {
+    const payload = overviewPayload()
+    payload.current.providerDetails = [
+      { id: 'claude', label: 'Claude', cost: 10, hasUsage: true },
+      { id: 'hermes', label: 'Hermes', cost: 5, hasUsage: true },
+    ]
+    mocks.getOverview.mockResolvedValue(payload)
+
+    render(<App />)
+    expect(await screen.findByText('Most expensive sessions')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Providers'))
+    fireEvent.click(await screen.findByRole('option', { name: 'Claude' }))
+    await waitFor(() => expect(mocks.getOverview).toHaveBeenCalledWith('30days', 'claude'))
+
+    fireEvent.click(screen.getByText('Today'))
+    await waitFor(() => expect(mocks.getOverview).toHaveBeenCalledWith('today', 'claude'))
+
+    fireEvent.click(screen.getByLabelText('Providers'))
+    expect(screen.getByRole('option', { name: 'Claude' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Hermes' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /^Sessions/ }))
+    const sessionFilters = await screen.findByRole('group', { name: 'Filter sessions by provider' })
+    expect(within(sessionFilters).getByRole('button', { name: 'Claude' })).toBeInTheDocument()
+    expect(within(sessionFilters).queryByRole('button', { name: 'Hermes' })).not.toBeInTheDocument()
   })
 
   it('hides the Claude config picker when the payload carries no claudeConfigs', async () => {

--- a/app/renderer/App.test.tsx
+++ b/app/renderer/App.test.tsx
@@ -517,6 +517,25 @@ describe('App shortcuts', () => {
     expect(screen.queryByRole('option', { name: 'Hermes' })).not.toBeInTheDocument()
   })
 
+  it('keeps zero-cost providers in the picker when the CLI omits hasUsage', async () => {
+    // Every released CLI omits the field. Falling back to cost > 0 there hid
+    // subscription-backed providers whose period spend is $0.
+    const payload = overviewPayload()
+    payload.current.providers = { claude: 10, hermes: 0 }
+    payload.current.providerDetails = [
+      { id: 'claude', label: 'Claude', cost: 10 },
+      { id: 'hermes', label: 'Hermes', cost: 0 },
+    ]
+    mocks.getOverview.mockResolvedValue(payload)
+
+    render(<App />)
+    expect(await screen.findByText('Most expensive sessions')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('All providers'))
+    expect(await screen.findByRole('option', { name: 'Claude' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Hermes' })).toBeInTheDocument()
+  })
+
   it('does not carry another period provider catalog into a scoped period view', async () => {
     const payload = overviewPayload()
     payload.current.providerDetails = [

--- a/app/renderer/App.test.tsx
+++ b/app/renderer/App.test.tsx
@@ -498,14 +498,13 @@ describe('App shortcuts', () => {
     await waitFor(() => expect(mocks.getOverview).toHaveBeenCalledWith('30days', 'grok'))
   })
 
-  it('lists a detected provider with no spend this period and sorts it last', async () => {
-    // Hermes has usage only outside the current period: the CLI still emits it
-    // as a detected provider (cost 0), so the picker must show it, at the bottom.
+  it('hides idle providers while preserving explicit zero-cost activity', async () => {
     const payload = overviewPayload()
-    payload.current.providers = { claude: 10, hermes: 0 }
+    payload.current.providers = { claude: 10, hermes: 0, cursor: 0 }
     payload.current.providerDetails = [
-      { id: 'claude', label: 'Claude', cost: 10 },
-      { id: 'hermes', label: 'Hermes', cost: 0 },
+      { id: 'claude', label: 'Claude', cost: 10, hasUsage: true },
+      { id: 'hermes', label: 'Hermes', cost: 0, hasUsage: false },
+      { id: 'cursor', label: 'Cursor', cost: 0, hasUsage: true },
     ]
     mocks.getOverview.mockResolvedValue(payload)
 
@@ -513,14 +512,9 @@ describe('App shortcuts', () => {
     expect(await screen.findByText('Most expensive sessions')).toBeInTheDocument()
 
     fireEvent.click(screen.getByText('All providers'))
-    const claudeOption = await screen.findByRole('option', { name: 'Claude' })
-    const hermesOption = screen.getByRole('option', { name: 'Hermes' })
-    const options = screen.getAllByRole('option')
-    // Zero-cost Hermes appears, and sorts after the provider that has spend.
-    expect(options.indexOf(hermesOption)).toBeGreaterThan(options.indexOf(claudeOption))
-
-    fireEvent.click(hermesOption)
-    await waitFor(() => expect(mocks.getOverview).toHaveBeenCalledWith('30days', 'hermes'))
+    expect(await screen.findByRole('option', { name: 'Claude' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Cursor' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'Hermes' })).not.toBeInTheDocument()
   })
 
   it('hides the Claude config picker when the payload carries no claudeConfigs', async () => {

--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -402,12 +402,13 @@ function AppMain() {
     if (!overview.data || overview.switching || provider !== 'all' || claudeConfigSource || scope !== 'local') return
     const details = overview.data.current.providerDetails
     // Prefer providerDetails (internal id + display label); fall back to the
-    // providers map keys (lowercased display names) for older CLIs. Explicit
-    // `hasUsage` preserves subscription-backed zero-cost activity while idle
-    // discovery rows stay out of the selected-period picker.
+    // providers map keys (lowercased display names) for older CLIs. `hasUsage`
+    // keeps idle discovery rows out of the picker, but only when the CLI
+    // actually emits it: every released CLI omits it, and falling back to cost
+    // there hid subscription-backed providers whose period spend is $0.
     const found = details
       ? [...details]
-          .filter(entry => entry.hasUsage ?? entry.cost > 0)
+          .filter(entry => entry.hasUsage ?? true)
           .sort((a, b) => b.cost - a.cost)
           .map(entry => ({ id: entry.id, label: entry.label }))
       : Object.entries(overview.data.current.providers)

--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -388,30 +388,29 @@ function AppMain() {
   }, [])
 
   useEffect(() => {
-    if (!overview.data) return
+    // Only the all-provider payload is authoritative for the picker. A scoped
+    // payload contains just the selected provider; merging it forever also
+    // leaked idle providers across period changes.
+    if (!overview.data || provider !== 'all') return
     const details = overview.data.current.providerDetails
     // Prefer providerDetails (internal id + display label); fall back to the
-    // providers map keys (lowercased display names) for older CLIs. The CLI
-    // only emits detected providers, so keep every entry (including ones with
-    // no spend this period) and sort by cost so zero-cost ones sit at the
-    // bottom of the picker.
+    // providers map keys (lowercased display names) for older CLIs. Explicit
+    // `hasUsage` preserves subscription-backed zero-cost activity while idle
+    // discovery rows stay out of the selected-period picker.
     const found = details
       ? [...details]
+          .filter(entry => entry.hasUsage ?? entry.cost > 0)
           .sort((a, b) => b.cost - a.cost)
           .map(entry => ({ id: entry.id, label: entry.label }))
       : Object.entries(overview.data.current.providers)
           // Fallback map keys are lowercased display names; ones with spaces
           // ("grok build") cannot round-trip as --provider, so exclude them
           // rather than offer a filter that is guaranteed to error.
-          .filter(([key]) => /^[a-z0-9-]+$/.test(key))
+          .filter(([key, cost]) => cost > 0 && /^[a-z0-9-]+$/.test(key))
           .sort(([, a], [, b]) => b - a)
           .map(([key]) => ({ id: key, label: providerName(key) }))
-    setDetectedProviders(current => {
-      const next = [...current]
-      for (const item of found) if (!next.some(entry => entry.id === item.id)) next.push(item)
-      return next.length === current.length ? current : next
-    })
-  }, [overview.data])
+    setDetectedProviders(found)
+  }, [overview.data, provider])
 
   useEffect(() => {
     const currency = overview.data?.currency

--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -261,7 +261,11 @@ function AppMain() {
   const [settingsPane, setSettingsPane] = useState<SettingsPane>('general')
   const [period, setPeriod] = useState<Period>(initialPeriod)
   const [provider, setProvider] = useState<string>('all')
-  const [detectedProviders, setDetectedProviders] = useState<Array<{ id: string; label: string }>>([])
+  const [providerCatalog, setProviderCatalog] = useState<{
+    key: string | null
+    entries: Array<{ id: string; label: string }>
+  }>({ key: null, entries: [] })
+  const detectedProviders = providerCatalog.entries
   const [customRange, setCustomRange] = useState<DateRange | null>(null)
   const [claudeConfigSource, setClaudeConfigSource] = useState<string | null>(initialConfigSource)
   const [scope, setScopeState] = useState<Scope>(initialScope)
@@ -278,6 +282,10 @@ function AppMain() {
   // the config scope before this poll runs. Passing scope='local' produces the
   // same flag-free argv as before, so local users are unaffected.
   const activeOverviewKey = overviewMemoKey(provider, period, customRange, claudeConfigSource, scope, new Date(now))
+  // Provider membership is period/range-specific. Keep the catalog tied to the
+  // exact unscoped local overview that produced it so a scoped view cannot leak
+  // providers from a different time horizon while its own payload is loading.
+  const allProviderOverviewKey = overviewMemoKey('all', period, customRange, null, 'local', new Date(now))
   const overview = usePolled<MenubarPayload>(
     () => scope === 'combined'
       ? codeburn.getOverview(period, 'all', customRange ?? undefined, undefined, undefined, 'combined')
@@ -391,7 +399,7 @@ function AppMain() {
     // Only the all-provider payload is authoritative for the picker. A scoped
     // payload contains just the selected provider; merging it forever also
     // leaked idle providers across period changes.
-    if (!overview.data || provider !== 'all') return
+    if (!overview.data || overview.switching || provider !== 'all' || claudeConfigSource || scope !== 'local') return
     const details = overview.data.current.providerDetails
     // Prefer providerDetails (internal id + display label); fall back to the
     // providers map keys (lowercased display names) for older CLIs. Explicit
@@ -409,8 +417,19 @@ function AppMain() {
           .filter(([key, cost]) => cost > 0 && /^[a-z0-9-]+$/.test(key))
           .sort(([, a], [, b]) => b - a)
           .map(([key]) => ({ id: key, label: providerName(key) }))
-    setDetectedProviders(found)
-  }, [overview.data, provider])
+    setProviderCatalog({ key: allProviderOverviewKey, entries: found })
+  }, [allProviderOverviewKey, claudeConfigSource, overview.data, overview.switching, provider, scope])
+
+  const selectedProviderEntry = useMemo(() => provider === 'all'
+    ? null
+    : detectedProviders.find(entry => entry.id === provider) ?? { id: provider, label: providerName(provider) },
+  [detectedProviders, provider])
+  const visibleProviderEntries = useMemo(() => providerCatalog.key === allProviderOverviewKey
+    ? detectedProviders
+    : selectedProviderEntry
+      ? [selectedProviderEntry]
+      : [],
+  [allProviderOverviewKey, detectedProviders, providerCatalog.key, selectedProviderEntry])
 
   useEffect(() => {
     const currency = overview.data?.currency
@@ -531,7 +550,7 @@ function AppMain() {
       // Keep the current-main provider-switch contract while the shared Core
       // provider snapshot work is still held: warm the visible period for each
       // detected provider only after the higher-value period/report queue.
-      for (const targetProvider of detectedProviders.map(entry => entry.id)) {
+      for (const targetProvider of visibleProviderEntries.map(entry => entry.id)) {
         if (cancelled || targetProvider === provider) continue
         const key = overviewMemoKey(targetProvider, period, null, null)
         if (warmedKeys.current.has(key) || hasPolledMemo(key)) continue
@@ -557,7 +576,7 @@ function AppMain() {
     // `overview.data == null` (a boolean) gates on first-resolution without
     // re-running every poll; the data content itself is intentionally not a dep.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ready, period, provider, detectedProviders, customRange, claudeConfigSource, scope, snapshotRevision, overview.data == null])
+  }, [ready, period, provider, visibleProviderEntries, customRange, claudeConfigSource, scope, snapshotRevision, overview.data == null])
 
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), 1000)
@@ -661,9 +680,9 @@ function AppMain() {
   const claudeConfigs = overview.data?.claudeConfigs
   const providerOptions = [
     { value: 'all', label: 'All providers' },
-    ...detectedProviders.map(entry => ({ value: entry.id, label: entry.label })),
+    ...visibleProviderEntries.map(entry => ({ value: entry.id, label: entry.label })),
   ]
-  const providerLabel = detectedProviders.find(entry => entry.id === provider)?.label ?? providerName(provider)
+  const providerLabel = selectedProviderEntry?.label ?? providerName(provider)
   const activeConfigLabel = claudeConfigSource
     ? claudeConfigs?.options.find(option => option.id === claudeConfigSource)?.label ?? null
     : null
@@ -718,7 +737,7 @@ function AppMain() {
               {section === 'overview' ? (
                 <OverviewContent period={period} provider={provider} range={customRange} overview={overview} onNavigate={navigate} ready={ready} scope={scope} headlineSnapshot={headlineSnapshot} />
               ) : section === 'sessions' ? (
-                <Sessions period={period} provider={provider} range={customRange} refreshToken={refreshToken} detectedProviders={detectedProviders} onProviderChange={onProviderSelect} ready={ready} />
+                <Sessions period={period} provider={provider} range={customRange} refreshToken={refreshToken} detectedProviders={visibleProviderEntries} onProviderChange={onProviderSelect} ready={ready} />
               ) : section === 'pullRequests' ? (
                 <PullRequestsContent overview={overview} period={period} provider={provider} range={customRange} />
               ) : section === 'spend' ? (

--- a/app/renderer/sections/Settings.tsx
+++ b/app/renderer/sections/Settings.tsx
@@ -232,7 +232,7 @@ function ProvidersPane({ period, refreshToken }: { period: Period; refreshToken:
   // the internal id. Fall back to the providers map keys (lowercased display
   // names) for older CLIs that omit providerDetails.
   const providers = details
-    ? details.filter(entry => entry.hasUsage ?? entry.cost > 0).map(entry => ({ id: entry.id, label: entry.label, cost: entry.cost }))
+    ? details.filter(entry => entry.hasUsage ?? true).map(entry => ({ id: entry.id, label: entry.label, cost: entry.cost }))
     : Object.entries(overview.data?.current.providers ?? {}).map(([id, cost]) => ({ id, label: id.charAt(0).toUpperCase() + id.slice(1), cost }))
   return <section className="set-p on">
     <div><h3 className="set-h">Providers</h3><p className="set-sub">codeburn auto-detects coding tools from local session files. No setup needed.</p></div>

--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -2252,7 +2252,7 @@ enum ProviderFilter: String, CaseIterable, Identifiable {
         switch self {
         case .cursor: ["cursor"]
         case .cursorAgent: ["cursor-agent", "cursor agent"]
-        case .cline: ["cline", "cline-cli"]
+        case .cline: ["cline"]
         case .codewhale: ["codewhale"]
         case .rooCode: ["roo-code", "roo code"]
         case .kiloCode: ["kilo-code", "kilocode"]

--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -209,6 +209,7 @@ final class AppStore {
     private var antigravityRefreshGen: Int = 0
 
     private var cache: [PayloadCacheKey: CachedPayload] = [:]
+    private var selectionFallbackPayload: MenubarPayload?
     private var cacheDate: String = ""
     private var switchTask: Task<Void, Never>?
     private var payloadRefreshGeneration: UInt64 = 0
@@ -301,7 +302,7 @@ final class AppStore {
                 return combinedPayload
             }
         }
-        return cache[currentKey]?.payload ?? .empty
+        return cache[currentKey]?.payload ?? selectionFallbackPayload ?? .empty
     }
 
     /// Today (across all providers) backs day-specific views in the popover.
@@ -580,6 +581,9 @@ final class AppStore {
     /// Existing content stays mounted while the background fetch runs, so a tab
     /// click never becomes a loading gate or resets unrelated in-flight work.
     func switchTo(provider: ProviderFilter) {
+        if provider != selectedProvider, hasCachedData {
+            selectionFallbackPayload = payload
+        }
         selectedProvider = provider
         // A Claude config scope only applies to All/Claude views; picking any
         // other provider tab clears it (the CLI rejects the contradictory combo).
@@ -664,6 +668,7 @@ final class AppStore {
         lastErrorByKey.removeAll()
         if clearCache {
             cache.removeAll()
+            selectionFallbackPayload = nil
         }
     }
 
@@ -727,6 +732,7 @@ final class AppStore {
         if cacheDate != today {
             payloadRefreshGeneration &+= 1
             cache.removeAll()
+            selectionFallbackPayload = nil
             loadingCountsByKey.removeAll()
             loadingStartedAtByKey.removeAll()
             inFlightKeys.removeAll()
@@ -739,6 +745,7 @@ final class AppStore {
 
     func invalidateCache() {
         cache.removeAll()
+        selectionFallbackPayload = nil
     }
 
     private func reconcileClaudeConfigSelection(from payload: MenubarPayload, for key: PayloadCacheKey) {
@@ -906,6 +913,9 @@ final class AppStore {
                 return false
             }
             cache[key] = CachedPayload(payload: fresh, fetchedAt: Date())
+            if key == currentKey || (effectiveSelectedScope == .combined && key == localCurrentKey) {
+                selectionFallbackPayload = nil
+            }
             reconcileClaudeConfigSelection(from: fresh, for: key)
             lastSuccessByKey[key] = Date()
             lastErrorByKey[key] = nil
@@ -2242,7 +2252,7 @@ enum ProviderFilter: String, CaseIterable, Identifiable {
         switch self {
         case .cursor: ["cursor"]
         case .cursorAgent: ["cursor-agent", "cursor agent"]
-        case .cline: ["cline"]
+        case .cline: ["cline", "cline-cli"]
         case .codewhale: ["codewhale"]
         case .rooCode: ["roo-code", "roo code"]
         case .kiloCode: ["kilo-code", "kilocode"]

--- a/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
@@ -389,18 +389,14 @@ struct ProviderDetail: Codable, Sendable {
         id = try c.decode(String.self, forKey: .id)
         label = try c.decode(String.self, forKey: .label)
         cost = try c.decode(Double.self, forKey: .cost)
-        // Older CLIs emitted providerDetails without calls/hasUsage. Those
-        // payloads cannot distinguish period activity from a provider merely
-        // discovered on disk, so cost is the only safe activity signal.
-        let decodedCalls = try c.decodeIfPresent(Int.self, forKey: .calls)
-        calls = decodedCalls ?? 0
-        if let decodedUsage = try c.decodeIfPresent(Bool.self, forKey: .hasUsage) {
-            hasUsage = decodedUsage
-        } else if decodedCalls != nil {
-            hasUsage = cost > 0 || calls > 0
-        } else {
-            hasUsage = cost > 0
-        }
+        calls = try c.decodeIfPresent(Int.self, forKey: .calls) ?? 0
+        // EVERY released CLI omits hasUsage, so the absent case is the common
+        // one, not a legacy edge. Deriving activity from cost there hid every
+        // subscription-backed provider whose period spend is $0 (Hermes, Kimi,
+        // Copilot on an included plan). A provider the payload bothered to list
+        // is one the user has, so absent means visible; the strict signal
+        // applies only when the field is actually present.
+        hasUsage = try c.decodeIfPresent(Bool.self, forKey: .hasUsage) ?? true
     }
 }
 

--- a/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/MenubarPayload.swift
@@ -317,9 +317,9 @@ struct ProviderDetail: Codable, Sendable {
         id = try c.decode(String.self, forKey: .id)
         label = try c.decode(String.self, forKey: .label)
         cost = try c.decode(Double.self, forKey: .cost)
-        // Older CLIs emitted providerDetails without calls/hasUsage. When calls
-        // exists, derive activity from calls/cost; with neither signal, keep the
-        // detected provider visible rather than hiding valid $0 subscriptions.
+        // Older CLIs emitted providerDetails without calls/hasUsage. Those
+        // payloads cannot distinguish period activity from a provider merely
+        // discovered on disk, so cost is the only safe activity signal.
         let decodedCalls = try c.decodeIfPresent(Int.self, forKey: .calls)
         calls = decodedCalls ?? 0
         if let decodedUsage = try c.decodeIfPresent(Bool.self, forKey: .hasUsage) {
@@ -327,7 +327,7 @@ struct ProviderDetail: Codable, Sendable {
         } else if decodedCalls != nil {
             hasUsage = cost > 0 || calls > 0
         } else {
-            hasUsage = true
+            hasUsage = cost > 0
         }
     }
 }
@@ -342,7 +342,9 @@ enum ProviderVisibility {
                 .filter(\.hasUsage)
                 .flatMap { [$0.id.lowercased(), $0.label.lowercased()] })
         }
-        return Set(legacyProviders.keys.map { $0.lowercased() })
+        return Set(legacyProviders.compactMap { key, cost in
+            cost > 0 ? key.lowercased() : nil
+        })
     }
 }
 

--- a/mac/Sources/CodeBurnMenubar/Data/ProviderReconnectPresentation.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/ProviderReconnectPresentation.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct ProviderReconnectPresentation: Sendable, Equatable {
+    let title: String
+    let defaultReason: String
+    let instruction: String
+
+    init(provider: ProviderFilter) {
+        title = "Reconnect \(provider.rawValue)"
+        switch provider {
+        case .claude:
+            defaultReason = "Claude Code credentials need to be refreshed."
+            instruction = "Open Claude Code in your terminal and type `/login`, then click Reconnect."
+        case .codex:
+            defaultReason = "Codex credentials need to be refreshed."
+            instruction = "Run `codex login` in your terminal, then click Reconnect."
+        case .kimiCode:
+            defaultReason = "Kimi Code credentials need to be refreshed."
+            instruction = "Run the Kimi CLI once to refresh your login, then click Reconnect."
+        case .gemini:
+            defaultReason = "Gemini credentials need to be refreshed."
+            instruction = "Run the Gemini CLI once to refresh your login, then click Reconnect."
+        case .copilot:
+            defaultReason = "Copilot credentials need to be refreshed."
+            instruction = "Sign in with the Copilot CLI, an editor plugin, or `gh auth login`, then click Reconnect."
+        case .antigravity:
+            defaultReason = "The local Antigravity service is unavailable."
+            instruction = "Start the Antigravity app, then click Reconnect."
+        default:
+            defaultReason = "\(provider.rawValue) credentials need to be refreshed."
+            instruction = "Sign in to \(provider.rawValue) again, then retry."
+        }
+    }
+}

--- a/mac/Sources/CodeBurnMenubar/Data/ProviderStripPagingState.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/ProviderStripPagingState.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+enum ProviderStripPagingDirection: Sendable {
+    case backward
+    case forward
+
+    var offset: Int {
+        switch self {
+        case .backward: -1
+        case .forward: 1
+        }
+    }
+}
+
 struct ProviderStripPagingState: Sendable, Equatable {
     let filters: [ProviderFilter]
     let selectedProvider: ProviderFilter
@@ -25,9 +37,9 @@ struct ProviderStripPagingState: Sendable, Equatable {
     var canMoveForward: Bool { anchorIndex >= 0 && anchorIndex < filters.count - 1 }
 
     @discardableResult
-    mutating func move(direction: Int) -> ProviderFilter? {
-        guard !filters.isEmpty, direction != 0 else { return viewportAnchor }
-        let targetIndex = min(max(anchorIndex + (direction < 0 ? -1 : 1), 0), filters.count - 1)
+    mutating func move(direction: ProviderStripPagingDirection) -> ProviderFilter? {
+        guard !filters.isEmpty else { return viewportAnchor }
+        let targetIndex = min(max(anchorIndex + direction.offset, 0), filters.count - 1)
         viewportAnchor = filters[targetIndex]
         return viewportAnchor
     }

--- a/mac/Sources/CodeBurnMenubar/Data/ProviderStripPagingState.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/ProviderStripPagingState.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+struct ProviderStripPagingState: Sendable, Equatable {
+    let filters: [ProviderFilter]
+    let selectedProvider: ProviderFilter
+    private(set) var viewportAnchor: ProviderFilter?
+
+    init(
+        filters: [ProviderFilter],
+        selectedProvider: ProviderFilter,
+        viewportAnchor: ProviderFilter?
+    ) {
+        self.filters = filters
+        self.selectedProvider = selectedProvider
+        if let viewportAnchor, filters.contains(viewportAnchor) {
+            self.viewportAnchor = viewportAnchor
+        } else if filters.contains(selectedProvider) {
+            self.viewportAnchor = selectedProvider
+        } else {
+            self.viewportAnchor = filters.first
+        }
+    }
+
+    var canMoveBackward: Bool { anchorIndex > 0 }
+    var canMoveForward: Bool { anchorIndex >= 0 && anchorIndex < filters.count - 1 }
+
+    @discardableResult
+    mutating func move(direction: Int) -> ProviderFilter? {
+        guard !filters.isEmpty, direction != 0 else { return viewportAnchor }
+        let targetIndex = min(max(anchorIndex + (direction < 0 ? -1 : 1), 0), filters.count - 1)
+        viewportAnchor = filters[targetIndex]
+        return viewportAnchor
+    }
+
+    private var anchorIndex: Int {
+        guard let viewportAnchor else { return -1 }
+        return filters.firstIndex(of: viewportAnchor) ?? -1
+    }
+}

--- a/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
@@ -16,6 +16,7 @@ struct AgentTabStrip: View {
     @State private var stripViewportWidth: CGFloat = 0
     @State private var stripContentWidth: CGFloat = 0
     @State private var scrollWheelMonitor: Any?
+    @State private var viewportAnchor: ProviderFilter?
 
     var body: some View {
         GeometryReader { viewportGeo in
@@ -23,7 +24,7 @@ struct AgentTabStrip: View {
                 HStack(spacing: 4) {
                     if isOverflowing {
                         Button {
-                            selectAdjacentProvider(direction: -1, proxy: proxy)
+                            pageProviderStrip(direction: -1, proxy: proxy)
                         } label: {
                             Image(systemName: "chevron.left")
                                 .font(.system(size: 10, weight: .semibold))
@@ -44,6 +45,7 @@ struct AgentTabStrip: View {
                                     isActive: store.selectedProvider == filter,
                                     quota: store.quotaSummary(for: filter)
                                 ) {
+                                    viewportAnchor = filter
                                     store.switchTo(provider: filter)
                                     withAnimation(.easeInOut(duration: 0.18)) {
                                         proxy.scrollTo(filter.id, anchor: .center)
@@ -73,7 +75,7 @@ struct AgentTabStrip: View {
 
                     if isOverflowing {
                         Button {
-                            selectAdjacentProvider(direction: 1, proxy: proxy)
+                            pageProviderStrip(direction: 1, proxy: proxy)
                         } label: {
                             Image(systemName: "chevron.right")
                                 .font(.system(size: 10, weight: .semibold))
@@ -88,16 +90,30 @@ struct AgentTabStrip: View {
                 .onAppear {
                     stripViewportWidth = viewportGeo.size.width
                     installScrollWheelMonitorIfNeeded()
+                    viewportAnchor = pagingState.viewportAnchor
                     withAnimation(.easeInOut(duration: 0.18)) {
-                        proxy.scrollTo(store.selectedProvider.id, anchor: .center)
+                        if let viewportAnchor {
+                            proxy.scrollTo(viewportAnchor.id, anchor: .center)
+                        }
                     }
                 }
                 .onChange(of: viewportGeo.size.width) { _, newWidth in
                     stripViewportWidth = newWidth
                 }
                 .onChange(of: store.selectedProvider) { _, newProvider in
+                    viewportAnchor = visibleFilters.contains(newProvider) ? newProvider : pagingState.viewportAnchor
                     withAnimation(.easeInOut(duration: 0.18)) {
-                        proxy.scrollTo(newProvider.id, anchor: .center)
+                        if let viewportAnchor {
+                            proxy.scrollTo(viewportAnchor.id, anchor: .center)
+                        }
+                    }
+                }
+                .onChange(of: visibleFilters) { _, _ in
+                    viewportAnchor = pagingState.viewportAnchor
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        if let viewportAnchor {
+                            proxy.scrollTo(viewportAnchor.id, anchor: .center)
+                        }
                     }
                 }
                 .onDisappear {
@@ -149,19 +165,22 @@ struct AgentTabStrip: View {
         }
     }
 
-    private var currentFilterIndex: Int {
-        visibleFilters.firstIndex(of: store.selectedProvider) ?? 0
+    private var pagingState: ProviderStripPagingState {
+        ProviderStripPagingState(
+            filters: visibleFilters,
+            selectedProvider: store.selectedProvider,
+            viewportAnchor: viewportAnchor
+        )
     }
 
-    private var canMoveBackward: Bool { currentFilterIndex > 0 }
-    private var canMoveForward: Bool { currentFilterIndex < visibleFilters.count - 1 }
+    private var canMoveBackward: Bool { pagingState.canMoveBackward }
+    private var canMoveForward: Bool { pagingState.canMoveForward }
     private var isOverflowing: Bool { stripContentWidth > (stripViewportWidth - 30) }
 
-    private func selectAdjacentProvider(direction: Int, proxy: ScrollViewProxy) {
-        guard !visibleFilters.isEmpty else { return }
-        let targetIndex = min(max(currentFilterIndex + direction, 0), visibleFilters.count - 1)
-        let target = visibleFilters[targetIndex]
-        store.switchTo(provider: target)
+    private func pageProviderStrip(direction: Int, proxy: ScrollViewProxy) {
+        var state = pagingState
+        guard let target = state.move(direction: direction) else { return }
+        viewportAnchor = target
         withAnimation(.easeInOut(duration: 0.18)) {
             proxy.scrollTo(target.id, anchor: .center)
         }
@@ -410,38 +429,21 @@ private struct QuotaDetailPopover: View {
 
     private func terminalFailureCard(reason: String?) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text(reconnectTitle)
+            Text(reconnectPresentation.title)
                 .font(.system(size: 11.5, weight: .semibold))
                 .foregroundStyle(.red)
-            Text(reason ?? defaultReconnectReason)
+            Text(reason ?? reconnectPresentation.defaultReason)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
                 .lineLimit(2)
-            Text(reconnectInstruction)
+            Text(reconnectPresentation.instruction)
                 .font(.system(size: 10.5))
                 .foregroundStyle(.secondary)
         }
     }
 
-    private var reconnectTitle: String {
-        switch quota.providerFilter {
-        case .codex:  return "Reconnect Codex"
-        default:      return "Reconnect Claude"
-        }
-    }
-
-    private var defaultReconnectReason: String {
-        switch quota.providerFilter {
-        case .codex:  return "Refresh token rejected by OpenAI."
-        default:      return "Refresh token rejected by Anthropic."
-        }
-    }
-
-    private var reconnectInstruction: String {
-        switch quota.providerFilter {
-        case .codex:  return "Run `codex login` in your terminal, then click Reconnect."
-        default:      return "Open Claude Code in your terminal and type `/login`, then click Reconnect."
-        }
+    private var reconnectPresentation: ProviderReconnectPresentation {
+        ProviderReconnectPresentation(provider: quota.providerFilter)
     }
 }
 

--- a/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/AgentTabStrip.swift
@@ -24,7 +24,7 @@ struct AgentTabStrip: View {
                 HStack(spacing: 4) {
                     if isOverflowing {
                         Button {
-                            pageProviderStrip(direction: -1, proxy: proxy)
+                            pageProviderStrip(direction: .backward, proxy: proxy)
                         } label: {
                             Image(systemName: "chevron.left")
                                 .font(.system(size: 10, weight: .semibold))
@@ -75,7 +75,7 @@ struct AgentTabStrip: View {
 
                     if isOverflowing {
                         Button {
-                            pageProviderStrip(direction: 1, proxy: proxy)
+                            pageProviderStrip(direction: .forward, proxy: proxy)
                         } label: {
                             Image(systemName: "chevron.right")
                                 .font(.system(size: 10, weight: .semibold))
@@ -91,30 +91,18 @@ struct AgentTabStrip: View {
                     stripViewportWidth = viewportGeo.size.width
                     installScrollWheelMonitorIfNeeded()
                     viewportAnchor = pagingState.viewportAnchor
-                    withAnimation(.easeInOut(duration: 0.18)) {
-                        if let viewportAnchor {
-                            proxy.scrollTo(viewportAnchor.id, anchor: .center)
-                        }
-                    }
+                    scrollToViewportAnchor(proxy: proxy)
                 }
                 .onChange(of: viewportGeo.size.width) { _, newWidth in
                     stripViewportWidth = newWidth
                 }
                 .onChange(of: store.selectedProvider) { _, newProvider in
                     viewportAnchor = visibleFilters.contains(newProvider) ? newProvider : pagingState.viewportAnchor
-                    withAnimation(.easeInOut(duration: 0.18)) {
-                        if let viewportAnchor {
-                            proxy.scrollTo(viewportAnchor.id, anchor: .center)
-                        }
-                    }
+                    scrollToViewportAnchor(proxy: proxy)
                 }
                 .onChange(of: visibleFilters) { _, _ in
                     viewportAnchor = pagingState.viewportAnchor
-                    withAnimation(.easeInOut(duration: 0.18)) {
-                        if let viewportAnchor {
-                            proxy.scrollTo(viewportAnchor.id, anchor: .center)
-                        }
-                    }
+                    scrollToViewportAnchor(proxy: proxy)
                 }
                 .onDisappear {
                     removeScrollWheelMonitorIfNeeded()
@@ -132,7 +120,7 @@ struct AgentTabStrip: View {
         // Tabs reflect the selected range. The payload's activity signal keeps
         // token-only and subscription/flat-rate providers visible while hiding
         // providers merely discovered on disk. Older payloads lack the activity
-        // signal, so they preserve detected-provider visibility for compatibility.
+        // signal, so their zero-cost discovery rows fail closed.
         let activeKeys = ProviderVisibility.activeKeys(
             providerDetails: periodAll.current.providerDetails,
             legacyProviders: periodAll.current.providers
@@ -177,12 +165,17 @@ struct AgentTabStrip: View {
     private var canMoveForward: Bool { pagingState.canMoveForward }
     private var isOverflowing: Bool { stripContentWidth > (stripViewportWidth - 30) }
 
-    private func pageProviderStrip(direction: Int, proxy: ScrollViewProxy) {
+    private func pageProviderStrip(direction: ProviderStripPagingDirection, proxy: ScrollViewProxy) {
         var state = pagingState
         guard let target = state.move(direction: direction) else { return }
         viewportAnchor = target
+        scrollToViewportAnchor(proxy: proxy)
+    }
+
+    private func scrollToViewportAnchor(proxy: ScrollViewProxy) {
+        guard let viewportAnchor else { return }
         withAnimation(.easeInOut(duration: 0.18)) {
-            proxy.scrollTo(target.id, anchor: .center)
+            proxy.scrollTo(viewportAnchor.id, anchor: .center)
         }
     }
 

--- a/mac/Tests/CodeBurnMenubarTests/AgentTabProviderVisibilityTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/AgentTabProviderVisibilityTests.swift
@@ -4,11 +4,6 @@ import Testing
 
 @Suite("Agent tab provider visibility")
 struct AgentTabProviderVisibilityTests {
-    @Test func clineFilterRecognizesBothNativeAndCLIProviderIds() {
-        #expect(ProviderFilter.cline.providerKeys.contains("cline"))
-        #expect(ProviderFilter.cline.providerKeys.contains("cline-cli"))
-    }
-
     @Test("zero-cost providers with usage remain active while idle providers stay hidden")
     func zeroCostProvidersWithUsageRemainActive() {
         let details = [

--- a/mac/Tests/CodeBurnMenubarTests/AgentTabProviderVisibilityTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/AgentTabProviderVisibilityTests.swift
@@ -32,23 +32,28 @@ struct AgentTabProviderVisibilityTests {
         #expect(keys == ["codex"])
     }
 
-    @Test("legacy provider details require a positive cost or call signal")
-    func legacyProviderDetailDecoding() throws {
-        let noSignal = try JSONDecoder().decode(
-            ProviderDetail.self,
-            from: Data(#"{"id":"hermes","label":"Hermes Agent","cost":0}"#.utf8)
-        )
-        let positiveLegacyCost = try JSONDecoder().decode(
-            ProviderDetail.self,
-            from: Data(#"{"id":"codex","label":"Codex","cost":1.25}"#.utf8)
-        )
-        let explicitIdleCalls = try JSONDecoder().decode(
-            ProviderDetail.self,
-            from: Data(#"{"id":"hermes","label":"Hermes Agent","cost":0,"calls":0}"#.utf8)
-        )
+    @Test("provider details without hasUsage stay visible")
+    func absentHasUsageDefaultsToVisible() throws {
+        func decode(_ json: String) throws -> ProviderDetail {
+            try JSONDecoder().decode(ProviderDetail.self, from: Data(json.utf8))
+        }
+        // Every RELEASED CLI omits hasUsage. Deriving it from cost there hid
+        // every subscription-backed provider whose period spend is $0.
+        let noHasUsage = try decode(#"{"id":"hermes","label":"Hermes Agent","cost":0}"#)
+        let noHasUsageWithCalls = try decode(#"{"id":"hermes","label":"Hermes Agent","cost":0,"calls":0}"#)
+        let explicitlyIdle = try decode(#"{"id":"hermes","label":"Hermes Agent","cost":0,"calls":0,"hasUsage":false}"#)
+        let explicitlyActive = try decode(#"{"id":"codex","label":"Codex","cost":0,"calls":0,"hasUsage":true}"#)
 
-        #expect(!noSignal.hasUsage)
-        #expect(positiveLegacyCost.hasUsage)
-        #expect(!explicitIdleCalls.hasUsage)
+        #expect(noHasUsage.hasUsage)
+        #expect(noHasUsageWithCalls.hasUsage)
+        // The strict signal still applies wherever the CLI actually emits it.
+        #expect(!explicitlyIdle.hasUsage)
+        #expect(explicitlyActive.hasUsage)
+
+        let keys = ProviderVisibility.activeKeys(
+            providerDetails: [noHasUsage, explicitlyIdle],
+            legacyProviders: [:]
+        )
+        #expect(keys.contains("hermes"))
     }
 }

--- a/mac/Tests/CodeBurnMenubarTests/AgentTabProviderVisibilityTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/AgentTabProviderVisibilityTests.swift
@@ -4,6 +4,11 @@ import Testing
 
 @Suite("Agent tab provider visibility")
 struct AgentTabProviderVisibilityTests {
+    @Test func clineFilterRecognizesBothNativeAndCLIProviderIds() {
+        #expect(ProviderFilter.cline.providerKeys.contains("cline"))
+        #expect(ProviderFilter.cline.providerKeys.contains("cline-cli"))
+    }
+
     @Test("zero-cost providers with usage remain active while idle providers stay hidden")
     func zeroCostProvidersWithUsageRemainActive() {
         let details = [
@@ -22,28 +27,33 @@ struct AgentTabProviderVisibilityTests {
         #expect(!keys.contains("claude"))
     }
 
-    @Test("legacy payloads keep detected providers visible when activity is unknowable")
-    func legacyDetectedProviderFallback() {
+    @Test("legacy payloads show only providers with period spend")
+    func legacyProviderCostFallback() {
         let keys = ProviderVisibility.activeKeys(
             providerDetails: [],
             legacyProviders: ["codex": 3.25, "hermes agent": 0]
         )
 
-        #expect(keys == ["codex", "hermes agent"])
+        #expect(keys == ["codex"])
     }
 
-    @Test("legacy provider details without activity fields fail open, while calls remain authoritative")
+    @Test("legacy provider details require a positive cost or call signal")
     func legacyProviderDetailDecoding() throws {
         let noSignal = try JSONDecoder().decode(
             ProviderDetail.self,
             from: Data(#"{"id":"hermes","label":"Hermes Agent","cost":0}"#.utf8)
+        )
+        let positiveLegacyCost = try JSONDecoder().decode(
+            ProviderDetail.self,
+            from: Data(#"{"id":"codex","label":"Codex","cost":1.25}"#.utf8)
         )
         let explicitIdleCalls = try JSONDecoder().decode(
             ProviderDetail.self,
             from: Data(#"{"id":"hermes","label":"Hermes Agent","cost":0,"calls":0}"#.utf8)
         )
 
-        #expect(noSignal.hasUsage)
+        #expect(!noSignal.hasUsage)
+        #expect(positiveLegacyCost.hasUsage)
         #expect(!explicitIdleCalls.hasUsage)
     }
 }

--- a/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/AppStoreRefreshRecoveryTests.swift
@@ -84,6 +84,23 @@ private func menubarPayload(cost: Double,
 @Suite("AppStore refresh recovery")
 @MainActor
 struct AppStoreRefreshRecoveryTests {
+    @Test("provider switches retain the last rendered payload until the target loads")
+    func providerSwitchRetainsLastRenderedPayload() {
+        let store = AppStore()
+        store.suppressRefreshesForTesting()
+        store.setCachedPayloadForTesting(
+            menubarPayload(cost: 12.34),
+            period: .today,
+            provider: .all,
+            fetchedAt: Date()
+        )
+
+        store.switchTo(provider: .cursor)
+
+        #expect(store.selectedProvider == .cursor)
+        #expect(store.payload.current.cost == 12.34)
+    }
+
     @Test("stale visible payload triggers hard recovery without clearing cache")
     func stalePayloadTriggersHardRecoveryWithoutClearingCache() {
         let store = AppStore()

--- a/mac/Tests/CodeBurnMenubarTests/ProviderReconnectPresentationTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/ProviderReconnectPresentationTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import CodeBurnMenubar
+
+@Suite("Provider reconnect presentation")
+struct ProviderReconnectPresentationTests {
+    @Test("every quota provider gets provider-specific recovery copy", arguments: [
+        ProviderFilter.claude,
+        .codex,
+        .kimiCode,
+        .gemini,
+        .copilot,
+        .antigravity,
+    ])
+    func providerSpecificRecoveryCopy(_ provider: ProviderFilter) {
+        let presentation = ProviderReconnectPresentation(provider: provider)
+
+        #expect(presentation.title == "Reconnect \(provider.rawValue)")
+        #expect(!presentation.defaultReason.isEmpty)
+        #expect(!presentation.instruction.isEmpty)
+
+        for other in ["Claude", "Codex", "Kimi", "Gemini", "Copilot", "Antigravity"]
+            where other != provider.rawValue && !(provider == .kimiCode && other == "Kimi") {
+            #expect(!presentation.title.contains(other))
+            #expect(!presentation.instruction.contains(other))
+        }
+    }
+
+    @Test("unsupported providers receive neutral recovery copy")
+    func genericRecoveryCopy() {
+        let presentation = ProviderReconnectPresentation(provider: .cursor)
+
+        #expect(presentation.title == "Reconnect Cursor")
+        #expect(presentation.defaultReason == "Cursor credentials need to be refreshed.")
+        #expect(presentation.instruction == "Sign in to Cursor again, then retry.")
+    }
+}

--- a/mac/Tests/CodeBurnMenubarTests/ProviderStripPagingStateTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/ProviderStripPagingStateTests.swift
@@ -11,11 +11,11 @@ struct ProviderStripPagingStateTests {
             viewportAnchor: .all
         )
 
-        #expect(state.move(direction: 1) == .claude)
+        #expect(state.move(direction: .forward) == .claude)
         #expect(state.viewportAnchor == .claude)
         #expect(state.selectedProvider == .all)
 
-        #expect(state.move(direction: 1) == .cursor)
+        #expect(state.move(direction: .forward) == .cursor)
         #expect(state.viewportAnchor == .cursor)
         #expect(state.selectedProvider == .all)
         #expect(!state.canMoveForward)
@@ -30,7 +30,7 @@ struct ProviderStripPagingStateTests {
         )
 
         #expect(state.viewportAnchor == .claude)
-        #expect(state.move(direction: -1) == .all)
+        #expect(state.move(direction: .backward) == .all)
         #expect(state.selectedProvider == .claude)
     }
 
@@ -42,7 +42,7 @@ struct ProviderStripPagingStateTests {
             viewportAnchor: nil
         )
 
-        #expect(state.move(direction: 1) == nil)
+        #expect(state.move(direction: .forward) == nil)
         #expect(!state.canMoveBackward)
         #expect(!state.canMoveForward)
     }

--- a/mac/Tests/CodeBurnMenubarTests/ProviderStripPagingStateTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/ProviderStripPagingStateTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import CodeBurnMenubar
+
+@Suite("Provider strip paging")
+struct ProviderStripPagingStateTests {
+    @Test("paging changes the viewport without selecting a provider")
+    func pagingDoesNotSelect() {
+        var state = ProviderStripPagingState(
+            filters: [.all, .claude, .cursor],
+            selectedProvider: .all,
+            viewportAnchor: .all
+        )
+
+        #expect(state.move(direction: 1) == .claude)
+        #expect(state.viewportAnchor == .claude)
+        #expect(state.selectedProvider == .all)
+
+        #expect(state.move(direction: 1) == .cursor)
+        #expect(state.viewportAnchor == .cursor)
+        #expect(state.selectedProvider == .all)
+        #expect(!state.canMoveForward)
+    }
+
+    @Test("paging clamps a missing anchor to the selected provider")
+    func missingAnchorUsesSelection() {
+        var state = ProviderStripPagingState(
+            filters: [.all, .claude, .cursor],
+            selectedProvider: .claude,
+            viewportAnchor: .grok
+        )
+
+        #expect(state.viewportAnchor == .claude)
+        #expect(state.move(direction: -1) == .all)
+        #expect(state.selectedProvider == .claude)
+    }
+
+    @Test("an empty strip cannot page")
+    func emptyStrip() {
+        var state = ProviderStripPagingState(
+            filters: [],
+            selectedProvider: .all,
+            viewportAnchor: nil
+        )
+
+        #expect(state.move(direction: 1) == nil)
+        #expect(!state.canMoveBackward)
+        #expect(!state.canMoveForward)
+    }
+}

--- a/scripts/upgrade-path/run.mjs
+++ b/scripts/upgrade-path/run.mjs
@@ -33,7 +33,6 @@ const WORK = process.env['UPGRADE_PATH_WORK'] || join(tmpdir(), 'codeburn upgrad
 const OLD_SESSION_CACHE = 'session-cache.v7.json'
 const OLD_DAILY_CACHE = 'daily-cache.v17.json'
 const NEW_SESSION_CACHE_DIR = 'session-cache.v9'
-const NEW_DAILY_CACHE = 'daily-cache.v29.json'
 
 const HOME = join(WORK, 'user home')
 const PAYLOADS = join(WORK, 'payloads')
@@ -47,6 +46,14 @@ const ok = msg => console.log(`  ok    ${msg}`)
 const fail = msg => { failures++; console.log(`  FAIL  ${msg}`) }
 const skip = msg => { skipped++; console.log(`  skip  ${msg}`) }
 const check = (cond, msg) => (cond ? ok(msg) : fail(msg))
+
+function newestDailyCacheAfter(dir, baselineName) {
+  const baseline = Number(baselineName.match(/^daily-cache\.v(\d+)\.json$/)?.[1] ?? -1)
+  return readdirSync(dir)
+    .map(name => ({ name, version: Number(name.match(/^daily-cache\.v(\d+)\.json$/)?.[1] ?? -1) }))
+    .filter(candidate => candidate.version > baseline)
+    .sort((a, b) => b.version - a.version)[0]?.name ?? null
+}
 
 function run(cmd, args, opts = {}) {
   const r = spawnSync(cmd, args, { encoding: 'utf8', maxBuffer: 1 << 29, shell: false, ...opts })
@@ -205,10 +212,12 @@ const envelope = JSON.parse(readFileSync(join(upgradeCache, NEW_SESSION_CACHE_DI
 check(envelope.version === 9 && Object.keys(envelope.providers ?? {}).length > 0,
   `envelope at version ${envelope.version} with ${Object.keys(envelope.providers ?? {}).length} providers`)
 check(readdirSync(join(upgradeCache, NEW_SESSION_CACHE_DIR)).some(n => n !== 'envelope.json'), 'shards published alongside the envelope')
-check(existsSync(join(upgradeCache, NEW_DAILY_CACHE)), `${NEW_DAILY_CACHE} re-derived`)
+const newDailyCache = newestDailyCacheAfter(upgradeCache, OLD_DAILY_CACHE)
+check(newDailyCache !== null, `${newDailyCache ?? 'current daily cache'} re-derived`)
 check(existsSync(join(upgradeCache, OLD_DAILY_CACHE)), `${OLD_DAILY_CACHE} kept as the carry-forward baseline`)
+if (!newDailyCache) process.exit(1)
 const oldDays = JSON.parse(readFileSync(join(upgradeCache, OLD_DAILY_CACHE), 'utf8')).days.length
-const newDays = JSON.parse(readFileSync(join(upgradeCache, NEW_DAILY_CACHE), 'utf8')).days.length
+const newDays = JSON.parse(readFileSync(join(upgradeCache, newDailyCache), 'utf8')).days.length
 check(newDays >= oldDays, `daily history did not shrink: ${oldDays} -> ${newDays} days`)
 
 // ── 4. payload parity ────────────────────────────────────────────────────────
@@ -413,7 +422,10 @@ else {
   for (const a of aged) ok(`${a.date}: ${a.kind} (removed ${a.removed} of ${a.removed + a.kept} transcripts)`)
 
   capture(newBin, agingCache, join(PAYLOADS, 'aging-upgraded'))
-  const upDaily = JSON.parse(readFileSync(join(agingCache, NEW_DAILY_CACHE), 'utf8'))
+  const agingDailyCache = newestDailyCacheAfter(agingCache, OLD_DAILY_CACHE)
+  check(agingDailyCache !== null, `${agingDailyCache ?? 'current aging daily cache'} re-derived`)
+  if (!agingDailyCache) process.exit(1)
+  const upDaily = JSON.parse(readFileSync(join(agingCache, agingDailyCache), 'utf8'))
   const usd = n => `$${n.toFixed(6)}`
 
   for (const a of aged) {

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -27,7 +27,7 @@ import type { DateRange, ProjectSummary } from './types.js'
 // again here. 26 is the first free number on main's ladder — and it is load
 // bearing beyond the collision: the branch's own validators already hold
 // daily-cache.v21.json files whose copilot slices were carried stale by the
-// bug PENDING_REDERIVE_PROVIDERS fixes below, and only a number those files
+// bug PENDING_REDERIVE_PROVIDER_VERSIONS fixes below, and only a number those files
 // cannot claim gets them re-derived. isMigratableCache/adoptOlderDailyCaches
 // carry a same-or-newer version forward as FINALIZED without re-deriving it,
 // so a number can never mean two accountings. (feat/core-extraction also sits
@@ -174,7 +174,10 @@ import type { DateRange, ProjectSummary } from './types.js'
 // but optimize added reasoning again. Re-derive so report matches the live parse.
 // v29: #1118 OrcaRouter route pricing (fusion aliases + peel; auto stays unpriced).
 // v28 on main already shipped #1115.
-export const DAILY_CACHE_VERSION = 29
+// v30: Hermes cost provenance. Subscription-included sessions stay $0,
+// explicit estimates retain their status, and surviving Hermes sources replace
+// v29 slices produced by the old API-equivalent fallback.
+export const DAILY_CACHE_VERSION = 30
 const MIN_SUPPORTED_VERSION = 28
 
 /// Providers whose per-day CALL COUNT means something different at
@@ -197,7 +200,16 @@ const MIN_SUPPORTED_VERSION = 28
 /// for the (day, provider). A day whose copilot sources are gone yields no
 /// fresh slice at all, so it still carries forward whole — the #1033 bar is
 /// untouched, in both directions, and every other provider keeps the guard.
-const PENDING_REDERIVE_PROVIDERS: readonly string[] = ['copilot']
+const PENDING_REDERIVE_PROVIDER_VERSIONS: Readonly<Record<string, number>> = {
+  copilot: 26,
+  hermes: 30,
+}
+
+function providersPendingRederiveFrom(fromVersion: number): string[] {
+  return Object.entries(PENDING_REDERIVE_PROVIDER_VERSIONS)
+    .filter(([, contractVersion]) => fromVersion < contractVersion)
+    .map(([provider]) => provider)
+}
 // Version-suffixed so different binaries each own a distinct file and never
 // clobber an incompatible schema. Bumping the version mints a fresh filename;
 // adoptOlderDailyCaches then unions days out of every previous file (including
@@ -299,7 +311,7 @@ export type DailyCache = {
   watermarkTrusted?: boolean
   /// Providers still owed the one re-derivation that a migration from a
   /// pre-`DAILY_CACHE_VERSION` cache entitles them to, despite a shrinking
-  /// call count (see PENDING_REDERIVE_PROVIDERS). Set by the migration,
+  /// call count (see PENDING_REDERIVE_PROVIDER_VERSIONS). Set by the migration,
   /// cleared by the first COMPLETE re-derive — persisted rather than computed
   /// so a partial parse in between does not silently spend the entitlement.
   pendingRederive?: string[]
@@ -453,7 +465,10 @@ function migrateDays(days: Record<string, unknown>[]): DailyEntry[] {
 /// an unspent entitlement out of the parsed file so a same-version reload does
 /// not drop it.
 function pendingRederiveFor(fromVersion: number, parsed: unknown): string[] | undefined {
-  if (fromVersion < DAILY_CACHE_VERSION) return [...PENDING_REDERIVE_PROVIDERS]
+  if (fromVersion < DAILY_CACHE_VERSION) {
+    const pending = providersPendingRederiveFrom(fromVersion)
+    return pending.length > 0 ? pending : undefined
+  }
   const raw = (parsed as { pendingRederive?: unknown } | null)?.pendingRederive
   if (!Array.isArray(raw)) return undefined
   const kept = raw.filter((p): p is string => typeof p === 'string')
@@ -578,9 +593,17 @@ async function adoptOlderDailyCaches(): Promise<DailyCache> {
     days,
     // Anything adopted out of an OLDER file was derived under an older
     // accounting, so the providers whose call counts changed meaning get their
-    // one guarded-shrink-exempt re-derivation (see PENDING_REDERIVE_PROVIDERS).
-    pendingRederive: base.pendingRederive
-      ?? (rest.some(c => c.parsed.version < DAILY_CACHE_VERSION) ? [...PENDING_REDERIVE_PROVIDERS] : undefined),
+    // one guarded-shrink-exempt re-derivation (see
+    // PENDING_REDERIVE_PROVIDER_VERSIONS).
+    pendingRederive: (() => {
+      const pending = new Set(base.pendingRederive ?? [])
+      for (const candidate of rest) {
+        for (const provider of providersPendingRederiveFrom(candidate.parsed.version)) {
+          pending.add(provider)
+        }
+      }
+      return pending.size > 0 ? [...pending] : undefined
+    })(),
     // An untrusted base means nothing here was derived under the current
     // accounting: leave complete unset so the next hydration re-derives every
     // day whose sources survive (the merge keeps the rest).
@@ -1091,7 +1114,7 @@ export function mergeDayEntries(
   guardPartialSurvival = false,
   /// Providers whose baseline slices were recorded under an accounting where a
   /// call meant something else, so a shrink is not evidence of source loss for
-  /// this one re-derivation (see PENDING_REDERIVE_PROVIDERS). Only consulted
+  /// this one re-derivation (see PENDING_REDERIVE_PROVIDER_VERSIONS). Only consulted
   /// where the fresh parse actually produced a slice for the (date, provider);
   /// a slice it could not produce at all is carried by the branch above,
   /// exactly as before.

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -174,10 +174,11 @@ import type { DateRange, ProjectSummary } from './types.js'
 // but optimize added reasoning again. Re-derive so report matches the live parse.
 // v29: #1118 OrcaRouter route pricing (fusion aliases + peel; auto stays unpriced).
 // v28 on main already shipped #1115.
-// v30: Hermes cost provenance. Subscription-included sessions stay $0,
+// v31: Hermes cost provenance. Subscription-included sessions stay $0,
 // explicit estimates retain their status, and surviving Hermes sources replace
 // v29 slices produced by the old API-equivalent fallback.
-export const DAILY_CACHE_VERSION = 30
+// 31: #1234 Hermes cost contract; 30 is claimed by #1132.
+export const DAILY_CACHE_VERSION = 31
 const MIN_SUPPORTED_VERSION = 28
 
 /// Providers whose per-day CALL COUNT means something different at
@@ -202,7 +203,9 @@ const MIN_SUPPORTED_VERSION = 28
 /// untouched, in both directions, and every other provider keeps the guard.
 const PENDING_REDERIVE_PROVIDER_VERSIONS: Readonly<Record<string, number>> = {
   copilot: 26,
-  hermes: 30,
+  // Tracks DAILY_CACHE_VERSION: a v30 file may have been written by #1132's
+  // accounting, which never carried the Hermes cost contract.
+  hermes: 31,
 }
 
 function providersPendingRederiveFrom(fromVersion: number): string[] {

--- a/src/daily-cache.ts
+++ b/src/daily-cache.ts
@@ -465,14 +465,14 @@ function migrateDays(days: Record<string, unknown>[]): DailyEntry[] {
 /// an unspent entitlement out of the parsed file so a same-version reload does
 /// not drop it.
 function pendingRederiveFor(fromVersion: number, parsed: unknown): string[] | undefined {
-  if (fromVersion < DAILY_CACHE_VERSION) {
-    const pending = providersPendingRederiveFrom(fromVersion)
-    return pending.length > 0 ? pending : undefined
-  }
   const raw = (parsed as { pendingRederive?: unknown } | null)?.pendingRederive
-  if (!Array.isArray(raw)) return undefined
-  const kept = raw.filter((p): p is string => typeof p === 'string')
-  return kept.length > 0 ? kept : undefined
+  const pending = new Set(
+    Array.isArray(raw) ? raw.filter((p): p is string => typeof p === 'string') : [],
+  )
+  if (fromVersion < DAILY_CACHE_VERSION) {
+    for (const provider of providersPendingRederiveFrom(fromVersion)) pending.add(provider)
+  }
+  return pending.size > 0 ? [...pending] : undefined
 }
 
 function migratedFrom(parsed: { version: number; lastComputedDate: string | null; savingsConfigHash?: string; tzKey?: string; days: Record<string, unknown>[]; complete?: boolean; watermarkTrusted?: boolean }): DailyCache {
@@ -598,7 +598,7 @@ async function adoptOlderDailyCaches(): Promise<DailyCache> {
     pendingRederive: (() => {
       const pending = new Set(base.pendingRederive ?? [])
       for (const candidate of rest) {
-        for (const provider of providersPendingRederiveFrom(candidate.parsed.version)) {
+        for (const provider of pendingRederiveFor(candidate.parsed.version, candidate.parsed) ?? []) {
           pending.add(provider)
         }
       }

--- a/src/hermes-session-ledger.ts
+++ b/src/hermes-session-ledger.ts
@@ -22,8 +22,11 @@ import type { CachedCall, ProviderSection } from './session-cache.js'
 //   dropped: sealed days are not re-read. This slice does not bump
 //   DAILY_CACHE_VERSION (one cold re-parse for every user) to recover history.
 
-export const HERMES_SESSION_LEDGER_FILENAME = 'hermes-session-ledger.v2.json'
-export const HERMES_SESSION_LEDGER_VERSION = 2 as const
+// v3 discards the local-only v2 migration candidate. Seeding v2 from the warm
+// session cache could preserve lifetime totals while assigning historical
+// observations to the migration day, inflating that day's scoped Hermes spend.
+export const HERMES_SESSION_LEDGER_FILENAME = 'hermes-session-ledger.v3.json'
+export const HERMES_SESSION_LEDGER_VERSION = 3 as const
 
 export type HermesCostBasis = 'actual' | 'estimated' | 'calculated' | 'included'
 

--- a/src/hermes-session-ledger.ts
+++ b/src/hermes-session-ledger.ts
@@ -22,10 +22,10 @@ import type { CachedCall, ProviderSection } from './session-cache.js'
 //   dropped: sealed days are not re-read. This slice does not bump
 //   DAILY_CACHE_VERSION (one cold re-parse for every user) to recover history.
 
-export const HERMES_SESSION_LEDGER_FILENAME = 'hermes-session-ledger.v1.json'
-export const HERMES_SESSION_LEDGER_VERSION = 1 as const
+export const HERMES_SESSION_LEDGER_FILENAME = 'hermes-session-ledger.v2.json'
+export const HERMES_SESSION_LEDGER_VERSION = 2 as const
 
-export type HermesCostBasis = 'actual' | 'estimated' | 'calculated'
+export type HermesCostBasis = 'actual' | 'estimated' | 'calculated' | 'included'
 
 export type HermesTokenTotals = {
   inputTokens: number
@@ -299,7 +299,7 @@ function isNum(v: unknown): v is number {
 }
 
 function isCostBasis(v: unknown): v is HermesCostBasis {
-  return v === 'actual' || v === 'estimated' || v === 'calculated'
+  return v === 'actual' || v === 'estimated' || v === 'calculated' || v === 'included'
 }
 
 function validateTokens(o: Record<string, unknown>): o is Record<string, unknown> & HermesTokenTotals {

--- a/src/hermes-session-ledger.ts
+++ b/src/hermes-session-ledger.ts
@@ -1,5 +1,5 @@
 import { open, rename, unlink, mkdir } from 'fs/promises'
-import { existsSync, readFileSync } from 'fs'
+import { existsSync, readFileSync, unlinkSync } from 'fs'
 import { randomBytes } from 'crypto'
 import { join } from 'path'
 
@@ -349,7 +349,17 @@ function validateLedger(raw: unknown): raw is HermesSessionLedger {
 
 function readLedgerFromDisk(): HermesSessionLedger {
   const path = hermesSessionLedgerPath()
-  if (!existsSync(path)) return emptyHermesSessionLedger()
+  if (!existsSync(path)) {
+    // The v1 file is superseded and can never be read again: the parse-version
+    // bump forces a cold re-parse that rebuilds every cursor from source.
+    // Left behind it is dead bytes that only invite a future reader to trust
+    // observations recorded under an accounting this branch replaced.
+    const v1 = join(getCodeburnCacheDir(), 'hermes-session-ledger.v1.json')
+    if (existsSync(v1)) {
+      try { unlinkSync(v1) } catch { /* another process got there first */ }
+    }
+    return emptyHermesSessionLedger()
+  }
   try {
     const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'))
     if (!validateLedger(parsed)) return emptyHermesSessionLedger()

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ const { version } = require('../package.json')
 // Bump when the menubar payload's rendering semantics change without a package
 // release or daily-cache version change. The envelope version in session-cache
 // protects record shape; this protects the meaning of an otherwise valid one.
-const STATUS_SNAPSHOT_RENDER_VERSION = 3
+const STATUS_SNAPSHOT_RENDER_VERSION = 4
 const STATUS_SNAPSHOT_SEMANTIC_KEY = `${version}:render-${STATUS_SNAPSHOT_RENDER_VERSION}:daily-${DAILY_CACHE_VERSION}`
 import { loadCurrency, getCurrency, isValidCurrencyCode } from './currency.js'
 import { CodexThroughputReader, newestCodexSession, renderCodexThroughput } from './codex-throughput.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ const { version } = require('../package.json')
 // Bump when the menubar payload's rendering semantics change without a package
 // release or daily-cache version change. The envelope version in session-cache
 // protects record shape; this protects the meaning of an otherwise valid one.
-const STATUS_SNAPSHOT_RENDER_VERSION = 2
+const STATUS_SNAPSHOT_RENDER_VERSION = 3
 const STATUS_SNAPSHOT_SEMANTIC_KEY = `${version}:render-${STATUS_SNAPSHOT_RENDER_VERSION}:daily-${DAILY_CACHE_VERSION}`
 import { loadCurrency, getCurrency, isValidCurrencyCode } from './currency.js'
 import { CodexThroughputReader, newestCodexSession, renderCodexThroughput } from './codex-throughput.js'

--- a/src/models.ts
+++ b/src/models.ts
@@ -1248,9 +1248,6 @@ const autoModelNames: Record<string, string> = {
 }
 
 const SHORT_NAMES: Record<string, string> = {
-  // claude-fable-5 and claude-mythos-5 are outside the opus/sonnet/haiku families deriveClaudeShortName covers.
-  'claude-fable-5': 'Fable 5',
-  'claude-mythos-5': 'Mythos 5',
   // Modern claude-<family>-<major>-<minor> ids are derived in deriveClaudeShortName.
   // Only the legacy 3.x ids (family-last) need explicit mapping.
   'claude-3-7-sonnet': 'Sonnet 3.7',
@@ -1363,9 +1360,15 @@ const SORTED_SHORT_NAMES: [string, string][] = Object.entries(SHORT_NAMES)
 // Anthropic's id scheme is `claude-<family>-<major>[-<minor>]`, so every new
 // version is derivable — no hand-maintained entry per release. (Legacy 3.x ids
 // put the family last, e.g. `claude-3-5-sonnet`, and stay in SHORT_NAMES.)
-const CLAUDE_FAMILY: Record<string, string> = { opus: 'Opus', sonnet: 'Sonnet', haiku: 'Haiku' }
+const CLAUDE_FAMILY: Record<string, string> = {
+  opus: 'Opus',
+  sonnet: 'Sonnet',
+  haiku: 'Haiku',
+  fable: 'Fable',
+  mythos: 'Mythos',
+}
 function deriveClaudeShortName(canonical: string): string | undefined {
-  const m = canonical.match(/^claude-(opus|sonnet|haiku)-(\d+)(?:-(\d+))?/)
+  const m = canonical.match(/^claude-(opus|sonnet|haiku|fable|mythos)-(\d+)(?:-(\d+))?/)
   if (!m) return undefined
   const [, family, major, minor] = m
   return `${CLAUDE_FAMILY[family]} ${major}${minor ? `.${minor}` : ''}`

--- a/src/providers/hermes.ts
+++ b/src/providers/hermes.ts
@@ -470,6 +470,7 @@ function resolveHermesCost(
     return { costUSD: row.actual_cost_usd, costIsEstimated: false, costBasis: 'actual' }
   }
   const costStatus = row?.cost_status?.trim().toLowerCase()
+  const costSource = row?.cost_source?.trim().toLowerCase()
   // Included subscription usage is real activity but not metered API spend.
   // Its recorded zero must win over API-equivalent token pricing.
   if (costStatus === 'included') {
@@ -480,8 +481,10 @@ function resolveHermesCost(
   if (costStatus === 'estimated' && row?.estimated_cost_usd != null) {
     return { costUSD: row.estimated_cost_usd, costIsEstimated: true, costBasis: 'estimated' }
   }
-  // Older Hermes schemas may have a positive estimate without cost_status.
-  if (row && row.estimated_cost_usd != null && row.estimated_cost_usd > 0) {
+  // Only rows predating BOTH provenance fields use the legacy positive-estimate
+  // fallback. A provenance-aware `unknown` row can retain a partial estimate
+  // from earlier priced calls; treating that as the session total undercounts.
+  if (!costStatus && !costSource && row && row.estimated_cost_usd != null && row.estimated_cost_usd > 0) {
     return { costUSD: row.estimated_cost_usd, costIsEstimated: true, costBasis: 'estimated' }
   }
   return { costUSD: calculatedCost, costIsEstimated: true, costBasis: 'calculated' }

--- a/src/providers/hermes.ts
+++ b/src/providers/hermes.ts
@@ -37,6 +37,8 @@ type HermesSessionRow = {
   reasoning_tokens: number | null
   estimated_cost_usd: number | null
   actual_cost_usd: number | null
+  cost_status: string | null
+  cost_source: string | null
   api_call_count: number | null
   tool_call_count: number | null
   started_at: number | null
@@ -467,13 +469,20 @@ function resolveHermesCost(
   if (row && row.actual_cost_usd != null) {
     return { costUSD: row.actual_cost_usd, costIsEstimated: false, costBasis: 'actual' }
   }
-  // estimated_cost_usd = 0.0 is not a measurement: Hermes writes it when cost_status
-  // is 'unknown' (no pricing data) or 'included' (flat subscription), so trusting it
-  // would zero out every subscription session. Only positive estimates are trusted;
-  // anything else falls through to the token-based calculation. A genuinely free
-  // model still lands on $0 either way, since litellm prices it at 0.
+  const costStatus = row?.cost_status?.trim().toLowerCase()
+  // Included subscription usage is real activity but not metered API spend.
+  // Its recorded zero must win over API-equivalent token pricing.
+  if (costStatus === 'included') {
+    return { costUSD: 0, costIsEstimated: false, costBasis: 'included' }
+  }
+  // An explicit Hermes estimate is authoritative even when it is zero (for
+  // example, a provider's free tier). Preserve that provenance in the UI.
+  if (costStatus === 'estimated' && row?.estimated_cost_usd != null) {
+    return { costUSD: row.estimated_cost_usd, costIsEstimated: true, costBasis: 'estimated' }
+  }
+  // Older Hermes schemas may have a positive estimate without cost_status.
   if (row && row.estimated_cost_usd != null && row.estimated_cost_usd > 0) {
-    return { costUSD: row.estimated_cost_usd, costIsEstimated: false, costBasis: 'estimated' }
+    return { costUSD: row.estimated_cost_usd, costIsEstimated: true, costBasis: 'estimated' }
   }
   return { costUSD: calculatedCost, costIsEstimated: true, costBasis: 'calculated' }
 }
@@ -507,9 +516,11 @@ function observationToCall(
     reasoningTokens: observation.reasoningTokens,
     webSearchRequests: 0,
     costUSD: observation.costUSD,
-    // Later observations keep the stored basis: calculated stays estimated;
-    // provider-recorded actual/estimated keep main's measured behavior.
-    costIsEstimated: later ? observation.costBasis === 'calculated' : args.costIsEstimated,
+    // Later observations keep the stored basis. Included and actual are
+    // recorded facts; estimated and calculated remain estimates.
+    costIsEstimated: later
+      ? observation.costBasis === 'calculated' || observation.costBasis === 'estimated'
+      : args.costIsEstimated,
     tools: later ? [] : args.tools,
     bashCommands: later ? [] : args.bashCommands,
     timestamp: observation.timestamp,
@@ -637,6 +648,8 @@ function createParser(source: SessionSource, seenKeys: Set<string>, hermesHome: 
                   ${numberColumn(columns, 'reasoning_tokens')},
                   ${nullableColumn(columns, 'estimated_cost_usd')},
                   ${nullableColumn(columns, 'actual_cost_usd')},
+                  ${nullableColumn(columns, 'cost_status')},
+                  ${nullableColumn(columns, 'cost_source')},
                   ${numberColumn(columns, 'api_call_count')},
                   ${numberColumn(columns, 'tool_call_count')},
                   ${nullableColumn(columns, 'started_at')},

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -373,9 +373,11 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   // replays (double-counted before), takes the model from the reporting
   // assistant/message, and keeps agent-injected context out of the preview.
   dsh: 'seed-aware-v1',
-  // cost-provenance-v2: preserve Hermes included/estimated/actual status and
-  // rebuild the provider section alongside the v2 lifetime ledger.
-  hermes: 'reasoning-output-accounting-v1-est-cost-routed-ids-workspace-pr-v5-cost-provenance-v2',
+  // cost-provenance-v3: preserve Hermes included/estimated/actual status and
+  // rebuild the provider section alongside the v3 lifetime ledger. The parse
+  // bump is required with the ledger bump: seeding a new ledger from a section
+  // produced under v2 can turn historical accounting deltas into today's use.
+  hermes: 'reasoning-output-accounting-v1-est-cost-routed-ids-workspace-pr-v5-cost-provenance-v3',
   'lingtai-tui': 'token-ledger-registry-activity-v3',
   'ibm-bob': 'worktree-project-grouping-v1',
   // project-path-v1: the parser now records the session's full working

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -373,7 +373,9 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   // replays (double-counted before), takes the model from the reporting
   // assistant/message, and keeps agent-injected context out of the preview.
   dsh: 'seed-aware-v1',
-  hermes: 'reasoning-output-accounting-v1-est-cost-routed-ids-workspace-pr-v5-zero-estimate-fallback-v1',
+  // cost-provenance-v2: preserve Hermes included/estimated/actual status and
+  // rebuild the provider section alongside the v2 lifetime ledger.
+  hermes: 'reasoning-output-accounting-v1-est-cost-routed-ids-workspace-pr-v5-cost-provenance-v2',
   'lingtai-tui': 'token-ledger-registry-activity-v3',
   'ibm-bob': 'worktree-project-grouping-v1',
   // project-path-v1: the parser now records the session's full working

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -16,7 +16,7 @@ import { scanUserCorrections, medianTimeToFirstEditMs, aggregateFileChurn, compu
 import { buildPrAttribution, aggregateByBranch } from './sessions-report.js'
 import { scanAndDetect } from './optimize.js'
 import { callBillableOutputTokens, sessionBillableOutputTokens } from './session-output.js'
-import { getDaysInRange, ensureCacheHydrated, loadDailyCache, emptyCache, BACKFILL_DAYS, toDateString, type DailyCache, type DailyEntry, type ProjectDayStats, type ProviderDaySlice } from './daily-cache.js'
+import { getDaysInRange, ensureCacheHydrated, loadDailyCache, emptyCache, mergeDayEntries, BACKFILL_DAYS, toDateString, type DailyCache, type DailyEntry, type ProjectDayStats, type ProviderDaySlice } from './daily-cache.js'
 import { buildGranularHistory } from './granular-history.js'
 
 // Row caps for the by-PR / by-branch payload aggregations, ranked by cost.
@@ -284,21 +284,33 @@ function sliceDayToProvider(day: DailyEntry, provider: string): DailyEntry {
 }
 
 /// Overlay surviving provider-scoped source data onto the durable all-provider
-/// cache without touching unrelated providers. A fresh slice wins for its date;
-/// a missing fresh slice keeps the cached provider history because its source
-/// may simply have aged out. The result is provider-sliced so headline and
-/// history consumers cannot accidentally count unrelated providers.
+/// cache without touching unrelated providers. The result is provider-sliced so
+/// headline and history consumers cannot accidentally count unrelated providers.
+///
+/// A settled day's sources age off disk continuously, so a fresh
+/// provider-scoped parse of a historical date is a LOWER BOUND, not a
+/// correction. Setting it unconditionally (what this did) replaced finalized
+/// cache days with whatever the shrunken parse could still see, so the scoped
+/// view reported a fraction of the day the all-provider view served off the
+/// same cache.
+///
+/// The rule is therefore: fresh may FILL a (date, provider) the cache lacks,
+/// and wins on any day still inside the settle window, but it may never SHRINK
+/// a settled day the cache already holds. That is exactly mergeDayEntries with
+/// guardPartialSurvival, whose argument order matters: `fresh` is primary and
+/// the cache baseline is secondary, so the guard reads the shrink in the
+/// direction it expects. Filling still has to work, because on a cold cache
+/// the scoped parse is the only source a historical day has.
 export function overlayProviderDaySlices(
   baseline: DailyEntry[],
   fresh: DailyEntry[],
   provider: string,
 ): DailyEntry[] {
-  const byDate = new Map(baseline.map(day => [day.date, sliceDayToProvider(day, provider)]))
-  for (const day of fresh) {
-    if (!Object.hasOwn(day.providers, provider)) continue
-    byDate.set(day.date, sliceDayToProvider(day, provider))
-  }
-  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date))
+  const freshSliced = fresh
+    .filter(day => Object.hasOwn(day.providers, provider))
+    .map(day => sliceDayToProvider(day, provider))
+  const sliced = baseline.map(day => sliceDayToProvider(day, provider))
+  return mergeDayEntries(freshSliced, sliced, false, undefined, true)
 }
 
 /// Does a cached day's project entry pass the active name filters? Mirrors

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -585,10 +585,14 @@ export async function buildDurablePeriod(periodInfo: PeriodInfo, opts: Aggregate
         : aggregateProjectsIntoDays(fp(await parseAllSessions(todayRange, 'all'))).filter(d => d.date === todayStr)
     }
   } else {
-    // Provider-filtered: today's all-provider parse feeds the union (sliced
-    // below); the provider-scoped parse feeds the detail/enrichment fields.
-    todayAllDays = aggregateProjectsIntoDays(fp(await parseAllSessions(todayRange, 'all'))).filter(d => d.date === todayStr)
+    // Provider-filtered: one provider-scoped parse feeds both today's union
+    // slice and the detail/enrichment fields. Scanning every unrelated provider
+    // here made a first hover deserialize the entire multi-gigabyte cache even
+    // though the returned payload contains only `pf`.
     const rawProv = fp(await parseAllSessions(isTodayOnly ? todayRange : periodInfo.range, pf))
+    todayAllDays = rangeEndStr >= todayStr
+      ? aggregateProjectsIntoDays(filterProjectsByDays(rawProv, new Set([todayStr]))).filter(d => d.date === todayStr)
+      : []
     liveProjects = daysSelection && !isTodayOnly ? filterProjectsByDays(rawProv, daysSelection.days) : rawProv
     scanRange = isTodayOnly ? todayRange : periodInfo.range
   }

--- a/src/usage-aggregator.ts
+++ b/src/usage-aggregator.ts
@@ -15,7 +15,7 @@ import { scanUserCorrections, medianTimeToFirstEditMs, aggregateFileChurn, compu
 import { buildPrAttribution, aggregateByBranch } from './sessions-report.js'
 import { scanAndDetect } from './optimize.js'
 import { callBillableOutputTokens, sessionBillableOutputTokens } from './session-output.js'
-import { getDaysInRange, ensureCacheHydrated, emptyCache, BACKFILL_DAYS, toDateString, type DailyCache, type DailyEntry, type ProjectDayStats, type ProviderDaySlice } from './daily-cache.js'
+import { getDaysInRange, ensureCacheHydrated, loadDailyCache, emptyCache, BACKFILL_DAYS, toDateString, type DailyCache, type DailyEntry, type ProjectDayStats, type ProviderDaySlice } from './daily-cache.js'
 import { buildGranularHistory } from './granular-history.js'
 
 // Row caps for the by-PR / by-branch payload aggregations, ranked by cost.
@@ -282,6 +282,24 @@ function sliceDayToProvider(day: DailyEntry, provider: string): DailyEntry {
   }
 }
 
+/// Overlay surviving provider-scoped source data onto the durable all-provider
+/// cache without touching unrelated providers. A fresh slice wins for its date;
+/// a missing fresh slice keeps the cached provider history because its source
+/// may simply have aged out. The result is provider-sliced so headline and
+/// history consumers cannot accidentally count unrelated providers.
+export function overlayProviderDaySlices(
+  baseline: DailyEntry[],
+  fresh: DailyEntry[],
+  provider: string,
+): DailyEntry[] {
+  const byDate = new Map(baseline.map(day => [day.date, sliceDayToProvider(day, provider)]))
+  for (const day of fresh) {
+    if (!Object.hasOwn(day.providers, provider)) continue
+    byDate.set(day.date, sliceDayToProvider(day, provider))
+  }
+  return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date))
+}
+
 /// Does a cached day's project entry pass the active name filters? Mirrors
 /// parser.filterProjectsByName exactly — case-insensitive substring match
 /// against the project name OR its filesystem path, include first then exclude —
@@ -532,10 +550,10 @@ export type DurablePeriod = {
   /// Fresh per-period parse (provider + name filtered) for detail views that
   /// still need surviving session files.
   liveProjects: ProjectSummary[]
-  /// Hydrated all-provider cache (reused by the menubar's provider list + daily
-  /// history sections).
+  /// Shared durable cache. All-provider requests hydrate it; provider-scoped
+  /// requests load it without triggering unrelated provider scans.
   cache: DailyCache
-  /// Today-only slice, all providers, name-filtered (memo seed for the menubar).
+  /// Today-only, name-filtered slice for the active provider scope.
   todayAllDays: DailyEntry[]
   /// The scan range the live parse covered (today-only when the period is today).
   scanRange: DateRange
@@ -554,14 +572,18 @@ export async function buildDurablePeriod(periodInfo: PeriodInfo, opts: Aggregate
   const rangeEndStr = toDateString(periodInfo.range.end)
   const isTodayOnly = rangeStartStr === todayStr && rangeEndStr === todayStr
 
-  const cache = await hydrateCache()
+  // The shared daily cache is hydrated only by an all-provider request. A
+  // provider tab must not turn into a hidden all-provider scan on a cold or
+  // migrating cache; it loads the durable cache as-is and overlays the selected
+  // provider's surviving source data below.
+  const cache = pf === 'all' ? await hydrateCache() : await loadDailyCache()
 
-  // Today's live data always comes from an all-provider parse so the union (and
-  // any per-provider slice of it) sees every provider's today. `todayAllDays` is
-  // the today bucket only — the union filters the historical remainder out of the
-  // cache.
+  // The unscoped path parses all providers. A provider-scoped path parses only
+  // that provider and overlays its fresh slices onto the durable cache below.
+  // `todayAllDays` is the today bucket for whichever scope is active.
   let liveProjects: ProjectSummary[]
   let todayAllDays: DailyEntry[]
+  let freshProviderDays: DailyEntry[] = []
   let scanRange: DateRange
   if (pf === 'all') {
     if (isTodayOnly) {
@@ -590,6 +612,7 @@ export async function buildDurablePeriod(periodInfo: PeriodInfo, opts: Aggregate
     // here made a first hover deserialize the entire multi-gigabyte cache even
     // though the returned payload contains only `pf`.
     const rawProv = fp(await parseAllSessions(isTodayOnly ? todayRange : periodInfo.range, pf))
+    freshProviderDays = aggregateProjectsIntoDays(rawProv)
     todayAllDays = rangeEndStr >= todayStr
       ? aggregateProjectsIntoDays(filterProjectsByDays(rawProv, new Set([todayStr]))).filter(d => d.date === todayStr)
       : []
@@ -624,7 +647,14 @@ export async function buildDurablePeriod(periodInfo: PeriodInfo, opts: Aggregate
     : undefined
 
   const allDays = unionDaysForPeriod(cache, todayAllDays, periodInfo, daysSelection?.days ?? null, sliceHistorical)
-  const days = pf === 'all' ? allDays : allDays.map(d => sliceDayToProvider(d, pf))
+  const freshDaysInSelection = freshProviderDays.filter(day =>
+    day.date >= rangeStartStr
+      && day.date <= rangeEndStr
+      && (!daysSelection || daysSelection.days.has(day.date)),
+  )
+  const days = pf === 'all'
+    ? allDays
+    : overlayProviderDaySlices(allDays, freshDaysInSelection, pf)
   const data = buildPeriodDataFromDays(days, periodInfo.label)
 
   // Enrich the cache-authoritative headline with fields DailyEntry cannot carry.
@@ -747,11 +777,10 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
     // still renders.
   }
   if (!effectivelyScoped) {
-    // Every non-scoped headline — all-provider AND provider-filtered — is built
-    // by the one shared durable-totals builder. It unions the carry-forward
-    // cache with today's live parse (slicing to the provider when filtered), so
-    // days whose session files have expired still count. The provider list and
-    // daily-history sections below reuse its cache + today slice.
+    // Every non-config-scoped headline is built by the shared durable-totals
+    // builder. The all-provider path hydrates the cache; a provider-filtered
+    // path overlays that provider's surviving source slices without scanning
+    // unrelated providers. Expired-source history remains durable in both.
     const durable = await buildDurablePeriod(periodInfo, {
       provider: pf,
       project: opts.project,
@@ -873,38 +902,9 @@ export async function buildMenubarPayloadForRange(periodInfo: PeriodInfo, opts: 
     const fullHistory = [...allCacheDays, ...todayDays]
     dailyHistory = dailyEntriesToHistory(fullHistory)
   } else {
-    const emptyModels = [] as { name: string; cost: number; savingsUSD: number; calls: number; inputTokens: number; outputTokens: number }[]
-    const historyFromCache = allCacheDays.map(d => {
-      const prov = d.providers[pf] ?? { calls: 0, cost: 0, savingsUSD: 0 }
-      return {
-        date: d.date,
-        cost: prov.cost,
-        savingsUSD: prov.savingsUSD,
-        calls: prov.calls,
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheWriteTokens: 0,
-        topModels: emptyModels,
-      }
-    })
-    const todayFromParse = aggregateProjectsIntoDays(scanProjects)
-      .filter(d => d.date === todayStr)
-      .map(d => {
-        const prov = d.providers[pf] ?? { calls: 0, cost: 0, savingsUSD: 0 }
-        return {
-          date: d.date,
-          cost: prov.cost,
-          savingsUSD: prov.savingsUSD,
-          calls: prov.calls,
-          inputTokens: 0,
-          outputTokens: 0,
-          cacheReadTokens: 0,
-          cacheWriteTokens: 0,
-          topModels: emptyModels,
-        }
-      })
-    dailyHistory = [...historyFromCache, ...todayFromParse]
+    const freshHistory = [...aggregateProjectsIntoDays(scanProjects), ...(todayAllDays ?? [])]
+      .filter(day => day.date >= historyStartStr && day.date <= todayStr)
+    dailyHistory = dailyEntriesToHistory(overlayProviderDaySlices(allCacheDays, freshHistory, pf))
   }
 
   const home = homedir()

--- a/tests/cli-durable-totals.test.ts
+++ b/tests/cli-durable-totals.test.ts
@@ -84,6 +84,26 @@ async function seedCarriedCache(): Promise<string> {
   return day
 }
 
+/** Sources for the settled day still exist but explain only a fraction of what
+ *  the cache finalized there, which is what source aging looks like in the
+ *  window before a transcript is deleted outright. */
+async function seedPartialSourcesFor(date: string): Promise<void> {
+  const projectDir = join(ROOT, 'home', '.claude', 'projects', 'p')
+  await mkdir(projectDir, { recursive: true })
+  const [y, m, d] = date.split('-').map(Number)
+  const line = JSON.stringify({
+    type: 'assistant',
+    timestamp: new Date(y!, m! - 1, d!, 12, 0, 0).toISOString(),
+    sessionId: 's-partial',
+    message: {
+      type: 'message', role: 'assistant', model: 'claude-3-5-sonnet-20241022', id: 'm-partial',
+      content: [],
+      usage: { input_tokens: 1000, output_tokens: 200, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+    },
+  })
+  await writeFile(join(projectDir, 's-partial.jsonl'), line + '\n', 'utf-8')
+}
+
 /** Seed a real, priced Claude session dated TODAY (the live, surviving half). */
 async function seedLiveTodaySession(): Promise<void> {
   const projectDir = join(ROOT, 'home', '.claude', 'projects', 'p')
@@ -209,6 +229,25 @@ describe('CLI totals ↔ menubar parity through the durable daily cache', () => 
     expect(codexMenubar.current.cost).toBe(codexDurable.data.cost)
     expect(codexDurable.data.cost).toBe(0)
     expect(codexDurable.carriedCostUSD).toBe(0)
+  })
+
+  it('keeps the scoped view equal to the all-provider slice when a settled day only partially survives', async () => {
+    const day = await seedCarriedCache()
+    await seedPartialSourcesFor(day)
+    await seedLiveTodaySession()
+    const range = getDateRange('all').range
+
+    clearSessionCache()
+    const all = await buildMenubarPayloadForRange({ range, label: 'p' }, { provider: 'all', optimize: false, timeline: false })
+    clearSessionCache()
+    const scoped = await buildMenubarPayloadForRange({ range, label: 'p' }, { provider: 'claude', optimize: false, timeline: false })
+
+    // The corpus is entirely Claude, so the scoped headline IS the all-provider
+    // Claude slice. The scoped path used to overlay the shrunken re-parse over
+    // the settled day and report a fraction of the all-provider total.
+    expect(all.current.calls).toBeGreaterThan(40)
+    expect(scoped.current.calls).toBe(all.current.calls)
+    expect(scoped.current.cost).toBeCloseTo(all.current.cost, 6)
   })
 
   it('holds the equality in the plain live regime with no carried days', async () => {

--- a/tests/cli-status-menubar.test.ts
+++ b/tests/cli-status-menubar.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { existsSync, readdirSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter as pathDelimiter, join } from 'node:path'
@@ -822,6 +822,52 @@ describe('codeburn status --format menubar-json', () => {
       expect(settled.status, `stderr: ${settled.stderr}`).toBe(0)
       const settledPayload = JSON.parse(settled.stdout) as { current: { calls: number } }
       expect(settledPayload.current.calls).toBe(2)
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a provider payload cached under the previous render contract', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'codeburn-menubar-provider-render-'))
+
+    try {
+      const projectDir = join(home, '.claude', 'projects', 'myapp')
+      await mkdir(projectDir, { recursive: true })
+      const now = new Date()
+      const todayUtcMidnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+      const base = new Date(Math.max(todayUtcMidnight, now.getTime() - 2 * 3600_000))
+      const ts = (offset: number) => new Date(base.getTime() + offset).toISOString().replace(/\.\d+Z$/, 'Z')
+      await writeFile(
+        join(projectDir, 'session.jsonl'),
+        [userLine('s1', ts(0)), assistantLine('s1', ts(60_000), 'msg-1')].join('\n'),
+      )
+
+      const args = ['status', '--format', 'menubar-json', '--period', 'today', '--provider', 'all', '--no-optimize']
+      const first = runCli(args, home)
+      expect(first.status, `stderr: ${first.stderr}`).toBe(0)
+
+      const snapshotFiles = findSnapshotFiles(join(home, '.cache', 'codeburn'))
+      expect(snapshotFiles).toHaveLength(1)
+      const record = JSON.parse(await readFile(snapshotFiles[0]!, 'utf-8')) as {
+        semanticKey: string
+        payload: { current: { providerDetails: unknown[] } }
+      }
+      record.semanticKey = record.semanticKey.replace(/:render-\d+:/, ':render-2:')
+      record.payload.current.providerDetails = [
+        { id: 'legacy-idle', label: 'Legacy Idle', cost: 0 },
+      ]
+      await writeFile(snapshotFiles[0]!, JSON.stringify(record))
+
+      const second = runCli(args, home)
+      expect(second.status, `stderr: ${second.stderr}`).toBe(0)
+      const payload = JSON.parse(second.stdout) as {
+        current: { providerDetails: Array<{ id: string; calls: number; hasUsage: boolean }> }
+      }
+      expect(payload.current.providerDetails.map(provider => provider.id)).not.toContain('legacy-idle')
+      expect(payload.current.providerDetails.find(provider => provider.id === 'claude')).toMatchObject({
+        calls: 1,
+        hasUsage: true,
+      })
     } finally {
       await rm(home, { recursive: true, force: true })
     }

--- a/tests/daily-cache-carry-forward.test.ts
+++ b/tests/daily-cache-carry-forward.test.ts
@@ -798,6 +798,26 @@ describe('#946: a migration re-derives copilot instead of carrying it', () => {
     expect(loaded.pendingRederive).toEqual(['hermes'])
   })
 
+  it('preserves an older cache pending repair while adding a newer provider repair', async () => {
+    await writeFile(
+      join(TMP_CACHE_ROOT, `daily-cache.v${DAILY_CACHE_VERSION - 1}.json`),
+      JSON.stringify({
+        version: DAILY_CACHE_VERSION - 1,
+        savingsConfigHash: 'cfg-A',
+        tzKey: currentTzKey(),
+        lastComputedDate: daysAgoStr(1),
+        days: [day(settled, { copilot: PRE_STORE, hermes: slice(4603, 6764) })],
+        complete: true,
+        watermarkTrusted: true,
+        pendingRederive: ['copilot'],
+      }),
+      'utf-8',
+    )
+
+    const loaded = await loadDailyCache()
+    expect(loaded.pendingRederive).toEqual(['copilot', 'hermes'])
+  })
+
   it('still carries the slice whole when the sources are gone (never-lose, #1033)', async () => {
     await seedOlderCache([day(settled, { copilot: PRE_STORE })])
     // The re-derive finds nothing at all for that day: the store and the

--- a/tests/daily-cache-carry-forward.test.ts
+++ b/tests/daily-cache-carry-forward.test.ts
@@ -738,9 +738,9 @@ describe('#946: a migration re-derives copilot instead of carrying it', () => {
   /// so `loadDailyCache` takes the adoption path.
   const seedOlderCache = async (days: DailyEntry[]) => {
     await writeFile(
-      join(TMP_CACHE_ROOT, `daily-cache.v${DAILY_CACHE_VERSION - 4}.json`),
+      join(TMP_CACHE_ROOT, `daily-cache.v${DAILY_CACHE_VERSION - 5}.json`),
       JSON.stringify({
-        version: DAILY_CACHE_VERSION - 4,
+        version: DAILY_CACHE_VERSION - 5,
         savingsConfigHash: 'cfg-A',
         tzKey: currentTzKey(),
         lastComputedDate: daysAgoStr(1),
@@ -761,6 +761,41 @@ describe('#946: a migration re-derives copilot instead of carrying it', () => {
     expect(got.calls).toBe(27)
     // Spent by this re-derivation, so the guard is back on for every later run.
     expect(out.pendingRederive).toBeUndefined()
+  })
+
+  it('re-derives a Hermes slice after the cost-provenance contract changes', async () => {
+    const corrupt = slice(4603, 6764, { sessions: 6764 })
+    const corrected = slice(0.438, 6, { sessions: 6 })
+    await seedOlderCache([day(settled, { hermes: corrupt })])
+
+    const out = await ensureCacheHydrated(
+      noSessions,
+      () => [day(settled, { hermes: corrected })],
+      'cfg-A',
+    )
+
+    expect(out.days.find(d => d.date === settled)!.providers['hermes'])
+      .toMatchObject({ cost: 0.438, calls: 6, sessions: 6 })
+    expect(out.pendingRederive).toBeUndefined()
+  })
+
+  it('does not re-open Copilot re-derivation for a cache already past its contract change', async () => {
+    await writeFile(
+      join(TMP_CACHE_ROOT, `daily-cache.v${DAILY_CACHE_VERSION - 1}.json`),
+      JSON.stringify({
+        version: DAILY_CACHE_VERSION - 1,
+        savingsConfigHash: 'cfg-A',
+        tzKey: currentTzKey(),
+        lastComputedDate: daysAgoStr(1),
+        days: [day(settled, { copilot: PRE_STORE, hermes: slice(4603, 6764) })],
+        complete: true,
+        watermarkTrusted: true,
+      }),
+      'utf-8',
+    )
+
+    const loaded = await loadDailyCache()
+    expect(loaded.pendingRederive).toEqual(['hermes'])
   })
 
   it('still carries the slice whole when the sources are gone (never-lose, #1033)', async () => {
@@ -794,7 +829,7 @@ describe('#946: a migration re-derives copilot instead of carrying it', () => {
   it('a PARTIAL parse does not spend the entitlement', async () => {
     await seedOlderCache([day(settled, { copilot: PRE_STORE })])
     const partial = await ensureCacheHydrated(noSessions, () => [], 'cfg-A', () => false)
-    expect(partial.pendingRederive).toEqual(['copilot'])
+    expect(partial.pendingRederive).toEqual(['copilot', 'hermes'])
     // The next COMPLETE run still gets to re-derive.
     const out = await ensureCacheHydrated(noSessions, () => [day(settled, { copilot: STORE_BACKED })], 'cfg-A')
     expect(out.days.find(d => d.date === settled)!.providers['copilot'])

--- a/tests/daily-cache-carry-forward.test.ts
+++ b/tests/daily-cache-carry-forward.test.ts
@@ -736,11 +736,16 @@ describe('#946: a migration re-derives copilot instead of carrying it', () => {
 
   /// Seeds an older-version daily cache (what a 0.9.20 install leaves behind)
   /// so `loadDailyCache` takes the adoption path.
+  /// Pinned, not derived from DAILY_CACHE_VERSION: this fixture is the
+  /// pre-copilot-contract era, which is a fixed point in history.
+  /// `DAILY_CACHE_VERSION - 5` drifted across the copilot boundary (26) on the
+  /// next bump and silently stopped seeding the entitlement these tests check.
+  const PRE_COPILOT_CONTRACT_VERSION = 25
   const seedOlderCache = async (days: DailyEntry[]) => {
     await writeFile(
-      join(TMP_CACHE_ROOT, `daily-cache.v${DAILY_CACHE_VERSION - 5}.json`),
+      join(TMP_CACHE_ROOT, `daily-cache.v${PRE_COPILOT_CONTRACT_VERSION}.json`),
       JSON.stringify({
-        version: DAILY_CACHE_VERSION - 5,
+        version: PRE_COPILOT_CONTRACT_VERSION,
         savingsConfigHash: 'cfg-A',
         tzKey: currentTzKey(),
         lastComputedDate: daysAgoStr(1),

--- a/tests/daily-cache-version-rederivation.test.ts
+++ b/tests/daily-cache-version-rederivation.test.ts
@@ -4,8 +4,10 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 import {
+  DAILY_CACHE_VERSION,
   currentTzKey,
   ensureCacheHydrated,
+  loadDailyCache,
   toDateString,
   type DailyEntry,
 } from '../src/daily-cache.js'
@@ -105,5 +107,52 @@ describe('daily-cache re-derivation on a DAILY_CACHE_VERSION bump', () => {
     expect(refreshedDay?.providers.grok?.cost).toBe(2)
     expect(refreshedDay?.cost).toBe(2)
     expect(JSON.parse(await readFile(oldPath, 'utf8'))).toEqual(oldCache)
+  })
+})
+
+// v30 is claimed by two open branches at once: this one and #1132. A v30 file
+// on disk therefore carries UNKNOWN accounting, so adopting it as the
+// finalized base would serve #1132's numbers under this branch's contract.
+describe('daily-cache adoption of a v30 file written under a different accounting', () => {
+  it('carries its days forward but never adopts it as the finalized base', async () => {
+    const date = toDateString(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000))
+    const yesterday = toDateString(new Date(Date.now() - 24 * 60 * 60 * 1000))
+    const foreign = day(date, 42)
+    foreign.providers = {
+      hermes: {
+        calls: 1,
+        cost: 42,
+        savingsUSD: 0,
+        sessions: 1,
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 30,
+        cacheWriteTokens: 0,
+      },
+    }
+    await writeFile(
+      join(cacheRoot, 'daily-cache.v30.json'),
+      JSON.stringify({
+        version: 30,
+        savingsConfigHash: 'cfg',
+        tzKey: currentTzKey(),
+        lastComputedDate: yesterday,
+        days: [foreign],
+        complete: true,
+        watermarkTrusted: true,
+      }),
+    )
+
+    const loaded = await loadDailyCache()
+
+    expect(DAILY_CACHE_VERSION).toBe(31)
+    expect(loaded.version).toBe(31)
+    // A v30 candidate must not satisfy the same-version adoption at
+    // adoptOlderDailyCaches, so its trust markers cannot survive.
+    expect(loaded.complete).toBe(false)
+    expect(loaded.watermarkTrusted).toBe(false)
+    const carried = loaded.days.find(entry => entry.date === date)
+    expect(carried?.carried).toBe(true)
+    expect(loaded.pendingRederive).toContain('hermes')
   })
 })

--- a/tests/hermes-cost-fallback.test.ts
+++ b/tests/hermes-cost-fallback.test.ts
@@ -28,6 +28,7 @@ function seedDb(): void {
       input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,
       cache_read_tokens INTEGER DEFAULT 0, cache_write_tokens INTEGER DEFAULT 0,
       reasoning_tokens INTEGER DEFAULT 0, estimated_cost_usd REAL, actual_cost_usd REAL,
+      cost_status TEXT, cost_source TEXT,
       api_call_count INTEGER DEFAULT 0, tool_call_count INTEGER DEFAULT 0,
       started_at REAL, title TEXT
     )
@@ -41,18 +42,21 @@ function seedDb(): void {
   const startedAt = Date.now() / 1000 - 3600
   const insert = db.prepare(
     `INSERT INTO sessions (id, source, model, input_tokens, output_tokens,
-      estimated_cost_usd, actual_cost_usd, api_call_count, started_at)
-     VALUES (?, 'cli', ?, ?, ?, ?, ?, 1, ?)`,
+      estimated_cost_usd, actual_cost_usd, cost_status, cost_source, api_call_count, started_at)
+     VALUES (?, 'cli', ?, ?, ?, ?, ?, ?, ?, 1, ?)`,
   )
-  // Hermes writes estimated 0.0 when cost_status is 'unknown' or 'included'
-  // (subscription). CodeBurn must not trust that $0: the tokens are real, so
-  // cost falls through to the token-based calculation.
-  insert.run('zero-estimate', 'claude-opus-4-6', 100000, 10000, 0.0, null, startedAt)
+  // Subscription-included usage is recorded $0 spend even though it carries
+  // real tokens. API-equivalent pricing must not overwrite that provenance.
+  insert.run('included-zero', 'gpt-5.6-sol', 100000, 10000, 0.0, null, 'included', 'none', startedAt)
+  // Unknown cost with no usable estimate falls back to token pricing.
+  insert.run('unknown-zero', 'claude-opus-4-6', 100000, 10000, 0.0, null, 'unknown', 'none', startedAt)
   // A positive recorded estimate stays authoritative.
-  insert.run('positive-estimate', 'claude-opus-4-6', 100000, 10000, 0.5, null, startedAt)
+  insert.run('positive-estimate', 'claude-opus-4-6', 100000, 10000, 0.5, null, 'estimated', 'official_docs_snapshot', startedAt)
+  // An explicitly estimated free value remains zero.
+  insert.run('estimated-zero', 'free-model', 100000, 10000, 0.0, null, 'estimated', 'provider_models_api', startedAt)
   // An explicit $0 *actual* invoice amount is recorded fact and stays $0.
-  insert.run('zero-actual', 'claude-opus-4-6', 100000, 10000, null, 0.0, startedAt)
-  for (const id of ['zero-estimate', 'positive-estimate', 'zero-actual']) {
+  insert.run('zero-actual', 'claude-opus-4-6', 100000, 10000, null, 0.0, 'actual', 'invoice', startedAt)
+  for (const id of ['included-zero', 'unknown-zero', 'positive-estimate', 'estimated-zero', 'zero-actual']) {
     db.prepare('INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)')
       .run(id, 'user', `session ${id}`, startedAt)
     db.prepare('INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)')
@@ -77,17 +81,23 @@ afterEach(async () => {
 const skipUnlessSqlite = isSqliteAvailable() ? describe : describe.skip
 
 skipUnlessSqlite('hermes recorded-cost fallback', () => {
-  it('ignores a $0 estimated cost and calculates from tokens', async () => {
+  it('preserves included and recorded zeroes while estimating unknown cost', async () => {
     seedDb()
     const projects = await parseAllSessions(undefined, 'hermes')
     const sessions = projects.flatMap(project => project.sessions)
     const byId = new Map(sessions.map(s => [s.sessionId, s]))
 
-    const zeroEstimate = byId.get('zero-estimate')!
-    expect(zeroEstimate.totalCostUSD).toBeGreaterThan(0)
+    const included = byId.get('included-zero')!
+    expect(included.totalCostUSD).toBe(0)
+
+    const unknown = byId.get('unknown-zero')!
+    expect(unknown.totalCostUSD).toBeGreaterThan(0)
 
     const positive = byId.get('positive-estimate')!
     expect(positive.totalCostUSD).toBe(0.5)
+
+    const estimatedZero = byId.get('estimated-zero')!
+    expect(estimatedZero.totalCostUSD).toBe(0)
 
     const zeroActual = byId.get('zero-actual')!
     expect(zeroActual.totalCostUSD).toBe(0)

--- a/tests/hermes-cost-fallback.test.ts
+++ b/tests/hermes-cost-fallback.test.ts
@@ -50,13 +50,16 @@ function seedDb(): void {
   insert.run('included-zero', 'gpt-5.6-sol', 100000, 10000, 0.0, null, 'included', 'none', startedAt)
   // Unknown cost with no usable estimate falls back to token pricing.
   insert.run('unknown-zero', 'claude-opus-4-6', 100000, 10000, 0.0, null, 'unknown', 'none', startedAt)
+  // An unknown row may retain a partial estimate from earlier priced calls.
+  // It is not a complete session total and must still be recalculated.
+  insert.run('unknown-partial', 'claude-opus-4-6', 100000, 10000, 0.25, null, 'unknown', 'official_docs_snapshot', startedAt)
   // A positive recorded estimate stays authoritative.
   insert.run('positive-estimate', 'claude-opus-4-6', 100000, 10000, 0.5, null, 'estimated', 'official_docs_snapshot', startedAt)
   // An explicitly estimated free value remains zero.
   insert.run('estimated-zero', 'free-model', 100000, 10000, 0.0, null, 'estimated', 'provider_models_api', startedAt)
   // An explicit $0 *actual* invoice amount is recorded fact and stays $0.
   insert.run('zero-actual', 'claude-opus-4-6', 100000, 10000, null, 0.0, 'actual', 'invoice', startedAt)
-  for (const id of ['included-zero', 'unknown-zero', 'positive-estimate', 'estimated-zero', 'zero-actual']) {
+  for (const id of ['included-zero', 'unknown-zero', 'unknown-partial', 'positive-estimate', 'estimated-zero', 'zero-actual']) {
     db.prepare('INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)')
       .run(id, 'user', `session ${id}`, startedAt)
     db.prepare('INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)')
@@ -92,6 +95,10 @@ skipUnlessSqlite('hermes recorded-cost fallback', () => {
 
     const unknown = byId.get('unknown-zero')!
     expect(unknown.totalCostUSD).toBeGreaterThan(0)
+
+    const unknownPartial = byId.get('unknown-partial')!
+    expect(unknownPartial.totalCostUSD).toBeGreaterThan(0)
+    expect(unknownPartial.totalCostUSD).not.toBe(0.25)
 
     const positive = byId.get('positive-estimate')!
     expect(positive.totalCostUSD).toBe(0.5)

--- a/tests/hermes-session-ledger.test.ts
+++ b/tests/hermes-session-ledger.test.ts
@@ -1,10 +1,11 @@
-import { mkdir, mkdtemp, rm } from 'fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
   applyHermesSnapshot,
+  HERMES_SESSION_LEDGER_VERSION,
   hermesBaselineKey,
   hermesObservationKey,
   hermesSessionLedgerPath,
@@ -237,10 +238,36 @@ describe('hermes session ledger unit', () => {
     await mkdir(hermesSessionLedgerPath())
     let caught: unknown
     try {
-      await persistHermesSessionLedger({ version: 1, cursors: {} })
+      await persistHermesSessionLedger({ version: HERMES_SESSION_LEDGER_VERSION, cursors: {} })
     } catch (err) {
       caught = err
     }
     expect(isHermesLedgerPublicationError(caught)).toBe(true)
+  })
+
+  it('does not adopt a v1 ledger after the cost-provenance contract changes', async () => {
+    await writeFile(join(cacheDir, 'hermes-session-ledger.v1.json'), JSON.stringify({
+      version: 1,
+      cursors: {
+        default: {
+          corrupt: {
+            profile: 'default',
+            sessionId: 'corrupt',
+            lastSeen: {
+              inputTokens: 1,
+              outputTokens: 0,
+              cacheReadTokens: 0,
+              cacheWriteTokens: 0,
+              reasoningTokens: 0,
+              costUSD: 4603,
+              costBasis: 'calculated',
+            },
+            observations: [],
+          },
+        },
+      },
+    }))
+
+    expect(loadHermesSessionLedger().cursors).toEqual({})
   })
 })

--- a/tests/hermes-session-ledger.test.ts
+++ b/tests/hermes-session-ledger.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises'
+import { existsSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -245,14 +246,15 @@ describe('hermes session ledger unit', () => {
     expect(isHermesLedgerPublicationError(caught)).toBe(true)
   })
 
-  it('does not adopt a v2 ledger whose migration could re-date historical observations', async () => {
-    await writeFile(join(cacheDir, 'hermes-session-ledger.v2.json'), JSON.stringify({
-      version: 2,
+  it('ignores a superseded v1 ledger and removes it from the cache dir', async () => {
+    const v1Path = join(cacheDir, 'hermes-session-ledger.v1.json')
+    await writeFile(v1Path, JSON.stringify({
+      version: 1,
       cursors: {
         default: {
-          corrupt: {
+          historical: {
             profile: 'default',
-            sessionId: 'corrupt',
+            sessionId: 'historical',
             lastSeen: {
               inputTokens: 1,
               outputTokens: 0,
@@ -267,7 +269,11 @@ describe('hermes session ledger unit', () => {
         },
       },
     }))
+    expect(existsSync(v1Path)).toBe(true)
 
+    // No v3 file: the loader starts empty, and the v1 file it can never read
+    // again must not survive the load.
     expect(loadHermesSessionLedger().cursors).toEqual({})
+    expect(existsSync(v1Path)).toBe(false)
   })
 })

--- a/tests/hermes-session-ledger.test.ts
+++ b/tests/hermes-session-ledger.test.ts
@@ -245,9 +245,9 @@ describe('hermes session ledger unit', () => {
     expect(isHermesLedgerPublicationError(caught)).toBe(true)
   })
 
-  it('does not adopt a v1 ledger after the cost-provenance contract changes', async () => {
-    await writeFile(join(cacheDir, 'hermes-session-ledger.v1.json'), JSON.stringify({
-      version: 1,
+  it('does not adopt a v2 ledger whose migration could re-date historical observations', async () => {
+    await writeFile(join(cacheDir, 'hermes-session-ledger.v2.json'), JSON.stringify({
+      version: 2,
       cursors: {
         default: {
           corrupt: {

--- a/tests/menubar-json.test.ts
+++ b/tests/menubar-json.test.ts
@@ -295,7 +295,7 @@ describe('buildMenubarPayload', () => {
     ])
   })
 
-  it('keeps zero-cost detected providers in the legacy dict for compatibility', () => {
+  it('keeps the legacy provider dict additive while providerDetails remains the activity authority', () => {
     const providers: ProviderCost[] = [
       { name: 'claude', displayName: 'Claude', cost: 76.45 },
       { name: 'codex', displayName: 'Codex', cost: 0 },
@@ -303,6 +303,11 @@ describe('buildMenubarPayload', () => {
     ]
     const payload = buildMenubarPayload(emptyPeriod('Today'), providers, null)
     expect(payload.current.providers).toEqual({ claude: 76.45, codex: 0, cursor: 2.18 })
+    expect(payload.current.providerDetails).toEqual([
+      { id: 'claude', label: 'Claude', cost: 76.45, calls: 0, hasUsage: true },
+      { id: 'codex', label: 'Codex', cost: 0, calls: 0, hasUsage: false },
+      { id: 'cursor', label: 'Cursor', cost: 2.18, calls: 0, hasUsage: true },
+    ])
   })
 
   it('includes up to 365 daily history entries sorted ascending by date', () => {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -298,6 +298,11 @@ describe('getShortModelName', () => {
     expect(getShortModelName('claude-opus-9-9-20300101')).toBe('Opus 9.9')
   })
 
+  it('derives versioned Fable and Mythos labels from their model ids', () => {
+    expect(getShortModelName('claude-fable-5-1')).toBe('Fable 5.1')
+    expect(getShortModelName('claude-mythos-5-2-20300101')).toBe('Mythos 5.2')
+  })
+
   it('shows the real model name for pricing-sibling aliases, not the internal key', () => {
     // GLM-5.2 (and its lowercase Hermes spelling) price via the glm-5p1 sibling;
     // reports must show GLM-5.2, not the pricing key.

--- a/tests/usage-aggregator-provider-scope.test.ts
+++ b/tests/usage-aggregator-provider-scope.test.ts
@@ -1,8 +1,9 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
-import { buildMenubarPayloadForRange } from '../src/usage-aggregator.js'
+import { buildMenubarPayloadForRange, overlayProviderDaySlices } from '../src/usage-aggregator.js'
 import { getDateRange } from '../src/cli-date.js'
 import { loadPricing } from '../src/models.js'
+import type { DailyEntry, ProviderDaySlice } from '../src/daily-cache.js'
 
 const parseAllSessions = vi.hoisted(() => vi.fn(async () => []))
 
@@ -25,7 +26,11 @@ vi.mock('../src/daily-cache.js', async (importOriginal) => {
   const mod = await importOriginal<typeof import('../src/daily-cache.js')>()
   return {
     ...mod,
-    ensureCacheHydrated: vi.fn(async () => mod.emptyCache()),
+    ensureCacheHydrated: vi.fn(async (parseSessions: (range: { start: Date; end: Date }) => Promise<unknown>) => {
+      await parseSessions({ start: new Date(0), end: new Date() })
+      return mod.emptyCache()
+    }),
+    loadDailyCache: vi.fn(async () => mod.emptyCache()),
   }
 })
 
@@ -45,5 +50,40 @@ describe('provider-scoped menubar aggregation', () => {
 
     expect(parseAllSessions.mock.calls.map(([, provider]) => provider))
       .toEqual(['hermes'])
+  })
+
+  it('overlays a corrected live provider slice without losing expired-source history', () => {
+    const slice = (cost: number, calls: number): ProviderDaySlice => ({ cost, calls, savingsUSD: 0, sessions: calls })
+    const day = (date: string, providers: Record<string, ProviderDaySlice>): DailyEntry => ({
+      date,
+      cost: Object.values(providers).reduce((sum, provider) => sum + provider.cost, 0),
+      calls: Object.values(providers).reduce((sum, provider) => sum + provider.calls, 0),
+      sessions: Object.values(providers).reduce((sum, provider) => sum + (provider.sessions ?? 0), 0),
+      savingsUSD: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      editTurns: 0,
+      oneShotTurns: 0,
+      models: {},
+      categories: {},
+      providers,
+    })
+
+    const result = overlayProviderDaySlices(
+      [
+        day('2026-08-31', { hermes: slice(1.25, 2) }),
+        day('2026-09-01', { hermes: slice(4603, 6764), claude: slice(2, 3) }),
+      ],
+      [day('2026-09-01', { hermes: slice(0.438, 6) })],
+      'hermes',
+    )
+
+    expect(result.map(entry => ({ date: entry.date, cost: entry.cost, calls: entry.calls }))).toEqual([
+      { date: '2026-08-31', cost: 1.25, calls: 2 },
+      { date: '2026-09-01', cost: 0.438, calls: 6 },
+    ])
+    expect(result[1]!.providers).toEqual({ hermes: slice(0.438, 6) })
   })
 })

--- a/tests/usage-aggregator-provider-scope.test.ts
+++ b/tests/usage-aggregator-provider-scope.test.ts
@@ -1,0 +1,49 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { buildMenubarPayloadForRange } from '../src/usage-aggregator.js'
+import { getDateRange } from '../src/cli-date.js'
+import { loadPricing } from '../src/models.js'
+
+const parseAllSessions = vi.hoisted(() => vi.fn(async () => []))
+
+vi.mock('../src/parser.js', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../src/parser.js')>()
+  return {
+    ...mod,
+    parseAllSessions,
+    isSessionHydrationComplete: vi.fn(() => true),
+    sessionHydrationSnapshot: vi.fn(() => ({
+      complete: true,
+      deferredForFirstPaint: false,
+      indexedFiles: 0,
+      pendingFiles: 0,
+    })),
+  }
+})
+
+vi.mock('../src/daily-cache.js', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../src/daily-cache.js')>()
+  return {
+    ...mod,
+    ensureCacheHydrated: vi.fn(async () => mod.emptyCache()),
+  }
+})
+
+describe('provider-scoped menubar aggregation', () => {
+  beforeAll(async () => {
+    await loadPricing()
+  })
+
+  it('never scans unrelated providers to render one selected provider', async () => {
+    parseAllSessions.mockClear()
+
+    await buildMenubarPayloadForRange(getDateRange('today'), {
+      provider: 'hermes',
+      optimize: false,
+      timeline: false,
+    })
+
+    expect(parseAllSessions.mock.calls.map(([, provider]) => provider))
+      .toEqual(['hermes'])
+  })
+})

--- a/tests/usage-aggregator-provider-scope.test.ts
+++ b/tests/usage-aggregator-provider-scope.test.ts
@@ -52,7 +52,7 @@ describe('provider-scoped menubar aggregation', () => {
       .toEqual(['hermes'])
   })
 
-  it('overlays a corrected live provider slice without losing expired-source history', () => {
+  it('overlays today without letting a shrunken parse rewrite settled history', () => {
     const slice = (cost: number, calls: number): ProviderDaySlice => ({ cost, calls, savingsUSD: 0, sessions: calls })
     const day = (date: string, providers: Record<string, ProviderDaySlice>): DailyEntry => ({
       date,
@@ -71,19 +71,26 @@ describe('provider-scoped menubar aggregation', () => {
       providers,
     })
 
+    // 2026-08-20 is settled and its sources have partially aged off disk: the
+    // fresh parse sees 3 of the 100 calls the cache finalized, so the cache
+    // stays authoritative. 2026-08-21 is a settled day the cache never held
+    // (cold cache), where the fresh parse is the only source there is.
     const result = overlayProviderDaySlices(
       [
-        day('2026-08-31', { hermes: slice(1.25, 2) }),
-        day('2026-09-01', { hermes: slice(4603, 6764), claude: slice(2, 3) }),
+        day('2026-08-20', { hermes: slice(10, 100), claude: slice(2, 3) }),
       ],
-      [day('2026-09-01', { hermes: slice(0.438, 6) })],
+      [
+        day('2026-08-20', { hermes: slice(0.3, 3) }),
+        day('2026-08-21', { hermes: slice(0.438, 6) }),
+      ],
       'hermes',
     )
 
     expect(result.map(entry => ({ date: entry.date, cost: entry.cost, calls: entry.calls }))).toEqual([
-      { date: '2026-08-31', cost: 1.25, calls: 2 },
-      { date: '2026-09-01', cost: 0.438, calls: 6 },
+      { date: '2026-08-20', cost: 10, calls: 100 },
+      { date: '2026-08-21', cost: 0.438, calls: 6 },
     ])
+    expect(result[0]!.providers).toEqual({ hermes: slice(10, 100) })
     expect(result[1]!.providers).toEqual({ hermes: slice(0.438, 6) })
   })
 })


### PR DESCRIPTION
## Summary

- make `providerDetails.hasUsage` authoritative and fail closed for legacy payloads
- scope provider history/cache to active provider periods so stale providers and false zero totals do not leak into the menubar
- preserve Hermes measured/estimated provenance with the v3 session ledger and migration handling
- keep provider paging arrows navigational and surface only providers with current usage evidence
- derive versioned Claude family labels so observed ids such as `claude-fable-5-1` display as `Fable 5.1` without another hand-maintained entry
- make upgrade verification discover the newly derived daily-cache version instead of hard-coding a version that drifts at every accounting bump

## Verification

- 193 focused model/pricing tests, including Fable and Mythos future-minor regression coverage
- live CLI proof: `claude-fable-5-1` reports `Fable 5.1`
- 120 focused TypeScript tests across menubar status, cache carry-forward, Hermes cost/ledger, payload encoding, and provider scoping
- 56 Electron renderer tests
- 28 focused Swift tests for provider visibility, reconnect presentation, strip paging, and refresh recovery
- complete `verify:upgrade` path: migration, provider parity, stdio parity, worker determinism, warm-cache stability, partial source aging, and durable history
- clean branch against upstream `41f44edc`

This is draft pending maintainer review. The concurrency/reconciliation follow-up is intentionally separated into a dependent draft PR.
