### PR TITLE
fix(mac): build-local.sh works on modern SDKs and copies the resource bundle

### DIFF
--- a/mac/Scripts/build-local.sh
+++ b/mac/Scripts/build-local.sh
@@ -41,28 +41,51 @@ BUNDLE="${APPS}/${EXE}.app"
 
 trap 'rm -rf "${SCRATCH}"' EXIT
 
-# --- locate a Swift 6.x toolchain -------------------------------------------
-TC=""
+# --- toolchain + SDK selection ----------------------------------------------
+# Two supported configurations:
+#   1. Full Xcode installed, use its SDK. REQUIRED on macOS 15+ SDKs, where
+#      SwiftUI's @State is a macro whose plugin (libSwiftUIMacros.dylib) ships
+#      ONLY inside Xcode. The Command Line Tools do not carry it, so a CLT-only
+#      build of any SwiftUI view fails with "external macro implementation type
+#      'SwiftUIMacros.StateMacro' could not be found".
+#   2. Command Line Tools with the macOS 14 SDK plus a swift.org toolchain.
+#      That SDK's SwiftUI lacks the @MainActor annotations later SDKs added,
+#      which is what the source patching below exists for.
+SWIFT=""
 for cand in "${HOME}/Library/Developer/Toolchains/swift-6.2-RELEASE.xctoolchain" \
             "${HOME}/Library/Developer/Toolchains/swift-latest.xctoolchain" \
             /Library/Developer/Toolchains/swift-latest.xctoolchain; do
-  [[ -x "${cand}/usr/bin/swift" ]] && { TC="${cand}"; break; }
+  [[ -x "${cand}/usr/bin/swift" ]] && { SWIFT="${cand}/usr/bin/swift"; break; }
 done
-if [[ -z "${TC}" ]]; then
-  echo "✗ No swift.org Swift 6.x toolchain found in ~/Library/Developer/Toolchains/." >&2
-  echo "  Install one from https://www.swift.org/install/macos/ (Swift 6.2)." >&2
+[[ -n "${SWIFT}" ]] || SWIFT="$(command -v swift || true)"
+if [[ -z "${SWIFT}" ]]; then
+  echo "✗ No swift compiler found (no swift.org toolchain, no swift on PATH)." >&2
   exit 1
 fi
-SWIFT="${TC}/usr/bin/swift"
-export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
-SDK_VERSION="$(xcrun --sdk macosx --show-sdk-version)"
+
+# Prefer Xcode's SDK when present: its SwiftUI and its macro plugins are a
+# matched pair. Mixing an Xcode plugin with a CLT SDK expands @State into
+# calls the SDK does not declare (e.g. State._makeStorage_v0).
+XCODE_SDK="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+if [[ -d "${XCODE_SDK}" ]]; then
+  export SDKROOT="${XCODE_SDK}"
+else
+  export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+fi
+SDK_VERSION="$(plutil -extract Version raw "${SDKROOT}/SDKSettings.plist" 2>/dev/null \
+               || xcrun --sdk macosx --show-sdk-version)"
+
+PATCH_MAINACTOR=0
 case "${SDK_VERSION}" in
-  14.*) ;;
+  14.*) PATCH_MAINACTOR=1 ;;
   *)
-    echo "✗ Active SDK is macOS ${SDK_VERSION}, not 14.x, xcode-select is likely" >&2
-    echo "  pointed at a newer Xcode instead of the Command Line Tools. Run:" >&2
-    echo "    sudo xcode-select -s /Library/Developer/CommandLineTools" >&2
-    exit 1
+    if [[ ! -d "/Applications/Xcode.app" ]]; then
+      echo "✗ Active SDK is macOS ${SDK_VERSION}, whose SwiftUI needs a macro" >&2
+      echo "  plugin that only full Xcode ships. Install Xcode:" >&2
+      echo "    mas install 497799835" >&2
+      echo "  or point xcode-select at a macOS 14 SDK for the legacy path." >&2
+      exit 1
+    fi
     ;;
 esac
 echo "▸ Toolchain : $("${SWIFT}" --version | head -1)"
