### PR TITLE
fix(mac): preserve explicit Copilot disconnect

### DIFF
--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -166,8 +166,9 @@ final class AppStore {
     var copilotError: String?
     // Same file-based activation as Kimi/Gemini — reading
     // Copilot discovery never raises a keychain prompt, so we start dormant and
-    // auto-activate on the first refresh tick.
-    var copilotLoadState: SubscriptionLoadState = CopilotSubscriptionService.hasCredential ? .dormant : .notBootstrapped
+    // auto-activate on the first refresh tick unless the user explicitly
+    // disconnected. That opt-out is persisted and applied in `init`.
+    var copilotLoadState: SubscriptionLoadState = .notBootstrapped
 
     var antigravityUsage: AntigravityUsage?
     var antigravityError: String?
@@ -201,6 +202,19 @@ final class AppStore {
         (CapacityDockProvider) -> Void = {
             CapacityDockPreferences.removeProvider($0)
         }
+    @ObservationIgnored var copilotQuotaRuntime: CopilotQuotaRuntime
+
+    init(copilotQuotaRuntime: CopilotQuotaRuntime = .live) {
+        self.copilotQuotaRuntime = copilotQuotaRuntime
+        copilotLoadState = Self.initialCopilotLoadState(runtime: copilotQuotaRuntime)
+    }
+
+    private static func initialCopilotLoadState(runtime: CopilotQuotaRuntime) -> SubscriptionLoadState {
+        if CopilotExplicitDisconnect.isSet(defaults: runtime.defaults) {
+            return .notBootstrapped
+        }
+        return runtime.hasCredential() ? .dormant : .notBootstrapped
+    }
 
     /// Generation tokens for the in-flight refresh tasks. Incremented on every
     /// disconnect / reset so a fetch that started before the disconnect cannot
@@ -1708,25 +1722,41 @@ final class AppStore {
 
     /// Same prompt-free activation as Kimi/Gemini: the whole Copilot discovery
     /// chain is prompt-free, so the first refresh tick activates dormant state.
+    /// Automatic cadence must not clear an explicit disconnect; that happens
+    /// only in `connectCopilot`.
     func bootstrapCopilot() async {
+        if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) {
+            copilotLoadState = .notBootstrapped
+            return
+        }
         // Capture the generation before the await so a disconnect that lands
         // mid-fetch cannot be resurrected into .loaded when the fetch returns.
         let gen = copilotRefreshGen
         copilotLoadState = .bootstrapping
         do {
-            let usage = try await CopilotSubscriptionService.refresh()
+            let usage = try await copilotQuotaRuntime.refresh()
             guard gen == copilotRefreshGen else { return }
+            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return }
             copilotUsage = usage
             copilotError = nil
             copilotLoadState = .loaded
         } catch let err as CopilotSubscriptionService.FetchError {
             guard gen == copilotRefreshGen else { return }
+            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return }
             applyCopilotFetchError(err)
         } catch {
             guard gen == copilotRefreshGen else { return }
+            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return }
             copilotError = sanitizeForUI(error.localizedDescription)
             copilotLoadState = .failed
         }
