### PR TITLE
test(menubar): ignore idleSeconds in the payload parity check

### DIFF
--- a/tests/menubar-report-parity.test.ts
+++ b/tests/menubar-report-parity.test.ts
@@ -68,10 +68,12 @@ async function seedFixture(): Promise<void> {
   process.env['CODEBURN_CACHE_DIR'] = cacheDir
 }
 
-/** Everything but the per-call wall-clock `generated` stamp. */
+/** Everything but the wall-clock fields: the `generated` stamp and each live session's
+ *  `idleSeconds`, which ticks between two builds that straddle a second boundary. */
 function stableShape(payload: unknown): unknown {
-  const clone = structuredClone(payload) as { generated?: string }
+  const clone = structuredClone(payload) as { generated?: string; liveSessions?: { sessions: { idleSeconds: number }[] } }
   clone.generated = ''
+  for (const session of clone.liveSessions?.sessions ?? []) session.idleSeconds = 0
   return clone
 }
 


### PR DESCRIPTION
The parity test builds the menubar payload twice over the same warm cache and expects the two to match. Since `liveSessions` landed (#1237), each session carries `idleSeconds`, whole seconds since its last activity, so two builds that straddle a second boundary differ by one and the test fails at random. First seen on the macOS runner of the branch CI.

`stableShape` now zeroes `idleSeconds` the way it already blanks the `generated` stamp. Test only.