### PR TITLE
fix(mac): treat omitted Grok credit percent as 0% in an active window

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Data/GrokBuildSubscriptionService.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/GrokBuildSubscriptionService.swift
@@ -202,26 +202,28 @@ enum GrokBuildSubscriptionService {
             credential: credential,
             deps: deps
         )
-        let billing = try decodeBilling(billingData)
+        let billing = try decodeBilling(billingData, now: now)
         let settingsPlan = try await fetchPlan(credential: credential, deps: deps)
         let plan = normalizedPlan(settingsPlan) ?? normalizedPlan(billing.subscriptionTier)
-        let window = QuotaSummary.Window(
-            label: windowLabel(resetsAt: billing.resetsAt, now: now),
-            percent: billing.usedPercent,
-            resetsAt: billing.resetsAt
-        )
+        let window = billing.usedPercent.map { percent in
+            QuotaSummary.Window(
+                label: windowLabel(resetsAt: billing.resetsAt, now: now),
+                percent: percent,
+                resetsAt: billing.resetsAt
+            )
+        }
         return QuotaSummary(
             providerFilter: .grok,
             connection: .connected,
             primary: window,
-            details: [window],
+            details: window.map { [$0] } ?? [],
             planLabel: plan,
             footerLines: ["Source: Grok Build"]
         )
     }
 
     private struct BillingSnapshot {
-        let usedPercent: Double
+        let usedPercent: Double?
         let resetsAt: Date?
         let subscriptionTier: String?
     }
@@ -237,10 +239,16 @@ enum GrokBuildSubscriptionService {
         let billingPeriodEnd: String?
         let onDemandCap: Amount?
         let onDemandUsed: Amount?
+        let used: Amount?
+        let monthlyLimit: Amount?
         let subscriptionTier: String?
+        let isUnifiedBillingUser: Bool?
     }
 
-    private struct CurrentPeriod: Decodable { let end: String? }
+    private struct CurrentPeriod: Decodable {
+        let start: String?
+        let end: String?
+    }
     private struct Amount: Decodable { let val: Double? }
     private struct SettingsEnvelope: Decodable {
         let subscriptionTierDisplay: String?
@@ -250,7 +258,7 @@ enum GrokBuildSubscriptionService {
         }
     }
 
