### PR TITLE
fix(cli): default NODE_ENV to production so the dashboard stops leaking React user-timing entries

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,15 @@ if (major < 22 || (major === 22 && minor < 13)) {
   process.exit(1)
 }
 
+// React (loaded by Ink) picks its development build unless NODE_ENV is exactly
+// "production". That build records a performance.measure() entry on every
+// render into Node's user-timing buffer, which nothing ever trims, so an
+// interactive dashboard left open for days grows until V8 aborts with
+// "JavaScript heap out of memory". Default to the production build; an
+// explicit NODE_ENV in the shell still wins. This must run before main.js is
+// imported because React reads NODE_ENV at module load.
+if (!process.env.NODE_ENV) process.env.NODE_ENV = 'production'
+
 import('./main.js').catch((err) => {
   process.stderr.write(String(err?.message ?? err) + '\n')
   process.exit(1)

--- a/src/compare.tsx
+++ b/src/compare.tsx
@@ -8,6 +8,7 @@ import { parseAllSessions, setInteractiveScanUI } from './parser.js'
 import { getAllProviders } from './providers/index.js'
 import type { ProjectSummary, DateRange } from './types.js'
 import { patchStdoutForWindows } from './ink-win.js'
+import { startUserTimingGuard } from './user-timing-guard.js'
 import { recommendModelDefault, type ModelDefaultRecommendation } from './act/model-defaults.js'
 
 const ORANGE = '#FF8C42'
@@ -541,8 +542,13 @@ export async function renderCompare(range: DateRange, provider: string, modelA?:
     presetModels = [a.model, b.model]
   }
 
-  const { waitUntilExit } = render(
-    <CompareView projects={projects} onBack={() => process.exit(0)} presetModels={presetModels} />
-  )
-  await waitUntilExit()
+  const stopUserTimingGuard = startUserTimingGuard()
+  try {
+    const { waitUntilExit } = render(
+      <CompareView projects={projects} onBack={() => process.exit(0)} presetModels={presetModels} />
+    )
+    await waitUntilExit()
+  } finally {
+    stopUserTimingGuard()
+  }
 }

--- a/src/context-tui.tsx
+++ b/src/context-tui.tsx
@@ -3,6 +3,7 @@ import { render, Box, Text, useApp, useInput } from 'ink'
 
 import { formatTokens } from './format.js'
 import { patchStdoutForWindows } from './ink-win.js'
+import { startUserTimingGuard } from './user-timing-guard.js'
 import {
   buildContextTree,
   listRecentTitledSessions,
@@ -204,6 +205,11 @@ function ContextTuiApp({ initialScope }: { initialScope: Scope }) {
 
 export async function runContextTui(opts: { initialScope?: Scope } = {}): Promise<void> {
   patchStdoutForWindows()
-  const instance = render(<ContextTuiApp initialScope={opts.initialScope ?? 'effective'} />)
-  await instance.waitUntilExit()
+  const stopUserTimingGuard = startUserTimingGuard()
+  try {
+    const instance = render(<ContextTuiApp initialScope={opts.initialScope ?? 'effective'} />)
+    await instance.waitUntilExit()
+  } finally {
+    stopUserTimingGuard()
+  }
 }

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -24,6 +24,7 @@ import { getPlanUsages, type PlanUsage } from './plan-usage.js'
 import { planDisplayName } from './plans.js'
 import { formatDayRangeLabel, getDateRange, parseDayFlag, PERIODS, PERIOD_LABELS, shiftDay, type Period } from './cli-date.js'
 import { BSU, patchStdoutForWindows } from './ink-win.js'
+import { startUserTimingGuard } from './user-timing-guard.js'
 
 type View = 'dashboard' | 'optimize' | 'compare'
 
@@ -2463,6 +2464,7 @@ export async function renderDashboard(period: Period = 'week', provider: string 
       }
     }
     process.stdin.on('data', hardQuitGuard)
+    const stopUserTimingGuard = startUserTimingGuard()
     const app = renderDebouncedInteractive(process.stdout, ({ columns }) => (
       <InteractiveDashboard initialProjects={filteredProjects} initialDailyHistoryProjects={scrollableDailyHistory ? scannedProjects : undefined} initialPeriod={opened} initialProvider={provider} initialPlanUsages={planUsages} initialDurable={initialDurable} refreshSeconds={refreshSeconds} projectFilter={projectFilter} excludeFilter={excludeFilter} customRange={customRange} customRangeLabel={customRangeLabel} initialDay={initialDay} windowColumns={columns} initialIndexPendingFiles={paint.deferredFiles} initialHistoryIndexing={progressive} initialCacheWasCold={cacheWasCold} autoFallbackFromEmptyToday={auto} terminateProcess={exitCode => { setImmediate(() => exitAfterCacheCleanup(exitCode)) }} />
     ))
@@ -2471,6 +2473,7 @@ export async function renderDashboard(period: Period = 'week', provider: string 
     } finally {
       process.stdin.off('data', hardQuitGuard)
       app.dispose()
+      stopUserTimingGuard()
     }
   } else {
     const { unmount } = render(<StaticDashboard projects={filteredProjects} period={opened} activeProvider={provider} planUsages={planUsages} label={label} dayMode={initialDay != null} durable={initialDurable} />, { patchConsole: false })

--- a/src/sessions-tui.tsx
+++ b/src/sessions-tui.tsx
@@ -3,6 +3,7 @@ import { Box, Text, render, useApp, useInput, useWindowSize } from 'ink'
 
 import { formatTokens } from './format.js'
 import { patchStdoutForWindows } from './ink-win.js'
+import { startUserTimingGuard } from './user-timing-guard.js'
 import {
   cleanSessionProjectLabel,
   sessionDisplayName,
@@ -251,6 +252,11 @@ function SessionsTui({ rows, period, initialProvider }: { rows: SessionRow[]; pe
 
 export async function runSessionsTui(rows: SessionRow[], opts: { period: string; provider: string }): Promise<void> {
   patchStdoutForWindows()
-  const instance = render(<SessionsTui rows={rows} period={opts.period} initialProvider={opts.provider} />)
-  await instance.waitUntilExit()
+  const stopUserTimingGuard = startUserTimingGuard()
+  try {
+    const instance = render(<SessionsTui rows={rows} period={opts.period} initialProvider={opts.provider} />)
+    await instance.waitUntilExit()
+  } finally {
+    stopUserTimingGuard()
+  }
 }

--- a/src/user-timing-guard.ts
+++ b/src/user-timing-guard.ts
@@ -19,23 +19,27 @@ export function userTimingEntryCount(): number {
   return performance.getEntriesByType('mark').length + performance.getEntriesByType('measure').length
 }
 
+/** Drops every user-timing mark and measure without looking at them first. */
+export function clearUserTimingEntries(): void {
+  performance.clearMarks()
+  performance.clearMeasures()
+}
+
 /** Drops every user-timing mark and measure; returns how many were dropped. */
 export function dropUserTimingEntries(): number {
   const count = userTimingEntryCount()
-  if (count > 0) {
-    performance.clearMarks()
-    performance.clearMeasures()
-  }
+  if (count > 0) clearUserTimingEntries()
   return count
 }
 
 /**
  * Drops user-timing entries every `intervalMs` until the returned stop
  * function is called. The timer is unref'd so it never keeps the process alive;
- * stopping drops whatever accumulated since the last tick.
+ * stopping drops whatever accumulated since the last tick. The tick clears
+ * blind: counting first would copy the buffer it is about to empty.
  */
 export function startUserTimingGuard(intervalMs = USER_TIMING_GUARD_INTERVAL_MS): () => void {
-  const timer = setInterval(dropUserTimingEntries, intervalMs)
+  const timer = setInterval(clearUserTimingEntries, intervalMs)
   timer.unref()
   let stopped = false
   return () => {

--- a/src/user-timing-guard.ts
+++ b/src/user-timing-guard.ts
@@ -1,0 +1,47 @@
+import { performance } from 'node:perf_hooks'
+
+// React's development build - the one Ink loads whenever NODE_ENV is anything
+// but "production" - records a performance.measure() entry for every render
+// (its Chrome DevTools "Scheduler ⚛" / "Components ⚛" tracks). Node keeps
+// user-timing marks and measures in a process-wide buffer that nothing trims,
+// so an interactive Ink UI left open accumulates them until V8 aborts with
+// "JavaScript heap out of memory" (roughly 700 entries a minute for the
+// dashboard; a few days is enough to exhaust the default heap).
+//
+// The launcher defaults NODE_ENV to "production", which selects the build that
+// records nothing. This guard covers the remaining case - an explicit
+// NODE_ENV=development in the user's shell - by dropping the buffer on a
+// timer. codeburn records no marks or measures of its own, so nothing is lost.
+
+export const USER_TIMING_GUARD_INTERVAL_MS = 30_000
+
+export function userTimingEntryCount(): number {
+  return performance.getEntriesByType('mark').length + performance.getEntriesByType('measure').length
+}
+
+/** Drops every user-timing mark and measure; returns how many were dropped. */
+export function dropUserTimingEntries(): number {
+  const count = userTimingEntryCount()
+  if (count > 0) {
+    performance.clearMarks()
+    performance.clearMeasures()
+  }
+  return count
+}
+
+/**
+ * Drops user-timing entries every `intervalMs` until the returned stop
+ * function is called. The timer is unref'd so it never keeps the process alive;
+ * stopping drops whatever accumulated since the last tick.
+ */
+export function startUserTimingGuard(intervalMs = USER_TIMING_GUARD_INTERVAL_MS): () => void {
+  const timer = setInterval(dropUserTimingEntries, intervalMs)
+  timer.unref()
+  let stopped = false
+  return () => {
+    if (stopped) return
+    stopped = true
+    clearInterval(timer)
+    dropUserTimingEntries()
+  }
+}

--- a/tests/cli-node-env.test.ts
+++ b/tests/cli-node-env.test.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from 'node:child_process'
+import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+// The launcher (src/cli.ts, copied verbatim to dist/cli.js) is the only place
+// that runs before React and Ink are imported. React picks its development
+// build unless NODE_ENV is exactly "production", and that build records a
+// performance.measure() entry on every render into Node's user-timing buffer,
+// which nothing ever trims: an interactive dashboard left open for days grows
+// until V8 aborts with "JavaScript heap out of memory". The launcher must
+// default NODE_ENV to "production" while leaving an explicit value untouched.
+
+let dir: string
+
+function runLauncher(env: Record<string, string | undefined>): string {
+  const base = { ...process.env }
+  delete base['NODE_ENV']
+  const result = spawnSync(process.execPath, [join(dir, 'cli.js')], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...base, ...env },
+  })
+  expect(result.status, result.stderr).toBe(0)
+  return result.stdout.trim()
+}
+
+describe('CLI launcher NODE_ENV default', () => {
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'codeburn-cli-node-env-'))
+    copyFileSync(join(process.cwd(), 'src', 'cli.ts'), join(dir, 'cli.js'))
+    // Stand-in for dist/main.js: report the environment the launcher handed us.
+    writeFileSync(join(dir, 'main.js'), 'process.stdout.write(JSON.stringify(process.env.NODE_ENV ?? null))\n')
+    writeFileSync(join(dir, 'package.json'), '{"type":"module"}\n')
+  })
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('defaults NODE_ENV to production when the shell leaves it unset', () => {
+    expect(runLauncher({})).toBe('"production"')
+  })
+
+  it('treats an empty NODE_ENV as unset', () => {
+    expect(runLauncher({ NODE_ENV: '' })).toBe('"production"')
+  })
+
+  it('keeps an explicit NODE_ENV', () => {
+    expect(runLauncher({ NODE_ENV: 'development' })).toBe('"development"')
+  })
+})

--- a/tests/fixtures/ink-user-timing-probe.tsx
+++ b/tests/fixtures/ink-user-timing-probe.tsx
@@ -1,0 +1,44 @@
+// Child-process probe for tests/user-timing-guard.test.tsx.
+//
+// Renders a ticking Ink component into a throwaway stream for a while and
+// reports how many user-timing entries React left in Node's buffer. It has to
+// run in a plain Node process: vitest swaps `console` for one without
+// `timeStamp`, and React's development build only records its performance
+// tracks when `console.timeStamp` and `performance.measure` both exist at
+// module load - which is exactly the case in the shipped CLI.
+//
+//   argv[2]  'guard' to run startUserTimingGuard(10) for the duration
+//   argv[3]  how long to keep rendering, in ms (default 500)
+//
+// Prints one JSON line: { nodeEnv, renders, entriesWhileRunning, entriesAfterStop }.
+import { PassThrough } from 'node:stream'
+
+import React, { useEffect, useState } from 'react'
+import { render, Text } from 'ink'
+
+import { startUserTimingGuard, userTimingEntryCount } from '../../src/user-timing-guard.js'
+
+const useGuard = process.argv[2] === 'guard'
+const durationMs = Number(process.argv[3] ?? 500)
+let renders = 0
+
+function Ticker() {
+  const [n, setN] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => setN(v => v + 1), 2)
+    return () => clearInterval(id)
+  }, [])
+  renders++
+  return <Text>tick {n}</Text>
+}
+
+const stdout = Object.assign(new PassThrough(), { columns: 80, rows: 24 })
+stdout.resume()
+const stop = useGuard ? startUserTimingGuard(10) : () => {}
+const app = render(<Ticker />, { stdout: stdout as unknown as NodeJS.WriteStream, patchConsole: false })
+await new Promise<void>(resolve => setTimeout(resolve, durationMs))
+app.unmount()
+const entriesWhileRunning = userTimingEntryCount()
+stop()
+const entriesAfterStop = userTimingEntryCount()
+process.stdout.write(JSON.stringify({ nodeEnv: process.env.NODE_ENV ?? null, renders, entriesWhileRunning, entriesAfterStop }) + '\n')

