### PR TITLE
fix(mac): prefer the node beside the CLI over a version manager's default

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Security/CodeburnCLI.swift
+++ b/mac/Sources/CodeBurnMenubar/Security/CodeburnCLI.swift
@@ -131,16 +131,20 @@ enum CodeburnCLI {
     ) -> Process {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        // Resolved once so the PATH we build and the argv we run can never disagree
+        // about which install of the CLI this launch is talking about.
+        let argv = baseArgv()
         var environment = ProcessInfo.processInfo.environment
         environment["PATH"] = augmentedPath(
             environment["PATH"] ?? "",
             homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path,
-            environment: environment
+            environment: environment,
+            resolvedCLI: argv.first
         )
         process.environment = environment
         // `env --` treats everything following as argv, not VAR=val pairs -- guards against an
         // argument accidentally resembling an env assignment.
-        process.arguments = ["--"] + baseArgv() + subcommand
+        process.arguments = ["--"] + argv + subcommand
         // The menubar runs as an accessory app with no foreground window, and macOS
         // background-throttles accessory apps and their children. Without this lift the
         // codeburn subprocess parses 5-10x slower than the same command run from a
@@ -154,12 +158,27 @@ enum CodeburnCLI {
         return safeArgPattern.firstMatch(in: s, range: range) != nil
     }
 
+    /// `resolvedCLI` defaults to the CLI this app would actually launch; tests pass
+    /// a fixture path so PATH ordering can be asserted without a real install.
     static func augmentedPath(
         _ existing: String,
         homeDirectory: String,
-        environment: [String: String]
+        environment: [String: String],
+        resolvedCLI: String? = nil
     ) -> String {
         var parts = existing.split(separator: ":", omittingEmptySubsequences: true).map(String.init)
+        // The CLI's shebang resolves `node` through PATH, so whichever node comes
+        // first wins — and a version manager's default can easily be older than
+        // the 22.13 the CLI requires, which surfaces as "Could not load Today"
+        // rather than anything pointing at Node. The interpreter that sits beside
+        // the CLI we are about to run is known to satisfy it, so it goes first.
+        if let cli = resolvedCLI ?? baseArgv().first, cli.hasPrefix("/") {
+            let binDir = (cli as NSString).deletingLastPathComponent
+            if FileManager.default.isExecutableFile(atPath: "\(binDir)/node") {
+                parts.removeAll { $0 == binDir }
+                parts.insert(binDir, at: 0)
+            }
+        }
         let userPaths = userNodePaths(homeDirectory: homeDirectory, environment: environment)
         for extra in additionalPathEntries + userPaths where !parts.contains(extra) {
             parts.append(extra)

--- a/mac/Tests/CodeBurnMenubarTests/CodeburnCLIPathTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CodeburnCLIPathTests.swift
@@ -139,4 +139,88 @@ struct CodeburnCLIPathTests {
         #expect(entries.contains("/etc/profiles/per-user/test/bin"))
         #expect(entries.contains("/run/current-system/sw/bin"))
     }
+
+    /// Regression: the app picked up whichever `node` came first on the inherited
+    /// PATH, so an nvm default of v20 shadowed the v24 that installed the CLI and
+    /// every refresh failed with "codeburn requires Node.js >= 22.13.0".
+    @Test("interpreter beside the CLI wins over an older node on PATH")
+    func siblingNodeIsPreferredOverInheritedPath() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodeburnCLIPathTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let newBin = root.appendingPathComponent("node/v24/bin", isDirectory: true)
+        let oldBin = root.appendingPathComponent("node/v20/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: newBin, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: oldBin, withIntermediateDirectories: true)
+        for bin in [newBin, oldBin] {
+            let node = bin.appendingPathComponent("node")
+            try "#!/bin/sh\n".write(to: node, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: node.path)
+        }
+
+        let path = CodeburnCLI.augmentedPath(
+            "\(oldBin.path):/usr/bin:/bin",
+            homeDirectory: root.appendingPathComponent("home").path,
+            environment: [:],
+            resolvedCLI: newBin.appendingPathComponent("codeburn").path
+        )
+        let entries = path.split(separator: ":").map(String.init)
+
+        #expect(entries.first == newBin.path)
+        #expect(entries.firstIndex(of: newBin.path)! < entries.firstIndex(of: oldBin.path)!)
+        // The stale entry still has to survive: it is where the rest of that
+        // toolchain lives, it just no longer decides which node runs.
+        #expect(entries.contains(oldBin.path))
+    }
+
+    @Test("a CLI directory already on PATH is promoted, not duplicated")
+    func siblingNodeDirectoryIsNotDuplicated() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodeburnCLIPathTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let bin = root.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let node = bin.appendingPathComponent("node")
+        try "#!/bin/sh\n".write(to: node, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: node.path)
+
+        let path = CodeburnCLI.augmentedPath(
+            "/usr/bin:\(bin.path):/bin",
+            homeDirectory: root.appendingPathComponent("home").path,
+            environment: [:],
+            resolvedCLI: bin.appendingPathComponent("codeburn").path
+        )
+        let entries = path.split(separator: ":").map(String.init)
+
+        #expect(entries.first == bin.path)
+        #expect(entries.filter { $0 == bin.path }.count == 1)
+    }
+
+    /// A bare `codeburn` (PATH lookup) or a directory with no interpreter beside it
+    /// must leave the inherited order untouched -- reordering PATH on a guess would
+    /// change which tools every other lookup resolves to.
+    @Test("PATH order is untouched when there is no sibling interpreter")
+    func inheritedOrderSurvivesWithoutSiblingNode() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodeburnCLIPathTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let bin = root.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+
+        for cli in [bin.appendingPathComponent("codeburn").path, "codeburn"] {
+            let path = CodeburnCLI.augmentedPath(
+                "/usr/bin:/bin",
+                homeDirectory: root.appendingPathComponent("home").path,
+                environment: [:],
+                resolvedCLI: cli
+            )
+            let entries = path.split(separator: ":").map(String.init)
+            #expect(entries.first == "/usr/bin")
+            #expect(entries.dropFirst().first == "/bin")
+            #expect(!entries.contains(bin.path))
+        }
+    }
 }


