### PR TITLE
fix(kiro): emit workingDirectory so sync attribution can resolve the repo

### DIFF
--- a/src/providers/kiro.ts
+++ b/src/providers/kiro.ts
@@ -510,7 +510,12 @@ function parseCliSession(meta: KiroCliSessionMeta, entries: KiroCliEntry[], seen
       userMessage: pendingUserMessage,
       sessionId,
       project,
-      ...(meta.cwd ? { projectPath: meta.cwd } : {}),
+      // Both fields, from the same provider-recorded value: projectPath drives
+      // display/grouping, while workingDirectory is what sync attribution reads
+      // (buildRepoGroups' "trusted-session-cwd" mode). Setting only projectPath
+      // leaves every session attribution-blind — see the note on
+      // PROVIDER_PARSE_VERSIONS.kiro.
+      ...(meta.cwd ? { projectPath: meta.cwd, workingDirectory: meta.cwd } : {}),
     })
     turnIndex++
   }
@@ -668,7 +673,10 @@ async function parseWorkspaceSession(record: Record<string, unknown>, source: Se
     userMessage: pendingUserMessage,
     sessionId,
     ...(typeof record['workspaceDirectory'] === 'string' && record['workspaceDirectory']
-      ? { projectPath: record['workspaceDirectory'] as string }
+      ? {
+          projectPath: record['workspaceDirectory'] as string,
+          workingDirectory: record['workspaceDirectory'] as string,
+        }
       : {}),
   })
 
@@ -782,7 +790,9 @@ async function parseV2Session(source: SessionSource, seenKeys: Set<string>): Pro
           userMessage: turnUserMessage,
           sessionId,
           project: source.project,
-          ...(meta.workspacePaths?.[0] ? { projectPath: meta.workspacePaths[0] } : {}),
+          ...(meta.workspacePaths?.[0]
+            ? { projectPath: meta.workspacePaths[0], workingDirectory: meta.workspacePaths[0] }
+            : {}),
         })
       }
     }

