### PR TITLE
chore: keep real people and machines out of a public repository

### DIFF
--- a/app/renderer/App.test.tsx
+++ b/app/renderer/App.test.tsx
@@ -1193,7 +1193,7 @@ describe('usage_snapshot telemetry props', () => {
     // A path-like project name that MUST NEVER reach telemetry: the snapshot never
     // reads topProjects, and this guards against a future field accidentally doing so.
     p.current.topProjects = [{
-      name: '/Users/torukmakto/secret-client/private-repo',
+      name: '/Users/x/secret-client/private-repo',
       cost: 42, savingsUSD: 0, sessions: 1, avgCostPerSession: 42, sessionDetails: [],
     }]
     return p

--- a/app/renderer/sections/Sessions.test.tsx
+++ b/app/renderer/sections/Sessions.test.tsx
@@ -35,7 +35,7 @@ function session(overrides: Partial<SessionRow> & Pick<SessionRow, 'sessionId' |
 const rows: SessionRow[] = [
   session({
     sessionId: 'claude-session-123456789',
-    project: '-Users-torukmakto-Projects-codeburn',
+    project: '-Users-devuser-Projects-codeburn',
     provider: 'claude',
     models: ['Opus 4.8'],
     cost: 8.41,
@@ -136,7 +136,7 @@ describe('Sessions', () => {
     expect(screen.getByText('Codex').closest('.provider-h')).toHaveTextContent('Codex3 sessions$11.92')
     expect(container.querySelectorAll('.session-row')).toHaveLength(6)
     expect(screen.getByText('projects/codeburn')).toBeInTheDocument()
-    expect(screen.queryByText('-Users-torukmakto-Projects-codeburn')).not.toBeInTheDocument()
+    expect(screen.queryByText('-Users-devuser-Projects-codeburn')).not.toBeInTheDocument()
   })
 
   it('filters by project and offers to clear a search with no matches', async () => {

--- a/app/renderer/sections/Settings.test.tsx
+++ b/app/renderer/sections/Settings.test.tsx
@@ -41,12 +41,12 @@ vi.mock('../lib/ipc', async orig => {
   return { ...actual, codeburn: mocks }
 })
 
-const identity: Identity = { name: 'Toruk MacBook Pro', fingerprint: 'AA:11:22:33:44:55:66:77' }
+const identity: Identity = { name: 'Studio MacBook Pro', fingerprint: 'AA:11:22:33:44:55:66:77' }
 const actionOk: ActionResult = { ok: true, stdout: 'updated', stderr: '', code: 0 }
 const devices: CombinedUsage = {
   perDevice: [
-    { id: 'local', name: 'Toruk MacBook Pro', local: true, cost: 120.1, calls: 100, sessions: 10, inputTokens: 1, outputTokens: 2, cacheCreateTokens: 3, cacheReadTokens: 4, totalTokens: 10 },
-    { id: 'mini', name: 'toruk-mini', local: false, cost: 41.2, calls: 680, sessions: 34, inputTokens: 11, outputTokens: 12, cacheCreateTokens: 13, cacheReadTokens: 14, totalTokens: 50 },
+    { id: 'local', name: 'Studio MacBook Pro', local: true, cost: 120.1, calls: 100, sessions: 10, inputTokens: 1, outputTokens: 2, cacheCreateTokens: 3, cacheReadTokens: 4, totalTokens: 10 },
+    { id: 'mini', name: 'studio-mini', local: false, cost: 41.2, calls: 680, sessions: 34, inputTokens: 11, outputTokens: 12, cacheCreateTokens: 13, cacheReadTokens: 14, totalTokens: 50 },
   ],
   combined: { cost: 161.3, calls: 780, sessions: 44, inputTokens: 12, outputTokens: 14, cacheCreateTokens: 16, cacheReadTokens: 18, totalTokens: 60, deviceCount: 2, reachableCount: 2 },
 }
@@ -80,7 +80,7 @@ describe('Settings', () => {
     mocks.getIdentity.mockResolvedValue(identity)
     mocks.getDevices.mockResolvedValue(devices)
     mocks.getDevicesScan.mockResolvedValue(scan)
-    mocks.getShareStatus.mockResolvedValue({ sharing: true, name: 'Toruk MacBook Pro', port: 9732, always: false, peers: 1, pending: [] })
+    mocks.getShareStatus.mockResolvedValue({ sharing: true, name: 'Studio MacBook Pro', port: 9732, always: false, peers: 1, pending: [] })
     mocks.getQuota.mockResolvedValue(quotaProviders)
     mocks.getPlans.mockResolvedValue({ currency: 'EUR', today: { cost: 0, savings: 0, calls: 0 }, month: { cost: 0, savings: 0, calls: 0 }, plans: { claude: { id: 'claude-max', provider: 'claude', budget: 200, spent: 48, percentUsed: 24, status: 'under', projectedMonthEnd: 120, daysUntilReset: 19, periodStart: '2026-07-01', periodEnd: '2026-08-01' } } })
     mocks.getOverview.mockResolvedValue(overview)
@@ -95,7 +95,7 @@ describe('Settings', () => {
     mocks.removeDevice.mockResolvedValue(actionOk)
     mocks.setPlan.mockResolvedValue(actionOk)
     mocks.resetPlan.mockResolvedValue(actionOk)
-    mocks.chooseDirectory.mockResolvedValue('/Users/toruk/Exports')
+    mocks.chooseDirectory.mockResolvedValue('/Users/x/Exports')
     mocks.exportData.mockResolvedValue(actionOk)
     mocks.telemetryTrack.mockResolvedValue(true)
     mocks.telemetryStatus.mockResolvedValue(telemetryOff)
@@ -147,14 +147,14 @@ describe('Settings', () => {
 
     await user.click(screen.getAllByRole('button', { name: 'Export' }).at(-1)!)
     await user.click(screen.getByRole('button', { name: 'Choose folder…' }))
-    await screen.findByText('/Users/toruk/Exports')
+    await screen.findByText('/Users/x/Exports')
     await user.click(screen.getByRole('button', { name: 'JSON' }))
     await user.click(screen.getAllByRole('button', { name: 'Export' }).at(-1)!)
     expect(mocks.telemetryTrack).toHaveBeenCalledWith('export', { format: 'json', provider: 'all' })
 
     // The chosen folder is a real path on this machine and never travels.
     const sent = JSON.stringify(mocks.telemetryTrack.mock.calls)
-    expect(sent).not.toContain('/Users/toruk')
+    expect(sent).not.toContain('/Users/x')
   })
 
   // The main process drops any event raised while telemetry is off, so an opt-in tracked
@@ -407,24 +407,24 @@ describe('Settings', () => {
     await user.click(screen.getAllByRole('button', { name: 'Export' }).at(-1)!)
     await user.click(screen.getByRole('button', { name: 'Choose folder…' }))
     expect(mocks.chooseDirectory).toHaveBeenCalledOnce()
-    expect(await screen.findByText('/Users/toruk/Exports')).toBeInTheDocument()
+    expect(await screen.findByText('/Users/x/Exports')).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'JSON' }))
     await user.click(screen.getByLabelText('Provider'))
     await user.click(screen.getByRole('option', { name: 'Claude' }))
     await user.click(screen.getAllByRole('button', { name: 'Export' }).at(-1)!)
-    expect(mocks.exportData).toHaveBeenCalledWith('json', 'claude', '/Users/toruk/Exports')
-    expect(await screen.findByText('Exported to /Users/toruk/Exports')).toBeInTheDocument()
+    expect(mocks.exportData).toHaveBeenCalledWith('json', 'claude', '/Users/x/Exports')
+    expect(await screen.findByText('Exported to /Users/x/Exports')).toBeInTheDocument()
   })
 
   it('renders real device status and removes paired devices without fake pairing controls', async () => {
     const user = userEvent.setup()
     render(<Settings period="month" />)
     await user.click(screen.getByRole('button', { name: 'Devices' }))
-    expect(await screen.findByText('Toruk MacBook Pro')).toBeInTheDocument()
-    expect(screen.getByText('Local device name: Toruk MacBook Pro')).toBeInTheDocument()
+    expect(await screen.findByText('Studio MacBook Pro')).toBeInTheDocument()
+    expect(screen.getByText('Local device name: Studio MacBook Pro')).toBeInTheDocument()
     expect(await screen.findByText('Mac Studio')).toBeInTheDocument()
     expect(screen.getByText('fingerprint 7F:2A:…:C4')).toBeInTheDocument()
-    expect(await screen.findByText('toruk-mini')).toBeInTheDocument()
+    expect(await screen.findByText('studio-mini')).toBeInTheDocument()
     expect(screen.getByText('34 sessions · $41.20 this month')).toBeInTheDocument()
     expect(screen.getByText('Visible')).toBeInTheDocument()
     expect(screen.getByText(/Pairing is interactive/)).toBeInTheDocument()
@@ -432,7 +432,7 @@ describe('Settings', () => {
     expect(screen.queryByText('Pull now')).not.toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Remove' }))
     await user.click(screen.getByRole('button', { name: 'Confirm' }))
-    expect(mocks.removeDevice).toHaveBeenCalledWith('toruk-mini')
+    expect(mocks.removeDevice).toHaveBeenCalledWith('studio-mini')
     expect(screen.getByText('Combined view active · 2 devices')).toBeInTheDocument()
   })
 

--- a/perf/README.md
+++ b/perf/README.md
@@ -9,13 +9,13 @@ It extends the [release-acceptance ledger](../docs/release-acceptance/README.md)
 | Metric | Command | What the number is | What it is not |
 |---|---|---|---|
 | Cold start (wait-path) | `run-metric.mjs --metric cold-start-cli` | One-shot `status --format menubar-json` argv Desktop/Menu Bar already spawn | Installed window show / flame in the menu bar |
-| Session parse | `--metric session-parse` | Cold parse of the synthetic fixture; MB/s and ms | Founder corpus (35 GB) |
+| Session parse | `--metric session-parse` | Cold parse of the synthetic fixture; MB/s and ms | A large real corpus |
 | Incremental re-parse | `--metric incremental-reparse` | Append two JSONL lines on the same inode, then re-run | Rewrite / inode change |
 | Period switch | `--metric period-switch` | Warm `serve --stdio` 7D/30D p50/p95 | Installed Desktop 250 ms p95 on the live corpus |
 | Dock/TUI interactions | `--metric dock-tui-proxy` | Overview-refresh and view-switch wait path | Capacity Dock hover (native, never spawns this argv) or TTY TUI keys |
 | Memory | `--metric memory` | RSS after cold load; optional `--idle-ms 3600000` | Packaged app RSS |
 
-Historical receipt, not this fixture: installed Desktop 0.9.21, live corpus, 2026-08-27, 7D useful summary **18286.98 ms** after 30 s idle. Spec target: **250 ms p95** ready summary, zero raw reads on unchanged generation. Evidence: `/Users/a/Documents/Codeburn-audits/snappy-performance-20260827T095615Z/baselines/installed-0.9.21/ui-period-baseline.json`.
+Historical receipt, not this fixture: installed Desktop 0.9.21, live corpus, 2026-08-27, 7D useful summary **18286.98 ms** after 30 s idle. Spec target: **250 ms p95** ready summary, zero raw reads on unchanged generation. That receipt came from an installed-app audit run that is not published, so treat the number as historical context rather than something you can re-derive from this repo.
 
 ## One-command reproduction
 

--- a/tests/live-sessions.test.ts
+++ b/tests/live-sessions.test.ts
@@ -128,7 +128,7 @@ describe('scanTranscript', () => {
 
   it('flags a sidechain and degrades with no usage at all', async () => {
     const scan = await scanTranscript(await transcript([
-      { type: 'user', sessionId: 'parent-1', isSidechain: true, cwd: '/Users/x/eywa' },
+      { type: 'user', sessionId: 'parent-1', isSidechain: true, cwd: '/Users/x/atlas' },
     ]))
     expect(scan.isSidechain).toBe(true)
     expect(scan.sessionId).toBe('parent-1')

--- a/tests/sessions-report.test.ts
+++ b/tests/sessions-report.test.ts
@@ -107,21 +107,21 @@ describe('sessions JSON emitter', () => {
   it('hides home-directory slugs and renders compact agent/worktree names', () => {
     const rows = aggregateSessions([makeProject()])
     rows[0]!.sessionId = 'agent-a72cc958e305e4957'
-    rows[0]!.project = '-Users-torukmakto-Projects-eywa-eywa--claude-worktrees-issue-131'
+    rows[0]!.project = '-Users-devuser-Projects-eywa-eywa--claude-worktrees-issue-131'
     const output = renderTable(rows, { terminalWidth: 160 })
 
     expect(output).toContain('Agent a72cc958')
     expect(output).toContain('eywa · issue-131')
-    expect(output).not.toContain('Users-torukmakto')
+    expect(output).not.toContain('Users-devuser')
   })
 
   it('normalizes Claude dot-worktree slugs without exposing the home directory', () => {
     const rows = aggregateSessions([makeProject()])
-    rows[0]!.project = 'Users-torukmakto-codeburn-.claude-worktrees-agent-a213f7c77871f483f'
+    rows[0]!.project = 'Users-devuser-codeburn-.claude-worktrees-agent-a213f7c77871f483f'
     const output = renderTable(rows, { terminalWidth: 120 })
 
     expect(output).toContain('codeburn · agent a213f7c7')
-    expect(output).not.toContain('Users-torukmakto')
+    expect(output).not.toContain('Users-devuser')
     expect(output).not.toContain('.claude-worktrees')
   })
 


### PR DESCRIPTION
Audit of everything on `main` since `v0.9.23` — 252 commits, 323 files, ~41k added lines — for personal, customer, employer or infrastructure exposure. Three independent passes plus a mechanical sweep of every added line.

**Clean across the whole range:** no email addresses in content, no key/token/password-shaped strings, no server address or paths, no Cognito or account identifiers, no internal or staging hosts, no customer or employer reference, no committed logs, caches, exports or `.env` files. New network destinations are all first-party provider APIs, each receiving only that provider's own token. The telemetry snapshot holds its approved scope, verified by planted canaries asserting that project names, branches, paths and prose never reach it. `assets/capacity-dock.jpg` was opened and its EXIF checked: no GPS, no device, no timestamp.

**Five places used a real value where an invented one would do.** None is a credential; none identifies a customer.

| Where | What |
|---|---|
| `perf/README.md:18` | absolute path into a contributor's private audit workspace, cited as evidence no reader can open |
| `perf/README.md:12` | "Founder corpus (35 GB)" — a personal fact about one identifiable person |
| `tests/live-sessions.test.ts` | a private product name as a fixture working directory |
| `tests/sessions-report.test.ts`, `app/renderer/sections/Sessions.test.tsx` | the maintainer's real OS username, inside the tests that assert such paths are redacted |
| `app/renderer/sections/Settings.test.tsx`, `app/renderer/App.test.tsx` | two real machine names, and the username again in a telemetry canary |

The measurement in `perf/README.md` is kept; only its unopenable local path goes, replaced by a sentence saying the artifact is not published. Every fixture change is a rename — no assertion is weakened, and the redaction tests read better when the scrubbed string is obviously synthetic.

Tests: 22 CLI, 102 desktop, all passing.

**Not changed, for the record.** The maintainer's name in the About footer is a deliberate copyright line. The marketing screenshot is genuinely their own screen but shows only a $3.88 daily spend, quota percentages, a plan tier and a clock. Their personal email appears as a commit author in history from April onward, long predating this range. And the two files committed by mistake earlier today were removed from the tree in `10159d1d` but remain in history.