### PR TITLE
docs(readme): bust the cached Capacity Dock image

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
   <tr>
     <td align="center" colspan="2">
       <strong>Capacity Dock</strong> <em>&middot; macOS menubar and Windows tray</em><br/>
-      <img src="https://raw.githubusercontent.com/getagentseal/codeburn/main/assets/capacity-dock.jpg" alt="CodeBurn Capacity Dock showing live provider usage rings on the screen edge" width="66%" /><br/>
+      <img src="https://raw.githubusercontent.com/getagentseal/codeburn/main/assets/capacity-dock.jpg?v=0.9.24" alt="CodeBurn Capacity Dock showing live provider usage rings on the screen edge" width="66%" /><br/>
       <code>codeburn menubar</code>
     </td>
   </tr>


### PR DESCRIPTION
GitHub's image proxy is still serving the pre-#1256 capture because the URL did not change. A version query on the src makes it a new URL. No other change.