### PR TITLE
Make release builds hermetic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,8 @@ There is no separate build step required to run the dev CLI. `npm run dev` runs 
 | `npm run test:locks` | Runs the three parallelism-sensitive `cache-refresh-lock` suites serially. |
 | `npm run test:watch` | Same scope as `npm test`, in watch mode. |
 | `npm run dev -- status` | Runs the CLI in dev mode against your real data. |
-| `npm run build` | Bundles the litellm pricing snapshot, then runs `tsup` to produce `dist/cli.js`. |
-| `npm run bundle-litellm` | Refreshes `src/data/litellm-snapshot.json` from the upstream litellm repo. |
+| `npm run build` | Builds the CLI and dashboard from the checked-in pricing catalogs without mutating tracked source files. |
+| `npm run bundle-litellm` | Explicitly refreshes the checked-in pricing catalogs from their upstream sources. Review and commit the resulting data changes separately. |
 
 To test a specific suite, run vitest directly with a path:
 

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   ],
   "scripts": {
     "bundle-litellm": "node scripts/bundle-litellm.mjs",
-    "build": "node scripts/bundle-litellm.mjs && tsup && node -e \"const fs=require('fs'); fs.copyFileSync('src/cli.ts','dist/cli.js'); fs.chmodSync('dist/cli.js',0o755)\" && npm run build:dash",
+    "build": "tsup && node -e \"const fs=require('fs'); fs.copyFileSync('src/cli.ts','dist/cli.js'); fs.chmodSync('dist/cli.js',0o755)\" && npm run build:dash",
     "build:cli": "tsup && node -e \"const fs=require('fs'); fs.copyFileSync('src/cli.ts','dist/cli.js'); fs.chmodSync('dist/cli.js',0o755)\"",
-    "build:dash": "cd dash && npm install --no-audit --no-fund --silent && npm run build",
+    "build:dash": "cd dash && npm ci --no-audit --no-fund --silent && npm run build",
     "dev": "NODE_OPTIONS=--no-deprecation tsx src/cli.ts",
     "test": "vitest run tests --exclude \"tests/cache-refresh-lock*\"",
     "test:locks": "vitest run tests/cache-refresh-lock.test.ts tests/cache-refresh-lock-corrupt-body.test.ts tests/cache-refresh-lock-process.test.ts tests/cache-refresh-lock-status-snapshot.test.ts --poolOptions.forks.singleFork=true",

--- a/tests/release-build-contract.test.ts
+++ b/tests/release-build-contract.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+  scripts: Record<string, string>
+}
+
+describe('release build contract', () => {
+  it('builds from checked-in pricing catalogs instead of mutating them from the network', () => {
+    expect(packageJson.scripts['bundle-litellm']).toBe('node scripts/bundle-litellm.mjs')
+    expect(packageJson.scripts.build).not.toContain('bundle-litellm')
+  })
+
+  it('installs dashboard dependencies without rewriting the lockfile', () => {
+    expect(packageJson.scripts['build:dash']).toContain('npm ci')
+    expect(packageJson.scripts['build:dash']).not.toContain('npm install')
+  })
+})


### PR DESCRIPTION
## Summary

- remove the live LiteLLM update/mutation from the release build path
- use `npm ci` for the dashboard release build
- document the reproducible build contract

## Verification

- 2 release-build contract tests
- full production `npm run build`
- clean independent branch against upstream `41f44edc`

This is deliberately independent of the provider/runtime repair so reviewers can evaluate the build-pipeline change on its own.