--- a/src/providers/kiro.ts
+++ b/src/providers/kiro.ts
@@ -510,11 +510,7 @@ function parseCliSession(meta: KiroCliSessionMeta, entries: KiroCliEntry[], seen
       userMessage: pendingUserMessage,
       sessionId,
       project,
-      // Both fields, from the same provider-recorded value: projectPath drives
-      // display/grouping, while workingDirectory is what sync attribution reads
-      // (buildRepoGroups' "trusted-session-cwd" mode). Setting only projectPath
-      // leaves every session attribution-blind — see the note on
-      // PROVIDER_PARSE_VERSIONS.kiro.
+      // workingDirectory is what sync attribution reads; see PROVIDER_PARSE_VERSIONS.kiro.
       ...(meta.cwd ? { projectPath: meta.cwd, workingDirectory: meta.cwd } : {}),
     })
     turnIndex++

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -385,7 +385,18 @@ export const PROVIDER_PARSE_VERSIONS: Record<string, string> = {
   // sessions' workspaceDirectory), which sync attribution needs to resolve
   // the git repo. Cached entries from before the bump lack projectPath and
   // would serve attribution-blind sessions forever without a re-parse.
-  kiro: 'ide-parsing-v1-est-cost-project-path-v1',
+  // working-directory-v1: project-path-v1 wired the session's directory to
+  // projectPath only, but sync attribution does not read that field. It calls
+  // buildRepoGroups in "trusted-session-cwd" mode, which resolves the repo from
+  // `session.workingDirectory` and drops any session whose own directory does
+  // not resolve — so every kiro session stayed attribution-blind despite
+  // carrying the path. All three parsers now emit workingDirectory from the
+  // same provider-recorded value; parser.ts stamps
+  // workingDirectoryProvenance: 'provider-field' on it, which is what the
+  // consumer requires (a marker-less value is treated as synthesized and fails
+  // closed). Entries cached under project-path-v1 hold projectPath but no
+  // workingDirectory, so a re-parse is required for the fix to take effect.
+  kiro: 'ide-parsing-v1-est-cost-project-path-v1-working-directory-v1',
   // nested-agent-v1: OMP writes crewmate transcripts one directory below each
   // parent session. reported-cost-v2 persists those measured costs through the
   // cache, including the explicit zero on xai-oauth turns.

--- a/tests/kiro-projectpath.test.ts
+++ b/tests/kiro-projectpath.test.ts
@@ -132,7 +132,12 @@ async function seedWorkspaceSession(id: string, workspaceDirectory: string): Pro
 
 async function kiroCalls() {
   const projects = await parseAllSessions(undefined, 'kiro')
-  return projects.flatMap(p => p.sessions.map(s => ({ project: p.project, projectPath: p.projectPath, session: s })))
+  return projects.flatMap(p => p.sessions.map(s => ({
+    project: p.project,
+    projectPath: p.projectPath,
+    workingDirectory: s.workingDirectory,
+    session: s,
+  })))
 }
 
 describe('kiro projectPath emission', () => {
@@ -159,6 +164,60 @@ describe('kiro projectPath emission', () => {
     const row = rows.find(r => r.project === 'ws-project')
     expect(row).toBeDefined()
     expect(row!.projectPath).toBe(WS_DIR)
+  })
+})
+
+/**
+ * Sync attribution reads `session.workingDirectory`, NOT projectPath:
+ * computeAttributionRecords calls buildRepoGroups in "trusted-session-cwd"
+ * mode, resolves the repo from that field, and drops any session whose own
+ * directory does not resolve. project-path-v1 populated projectPath alone, so
+ * kiro sessions stayed attribution-blind while appearing to carry the path.
+ */
+describe('kiro workingDirectory emission (sync attribution)', () => {
+  it('CLI session: workingDirectory is the full meta.cwd', async () => {
+    await seedCliSession('cli-101', CLI_CWD)
+    const rows = await kiroCalls()
+    const row = rows.find(r => r.project === 'my-project')
+    expect(row).toBeDefined()
+    expect(row!.workingDirectory).toBe(CLI_CWD)
+  })
+
+  it('v2 IDE session: workingDirectory is workspacePaths[0]', async () => {
+    await seedV2Session('v2-101', V2_WORKSPACE)
+    const rows = await kiroCalls()
+    const row = rows.find(r => r.project === 'ide-project')
+    expect(row).toBeDefined()
+    expect(row!.workingDirectory).toBe(V2_WORKSPACE)
+  })
+
+  it('workspace session: workingDirectory is workspaceDirectory', async () => {
+    const WS_DIR = '/local/home/testuser/workplace/ws-wd-project'
+    await seedWorkspaceSession('ws-101', WS_DIR)
+    const rows = await kiroCalls()
+    const row = rows.find(r => r.project === 'ws-wd-project')
+    expect(row).toBeDefined()
+    expect(row!.workingDirectory).toBe(WS_DIR)
+  })
+
+  // Provenance is asserted implicitly by the three cases above rather than by a
+  // test of its own. parser.ts only promotes a call's workingDirectory onto the
+  // session when workingDirectoryProvenance === 'provider-field', failing closed
+  // otherwise (an unmarked value may have been synthesized from projectPath by
+  // an older build). So a populated session.workingDirectory is itself proof the
+  // marker was stamped; the marker lives on cached calls, which parseAllSessions
+  // does not surface.
+
+  // A home-root cwd is rejected by isTrustedAbsoluteWorkingDirectory, so the
+  // field must be absent rather than present-and-untrusted. Real Kiro IDE
+  // sessions opened on the home directory hit this: 5 of 8 observed
+  // session.json files carried workspacePaths: ['/home/<user>'].
+  it('a home-root cwd yields projectPath but no workingDirectory', async () => {
+    await seedCliSession('cli-103', HOME)
+    const rows = await kiroCalls()
+    const row = rows.find(r => r.projectPath === HOME)
+    expect(row).toBeDefined()
+    expect(row!.workingDirectory).toBeUndefined()
   })
 })
 
@@ -201,5 +260,51 @@ describe('kiro projectPath cache invalidation (project-path-v1 bump)', () => {
     const row = rows.find(r => r.project === 'my-project')
     expect(row).toBeDefined()
     expect(row!.projectPath).toBe(CLI_CWD)
+  })
+})
+
+/**
+ * The working-directory-v1 bump. A cache written by the project-path-v1 release
+ * holds projectPath but no workingDirectory, and without a fingerprint change
+ * those entries would be served forever — leaving attribution broken for exactly
+ * the users who already had a warm cache, which is everyone upgrading.
+ */
+describe('kiro workingDirectory cache invalidation (working-directory-v1 bump)', () => {
+  /** The fingerprint the project-path-v1 release wrote. */
+  function projectPathV1Fingerprint(): string {
+    const parts = [
+      `KIRO_HOME=${process.env['KIRO_HOME'] ?? ''}`,
+      'parser=ide-parsing-v1-est-cost-project-path-v1',
+    ]
+    return createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 16)
+  }
+
+  it('the bump changed the env fingerprint', () => {
+    expect(computeEnvFingerprint('kiro')).not.toBe(projectPathV1Fingerprint())
+  })
+
+  it('a project-path-v1 cache entry is re-parsed and gains workingDirectory', async () => {
+    const jsonlPath = await seedCliSession('cli-201', CLI_CWD)
+    const fp = await fingerprintFile(jsonlPath)
+    if (!fp) throw new Error('failed to fingerprint seeded session file')
+    const cache: SessionCache = {
+      version: CACHE_VERSION,
+      providers: {
+        kiro: {
+          envFingerprint: projectPathV1Fingerprint(),
+          files: {
+            [jsonlPath]: { fingerprint: fp, mcpInventory: [], turns: [] },
+          },
+        },
+      },
+    }
+    await mkdir(CACHE_DIR, { recursive: true })
+    await writeCacheOnDisk(cache)
+    clearSessionCache()
+
+    const rows = await kiroCalls()
+    const row = rows.find(r => r.project === 'my-project')
+    expect(row).toBeDefined()
+    expect(row!.workingDirectory).toBe(CLI_CWD)
   })
 })


