### PR TITLE
fix(dash): keep workflow rows current across period changes

### DIFF
--- a/dash/src/components/WorkflowPanel.tsx
+++ b/dash/src/components/WorkflowPanel.tsx
@@ -94,8 +94,11 @@ export function WorkflowPanel({ current }: { current: Current }) {
         <div className="border-t border-border pt-3">
           <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-tertiary-foreground">Most reworked</div>
           <div className="flex flex-col gap-1.5">
-            {reworked.slice(0, 8).map((f) => (
-              <div key={f.path} className="flex items-baseline justify-between gap-3">
+            {reworked.slice(0, 8).map((f, i) => (
+              // Ranked summary rows are stateless. The payload only has basename
+              // `path`, which can repeat across projects, so path+index is unique
+              // without inventing an id or merging counts.
+              <div key={`${f.path}:${i}`} className="flex items-baseline justify-between gap-3">
                 <span className="truncate font-mono text-[12.5px] text-foreground" title={f.path}>
                   {f.path}
                 </span>

--- a/dash/src/components/WorkflowPanel.tsx
+++ b/dash/src/components/WorkflowPanel.tsx
@@ -95,9 +95,9 @@ export function WorkflowPanel({ current }: { current: Current }) {
           <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-tertiary-foreground">Most reworked</div>
           <div className="flex flex-col gap-1.5">
             {reworked.slice(0, 8).map((f, i) => (
-              // Ranked summary rows are stateless. The payload only has basename
-              // `path`, which can repeat across projects, so path+index is unique
-              // without inventing an id or merging counts.
+              // Ranked summary rows are stateless and paths can repeat. Include
+              // the rank so React keys stay unique without merging counts or
+              // requiring a row identity that the payload does not provide.
               <div key={`${f.path}:${i}`} className="flex items-baseline justify-between gap-3">
                 <span className="truncate font-mono text-[12.5px] text-foreground" title={f.path}>
                   {f.path}


### PR DESCRIPTION
Switching periods could leave stale rows in the web dashboard’s “Most reworked” list when filenames repeat. React keyed rows only by path, so a Lifetime → 7 days → Lifetime transition could render nine rows although the current slice contains eight. Include the rank in each stateless row’s key; counts and API data stay unchanged.

Verified in the real browser with synthetic data: the old build retained a 14-edit week row; the fix restores exactly eight Lifetime rows, matching both the initial render and the API response. Standalone and combined dashboard type-checks and production builds pass. The combined dashboard differs from the before build only in this component; CSS and CLI are unchanged.