+    }
+
+    /// User-initiated Connect / Reconnect / Load Quota. Clears persisted
+    /// explicit disconnect so discovery may run again.
+    func connectCopilot() async {
+        CopilotExplicitDisconnect.clear(defaults: copilotQuotaRuntime.defaults)
+        await bootstrapCopilot()
     }
 
     func refreshCopilot() async {
@@ -1735,29 +1765,36 @@ final class AppStore {
 
     @discardableResult
     func refreshCopilotReportingSuccess() async -> Bool {
+        if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) {
+            if copilotLoadState != .notBootstrapped { copilotLoadState = .notBootstrapped }
+            return false
+        }
         if case .dormant = copilotLoadState {
             await bootstrapCopilot()
             return copilotLoadState == .loaded
         }
-        guard CopilotSubscriptionService.hasCredential else {
+        guard copilotQuotaRuntime.hasCredential() else {
             if copilotLoadState != .notBootstrapped { copilotLoadState = .notBootstrapped }
             return false
         }
         let gen = copilotRefreshGen
         if copilotUsage == nil { copilotLoadState = .loading }
         do {
-            let usage = try await CopilotSubscriptionService.refresh()
+            let usage = try await copilotQuotaRuntime.refresh()
             guard gen == copilotRefreshGen else { return false }
+            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return false }
             copilotUsage = usage
             copilotError = nil
             copilotLoadState = .loaded
             return true
         } catch let err as CopilotSubscriptionService.FetchError {
             guard gen == copilotRefreshGen else { return false }
+            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return false }
             applyCopilotFetchError(err)
             return false
         } catch {
             guard gen == copilotRefreshGen else { return false }
+            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return false }
             copilotError = sanitizeForUI(error.localizedDescription)
             copilotLoadState = .failed
             return false
@@ -1765,7 +1802,8 @@ final class AppStore {
     }
 
     func disconnectCopilot() {
-        CopilotSubscriptionService.disconnect()
+        copilotQuotaRuntime.disconnectService()
+        CopilotExplicitDisconnect.mark(defaults: copilotQuotaRuntime.defaults)
         copilotRefreshGen &+= 1
         copilotUsage = nil
         copilotError = nil
@@ -2217,7 +2255,7 @@ final class AppStore {
         case .codex: await bootstrapCodex()
         case .kimiCode: await bootstrapKimi()
         case .gemini: await bootstrapGemini()
-        case .copilot: await bootstrapCopilot()
+        case .copilot: await connectCopilot()
         case .antigravity: await bootstrapAntigravity()
         default: break
         }

--- a/mac/Sources/CodeBurnMenubar/AppStore.swift
+++ b/mac/Sources/CodeBurnMenubar/AppStore.swift
@@ -1736,17 +1736,14 @@ final class AppStore {
         do {
             let usage = try await copilotQuotaRuntime.refresh()
             guard gen == copilotRefreshGen else { return }
-            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return }
             copilotUsage = usage
             copilotError = nil
             copilotLoadState = .loaded
         } catch let err as CopilotSubscriptionService.FetchError {
             guard gen == copilotRefreshGen else { return }
-            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return }
             applyCopilotFetchError(err)
         } catch {
             guard gen == copilotRefreshGen else { return }
-            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return }
             copilotError = sanitizeForUI(error.localizedDescription)
             copilotLoadState = .failed
         }
@@ -1782,19 +1779,16 @@ final class AppStore {
         do {
             let usage = try await copilotQuotaRuntime.refresh()
             guard gen == copilotRefreshGen else { return false }
-            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return false }
             copilotUsage = usage
             copilotError = nil
             copilotLoadState = .loaded
             return true
         } catch let err as CopilotSubscriptionService.FetchError {
             guard gen == copilotRefreshGen else { return false }
-            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return false }
             applyCopilotFetchError(err)
             return false
         } catch {
             guard gen == copilotRefreshGen else { return false }
-            if CopilotExplicitDisconnect.isSet(defaults: copilotQuotaRuntime.defaults) { return false }
             copilotError = sanitizeForUI(error.localizedDescription)
             copilotLoadState = .failed
             return false

--- a/mac/Sources/CodeBurnMenubar/Data/CopilotExplicitDisconnect.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CopilotExplicitDisconnect.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Persisted opt-out for live Copilot quota tracking after an explicit
+/// Disconnect. Credentials stay untouched; this flag only stops automatic
+/// discovery from bringing quota tracking back on the next refresh or relaunch.
+/// Absent key is false, so first-use autodiscovery is unchanged.
+enum CopilotExplicitDisconnect {
+    static let defaultsKey = "codeburn.copilot.explicitlyDisconnected"
+
+    static func isSet(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: defaultsKey)
+    }
+
+    static func mark(defaults: UserDefaults = .standard) {
+        defaults.set(true, forKey: defaultsKey)
+    }
+
+    static func clear(defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: defaultsKey)
+    }
+}
+
+/// Injectable Copilot quota I/O for AppStore. Production uses `.live`;
+/// tests pass an ephemeral UserDefaults suite and stubbed fetch/credential
+/// checks so they never touch installed prefs, Keychain, or `gh`.
+@MainActor
+struct CopilotQuotaRuntime {
+    var hasCredential: () -> Bool
+    var refresh: @Sendable () async throws -> CopilotUsage
+    var disconnectService: () -> Void
+    var defaults: UserDefaults
+
+    static let live = CopilotQuotaRuntime(
+        hasCredential: { CopilotSubscriptionService.hasCredential },
+        refresh: { try await CopilotSubscriptionService.refresh() },
+        disconnectService: { CopilotSubscriptionService.disconnect() },
+        defaults: .standard
+    )
+}