### PR DESCRIPTION
## Summary

On a machine where a Node version manager's *default* version is older than the 22.13 the CLI requires, the menubar app renders no data: every CLI spawn exits 1 with `codeburn requires Node.js >= 22.13.0 (current: v20.20.2)`, and the popover shows "Could not load Today" with nothing pointing at Node.

`CodeburnCLI.makeProcess` runs the CLI through `/usr/bin/env` and builds `PATH` by taking the inherited value and **appending** `additionalPathEntries` plus `userNodePaths`. The published launcher begins `#!/usr/bin/env node`, so whichever `node` comes first on that PATH wins — and on an nvm machine the first one is the *default alias*, which is easily an older major than the one the CLI was installed under. The CLI itself lives at `~/.nvm/versions/node/v24.20.0/bin/codeburn` (resolved and cached by `installedArgv()`), right next to a v24 `node` that would run it fine; the app just never puts that directory ahead of the inherited entries.

`augmentedPath` now takes the resolved CLI path and, when an executable `node` sits in the same directory, moves that directory to the **front** of PATH (promoting it if it was already present, so nothing is duplicated and nothing is dropped). The interpreter beside the CLI is by construction the one that installed it and satisfies its engine range. When the CLI resolves through PATH (bare `codeburn`) or has no sibling interpreter, the inherited order is left exactly as before — so #1263's Nix layout (CLI in `~/.local/bin`, node in a profile directory) is untouched, and every existing `userNodePaths` consumer keeps its precedence.

`makeProcess` also resolved the CLI twice — once for PATH, once for argv. It now resolves once and passes the same value to both, so they cannot disagree about which install a launch is talking about.

## Change evidence