@@ -73,6 +96,7 @@ echo "▸ Staging sources in ${SCRATCH}..."
 # Tests/ is copied only so the manifest's testTarget path resolves; `swift build`
 # (product only) never compiles it, so it needs no @MainActor patching.
 cp -R "${MAC_DIR}/Sources" "${MAC_DIR}/Tests" "${MAC_DIR}/Package.swift" "${SCRATCH}/"
+if (( PATCH_MAINACTOR )); then
 find "${SCRATCH}/Sources" -name "*.swift" -print0 | while IFS= read -r -d '' f; do
   # Slurp mode ([^{]* spans newlines) so this also catches multi-line generic
   # struct headers and `extension X: View` conformances, not just the
@@ -83,21 +107,18 @@ find "${SCRATCH}/Sources" -name "*.swift" -print0 | while IFS= read -r -d '' f; 
     s/\@MainActor\n\@MainActor\n/\@MainActor\n/g;
   ' "$f"
 done
+else
+  echo "▸ SDK ${SDK_VERSION} already annotates SwiftUI, skipping @MainActor patch."
+fi
 
-# --- build each arch separately, then lipo into one universal binary --------
-# `swift build --arch arm64 --arch x86_64` together shells out to xcbuild,
-# which the Command Line Tools doesn't ship, each arch alone stays on the
-# plain SwiftPM build path, so build twice and merge with lipo instead.
-BINS=()
-for arch in arm64 x86_64; do
-  echo "▸ Building ${arch} release..."
-  ( cd "${SCRATCH}" && "${SWIFT}" build -c release --arch "${arch}" )
-  bin="$(cd "${SCRATCH}" && "${SWIFT}" build -c release --arch "${arch}" --show-bin-path)/${EXE}"
-  [[ -x "${bin}" ]] || { echo "✗ ${arch} build produced no binary" >&2; exit 1; }
-  BINS+=("${bin}")
-done
-BIN="${SCRATCH}/${EXE}-universal"
-lipo -create -output "${BIN}" "${BINS[@]}"
+# --- build one universal binary ---------------------------------------------
+# A single two-arch invocation goes through xcbuild and already emits a fat
+# binary, so there is nothing left for lipo to merge.
+echo "▸ Building universal release..."
+( cd "${SCRATCH}" && "${SWIFT}" build -c release --arch arm64 --arch x86_64 )
+PRODUCTS="$(cd "${SCRATCH}" && "${SWIFT}" build -c release --arch arm64 --arch x86_64 --show-bin-path)"
+BIN="${PRODUCTS}/${EXE}"
+[[ -x "${BIN}" ]] || { echo "✗ build produced no binary at ${BIN}" >&2; exit 1; }
 
 # --- assemble the .app bundle ------------------------------------------------
 echo "▸ Assembling ${BUNDLE}..."
@@ -106,6 +127,13 @@ rm -rf "${BUNDLE}"
 mkdir -p "${BUNDLE}/Contents/MacOS" "${BUNDLE}/Contents/Resources"
 cp "${BIN}" "${BUNDLE}/Contents/MacOS/${EXE}"
 cp "${ICON_SOURCE}" "${BUNDLE}/Contents/Resources/menubar-logo.png"
