### PR TITLE
ci(upgrade-path): drop liveSessions from the worker-parity comparison

### DIFF
--- a/mac/Tests/CodeBurnMenubarTests/CapacityDockGlanceTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CapacityDockGlanceTests.swift
@@ -65,7 +65,7 @@ struct CapacityDockGlanceTests {
     @Test("The tint's fade tail never inverts on a short fill")
     func pillFadeStart() {
         // A long band keeps a 12pt tail, so the fade starts near its end.
-        #expect(CapacityDockGlance.pillFadeStart(filledWidth: 112, scale: 1) == 100.0 / 112.0)
+        #expect(abs(CapacityDockGlance.pillFadeStart(filledWidth: 112, scale: 1) - 100.0 / 112.0) < 1e-9)
         // Shorter than the tail, the whole band is the fade.
         #expect(CapacityDockGlance.pillFadeStart(filledWidth: 8, scale: 1) == 0)
         #expect(CapacityDockGlance.pillFadeStart(filledWidth: 0, scale: 1) == 0)

--- a/scripts/upgrade-path/run.mjs
+++ b/scripts/upgrade-path/run.mjs
@@ -125,7 +125,9 @@ function capture(bin, cacheDir, outDir, extra = {}) {
 }
 
 // The one field that moves between two runs of the same payload.
-const stripGenerated = obj => JSON.parse(JSON.stringify(obj, (k, v) => (k.startsWith('generated') ? undefined : v)))
+// liveSessions is a wall-clock snapshot (idleSeconds, lastActivityAt), not a parse
+// product, so two invocations legitimately differ there.
+const stripGenerated = obj => JSON.parse(JSON.stringify(obj, (k, v) => (k.startsWith('generated') || k === 'liveSessions' ? undefined : v)))
 
 // Shards carry real stat data and are published under a random filename, so
 // "identical" means identical after normalizing both away.


### PR DESCRIPTION
Follow-up to #1237. The upgrade-path CI's "menubar-json payload identical with and without workers" check compares two CLI invocations; the new `liveSessions` block carries wall-clock fields (`idleSeconds`, `lastActivityAt`) so it differs between them by design. Strip it in `stripGenerated`, the same way the parse-workers unit test already does. Fixes the four red upgrade-path jobs on main after #1237.