--- a/mac/Sources/CodeBurnMenubar/Data/CopilotQuotaPresentation.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CopilotQuotaPresentation.swift
@@ -11,9 +11,9 @@ import Foundation
 /// genuinely nothing to show.
 ///
 /// Explicit Disconnect is different from missing credentials: the store keeps
-/// `.notBootstrapped` while credentials stay on disk. Plan and Settings copy
-/// therefore take the persisted opt-out flag and must not claim the token is
-/// gone.
+/// `.notBootstrapped` while credentials stay on disk. Plan, Settings, and
+/// Capacity Dock nil-quota copy therefore take the persisted opt-out flag and
+/// must not claim the token is gone.
 enum CopilotQuotaPresentation {
     /// Which Plan-tab subview to render, given the load state and whether a
     /// last-known snapshot exists.

--- a/mac/Sources/CodeBurnMenubar/Data/CopilotQuotaPresentation.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CopilotQuotaPresentation.swift
@@ -9,11 +9,18 @@ import Foundation
 /// with a quiet caption instead of flapping to a reconnect screen; the
 /// reconnect screen is reserved for the no-data case, where there is
 /// genuinely nothing to show.
+///
+/// Explicit Disconnect is different from missing credentials: the store keeps
+/// `.notBootstrapped` while credentials stay on disk. Plan and Settings copy
+/// therefore take the persisted opt-out flag and must not claim the token is
+/// gone.
 enum CopilotQuotaPresentation {
     /// Which Plan-tab subview to render, given the load state and whether a
     /// last-known snapshot exists.
     enum PlanContent: Equatable {
         case noCredentials
+        /// Explicit Disconnect: quota tracking is off, credentials untouched.
+        case disconnected
         case loading
         case failed
         case transientFailed
@@ -24,9 +31,26 @@ enum CopilotQuotaPresentation {
         case usage(idle: Bool)
     }
 
-    static func planContent(loadState: SubscriptionLoadState, hasUsage: Bool) -> PlanContent {
+    static let noCredentialsPlanTitle = "No Copilot credentials found"
+    static let noCredentialsPlanMessage =
+        "Sign in via an editor's Copilot plugin first. Then click Try Again."
+    static let disconnectedPlanTitle = "Copilot quota tracking disconnected"
+    static let disconnectedPlanMessage =
+        "Your Copilot credentials are untouched. Click Connect to resume."
+    static let noCredentialsSettingsDetail =
+        "Usage tracking still works. For live quota, sign in with the Copilot CLI or gh auth login, or paste a token below, then click Connect."
+    static let disconnectedSettingsDetail =
+        "Quota tracking disconnected. Credentials are untouched. Click Connect to resume."
+
+    static func planContent(
+        loadState: SubscriptionLoadState,
+        hasUsage: Bool,
+        explicitlyDisconnected: Bool = false
+    ) -> PlanContent {
         switch loadState {
-        case .notBootstrapped, .noCredentials:
+        case .notBootstrapped:
+            return explicitlyDisconnected ? .disconnected : .noCredentials
+        case .noCredentials:
             return .noCredentials
         case .dormant, .bootstrapping:
             return .loading
@@ -39,6 +63,10 @@ enum CopilotQuotaPresentation {
         case .terminalFailure(let reason):
             return hasUsage ? .usage(idle: true) : .reconnect(reason: reason)
         }
+    }
+
+    static func settingsNotConnectedDetail(explicitlyDisconnected: Bool) -> String {
+        explicitlyDisconnected ? disconnectedSettingsDetail : noCredentialsSettingsDetail
     }
 
     /// Snapshot age past which a loaded view stamps an "as of <time>" caption,

--- a/mac/Sources/CodeBurnMenubar/Views/CapacityDockView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/CapacityDockView.swift
@@ -695,7 +695,12 @@ struct CapacityDockDetailView: View {
         } else {
             VStack(alignment: .leading, spacing: 11 * model.detailScale) {
                 header(provider, plan: nil)
-                Text(ProviderConnectionGuidance.dockInstruction(for: provider))
+                Text(
+                    provider == .copilot
+                        && CopilotExplicitDisconnect.isSet(defaults: store.copilotQuotaRuntime.defaults)
+                        ? CopilotQuotaPresentation.disconnectedSettingsDetail
+                        : ProviderConnectionGuidance.dockInstruction(for: provider)
+                )
                     .font(.system(size: 12))
                     .foregroundStyle(Color.capacityDockText.opacity(0.62))
                     .fixedSize(horizontal: false, vertical: true)

--- a/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
@@ -2470,7 +2470,7 @@ private struct CopilotPlanInsight: View {
                 PlanNoCredentialsView(
                     title: "No Copilot credentials found",
                     message: "Sign in via an editor's Copilot plugin first. Then click Try Again."
-                ) { Task { await store.bootstrapCopilot() } }
+                ) { Task { await store.connectCopilot() } }
             case .loading:
                 PlanLoadingView(message: "Reading Copilot credentials...")
             case .failed:
@@ -2486,7 +2486,7 @@ private struct CopilotPlanInsight: View {
                     title: "Refresh Copilot login",
                     reason: reason,
                     fallback: "Your Copilot sign-in has expired. Sign in via an editor's Copilot plugin again, then click Reconnect."
-                ) { Task { await store.bootstrapCopilot() } }
+                ) { Task { await store.connectCopilot() } }
             case let .usage(idle):
                 if let usage = store.copilotUsage {
                     loadedBody(usage: usage, idle: idle)

--- a/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
@@ -2465,11 +2465,20 @@ private struct CopilotPlanInsight: View {
 
     var body: some View {
         Group {
-            switch CopilotQuotaPresentation.planContent(loadState: store.copilotLoadState, hasUsage: store.copilotUsage != nil) {
+            switch CopilotQuotaPresentation.planContent(
+                loadState: store.copilotLoadState,
+                hasUsage: store.copilotUsage != nil,
+                explicitlyDisconnected: CopilotExplicitDisconnect.isSet(defaults: store.copilotQuotaRuntime.defaults)
+            ) {
             case .noCredentials:
                 PlanNoCredentialsView(
-                    title: "No Copilot credentials found",
-                    message: "Sign in via an editor's Copilot plugin first. Then click Try Again."
+                    title: CopilotQuotaPresentation.noCredentialsPlanTitle,
+                    message: CopilotQuotaPresentation.noCredentialsPlanMessage
+                ) { Task { await store.connectCopilot() } }
+            case .disconnected:
+                PlanConnectView(
+                    title: CopilotQuotaPresentation.disconnectedPlanTitle,
+                    message: CopilotQuotaPresentation.disconnectedPlanMessage
                 ) { Task { await store.connectCopilot() } }
             case .loading:
                 PlanLoadingView(message: "Reading Copilot credentials...")

--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -1428,7 +1428,7 @@ private struct CopilotTokenSection: View {
                 )
                 token = ""
                 CopilotSubscriptionService.resetProbeCache()
-                await store.bootstrapCopilot()
+                await store.connectCopilot()
             } catch {
                 errorText = error.localizedDescription
             }
@@ -1529,13 +1529,13 @@ private struct CopilotConnectionRow: View {
                     Text("CodeBurn will stop tracking Copilot quota. Every credential it read stays untouched, and your Copilot clients keep working.")
                 }
         case .terminalFailure, .noCredentials, .failed:
-            Button("Reconnect") { Task { await store.bootstrapCopilot() } }
+            Button("Reconnect") { Task { await store.connectCopilot() } }
                 .buttonStyle(.borderedProminent)
         case .dormant:
-            Button("Load Quota") { Task { await store.bootstrapCopilot() } }
+            Button("Load Quota") { Task { await store.connectCopilot() } }
                 .buttonStyle(.borderedProminent)
         case .notBootstrapped:
-            Button("Connect") { Task { await store.bootstrapCopilot() } }
+            Button("Connect") { Task { await store.connectCopilot() } }
                 .buttonStyle(.borderedProminent)
         case .bootstrapping:
             ProgressView().controlSize(.small)

--- a/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/SettingsView.swift
@@ -1506,8 +1506,12 @@ private struct CopilotConnectionRow: View {
         case .bootstrapping: return "Looking for a GitHub token on this Mac."
         case .loading: return "Background refresh in progress."
         case .dormant: return "Tap Load Quota to fetch live usage from api.github.com."
-        case .notBootstrapped, .noCredentials:
-            return "Usage tracking still works. For live quota, sign in with the Copilot CLI or gh auth login, or paste a token below, then click Connect."
+        case .notBootstrapped:
+            return CopilotQuotaPresentation.settingsNotConnectedDetail(
+                explicitlyDisconnected: CopilotExplicitDisconnect.isSet(defaults: store.copilotQuotaRuntime.defaults)
+            )
+        case .noCredentials:
+            return CopilotQuotaPresentation.noCredentialsSettingsDetail
         case .failed: return store.copilotError ?? ""
         }
     }

--- a/mac/Tests/CodeBurnMenubarTests/AppStoreCopilotDisconnectTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/AppStoreCopilotDisconnectTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Testing
+@testable import CodeBurnMenubar
+
+@Suite("AppStore Copilot explicit disconnect")
+@MainActor
+struct AppStoreCopilotDisconnectTests {
+    @Test("explicit disconnect blocks the next refresh fetch")
+    func disconnectThenRefreshDoesNotFetch() async throws {
+        try await withIsolatedCopilotStore(hasCredential: true) { store, fetch, defaults in
+            #expect(store.copilotLoadState == .dormant)
+
+            store.disconnectCopilot()
+
+            #expect(store.copilotLoadState == .notBootstrapped)
+            #expect(store.copilotUsage == nil)
+            #expect(CopilotExplicitDisconnect.isSet(defaults: defaults))
+
+            let fetched = await store.refreshCopilotReportingSuccess()
+
+            #expect(fetched == false)
+            #expect(await fetch.recordedCount() == 0)
+            #expect(store.copilotLoadState == .notBootstrapped)
+            #expect(store.copilotUsage == nil)
+        }
+    }
+
+    @Test("relaunch honors persisted Copilot opt-out")
+    func relaunchRemainsDisconnected() async throws {
+        try await withIsolatedCopilotStore(hasCredential: true) { store, fetch, defaults in
+            store.disconnectCopilot()
+            #expect(CopilotExplicitDisconnect.isSet(defaults: defaults))
+
+            let relaunched = AppStore(copilotQuotaRuntime: CopilotQuotaRuntime(
+                hasCredential: { true },
+                refresh: { await fetch.next() },
+                disconnectService: {},
+                defaults: defaults
+            ))
+
+            #expect(relaunched.copilotLoadState == .notBootstrapped)
+
+            let fetched = await relaunched.refreshCopilotReportingSuccess()
+
+            #expect(fetched == false)
+            #expect(await fetch.recordedCount() == 0)
+            #expect(relaunched.copilotLoadState == .notBootstrapped)
+            #expect(relaunched.copilotUsage == nil)
+        }
+    }
+
+    @Test("explicit reconnect clears opt-out and fetches")
+    func explicitReconnectResumes() async throws {
+        try await withIsolatedCopilotStore(hasCredential: true) { store, fetch, defaults in
+            store.disconnectCopilot()
+            #expect(CopilotExplicitDisconnect.isSet(defaults: defaults))
+
+            await store.connectCopilot()
+
+            #expect(!CopilotExplicitDisconnect.isSet(defaults: defaults))
+            #expect(await fetch.recordedCount() == 1)
+            #expect(store.copilotLoadState == .loaded)
+            #expect(store.copilotUsage?.plan == "Individual")
+        }
+    }
+
+    @Test("first-use with credentials still auto-discovers")
+    func firstUseAutodiscoveryFetches() async throws {
+        try await withIsolatedCopilotStore(hasCredential: true) { store, fetch, defaults in
+            #expect(!CopilotExplicitDisconnect.isSet(defaults: defaults))
+            #expect(store.copilotLoadState == .dormant)
+
+            let fetched = await store.refreshCopilotReportingSuccess()
+
+            #expect(fetched == true)
+            #expect(await fetch.recordedCount() == 1)
+            #expect(store.copilotLoadState == .loaded)
+            #expect(!CopilotExplicitDisconnect.isSet(defaults: defaults))
+        }
+    }
+
+    @Test("first-use without credentials does not fetch")
+    func firstUseWithoutCredentialsStaysIdle() async throws {
+        try await withIsolatedCopilotStore(hasCredential: false) { store, fetch, defaults in
+            #expect(store.copilotLoadState == .notBootstrapped)
+            #expect(!CopilotExplicitDisconnect.isSet(defaults: defaults))
+
+            let fetched = await store.refreshCopilotReportingSuccess()
+
+            #expect(fetched == false)
+            #expect(await fetch.recordedCount() == 0)
+            #expect(store.copilotLoadState == .notBootstrapped)
+        }
+    }
+
+    @Test("disconnect discards an in-flight Copilot fetch")
+    func inFlightFetchCannotResurrectAfterDisconnect() async throws {
+        try await withIsolatedCopilotStore(hasCredential: true) { store, fetch, defaults in
+            await fetch.setParkNext(true)
+            let refresh = Task { await store.refreshCopilotReportingSuccess() }
+            try #require(await fetch.waitUntilParked())
+
+            store.disconnectCopilot()
+            await fetch.open()
+            let fetched = await refresh.value
+
+            #expect(fetched == false)
+            #expect(store.copilotLoadState == .notBootstrapped)
+            #expect(store.copilotUsage == nil)
+            #expect(CopilotExplicitDisconnect.isSet(defaults: defaults))
+        }
+    }
+
+    @Test("automatic bootstrap does not clear persisted opt-out")
+    func automaticBootstrapLeavesOptOut() async throws {
+        try await withIsolatedCopilotStore(hasCredential: true) { store, fetch, defaults in
+            store.disconnectCopilot()
+            await store.bootstrapCopilot()
+
+            #expect(CopilotExplicitDisconnect.isSet(defaults: defaults))
+            #expect(await fetch.recordedCount() == 0)
+            #expect(store.copilotLoadState == .notBootstrapped)
+        }
+    }
+
+    @Test("disconnect wins over an in-flight explicit connect")
+    func disconnectWinsOverPendingConnect() async throws {
+        try await withIsolatedCopilotStore(hasCredential: true) { store, fetch, defaults in
+            store.disconnectCopilot()
+            await fetch.setParkNext(true)
+            let connect = Task { await store.connectCopilot() }
+            try #require(await fetch.waitUntilParked())
+
+            store.disconnectCopilot()
+            await fetch.open()
+            await connect.value
+
+            #expect(CopilotExplicitDisconnect.isSet(defaults: defaults))
+            #expect(store.copilotLoadState == .notBootstrapped)
+            #expect(store.copilotUsage == nil)
+        }
+    }
+}
+
+@MainActor
+private func withIsolatedCopilotStore(
+    hasCredential: Bool,
+    _ body: @MainActor (AppStore, CopilotFetchStub, UserDefaults) async throws -> Void
+) async throws {
+    let suiteName = "codeburn.copilot.disconnect.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    let fetch = CopilotFetchStub()
+    let store = AppStore(copilotQuotaRuntime: CopilotQuotaRuntime(
+        hasCredential: { hasCredential },
+        refresh: { await fetch.next() },
+        disconnectService: {},
+        defaults: defaults
+    ))
+    try await body(store, fetch, defaults)
+}
+
+private actor CopilotFetchStub {
+    private(set) var count = 0
+    private var parkNext = false
+    private var parked: CheckedContinuation<Void, Never>?
+    private var isParked = false
+
+    func recordedCount() -> Int { count }
+
+    func setParkNext(_ value: Bool) {
+        parkNext = value
+    }
+
+    func next() async -> CopilotUsage {
+        count += 1
+        if parkNext {
+            parkNext = false
+            isParked = true
+            await withCheckedContinuation { parked = $0 }
+        }
+        return CopilotUsage(
+            details: [
+                CopilotUsage.Window(label: "Premium requests", usedPercent: 30, resetsAt: nil)
+            ],
+            plan: "Individual",
+            fetchedAt: Date(timeIntervalSince1970: 1_786_000_000)
+        )
+    }
+
+    func waitUntilParked() async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while !isParked {
+            if ContinuousClock.now >= deadline { return false }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return true
+    }
+
+    func open() {
+        parked?.resume()
+        parked = nil
+        isParked = false
+    }
+}

--- a/mac/Tests/CodeBurnMenubarTests/CopilotQuotaPresentationTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CopilotQuotaPresentationTests.swift
@@ -6,7 +6,9 @@ import Testing
 /// means the user must sign in via an editor's Copilot plugin again. These
 /// tests pin the display decision: a terminal login with a snapshot on hand
 /// must keep showing the bars (with a quiet idle caption), and only the
-/// no-data case falls through to the reconnect screen.
+/// no-data case falls through to the reconnect screen. Explicit Disconnect
+/// is a separate no-data path: credentials remain, so copy must not claim
+/// they are missing.
 @Suite("Copilot quota presentation")
 struct CopilotQuotaPresentationTests {
     typealias Presentation = CopilotQuotaPresentation
@@ -34,10 +36,64 @@ struct CopilotQuotaPresentationTests {
         #expect(Presentation.planContent(loadState: .transientFailure(retryAt: nil), hasUsage: false) == .transientFailed)
     }
 
-    @Test("credential-absent states route to the connect prompt")
+    @Test("absent-flag first use and real noCredentials keep the sign-in copy")
     func credentialStatesRouteToNoCredentials() {
         #expect(Presentation.planContent(loadState: .notBootstrapped, hasUsage: false) == .noCredentials)
+        #expect(Presentation.planContent(loadState: .notBootstrapped, hasUsage: false, explicitlyDisconnected: false) == .noCredentials)
         #expect(Presentation.planContent(loadState: .noCredentials, hasUsage: false) == .noCredentials)
+        #expect(Presentation.planContent(loadState: .noCredentials, hasUsage: false, explicitlyDisconnected: true) == .noCredentials)
+        #expect(Presentation.noCredentialsPlanTitle == "No Copilot credentials found")
+        #expect(Presentation.noCredentialsPlanMessage.contains("Sign in via an editor's Copilot plugin first"))
+        #expect(Presentation.settingsNotConnectedDetail(explicitlyDisconnected: false) == Presentation.noCredentialsSettingsDetail)
+        #expect(Presentation.noCredentialsSettingsDetail.contains("sign in"))
+    }
+
+    @Test("explicit disconnect copy differs from first-use; clearing the flag restores first-use")
+    func explicitDisconnectDiffersFromFirstUseAndClears() throws {
+        let suiteName = "codeburn.copilot.presentation.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(!CopilotExplicitDisconnect.isSet(defaults: defaults))
+        let firstUse = Presentation.planContent(
+            loadState: .notBootstrapped,
+            hasUsage: false,
+            explicitlyDisconnected: CopilotExplicitDisconnect.isSet(defaults: defaults)
+        )
+        #expect(firstUse == .noCredentials)
+
+        CopilotExplicitDisconnect.mark(defaults: defaults)
+        #expect(CopilotExplicitDisconnect.isSet(defaults: defaults))
+        let disconnected = Presentation.planContent(
+            loadState: .notBootstrapped,
+            hasUsage: false,
+            explicitlyDisconnected: CopilotExplicitDisconnect.isSet(defaults: defaults)
+        )
+        #expect(disconnected == .disconnected)
+        #expect(disconnected != firstUse)
+        #expect(Presentation.disconnectedPlanTitle != Presentation.noCredentialsPlanTitle)
+        #expect(!Presentation.disconnectedPlanTitle.localizedCaseInsensitiveContains("no copilot credentials"))
+        #expect(!Presentation.disconnectedPlanMessage.localizedCaseInsensitiveContains("sign in"))
+        #expect(Presentation.disconnectedPlanMessage.localizedCaseInsensitiveContains("untouched"))
+        #expect(Presentation.disconnectedPlanMessage.localizedCaseInsensitiveContains("connect"))
+        let settings = Presentation.settingsNotConnectedDetail(explicitlyDisconnected: true)
+        #expect(settings == Presentation.disconnectedSettingsDetail)
+        #expect(settings != Presentation.noCredentialsSettingsDetail)
+        #expect(!settings.localizedCaseInsensitiveContains("sign in"))
+        #expect(settings.localizedCaseInsensitiveContains("untouched"))
+        #expect(settings.localizedCaseInsensitiveContains("connect"))
+
+        CopilotExplicitDisconnect.clear(defaults: defaults)
+        #expect(!CopilotExplicitDisconnect.isSet(defaults: defaults))
+        #expect(
+            Presentation.planContent(
+                loadState: .notBootstrapped,
+                hasUsage: false,
+                explicitlyDisconnected: CopilotExplicitDisconnect.isSet(defaults: defaults)
+            ) == .noCredentials
+        )
+        #expect(Presentation.settingsNotConnectedDetail(explicitlyDisconnected: false) == Presentation.noCredentialsSettingsDetail)
     }
 
     @Test("a fresh snapshot is not stamped stale")


### PR DESCRIPTION
Refs #1273.

After Disconnect, discoverable Copilot credentials could reactivate quota tracking on the next refresh or relaunch. Persist the explicit opt-out, preserve it during automatic refresh, and clear it only when the user connects again. Credentials and historical usage are preserved. Plan, Settings, and Capacity Dock distinguish an explicit disconnect from missing credentials.

Validation: the initial fix passed 46 focused/adjacent standalone tests and 47 integrated tests, including in-flight cancellation and same-defaults relaunch. The presentation follow-up passed 16 focused tests. A universal native QA build passed compilation and strict ad-hoc signature verification. Actual UI checks exercised Disconnect, Refresh, normal Quit, same-profile relaunch remaining disconnected, and explicit Connect resuming discovery. Capacity Dock's incorrect OAuth guidance was reproduced and the corrected message and Connect action verified in the app. Tests used a separate bundle identity, a fictional token, and blocked network/Keychain access; no live-account or release-signing acceptance is claimed.