+
+# SwiftPM emits target resources as a separate .bundle that Bundle.module
+# resolves from the app's Resources dir. Without it the app dies immediately
+# with "unable to find bundle named CodeBurnMenubar_CodeBurnMenubar".
+for rb in "${PRODUCTS}"/*.bundle; do
+  [[ -d "${rb}" ]] && cp -R "${rb}" "${BUNDLE}/Contents/Resources/"
+done
 
 ICONSET="${SCRATCH}/AppIcon.iconset"; mkdir -p "${ICONSET}"
 for spec in "16:16x16" "32:16x16@2x" "32:32x32" "64:32x32@2x" "128:128x128" \


### PR DESCRIPTION
## Summary

`mac/Scripts/build-local.sh` cannot produce a working app on a current macOS toolchain. This pull request corrects 2 defects. Neither is specific to any package manager or host configuration: the first breaks every app the script assembles, and the second stops the script before it compiles anything.

### 1. The assembled app could not launch, because the resource bundle was never copied

The script copies the product binary and the generated icons into the bundle, but not the SwiftPM resource bundle. Any app it assembled terminated during startup:

```
CodeBurnMenubar/resource_bundle_accessor.swift:44: Fatal error: unable to find bundle named CodeBurnMenubar_CodeBurnMenubar
```

`Bundle.module` resolves that bundle from the app's `Contents/Resources`. SwiftPM emits it as a sibling of the executable in the build products directory, so it has to be copied in alongside the binary. The script now copies every `*.bundle` from that directory.

This became reachable when target resources entered `Package.swift`; the script was never updated to match. It is independent of defect 2 and of any host specifics.

### 2. The script exited before compiling on any SDK newer than 14.x

Two hard exits made the script unusable on a current toolchain:

- It required a swift.org toolchain in `~/Library/Developer/Toolchains/` and exited 1 when none was present, even though the `swift` provided by Xcode or the Command Line Tools is sufficient.
- It required the active SDK to report `14.x` and exited 1 otherwise.

Selection is now capability-driven rather than pinned. The compiler is a swift.org toolchain when one is installed, otherwise `swift` from `PATH`. The SDK is Xcode's when `/Applications/Xcode.app` is present, otherwise whatever `xcrun` reports. When the SDK is newer than 14.x and Xcode is absent, the script fails with an actionable message instead of a version mismatch.

Preferring Xcode's SDK is not cosmetic. On macOS 15+ SDKs SwiftUI's `@State` is a macro, and the plugin that expands it, `libSwiftUIMacros.dylib`, ships only inside Xcode. Command Line Tools 27.0 carries only `libObservationMacros.dylib` and `libSwiftMacros.dylib`, so compiling any view against the CLT SDK fails:

```
error: external macro implementation type 'SwiftUIMacros.StateMacro' could not be found for macro 'State()'; plugin for module 'SwiftUIMacros' not found
```

An SDK and its macro plugins must be used as a matched pair. Supplying Xcode 26.6's plugin to the CLT 27.0 SDK expands `@State` into a member that SDK does not declare:

```
macro expansion @State:1:46: error: type 'State<Value>' has no member '_makeStorage_v0'
```

Selecting Xcode's own SDK avoids this entirely: there `@State` is an ordinary property wrapper and no macro plugin participates in the build.

Two consequences follow. The `@MainActor` source rewriting is now gated to the `14.x` SDK it was written for, because later SDKs already carry those annotations; the `14.*` branch keeps the original `perl` rewrite verbatim. And the two-arch build is a single invocation, which routes through xcbuild and emits a fat binary directly, so the separate per-arch builds and the `lipo` merge that followed them are redundant.

## Change evidence

| Change | Why | Receipt |
|---|---|---|
| Copy every `*.bundle` from the products directory into `Contents/Resources` | Without it, every app the script assembles dies during startup. | Reproduced the pre-fix failure by launching the assembled bundle's executable directly: `resource_bundle_accessor.swift:44: Fatal error: unable to find bundle named CodeBurnMenubar_CodeBurnMenubar`, process exit code -5, no child process spawned. After the change, `Contents/Resources` lists `AppIcon.icns`, `CodeBurnMenubar_CodeBurnMenubar.bundle`, `menubar-logo.png`, and the same launch stays alive and spawns its `codeburn serve --stdio` child, confirmed by `pgrep -P <app pid>` reporting a matching ppid. |
| Capability-driven compiler and SDK selection | The script exited 1 without compiling on a machine holding no swift.org toolchain and an SDK newer than 14.x. | Ran `mac/Scripts/build-local.sh dev-nixfix` end to end: rc 0 in 41 s. Output records `Toolchain : Apple Swift version 6.4 (swiftlang-6.4.0.33.1 clang-2100.3.33.1)` and `SDK : /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk (26.5)`, then `✓ Installed`. Before the change the same invocation exited 1 at the toolchain probe on this host, having compiled nothing. |
| Unchanged universal output and deployment target | Selection changes must not alter what ships. | `lipo -info` on the assembled binary reports `x86_64 arm64`. `vtool -show-build` reports `minos 14.0`. Both match the script's prior contract. |
| Single two-arch invocation instead of per-arch builds plus `lipo` | One invocation already emits a fat binary, leaving nothing to merge. | `swift build -c release --arch arm64 --arch x86_64` returned rc 0 in 38 s and `lipo -info` on the product reported `x86_64 arm64`, with no `lipo -create` step involved. `--show-bin-path` under the same flags resolves to `.build/out/Products/Release`, which is also where the resource bundle is emitted, so one query locates both copy sources. |
| `@MainActor` rewriting gated to the 14.x SDK | The rewrite exists for an SDK whose SwiftUI lacks those annotations; running it elsewhere edits staged sources for no reason. | The successful run above printed `SDK 26.5 already annotates SwiftUI, skipping @MainActor patch` and still produced a launchable app, so the rewrite is not required on the newer SDK. The `14.*` branch retains the original `perl` invocation unchanged, so the legacy path is untouched. |
| No impact on the TypeScript surface | The change set touches only `mac/`, so the existing suite must stay green. | Ran `npm test`: 272 test files passed, 2 skipped; 3738 tests passed, 5 skipped, 0 failed; duration 34.30 s. Ran `npm run build`: rc 0, emitting `dist/main.js` (2.29 MB), `dist/parse-worker.js` (864.47 KB), and the dash bundle. |

## Environment

Verified on macOS 27.0, Apple Silicon, with no swift.org toolchain installed.

| Fact | Value |
|---|---|
| `xcode-select -p` | `/Library/Developer/CommandLineTools` |
| Command Line Tools | `com.apple.pkg.CLTools_Executables` version 27.0.0.0.1787197235 |
| CLT host plugins | `libObservationMacros.dylib`, `libSwiftMacros.dylib` only; no `libSwiftUIMacros.dylib` anywhere under CLT or its SDK |
| Xcode | 26.6 (17F113), bundled SDK macOS 26.5, platform plugins include `libSwiftUIMacros.dylib` |
| `~/Library/Developer/Toolchains` | absent |

Note that `xcode-select` still points at the Command Line Tools in the verified run. The script selects Xcode's SDK explicitly, so a global `xcode-select` switch is not required and neither is `sudo xcodebuild -license accept`.

## Notes

The script's header comment is unchanged and still describes the Sonoma case it was written for; the `14.x` path behaves exactly as before.

The `x86_64` slice was cross-compiled and not executed; only the `arm64` slice was run.

Companion pull request #1263 fixes a separate runtime defect in `CodeburnCLI.swift`. The two do not overlap in files. This one is a prerequisite for building and verifying that change locally on a modern toolchain, so it should land first.

## Testing

- [x] I have tested this locally against real data (not just unit tests)
- [x] `npm test` passes
- [x] `npm run build` succeeds

Real-data check: the app the fixed script assembles was installed to `~/Applications/CodeBurnMenubar.app`, launched, and rendered a flame icon with a live dollar figure in the menu bar against the local corpus, with its `codeburn serve --stdio` child confirmed alive by ppid.

## Files (1)

- mac/Scripts/build-local.sh [MODIFIED] (+56 -28)
