### PR TITLE
fix(mac): the Capacity Dock popover appears inside a full-screen space

### DIFF
--- a/mac/Sources/CodeBurnMenubar/CapacityDockController.swift
+++ b/mac/Sources/CodeBurnMenubar/CapacityDockController.swift
@@ -559,6 +559,10 @@ final class CapacityDockController {
         model.detailHeight = glanceDetailHeight(for: provider)
         ensureDetailPanel()
         layoutDetail(for: provider, transaction: wasShowingDetail ? .detailFollow : .detailPresent)
+        // A panel that lost its all-spaces membership returns to the desktop space alone,
+        // so hovering inside a full-screen app presented the popover where it could not be
+        // seen. The rail escapes this by never being ordered out.
+        detailPanel?.reassertSpaceMembership()
         detailPanel?.orderFrontRegardless()
     }
 
@@ -1384,11 +1388,21 @@ private final class CapacityDockPanel: NSPanel {
         hidesOnDeactivate = false
         isReleasedWhenClosed = false
         isMovable = false
-        isFloatingPanel = true
         isExcludedFromWindowsMenu = true
         becomesKeyOnlyIfNeeded = true
         animationBehavior = .none
-        collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+        collectionBehavior = Self.spaceBehavior
+    }
+
+    /// Membership of every space, including the one a full-screen app owns. The window
+    /// server drops it from a panel across a display sleep or a display reconfiguration,
+    /// and writing it again is what re-registers the window, so this is re-asserted
+    /// before each presentation rather than only at init.
+    static let spaceBehavior: NSWindow.CollectionBehavior =
+        [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+
+    func reassertSpaceMembership() {
+        collectionBehavior = Self.spaceBehavior
     }
 
     override var canBecomeKey: Bool { false }


### PR DESCRIPTION
Hovering a Capacity Dock pill while a full-screen app is frontmost showed nothing. The rail was visible there, so the dock looked alive; the popover simply never appeared.

**Cause.** The detail panel had lost its all-spaces membership and been reduced to the desktop space. Measured on a running instance with `CGSCopySpacesForWindows`, active space `137`:

```
#2628 (rail)   a1.00  0,250  53x225  ONSCREEN  spaces=[63, 24, 3, 137]
#2631 (detail) a1.00 63,154 315x303  off       spaces=[3]
```

Everything else worked: hover was detected, the frame was correct and on screen, alpha reached 1. The window was presented in a space the user was not looking at. The membership is set once in `init` and never re-asserted; the window server drops it across a display sleep or reconfiguration, and the rail escapes only because it is never ordered out.

**Fix.** Re-assert the behaviour in `showDetail`, the single funnel every presentation passes through. Assigning `collectionBehavior` is what re-registers the window, so it must be written rather than read-and-compared, and while the window is ordered out.

**Second, separate defect.** A duplicate `isFloatingPanel = true` ran *after* the shielding level was assigned. `NSPanel.isFloatingPanel` writes `level = .floating`, so it silently discarded the level the comment above it asks for. The dock measured at layer 3; any floating window could cover it.

**Verified on the reporter's machine after the fix**, one display, inside a full-screen space:

```
active=137
#7206 (detail) a1.00 57,86 315x303 off spaces=[3, 63, 24, 137]
#7202 (rail)   a1.00  0,182 53x111 ON  spaces=[3, 63, 24, 137]
```

Both windows now report layer `2147483628`, the shielding level. The popover appears over a full-screen app, confirmed by hand. `swift test`: 400 tests pass.