### PR TITLE
test(windows): stop the cross-process test starving itself on a loaded runner

### DIFF
--- a/windows/src-tauri/src/dock.rs
+++ b/windows/src-tauri/src/dock.rs
@@ -2052,7 +2052,13 @@ mod tests {
         // A key neither side writes, to prove the merge preserves it through all the churn.
         fs::write(&dock_file, "{\"other\":\"keep\"}").unwrap();
 
-        let iters: u32 = 100;
+        // 100 rounds a side, both taking the lock, while a reader thread hammers the same
+        // file. The production wait budget is 2s with a 50ms poll, which is right for a UI
+        // that writes on a click but starves under this much contention: a waiter that keeps
+        // losing the race after each poll can exceed 2s on a loaded runner, which is what
+        // reddened main rather than any lost update. Fewer rounds keep the property under
+        // test and stop the harness from being the thing that fails.
+        let iters: u32 = 24;
         let nolock = std::env::var("CB_TRAY_XPROC_NOLOCK").ok().as_deref() == Some("1");
 
         let mut child = match Command::new("node")


### PR DESCRIPTION
`main` went red on the merge of #1248: `check (ubuntu-latest)` failed with

```
called `Result::unwrap()` on an `Err` value: could not lock
  /tmp/.../.windows-dock.lock within 2s; another process is writing these
  preferences, so nothing was changed
```

Not a lost update, and not a fault in the lock — the harness starved itself. It ran 100 rounds a side, both sides taking the lock, while a reader thread hammered the same file. Production allows a 2s wait with a 50ms poll, which is right for a UI that writes on a click but not for sustained contention: a waiter that loses the race after each poll can exceed the budget, and the acquire then fails exactly as designed. It passed on the PR branch and failed on main because the runner was busier.

24 rounds a side keeps the property under test. Measured here, ten runs each way:

| | result |
|---|---|
| `CB_TRAY_XPROC_NOLOCK=1` | 10/10 **FAIL** |
| lock enabled | 10/10 **PASS** |

So it still catches a lost update exactly as reliably as before.

The production budget and poll are deliberately untouched — tuning shipped timings to make a test pass would be the wrong way round. If sustained contention ever becomes a real workload, the 50ms poll is the thing to revisit, since that is what allows starvation, not the 2s budget.