### PR TITLE
fix(desktop): keep settings navigation from shrinking

### DIFF
--- a/app/renderer/styles/plain.css
+++ b/app/renderer/styles/plain.css
@@ -345,7 +345,9 @@ body { overflow: hidden; background: var(--bg); color: var(--ink); }
 
 /* Settings */
 .body.set-body { align-self: stretch; align-items: stretch; justify-content: flex-start; width: auto; height: 100%; min-height: 0; max-width: none; margin: 0; padding: 0; overflow: hidden; flex-direction: row; gap: 0; }
-.body.set-body > .set-rail, .body.set-body > .set-pane { width: auto; max-width: none; min-height: 0; margin: 0; flex-shrink: 1; }
+.body.set-body > .set-rail, .body.set-body > .set-pane { width: auto; max-width: none; min-height: 0; margin: 0; }
+.body.set-body > .set-rail { flex-shrink: 0; }
+.body.set-body > .set-pane { flex-shrink: 1; }
 .set-rail { flex: 0 0 198px; border-right: 1px solid var(--line); padding: 14px 12px; display: flex; flex-direction: column; gap: 2px; overflow-y: auto; }
 .set-rail-item { display: flex; align-items: center; gap: 10px; padding: 7px 10px; border-radius: 7px; font-size: var(--fs-body); color: var(--mut); cursor: pointer; white-space: nowrap; border: 0; background: transparent; font: inherit; text-align: left; width: 100%; }
 .set-rail-item:hover { background: var(--hover); color: var(--ink); }


### PR DESCRIPTION
Opening Privacy & data can compress the settings navigation and clip labels even at the default window width. Keep the navigation rail from shrinking while allowing the content pane to shrink; retain the existing responsive rail widths.

This is the previously verified four-line CSS change, isolated on current main. The stylesheet and Settings component match the locally packaged candidate used for the visual check. Validation covered Privacy, General and Plans at default 1200px and minimum 900px widths, plus Light/System appearance. This turn also exercised the existing packaged candidate's settings and keyboard navigation. No new package or full-suite run is claimed for this isolated branch; git diff --check passes.
