### PR TITLE
fix(mac): give the glance staleness line a section of its own

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Views/CapacityDockView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/CapacityDockView.swift
@@ -105,7 +105,10 @@ enum CapacityDockMetrics {
         let connectionExtra: CGFloat = switch quota.connection {
         case .terminalFailure: 90
         case .disconnected: 18
-        case .loading, .stale, .transientFailure: 16
+        // The staleness line is a section like any other, so it needs a section's
+        // height. It used to get 16, a bare 10pt line box with no padding, which is
+        // why it sat crammed against the header with the blocks below pushed into it.
+        case .loading, .stale, .transientFailure: CapacityDockGlance.noticeHeight
         case .connected: 0
         }
         height += connectionExtra
@@ -139,6 +142,20 @@ enum CapacityDockGlance {
     static let windowsHeight: CGFloat = 77
     /// 8 top + one secondary line + 16 bottom.
     static let windowsEmptyHeight: CGFloat = 37
+    /// The staleness or reconnect line under the header. It is a section like any
+    /// other, so the panel has to reserve its height: the frame is computed, not
+    /// fitted, and an unreserved line squeezes every block below it.
+    /// 6 top + a 10pt line box + 8 bottom.
+    static let noticeHeight: CGFloat = 27
+    /// Whether the band is drawn as its own padded section. Disconnected and
+    /// reconnect draw their own blocks with an action button instead.
+    static func drawsNotice(_ connection: QuotaSummary.Connection) -> Bool {
+        switch connection {
+        case .connected, .disconnected, .terminalFailure: return false
+        case .loading, .stale, .transientFailure: return true
+        }
+    }
+
     /// The list scrolls past this many pills rather than truncating.
     static let maxVisibleSessionRows = 4
     static let maxWindowColumns = 4
@@ -688,7 +705,10 @@ struct CapacityDockDetailView: View {
     private func glance(for provider: CapacityDockProvider, quota: QuotaSummary) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             headerSection(provider, plan: quota.planLabel).dividerBelow()
-            connectionLabel(quota.connection, provider: provider)
+            noticeSection(quota.connection, provider: provider)
+            if !CapacityDockGlance.drawsNotice(quota.connection) {
+                connectionLabel(quota.connection, provider: provider)
+            }
             if let sessions = store.capacityDockLiveSessions(for: provider) {
                 sessionsSection(sessions).dividerBelow()
             }
@@ -708,6 +728,25 @@ struct CapacityDockDetailView: View {
             .padding(.top, CapacityDockGlance.contentInset * s)
             .padding(.bottom, 8 * s)
             .padding(.horizontal, CapacityDockGlance.contentInset * s)
+    }
+
+    /// The notice carries the same horizontal inset as every other section, its own
+    /// vertical padding, and a divider, so it reads as a band rather than as text
+    /// crammed against the header.
+    @ViewBuilder
+    private func noticeSection(
+        _ connection: QuotaSummary.Connection,
+        provider: CapacityDockProvider
+    ) -> some View {
+        let s = model.detailScale
+        if CapacityDockGlance.drawsNotice(connection) {
+            connectionLabel(connection, provider: provider)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 6 * s)
+                .padding(.bottom, 8 * s)
+                .padding(.horizontal, CapacityDockGlance.contentInset * s)
+                .dividerBelow()
+        }
     }
 
     @ViewBuilder

--- a/mac/Tests/CodeBurnMenubarTests/CapacityDockGlanceTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CapacityDockGlanceTests.swift
@@ -6,10 +6,14 @@ private func window(_ label: String, _ percent: Double, resetsAt: Date? = nil) -
     QuotaSummary.Window(label: label, percent: percent, resetsAt: resetsAt)
 }
 
-private func quota(_ details: [QuotaSummary.Window], primary: QuotaSummary.Window? = nil) -> QuotaSummary {
+private func quota(
+    _ details: [QuotaSummary.Window],
+    primary: QuotaSummary.Window? = nil,
+    connection: QuotaSummary.Connection = .connected
+) -> QuotaSummary {
     QuotaSummary(
         providerFilter: .all,
-        connection: .connected,
+        connection: connection,
         primary: primary,
         details: details,
         planLabel: "Max 20x",
@@ -27,6 +31,42 @@ struct CapacityDockGlanceTests {
         #expect(CapacityDockGlance.windows(quota([five, weekly, fable])) == [five, weekly, fable])
         let many = (0..<6).map { window("w\($0)", Double($0) / 10) }
         #expect(CapacityDockGlance.windows(quota(many)).count == CapacityDockGlance.maxWindowColumns)
+    }
+
+    @Test("The staleness notice is a section the panel reserves height for")
+    func noticeIsReserved() {
+        let windows = [window("5-hour", 0.2), window("Weekly", 0.95)]
+        func height(_ connection: QuotaSummary.Connection) -> CGFloat {
+            CapacityDockMetrics.detailHeight(
+                quota: quota(windows, connection: connection),
+                sessionCount: 2,
+                hasToday: true,
+                tailEdge: .right,
+                scale: 1
+            )
+        }
+        // The line is drawn between the header and the sections below it. Without its
+        // own reserved height it squeezed every block under it, because the panel frame
+        // is computed rather than fitted.
+        let connected = height(.connected)
+        for stale in [QuotaSummary.Connection.stale, .transientFailure, .loading] {
+            #expect(CapacityDockGlance.drawsNotice(stale))
+            #expect(height(stale) == connected + CapacityDockGlance.noticeHeight)
+        }
+        // Disconnected and reconnect draw their own blocks with an action button.
+        #expect(!CapacityDockGlance.drawsNotice(.disconnected))
+        // Reconnect draws its own block and is accounted for separately.
+        #expect(height(.terminalFailure(reason: nil)) > connected)
+        for scale in [0.9, 1.0, 1.25] {
+            let h = CapacityDockMetrics.detailHeight(
+                quota: quota(windows, connection: .stale),
+                sessionCount: 2,
+                hasToday: true,
+                tailEdge: .right,
+                scale: CGFloat(scale)
+            )
+            #expect(h == h.rounded())
+        }
     }
 
     @Test("A provider with only a primary window still draws one column")


### PR DESCRIPTION
The staleness line sat crammed against the header, with the blocks below pushed into it.

Its height *was* reserved, but only as `16` — a bare 10pt line box. Every other block in the glance carries 8–10pt of padding, a 16pt side inset and a divider; this one carried none, so it read as text jammed under the header rather than as a band.

**Change.** `noticeSection` gives it the same inset, its own padding (6 top / 8 bottom) and a divider, and the reservation grows 16 → 27 to match, so nothing below is squeezed. Only `.loading`, `.stale` and `.transientFailure` are affected: `.disconnected` and `.terminalFailure` keep their existing blocks with the action button, and `drawsNotice` is what separates the two.

**Test.** `noticeIsReserved` pins that the reserved height equals the band's height for every in-progress connection, that disconnected/reconnect are excluded, and that the total stays a whole number of points at 0.9, 1.0 and 1.25 — a fractional panel height re-runs the window's layout at display cadence for as long as the dock is up.

401 Swift tests pass. Verified by hand on the reporter's machine against a stale Kimi Code card.