### PR TITLE
fix(mac): label Stats totals for the selected period

### DIFF
--- a/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/HeatmapSection.swift
@@ -1216,8 +1216,8 @@ private struct StatsInsight: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 VStack(alignment: .leading, spacing: 8) {
-                    StatRow(label: "Sessions today", value: SessionCountLabel.text(sessions: payload.current.sessions, basis: payload.current.sessionCountBasis))
-                    StatRow(label: "Calls today", value: payload.current.calls.asThousandsSeparated())
+                    StatRow(label: "Sessions", value: SessionCountLabel.text(sessions: payload.current.sessions, basis: payload.current.sessionCountBasis))
+                    StatRow(label: "Calls", value: payload.current.calls.asThousandsSeparated())
                     StatRow(label: "Current streak", value: stats.currentStreak)
                     StatRow(label: "Longest streak", value: stats.longestStreak)
                 }


### PR DESCRIPTION
The native Stats view labels selected-period totals as “Sessions today” and “Calls today,” even when Lifetime is selected. Use “Sessions” and “Calls”; the selected period remains visible above. Values and session-count qualifiers are unchanged.

Verified in a universal native QA build with synthetic data: Lifetime/Claude shows $750.10, 33,866 calls and at least 2,509 sessions under the corrected labels; Today shows 0 calls/0 sessions. The pre-change labeling error was reproduced in the app. Compilation and strict ad-hoc signature verification pass. This changes only two label strings.
