### PR TITLE
fix(mac): scope Grok's omitted-percent rule to unified billing; finish the fixture scrub

### DIFF
--- a/codeburn-desktop-wireframes.html
+++ b/codeburn-desktop-wireframes.html
@@ -659,7 +659,7 @@
               <div class="panel">
                 <div class="phead"><b>Paired</b></div>
                 <div class="pbody">
-                  <div class="li"><div class="lx"><b>toruk-mini</b><span>last pull 2h ago · 34 sessions · $41.20 this month</span></div><span class="btn btn-s">Pull now</span></div>
+                  <div class="li"><div class="lx"><b>studio-mini</b><span>last pull 2h ago · 34 sessions · $41.20 this month</span></div><span class="btn btn-s">Pull now</span></div>
                   <div class="li"><div class="lx"><b>Combine usage from paired devices</b><span>scope captions gain “· 2 devices” when on</span></div><span class="tglon"></span></div>
                 </div>
               </div>

--- a/mac/Sources/CodeBurnMenubar/Data/GrokBuildSubscriptionService.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/GrokBuildSubscriptionService.swift
@@ -278,10 +278,13 @@ enum GrokBuildSubscriptionService {
                   let cap = config.monthlyLimit?.val,
                   used.isFinite, cap.isFinite, used >= 0, cap > 0 {
             rawPercent = used / cap * 100
-        } else if isActiveBillingPeriod(config.currentPeriod, now: now) {
+        } else if config.isUnifiedBillingUser == true,
+                  isActiveBillingPeriod(config.currentPeriod, now: now) {
             // Grok's web client and proto3 both treat an omitted
             // creditUsagePercent as 0 during an active window. After a weekly
             // reset the field is simply absent — that is 0% used, not unknown.
+            // Only unified-billing accounts carry that contract; for anyone
+            // else an omitted field stays unknown rather than a fabricated 0%.
             rawPercent = 0
         } else {
             rawPercent = nil


### PR DESCRIPTION
Two one-line follow-ups from the pre-release review of main.

**Grok omitted percent.** #1242 made an omitted \`creditUsagePercent\` inside an active billing window read as 0%. The commit and its tests describe a unified-billing account, but the branch was not gated on \`isUnifiedBillingUser\`, so any Grok account whose window was open would show "Weekly 0%" if the field ever went missing. The branch now requires unified billing; everyone else falls back to unknown, as before.

**Fixture scrub.** \`codeburn-desktop-wireframes.html\` still carried the one device name #1250 replaced in every other tracked file.

Verification: \`swift test --filter GrokBuildSubscriptionServiceTests\` 8/8 (both #1242 tests set \`isUnifiedBillingUser: true\` and still pass).