--- a/tests/user-timing-guard.test.tsx
+++ b/tests/user-timing-guard.test.tsx
@@ -1,0 +1,77 @@
+import { spawnSync } from 'node:child_process'
+import { performance } from 'node:perf_hooks'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { dropUserTimingEntries, startUserTimingGuard, userTimingEntryCount } from '../src/user-timing-guard.js'
+
+// React's development build - the one Ink loads whenever NODE_ENV is not
+// "production" - writes a performance.measure() entry per render into Node's
+// user-timing buffer, and Node never trims that buffer, so a long-lived Ink UI
+// grows without bound until V8 aborts with "JavaScript heap out of memory".
+// The launcher defaults NODE_ENV to "production"; the guard covers an explicit
+// NODE_ENV=development by dropping the entries on a timer.
+
+type ProbeReport = { nodeEnv: string | null; renders: number; entriesWhileRunning: number; entriesAfterStop: number }
+
+function runProbe(nodeEnv: string, mode: 'guard' | 'plain' = 'plain', durationMs = 500): ProbeReport {
+  const result = spawnSync(process.execPath, ['--import', 'tsx', 'tests/fixtures/ink-user-timing-probe.tsx', mode, String(durationMs)], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: { ...process.env, NODE_ENV: nodeEnv },
+  })
+  expect(result.status, result.stderr).toBe(0)
+  return JSON.parse(result.stdout.trim().split('\n').at(-1)!) as ProbeReport
+}
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+afterEach(() => {
+  dropUserTimingEntries()
+})
+
+describe('user-timing guard', () => {
+  it('counts and drops marks and measures', () => {
+    performance.mark('codeburn-test-mark')
+    performance.measure('codeburn-test-measure')
+    expect(userTimingEntryCount()).toBeGreaterThanOrEqual(2)
+
+    const dropped = dropUserTimingEntries()
+
+    expect(dropped).toBeGreaterThanOrEqual(2)
+    expect(userTimingEntryCount()).toBe(0)
+  })
+
+  it('stops dropping once stopped', async () => {
+    const stop = startUserTimingGuard(5)
+    stop()
+    performance.measure('codeburn-after-stop')
+    await sleep(25)
+    expect(userTimingEntryCount()).toBe(1)
+  })
+
+  describe('against a real Ink render loop', () => {
+    it('React development build leaves an entry backlog behind (the premise)', () => {
+      const plain = runProbe('development')
+      expect(plain.renders).toBeGreaterThan(1)
+      expect(plain.entriesWhileRunning).toBeGreaterThan(plain.renders)
+      // Nothing drops them without the guard.
+      expect(plain.entriesAfterStop).toBe(plain.entriesWhileRunning)
+    })
+
+    it('React production build (the launcher default) records nothing', () => {
+      const production = runProbe('production')
+      expect(production.renders).toBeGreaterThan(1)
+      expect(production.entriesWhileRunning).toBe(0)
+    })
+
+    it('the guard keeps the backlog bounded while rendering and empties it on stop', () => {
+      const plain = runProbe('development')
+      const guarded = runProbe('development', 'guard')
+      expect(guarded.renders).toBeGreaterThan(1)
+      // At most one 10ms tick's worth of entries is ever pending.
+      expect(guarded.entriesWhileRunning).toBeLessThan(plain.entriesWhileRunning / 2)
+      expect(guarded.entriesAfterStop).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #1268.

## What

The interactive dashboard left open for a few days dies with `FATAL ERROR: Ineffective mark-compacts near heap limit ... JavaScript heap out of memory`.

`dist/cli.js` never sets `NODE_ENV` and `react`/`ink` are external to the tsup bundle, so Ink loads React's **development** reconciler. Since React 19.2 that build calls `performance.measure()` on every render, commit and component for its DevTools performance tracks, and Node keeps user-timing entries in a process-wide buffer that nothing trims. The dashboard re-renders on every progress tick and refresh, so the buffer grows by ~740 `PerformanceMeasure` entries (plus their `{ devtools: ... }` detail objects and strings) a minute, until the heap limit. Details and heap-snapshot diffs are in the issue.

## Fix

- `src/cli.ts` (the launcher every client spawns, copied verbatim to `dist/cli.js`) defaults `NODE_ENV` to `production` before importing `main.js`, so React loads the build that records nothing. An explicit `NODE_ENV` in the shell still wins. This has to live in the launcher: `main.js`'s static imports evaluate before any code in it could set the variable.
- `src/user-timing-guard.ts` drops the user-timing buffer every 30 s (unref'd timer) for the lifetime of each Ink UI: dashboard, `sessions`, `context`, `compare`. This covers an explicit `NODE_ENV=development`. codeburn records no marks or measures of its own, so nothing is lost.

## Tests

- `tests/cli-node-env.test.ts` spawns the real `src/cli.ts` against a stub `main.js`: unset and empty `NODE_ENV` become `production`, an explicit value is kept.
- `tests/user-timing-guard.test.tsx` unit-tests the guard, then drives a ticking Ink app in a child Node process (`tests/fixtures/ink-user-timing-probe.tsx`, because vitest's replaced `console` has no `timeStamp`, which is React's gate): the development build leaves 400+ entries after 500 ms and nothing removes them, the production build leaves 0, and the guard keeps the backlog to a handful and empties it on stop.

## Verification

- `npm test` on this branch: 274 files passed, 2 skipped; 3746 tests passed, 5 skipped.
- `npm test` on `main` (same machine, same run): 272 files passed, 2 skipped; 3738 tests passed, 5 skipped. The difference is exactly the two new files / eight new tests; zero new failures.
- `npx tsc --noEmit` clean.
- Real dashboard, `node --heapsnapshot-signal=SIGUSR2 dist/cli.js --refresh 60` in tmux, snapshots diffed by constructor: stock build goes from 3,073 to 26,677 `PerformanceMeasure` entries (+23,604, ~880 a minute) and +28.5 MB heap self size in 27 min; this branch holds zero entries in both snapshots and grows 0.6 MB (JIT code) over 5 min.