| Change | Why | Receipt |
|---|---|---|
| Sibling-`node` directory leads PATH | The engine gate fails on a version manager's default, while a compatible interpreter sits next to the CLI. | `swift test --filter CodeburnCLIPathTests`: 7 tests in 1 suite passed. New title: "interpreter beside the CLI wins over an older node on PATH". Fixture: two `node` stubs under `…/node/v24/bin` and `…/node/v20/bin`, inherited PATH `v20:/usr/bin:/bin`, `resolvedCLI` pointing into `v24/bin`. Asserts `v24/bin` is first, `v20/bin` still present and later. |
| Promote, don't duplicate | A CLI directory already on PATH must move, not appear twice. | Same run, title "a CLI directory already on PATH is promoted, not duplicated": inherited `/usr/bin:<bin>:/bin` with `resolvedCLI` in `<bin>` → `<bin>` first, exactly one occurrence. |
| Inherited order untouched when there is nothing to prefer | Reordering PATH on a guess would change what every other lookup resolves to; #1263's Nix case (no `node` beside the CLI) must not move. | Same run, title "PATH order is untouched when there is no sibling interpreter": for both a bare `codeburn` and an absolute CLI with no sibling `node`, PATH begins `/usr/bin:/bin` and the CLI's directory is not inserted. |
| Regression proof that the new tests bind to the defect | Confirm they fail without the fix rather than restating the implementation. | Removed only the reordering block from `augmentedPath` (signature kept so the tests still compile) and re-ran the filter: the two positive tests failed with the reported shape — `entries.first → ".../node/v20/bin"` where `v24/bin` was expected, and `entries.first → "/usr/bin"` where the CLI's directory was expected — while "PATH order is untouched…" and all four pre-existing tests (mise ×2, Nix ×2) still passed. Restored the block; `git diff` against the staged fix is empty. |
| `resolvedCLI` injection parameter | The production value comes from `baseArgv()`, which reads the persisted CLI path and probes the filesystem; tests pass a fixture path instead. Default `nil` keeps every existing caller unchanged. | Covered by the three tests above; `makeProcess` passes `argv.first`. |
| Full suite, branch vs `main` | CONTRIBUTING asks for both and zero new failures. | `swift test` from `mac/` on `main` (4a9d885): 424 tests in 53 suites passed, 0 failed. On this branch: 427 tests in 53 suites passed, 0 failed. Difference is exactly the 3 new tests. |
| End-to-end on the affected machine | A unit test cannot show the shipped bundle picks the right interpreter under a GUI-inherited environment. | Before: the installed app's every refresh failed with the `>= 22.13.0 (current: v20.20.2)` error above. After rebuilding and reinstalling with this change, the status item rendered today's spend within one refresh and the figure matched `codeburn status --format menubar-json --period today` run from a shell. Reproduced the spawn directly: `PATH="$HOME/.nvm/versions/node/v24.20.0/bin:$PATH" ~/.nvm/versions/node/v24.20.0/bin/codeburn --version` → `0.9.23…`, rc 0; the same command without the prefix on that machine → rc 1 with the engine error. |

## Environment

Observed and fixed on macOS 26 (Darwin 25.6), Apple Silicon.

| Fact | Value |
|---|---|
| `~/.nvm/alias/default` | `20.20.2` |
| Persisted CLI path (`codeburn-cli-path.v1`) | `/Users/<user>/.nvm/versions/node/v24.20.0/bin/codeburn` |
| `node` beside it | v24.20.0 |
| `/opt/homebrew/bin/node` | v24.20.0 (present, but after the nvm default on the inherited PATH) |
| Spawn error before the fix | `codeburn requires Node.js >= 22.13.0 (current: v20.20.2)` / `Upgrade at https://nodejs.org/` |

## Notes

The change is confined to `augmentedPath` and `makeProcess` in `CodeburnCLI.swift`. It adds no dependency, alters no public interface, and leaves `isSafe`, `baseArgv`, `installedArgv`, `userNodePaths` (including #1263's Nix entries) and the `CODEBURN_BIN` override untouched. The only PATH entries it can move are ones that were already on PATH or already curated by the app.

This is complementary to #1263: that change teaches the app *where* a Node can be; this one settles *which* one wins when several are present. The stronger follow-up mentioned there — persisting the interpreter path and spawning `[node, cli.js]` directly — would subsume both; this PR keeps the `/usr/bin/env` design.

The description above is what this branch does and what was measured; the same defect on Windows (the npm `.cmd` shim also resolves `node` via PATH) is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