### PR DESCRIPTION
## Summary

- Every kiro session was invisible to `codeburn sync push --attribution` — it reported `Attribution: 0 facts total` at every window, so no session→commit correlation ever reached the endpoint.
- Cause: `project-path-v1` wired the session's directory to `projectPath`, but sync attribution reads `session.workingDirectory`. `computeAttributionRecords` calls `buildRepoGroups` in `"trusted-session-cwd"` mode, resolves the repo from that field, then filters to sessions whose own directory resolved (`group.ownIdentity`). With it unset, `isTrustedAbsoluteWorkingDirectory(undefined)` returns false on its first clause, every session is dropped, and `attributeCommits` joins the repo's commits against an empty session list. The path was being carried the whole time, just on the field nothing consumed.
- Fix: all three kiro parsers now emit `workingDirectory` from the same provider-recorded value they already use for `projectPath`, plus a `PROVIDER_PARSE_VERSIONS.kiro` bump so warm caches re-parse.

Downstream, three things change for kiro sessions, each the same treatment every other provider with a working directory already gets: plain `sync push` usage spans gain `ai.project` (the cwd basename, scrubbed by `safeProjectAttribute`) and `ai.subscription_covered`; and sessions become eligible for working-directory PR correlation, so a kiro session sharing a cwd with a PR-anchored session within 6h picks up its `prLinks`. The absolute path itself never leaves the machine: attribution records carry the normalized repo remote, shas and timestamps, with `project` derived from the remote's last segment.

`parser.ts` already stamps `workingDirectoryProvenance: 'provider-field'` on any provider-set value that clears the trust check, and that marker is what the consumer requires — an unmarked value is treated as synthesized from `projectPath` and fails closed.

The three sources, unchanged in meaning from what each parser already read:

| Parser | Field |
|---|---|
| CLI (`~/.kiro/sessions/cli/<id>.jsonl`) | companion `.json` → `cwd` |
| v2 IDE (`~/.kiro/sessions/<hash>/sess_<id>/`) | `session.json` → `workspacePaths[0]` |
| workspace sessions | record → `workspaceDirectory` |

The cache bump matters as much as the parser change: entries cached under `project-path-v1` hold `projectPath` but no `workingDirectory`, so without it the fix would miss every user who already has a warm cache — that is, everyone upgrading.

## Testing

- [x] I have tested this locally against real data (not just unit tests)
- [x] `npm test` passes
- [x] `npm run build` succeeds

Measured against a real corpus — 2457 CLI sessions and 8 v2 IDE sessions — same command, same window, patched build vs installed:

```
before:  [dry-run] Attribution: 0 facts total, would push 0 (0 sessions, 0 commits)
after:   [dry-run] Attribution: 190 facts total, would push 190 (21 sessions, 169 commits)
```

Then a real push, and what the receiving endpoint recorded:

```
Synced 11 calls ($4.85) to https://<endpoint>
  Attribution: 190 facts synced

receiver: attribution: received=190 written=190 | rejected=0
stored:   OTEL_ATTR_SESSION 21 | OTEL_ATTR_COMMIT 169
          ai_tool=kiro (169)  ai_origin=ai-generated (169)
```

Commits previously recorded as `human` by the CI census were corrected to `kiro` / `ai-generated` on the same key, which is the interaction this field was always meant to enable.

On `npm test`: 3860 pass, and `tests/perf-harness-phase0.test.ts` fails **identically on clean `main`** in this environment — the perf harness refuses to write fixtures under a real home directory (`assertIsolatedHome`). Verified by stashing the change and re-running. Unrelated to this diff.

New tests cover `workingDirectory` for all three session shapes, re-parse of a `project-path-v1` cache, and the home-root rejection — the last is not hypothetical: 5 of the 8 real IDE sessions carried `workspacePaths: ['/home/<user>']`, which `isUserHomeRoot` rejects by design, so the field must be absent rather than present-and-untrusted.

Provenance is asserted implicitly rather than directly: `parser.ts` only promotes a call's `workingDirectory` onto the session when the marker is present, so a populated `session.workingDirectory` is itself proof the marker was stamped. The marker lives on cached calls, which `parseAllSessions` does not surface.

## Scope

This recovers sessions whose recorded `cwd` sits inside a git work tree — 70 of the 2457 in the corpus above. Sessions run from directories outside any repo are unaffected, and no parser change can reach them; that is a separate question about what kiro records, not about this field.

