### PR TITLE
fix(doctor): report filesystem roots for seven providers

### DIFF
--- a/src/providers/forge.ts
+++ b/src/providers/forge.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import { extractBashCommands } from '../bash-utils.js'
 import { calculateCost } from '../models.js'
 import { getSqliteLoadError, isSqliteAvailable, openDatabase, type SqliteDatabase } from '../sqlite.js'
-import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
+import type { ParsedProviderCall, ProbeRoot, Provider, SessionParser, SessionSource } from './types.js'
 
 type ConversationRow = {
   conversation_id: string
@@ -268,6 +268,10 @@ export function createForgeProvider(dbPath = DEFAULT_DB_PATH): Provider {
 
     toolDisplayName(rawTool: string): string {
       return rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: dbPath, label: 'db' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/mux.ts
+++ b/src/providers/mux.ts
@@ -5,7 +5,7 @@ import { homedir } from 'os'
 import { readSessionLines } from '../fs-utils.js'
 import { calculateCost, getShortModelName } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { Provider, SessionSource, SessionParser, ParsedProviderCall, ProbeRoot } from './types.js'
 import { safeNumber } from '../parser.js'
 
 const toolNameMap: Record<string, string> = {
@@ -267,6 +267,10 @@ export function createMuxProvider(muxRoot?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return toolNameMap[rawTool] ?? rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: root, label: 'root' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/open-design.ts
+++ b/src/providers/open-design.ts
@@ -4,7 +4,7 @@ import { homedir, platform } from 'os'
 
 import { readSessionLines } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { Provider, SessionSource, SessionParser, ParsedProviderCall, ProbeRoot } from './types.js'
 
 const PROVIDER_NAME = 'open-design'
 const ENV_DIR = 'CODEBURN_OPEN_DESIGN_DIR'
@@ -244,6 +244,10 @@ export function createOpenDesignProvider(overrideDir?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: overrideDir ?? getOpenDesignDir(), label: 'sessions' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/openclaw.ts
+++ b/src/providers/openclaw.ts
@@ -5,7 +5,7 @@ import { homedir } from 'os'
 import { readSessionFile } from '../fs-utils.js'
 import { calculateCost } from '../models.js'
 import { extractBashCommands } from '../bash-utils.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { Provider, SessionSource, SessionParser, ParsedProviderCall, ProbeRoot } from './types.js'
 
 const toolNameMap: Record<string, string> = {
   bash: 'Bash',
@@ -261,6 +261,12 @@ export function createOpenClawProvider(overrideDir?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return toolNameMap[rawTool] ?? rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      // #899: empty agents root that exists must be distinguishable from missing install.
+      const roots = overrideDir ? [overrideDir] : getOpenClawDirs()
+      return roots.map(path => ({ path, label: 'agents' }))
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/zcode.ts
+++ b/src/providers/zcode.ts
@@ -3,7 +3,7 @@ import { homedir } from 'os'
 
 import { calculateCost } from '../models.js'
 import { isSqliteAvailable, getSqliteLoadError, openDatabase, type SqliteDatabase } from '../sqlite.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { Provider, SessionSource, SessionParser, ParsedProviderCall, ProbeRoot } from './types.js'
 
 /// ZCode (CLI v0.14.x) records usage in a single SQLite database at
 /// ~/.zcode/cli/db/db.sqlite. We read it because the other on-disk sources are
@@ -211,6 +211,10 @@ export function createZcodeProvider(dbPathOverride?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: dbPath, label: 'db' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/zed.ts
+++ b/src/providers/zed.ts
@@ -5,7 +5,7 @@ import zlib from 'zlib'
 
 import { calculateCost } from '../models.js'
 import { getSqliteLoadError, isSqliteAvailable, openDatabase, type SqliteDatabase } from '../sqlite.js'
-import type { ParsedProviderCall, Provider, SessionParser, SessionSource } from './types.js'
+import type { ParsedProviderCall, ProbeRoot, Provider, SessionParser, SessionSource } from './types.js'
 
 // Zed's built-in agent stores one row per thread in a single SQLite database;
 // the `data` blob is zstd-compressed JSON carrying `request_token_usage`
@@ -211,6 +211,10 @@ export function createZedProvider(dbPathOverride?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: dbPathOverride ?? getZedThreadsDbPath(), label: 'threads.db' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/src/providers/zerostack.ts
+++ b/src/providers/zerostack.ts
@@ -4,7 +4,7 @@ import { homedir, platform } from 'os'
 
 import { readSessionFile } from '../fs-utils.js'
 import { calculateCost, getShortModelName } from '../models.js'
-import type { Provider, SessionSource, SessionParser, ParsedProviderCall } from './types.js'
+import type { Provider, SessionSource, SessionParser, ParsedProviderCall, ProbeRoot } from './types.js'
 
 // zerostack (https://github.com/gi-dellav/zerostack) is a minimal Rust coding
 // agent. Each session is a single JSON file under <dataDir>/zerostack/sessions/.
@@ -131,6 +131,10 @@ export function createZerostackProvider(sessionsDir?: string): Provider {
 
     toolDisplayName(rawTool: string): string {
       return toolNameMap[rawTool] ?? rawTool
+    },
+
+    async probeRoots(): Promise<ProbeRoot[]> {
+      return [{ path: dir, label: 'sessions' }]
     },
 
     async discoverSessions(): Promise<SessionSource[]> {

--- a/tests/providers/openclaw.test.ts
+++ b/tests/providers/openclaw.test.ts
@@ -186,6 +186,14 @@ describe('openclaw provider', () => {
     expect(sources.length).toBe(0)
   })
 
+  it('reports the agents root to doctor even when it holds no sessions', async () => {
+    const dir = join(baseDir, 'empty-root')
+    await mkdir(dir, { recursive: true })
+    const provider = createOpenClawProvider(dir)
+    expect(await provider.discoverSessions()).toEqual([])
+    expect(await provider.probeRoots!()).toEqual([{ path: dir, label: 'agents' }])
+  })
+
   afterAll(async () => {
     await rm(baseDir, { recursive: true, force: true })
   })

--- a/tests/providers/probe-roots-899-census.test.ts
+++ b/tests/providers/probe-roots-899-census.test.ts
@@ -1,12 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { getAllProviders } from '../../src/providers/index.js'
 
-/**
- * #899 exact-main residual census (Codex REVIEW-2026-09-06-2306):
- * seven filesystem gaps + one intentional Vercel network exception.
- * Method presence is necessary but not sufficient for OpenClaw empty-root
- * semantics — see openclaw.test.ts doctor fixture.
- */
+// #899: every filesystem provider must report its roots to `doctor`;
+// Vercel Gateway is the one intentional network-only exception.
 const FILESYSTEM_GAP_NAMES = [
   'forge',
   'mux',

--- a/tests/providers/probe-roots-899-census.test.ts
+++ b/tests/providers/probe-roots-899-census.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { getAllProviders } from '../../src/providers/index.js'
+
+/**
+ * #899 exact-main residual census (Codex REVIEW-2026-09-06-2306):
+ * seven filesystem gaps + one intentional Vercel network exception.
+ * Method presence is necessary but not sufficient for OpenClaw empty-root
+ * semantics — see openclaw.test.ts doctor fixture.
+ */
+const FILESYSTEM_GAP_NAMES = [
+  'forge',
+  'mux',
+  'open-design',
+  'openclaw',
+  'zcode',
+  'zed',
+  'zerostack',
+] as const
+
+describe('#899 probeRoots census', () => {
+  it('closes the seven filesystem gaps; Vercel remains network exception', async () => {
+    const providers = await getAllProviders()
+    const byName = new Map(providers.map(p => [p.name, p]))
+
+    for (const name of FILESYSTEM_GAP_NAMES) {
+      const p = byName.get(name)
+      expect(p, `provider ${name} should be loaded`).toBeTruthy()
+      expect(p!.probeRoots, `${name} must implement probeRoots`).toBeTypeOf('function')
+      const roots = await p!.probeRoots!()
+      expect(roots.length, `${name} probeRoots must return ≥1 root`).toBeGreaterThanOrEqual(1)
+    }
+
+    const vercel = byName.get('vercel-gateway')
+    expect(vercel).toBeTruthy()
+    expect(vercel!.network).toBe(true)
+    expect(vercel!.probeRoots, 'Vercel is intentional network exception — no probeRoots').toBeUndefined()
+
+    const missingFilesystem = providers.filter(p => !p.network && !p.probeRoots).map(p => p.name)
+    expect(missingFilesystem).toEqual([])
+  })
+})


### PR DESCRIPTION
`doctor` cannot explain an empty or missing installation when a filesystem provider does not expose its search roots. Seven providers currently have this gap.

Add `probeRoots` for Forge, Mux, Open Design, OpenClaw, ZCode, Zed and Zerostack, using the same paths as their discovery code. OpenClaw reports the agents directory, allowing an existing empty root to be distinguished from a missing one. Vercel Gateway remains a network-only exception.

Validated against current main (`0b1cf56f`): 53 focused and adjacent provider/doctor tests passed, and TypeScript checking passed. The added census covers all non-network providers and explicitly checks the Vercel exception. Parsing and accounting behavior is unchanged.

Addresses the filesystem-root coverage portion of #899.