-    private static func decodeBilling(_ data: Data) throws -> BillingSnapshot {
+    private static func decodeBilling(_ data: Data, now: Date) throws -> BillingSnapshot {
         let envelope: BillingEnvelope
         do {
             envelope = try JSONDecoder().decode(BillingEnvelope.self, from: data)
@@ -266,17 +274,37 @@ enum GrokBuildSubscriptionService {
                   let cap = config.onDemandCap?.val,
                   used.isFinite, cap.isFinite, used >= 0, cap > 0 {
             rawPercent = used / cap * 100
+        } else if let used = config.used?.val,
+                  let cap = config.monthlyLimit?.val,
+                  used.isFinite, cap.isFinite, used >= 0, cap > 0 {
+            rawPercent = used / cap * 100
+        } else if isActiveBillingPeriod(config.currentPeriod, now: now) {
+            // Grok's web client and proto3 both treat an omitted
+            // creditUsagePercent as 0 during an active window. After a weekly
+            // reset the field is simply absent — that is 0% used, not unknown.
+            rawPercent = 0
         } else {
             rawPercent = nil
         }
-        guard let rawPercent else { throw FetchError.parseFailure }
 
         let reset = parseDate(config.currentPeriod?.end ?? config.billingPeriodEnd)
+        if rawPercent == nil, reset == nil, config.isUnifiedBillingUser != true {
+            throw FetchError.parseFailure
+        }
+
         return BillingSnapshot(
-            usedPercent: min(1, max(0, rawPercent / 100)),
+            usedPercent: rawPercent.map { min(1, max(0, $0 / 100)) },
             resetsAt: reset,
             subscriptionTier: config.subscriptionTier ?? envelope.subscriptionTier
         )
+    }
+
+    private static func isActiveBillingPeriod(_ period: CurrentPeriod?, now: Date) -> Bool {
+        guard let end = parseDate(period?.end), end > now else { return false }
+        if let start = parseDate(period?.start) {
+            return start <= now
+        }
+        return true
     }
 
     private static func fetchRequired(

--- a/mac/Tests/CodeBurnMenubarTests/GrokBuildSubscriptionServiceTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/GrokBuildSubscriptionServiceTests.swift
@@ -198,6 +198,98 @@ struct GrokBuildSubscriptionServiceTests {
         #expect(result.planLabel == "SuperGrok")
     }
 
+    @Test("an active unified-billing window with no percent field is 0% used")
+    func treatsOmittedPercentInActivePeriodAsZero() async throws {
+        let credential = GrokBuildCredentialStore.Credential(
+            accessToken: "synthetic-oidc-token",
+            authMode: "oidc",
+            expiresAt: nil
+        )
+        let deps = GrokBuildSubscriptionService.Deps(
+            loadCredential: { credential },
+            fetch: { request in
+                let body: String
+                switch request.url?.path {
+                case "/v1/billing":
+                    body = #"""
+                    {"config":{"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-09-02T19:53:44.968223+00:00","end":"2026-09-09T19:53:44.968223+00:00"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0},"isUnifiedBillingUser":true,"prepaidBalance":{"val":0},"billingPeriodEnd":"2026-09-09T19:53:44.968223+00:00"}}
+                    """#
+                case "/v1/settings":
+                    body = #"{"subscription_tier_display":"SuperGrok Heavy"}"#
+                default:
+                    Issue.record("Unexpected Grok endpoint")
+                    body = "{}"
+                }
+                return (
+                    Data(body.utf8),
+                    HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: nil
+                    )!
+                )
+            }
+        )
+
+        let result = try await GrokBuildSubscriptionService.refresh(
+            deps: deps,
+            now: ISO8601DateFormatter().date(from: "2026-09-02T21:00:00Z")!
+        )
+
+        #expect(result.connection == .connected)
+        #expect(result.primary?.percent == 0)
+        #expect(result.primary?.label == "Weekly")
+        #expect(result.primary?.resetsAt != nil)
+        #expect(result.details.count == 1)
+        #expect(result.planLabel == "SuperGrok Heavy")
+        #expect(result.footerLines == ["Source: Grok Build"])
+    }
+
+    @Test("an expired unified-billing window without a percent is not invented as 0%")
+    func doesNotInventZeroOutsideActivePeriod() async throws {
+        let credential = GrokBuildCredentialStore.Credential(
+            accessToken: "synthetic-oidc-token",
+            authMode: "oidc",
+            expiresAt: nil
+        )
+        let deps = GrokBuildSubscriptionService.Deps(
+            loadCredential: { credential },
+            fetch: { request in
+                let body: String
+                switch request.url?.path {
+                case "/v1/billing":
+                    body = #"""
+                    {"config":{"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","start":"2026-08-26T19:53:44.968223+00:00","end":"2026-09-02T19:53:44.968223+00:00"},"onDemandCap":{"val":0},"onDemandUsed":{"val":0},"isUnifiedBillingUser":true}}
+                    """#
+                case "/v1/settings":
+                    body = #"{"subscription_tier_display":"SuperGrok Heavy"}"#
+                default:
+                    Issue.record("Unexpected Grok endpoint")
+                    body = "{}"
+                }
+                return (
+                    Data(body.utf8),
+                    HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: nil
+                    )!
+                )
+            }
+        )
+
+        let result = try await GrokBuildSubscriptionService.refresh(
+            deps: deps,
+            now: ISO8601DateFormatter().date(from: "2026-09-02T21:00:00Z")!
+        )
+
+        #expect(result.connection == .connected)
+        #expect(result.primary == nil)
+        #expect(result.planLabel == "SuperGrok Heavy")
+    }
+
     @Test("cancellation during the optional plan request cancels the refresh")
     func cancellationWinsDuringPlanFetch() async throws {
         let credential = GrokBuildCredentialStore.Credential(


### PR DESCRIPTION
## Summary
- SuperGrok Heavy unified billing (`GET /v1/billing?format=credits`) drops `creditUsagePercent` after a weekly reset. The Capacity Dock treated that as an unrecognized payload and showed no usage, even though grok.com still shows **0%**.
- During an active `currentPeriod` (`start <= now < end`), an omitted percent is now **0% used**, matching Grok's web client / proto3 default. A published percent or a usable used/cap ratio still wins. An expired window without a percent is not invented as 0%.
- Live check on SuperGrok Heavy: ring showed 0% right after reset, then 1% after more usage. No 0% screenshot (state already moved on); the 1% state matched grok.com.

## Testing
- [x] I have tested this locally against real data (not just unit tests)
- [x] `swift test --filter GrokBuildSubscriptionServiceTests` passes (8 tests)
- [ ] `npm test` — not run; this change is mac menubar only
- [ ] `npm run build` — not run; no CLI/JS change