### PR TITLE
feat(menubar): switch the Capacity Dock gauge between usage windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added (macOS)
+- **The Capacity Dock gauge can report the short usage window instead of the weekly one, without expanding the dock.** The resting rail shows one number per provider, and that number was always the weekly (else monthly) billing window. Clicking the provider already resting in the rail now switches its gauge to the provider's short rolling window — Claude's 5-hour limit, Codex's 5-hour or daily window, any `Hourly`, `Daily` or session row an adapter reports — and clicking again switches back. The choice is stored per provider under `CodeBurnCapacityDockGlanceWindows`, so Claude can sit on its 5-hour window while Codex stays weekly, and it survives relaunch. A per-model row such as `Weekly · Opus` is never read as a short window, a provider that reports only one window keeps the plain click-to-pin behaviour, and a stored horizon the provider stops reporting falls back to the window it does report rather than blanking the gauge to `--`. The rail's geometry is untouched, VoiceOver and keyboard users get the switch as a named action on the provider cell with the window named in the cell's value, and Escape or a click outside still unpins the dock. (#1243)
+
 ## 0.9.24 - 2026-09-04
 
 ### Added

--- a/docs/design/capacity-dock.md
+++ b/docs/design/capacity-dock.md
@@ -74,6 +74,12 @@ V1 does not include:
   preference exists, prefer Codex, then Claude, then the first supported
   provider.
 - A missing or disconnected quota is `--`, never `0%`.
+- The gauge reports one quota horizon: the weekly (else monthly) billing window
+  by default, or the provider's short rolling window (5-hour, hourly, daily,
+  session) when the user has switched it. The choice is stored per provider, so
+  Claude can rest on its 5-hour window while Codex stays weekly, and a stored
+  horizon the provider stops reporting falls back to the one it does report
+  rather than blanking the gauge. Switching never changes the rail's size.
 - Interactive provider cells remain at least 84 points along the provider axis,
   comfortably above the macOS 20-point minimum and 28-point default control
   targets. The detail hierarchy follows macOS text styles at 17, 12, 11, and
@@ -86,6 +92,11 @@ V1 does not include:
 - Expanded content lists only the providers selected in Settings.
 - Clicking a provider makes it the preferred/resting provider and keeps the
   rail expanded for that interaction.
+- Clicking the provider that already rests in the rail switches its gauge to its
+  other quota horizon when it reports two, and keeps the rail pinned; a provider
+  with one window keeps the plain pin toggle. VoiceOver and keyboard users get
+  the same switch as a named accessibility action on the provider cell. Escape
+  and an outside click still unpin.
 - Leaving both rail and detail bubble collapses after a forgiving 180 ms grace
   period unless pinned.
 - An outside click or Escape unpins and collapses.

--- a/mac/Sources/CodeBurnMenubar/CapacityDockController.swift
+++ b/mac/Sources/CodeBurnMenubar/CapacityDockController.swift
@@ -203,6 +203,9 @@ final class CapacityDockController {
             onProviderClick: { [weak self] provider in
                 self?.providerClicked(provider)
             },
+            onSwitchGlanceWindow: { [weak self] provider in
+                _ = self?.switchGlanceWindow(for: provider)
+            },
             onHide: { [weak self] in
                 self?.hideDock()
             },
@@ -573,11 +576,35 @@ final class CapacityDockController {
             if !model.interaction.isPinned {
                 model.interaction.togglePinned()
             }
+        } else if switchGlanceWindow(for: provider) {
+            // The resting gauge is the period switch once a provider publishes
+            // two horizons, so clicking the provider that already rests there
+            // changes the window rather than unpinning. Escape and an outside
+            // click still dismiss, and the hover expansion is untouched: this
+            // branch only ever pins, never collapses.
+            if !model.interaction.isPinned {
+                model.interaction.togglePinned()
+            }
         } else {
             model.interaction.togglePinned()
         }
         layoutRail()
         showDetail(for: provider)
+    }
+
+    /// Moves one provider's gauge to its other quota horizon. Reports whether
+    /// anything changed so the click handler can tell a period switch from a
+    /// provider that has only one window to show.
+    @discardableResult
+    private func switchGlanceWindow(for provider: CapacityDockProvider) -> Bool {
+        let quota = store.capacityDockQuotaSummary(for: provider)
+        let current = model.preferences.glanceWindow(for: provider)
+        let next = CapacityDockGlanceWindow.next(after: current, quota: quota)
+        guard next != current else { return false }
+        // Persisting posts the preferences notification, which reloads the
+        // snapshot into the model and redraws the gauge at its new window.
+        CapacityDockPreferences.setGlanceWindow(next, for: provider, defaults: defaults)
+        return true
     }
 
     private func connect(_ provider: CapacityDockProvider) {

--- a/mac/Sources/CodeBurnMenubar/Data/CapacityDockGlanceWindow.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CapacityDockGlanceWindow.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Which usage horizon one Capacity Dock gauge reports. Several providers
+/// publish both a short rolling window and a longer billing window — Claude's
+/// 5-hour and weekly limits, Codex's primary and secondary rate windows — and
+/// the resting rail has room for exactly one number. The kinds are deliberately
+/// provider-agnostic: the dock's collapsed row is one control for every
+/// provider, so the preference is "which horizon" rather than "which label".
+enum CapacityDockGlanceWindowKind: String, CaseIterable, Sendable {
+    /// The weekly (else monthly) billing horizon. The dock's original glance,
+    /// and the default for every provider.
+    case billing
+    /// The provider's short rolling window: 5-hour, session, hourly, daily.
+    case burst
+
+    var other: Self {
+        switch self {
+        case .billing: .burst
+        case .burst: .billing
+        }
+    }
+
+    /// Generic name for the horizon, used where no concrete window label is at
+    /// hand. Prefer the resolved window's own label when one exists.
+    var displayName: String {
+        switch self {
+        case .billing: "weekly"
+        case .burst: "5-hour"
+        }
+    }
+}
+
+/// Pure policy for the Capacity Dock glance: which of a provider's quota
+/// windows its gauge reports, given the stored preference and the windows the
+/// provider actually publishes, and what a click on the gauge switches to.
+///
+/// Kept out of the views so the fallbacks are testable: a stored preference can
+/// outlive the window it named (a plan change, a provider that stops reporting
+/// its 5-hour limit), and the gauge must never go blank because of it.
+enum CapacityDockGlanceWindow {
+    /// Labels that mark a billing horizon. Checked first, so Claude's
+    /// "Weekly · Opus" is never mistaken for a short window.
+    private static let billingNeedles = ["week", "month"]
+    /// Labels that mark a short rolling window across the provider adapters:
+    /// "5-hour", "Hourly", "Daily", "Current session".
+    private static let burstNeedles = ["hour", "session", "daily", "today", "minute"]
+
+    /// Every window the provider published, `primary` included once.
+    static func candidates(_ quota: QuotaSummary?) -> [QuotaSummary.Window] {
+        guard let quota else { return [] }
+        var candidates = quota.details
+        if let primary = quota.primary, !candidates.contains(primary) {
+            candidates.append(primary)
+        }
+        return candidates
+    }
+
+    /// The window a kind names, or nil when the provider publishes nothing for
+    /// that horizon.
+    static func window(
+        _ kind: CapacityDockGlanceWindowKind,
+        quota: QuotaSummary?
+    ) -> QuotaSummary.Window? {
+        switch kind {
+        // The billing horizon has one definition for the whole app; reuse it
+        // rather than teaching the dock a second idea of "the headline".
+        case .billing: quota?.headlineWindow
+        case .burst: burstWindow(quota)
+        }
+    }
+
+    /// The kind the gauge actually draws. The stored choice wins when the
+    /// provider reports that horizon; otherwise the other one does, so a
+    /// provider with a single window still shows a number instead of `--`.
+    static func resolvedKind(
+        preferred: CapacityDockGlanceWindowKind,
+        quota: QuotaSummary?
+    ) -> CapacityDockGlanceWindowKind {
+        if window(preferred, quota: quota) != nil { return preferred }
+        if window(preferred.other, quota: quota) != nil { return preferred.other }
+        return preferred
+    }
+
+    static func resolvedWindow(
+        preferred: CapacityDockGlanceWindowKind,
+        quota: QuotaSummary?
+    ) -> QuotaSummary.Window? {
+        window(resolvedKind(preferred: preferred, quota: quota), quota: quota)
+    }
+
+    /// Whether this provider has two distinct horizons to switch between. A
+    /// provider that reports one window — or whose short window *is* its
+    /// billing window — offers nothing to switch, so the gauge keeps its
+    /// existing click behaviour there.
+    static func isSwitchable(quota: QuotaSummary?) -> Bool {
+        guard let billing = window(.billing, quota: quota),
+              let burst = window(.burst, quota: quota) else { return false }
+        return billing != burst
+    }
+
+    /// What a click on the gauge selects. A provider with one usable horizon
+    /// keeps the kind it is already drawing, so the click is a no-op rather
+    /// than a stored change that redraws nothing.
+    static func next(
+        after preferred: CapacityDockGlanceWindowKind,
+        quota: QuotaSummary?
+    ) -> CapacityDockGlanceWindowKind {
+        let resolved = resolvedKind(preferred: preferred, quota: quota)
+        guard isSwitchable(quota: quota) else { return resolved }
+        return resolved.other
+    }
+
+    private static func burstWindow(_ quota: QuotaSummary?) -> QuotaSummary.Window? {
+        candidates(quota).first { window in
+            guard !matches(window.label, billingNeedles) else { return false }
+            return matches(window.label, burstNeedles)
+        }
+    }
+
+    private static func matches(_ label: String, _ needles: [String]) -> Bool {
+        needles.contains { label.range(of: $0, options: .caseInsensitive) != nil }
+    }
+}

--- a/mac/Sources/CodeBurnMenubar/Data/CapacityDockPreferences.swift
+++ b/mac/Sources/CodeBurnMenubar/Data/CapacityDockPreferences.swift
@@ -181,6 +181,7 @@ enum CapacityDockPreferences {
     static let scaleKey = "CodeBurnCapacityDockScale"
     static let themeKey = "CodeBurnCapacityDockTheme"
     static let gaugeShapeKey = "CodeBurnCapacityDockGaugeShape"
+    static let glanceWindowsKey = "CodeBurnCapacityDockGlanceWindows"
     static let manualSelectionKey = "CodeBurnCapacityDockManualSelection"
 
     static let defaultProvider: CapacityDockProvider = .codex
@@ -200,6 +201,14 @@ enum CapacityDockPreferences {
         let scale: Double
         let theme: CapacityDockTheme
         let gaugeShape: CapacityDockGaugeShape
+        /// Which quota horizon each provider's gauge reports, keyed by provider
+        /// id. Sparse: an absent provider uses the billing horizon, which is
+        /// what the dock has always shown.
+        let glanceWindows: [String: CapacityDockGlanceWindowKind]
+
+        func glanceWindow(for provider: CapacityDockProvider) -> CapacityDockGlanceWindowKind {
+            glanceWindows[provider.rawValue] ?? .billing
+        }
     }
 
     static func load(defaults: UserDefaults = .standard) -> Snapshot {
@@ -257,7 +266,10 @@ enum CapacityDockPreferences {
             theme: defaults.string(forKey: themeKey)
                 .flatMap(CapacityDockTheme.init(rawValue:)) ?? .graphite,
             gaugeShape: defaults.string(forKey: gaugeShapeKey)
-                .flatMap(CapacityDockGaugeShape.init(rawValue:)) ?? .squircle
+                .flatMap(CapacityDockGaugeShape.init(rawValue:)) ?? .squircle,
+            glanceWindows: normalizedGlanceWindows(
+                defaults.dictionary(forKey: glanceWindowsKey)
+            )
         )
     }
 
@@ -400,6 +412,48 @@ enum CapacityDockPreferences {
     ) {
         defaults.set(gaugeShape.rawValue, forKey: gaugeShapeKey)
         notifyChanged()
+    }
+
+    /// Records which horizon one provider's gauge reports. Stored per provider
+    /// rather than as one dock-wide switch because the providers are
+    /// independent questions: a user can watch Claude's 5-hour window while
+    /// keeping Codex on its weekly one.
+    static func setGlanceWindow(
+        _ kind: CapacityDockGlanceWindowKind,
+        for provider: CapacityDockProvider,
+        defaults: UserDefaults = .standard
+    ) {
+        var stored = storedGlanceWindows(defaults: defaults)
+        guard stored[provider.rawValue] != kind.rawValue else { return }
+        stored[provider.rawValue] = kind.rawValue
+        defaults.set(stored, forKey: glanceWindowsKey)
+        notifyChanged()
+    }
+
+    private static func storedGlanceWindows(defaults: UserDefaults) -> [String: String] {
+        var stored: [String: String] = [:]
+        for (identifier, value) in defaults.dictionary(forKey: glanceWindowsKey) ?? [:] {
+            guard let value = value as? String else { continue }
+            stored[identifier] = value
+        }
+        return stored
+    }
+
+    /// Drops entries a newer or older build cannot make sense of — an unknown
+    /// provider id, a horizon this build does not have — so a foreign value in
+    /// the domain cannot decide what the gauge shows.
+    private static func normalizedGlanceWindows(
+        _ stored: [String: Any]?
+    ) -> [String: CapacityDockGlanceWindowKind] {
+        guard let stored else { return [:] }
+        var normalized: [String: CapacityDockGlanceWindowKind] = [:]
+        for (identifier, value) in stored {
+            guard CapacityDockProvider(rawValue: identifier) != nil,
+                  let rawValue = value as? String,
+                  let kind = CapacityDockGlanceWindowKind(rawValue: rawValue) else { continue }
+            normalized[identifier] = kind
+        }
+        return normalized
     }
 
     private static func normalizedProviders(rawIdentifiers: [String]?) -> [CapacityDockProvider] {

--- a/mac/Sources/CodeBurnMenubar/Views/CapacityDockView.swift
+++ b/mac/Sources/CodeBurnMenubar/Views/CapacityDockView.swift
@@ -348,6 +348,7 @@ struct CapacityDockView: View {
     let model: CapacityDockViewModel
     let quota: (CapacityDockProvider) -> QuotaSummary?
     let onProviderClick: (CapacityDockProvider) -> Void
+    let onSwitchGlanceWindow: (CapacityDockProvider) -> Void
     let onHide: () -> Void
     let onDock: (CapacityDockEdge) -> Void
     let onDragChanged: (CGPoint, CGSize) -> Void
@@ -371,7 +372,9 @@ struct CapacityDockView: View {
                     quota: quota(provider),
                     scale: model.scale,
                     gaugeShape: model.preferences.gaugeShape,
-                    onClick: { onProviderClick(provider) }
+                    glanceWindow: model.preferences.glanceWindow(for: provider),
+                    onClick: { onProviderClick(provider) },
+                    onSwitchGlanceWindow: { onSwitchGlanceWindow(provider) }
                 )
                 .frame(
                     width: model.isVertical ? model.railWidth : model.rowHeight,
@@ -468,9 +471,13 @@ private struct CapacityDockProviderRow: View {
     let quota: QuotaSummary?
     let scale: CGFloat
     let gaugeShape: CapacityDockGaugeShape
+    let glanceWindow: CapacityDockGlanceWindowKind
     let onClick: () -> Void
+    let onSwitchGlanceWindow: () -> Void
 
-    private var headline: QuotaSummary.Window? { quota?.headlineWindow }
+    private var headline: QuotaSummary.Window? {
+        CapacityDockGlanceWindow.resolvedWindow(preferred: glanceWindow, quota: quota)
+    }
     private var percent: Double? { headline?.percent }
 
     var body: some View {
@@ -526,8 +533,40 @@ private struct CapacityDockProviderRow: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel("\(provider.displayName) usage")
-        .accessibilityValue(headline?.percentLabel ?? "Unknown")
-        .accessibilityHint("Click to keep Capacity Dock expanded")
+        .accessibilityValue(accessibilityValue)
+        .accessibilityHint(accessibilityHint)
+        // The gauge is the switch, and a click is a pointer gesture. Keyboard
+        // and VoiceOver users reach the same horizon change through a named
+        // action on the row. It is offered unconditionally because quota
+        // arrives asynchronously, and an action that appears and disappears as
+        // the first fetch lands is worse than one that no-ops for a provider
+        // with a single window.
+        .accessibilityAction(named: switchActionName, onSwitchGlanceWindow)
+    }
+
+    private var isSwitchable: Bool {
+        CapacityDockGlanceWindow.isSwitchable(quota: quota)
+    }
+
+    /// Names the horizon as well as the number: the ring looks identical
+    /// whichever window feeds it, so the window is the part a screen reader
+    /// has to say out loud.
+    private var accessibilityValue: String {
+        guard let headline else { return "Unknown" }
+        return "\(headline.label) \(headline.percentLabel)"
+    }
+
+    private var accessibilityHint: String {
+        isSwitchable
+            ? "Click to switch between this provider's usage windows"
+            : "Click to keep Capacity Dock expanded"
+    }
+
+    private var switchActionName: String {
+        let next = CapacityDockGlanceWindow.next(after: glanceWindow, quota: quota)
+        let label = CapacityDockGlanceWindow.window(next, quota: quota)?.label
+            ?? next.displayName
+        return "Show \(label) usage"
     }
 
     private var headlinePercentColor: Color {

--- a/mac/Tests/CodeBurnMenubarTests/CapacityDockGlanceWindowTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CapacityDockGlanceWindowTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import Testing
+@testable import CodeBurnMenubar
+
+private func window(
+    _ label: String,
+    _ percent: Double,
+    resetsAt: Date? = nil
+) -> QuotaSummary.Window {
+    QuotaSummary.Window(label: label, percent: percent, resetsAt: resetsAt)
+}
+
+private func quota(
+    _ details: [QuotaSummary.Window],
+    primary: QuotaSummary.Window? = nil,
+    filter: ProviderFilter = .claude
+) -> QuotaSummary {
+    QuotaSummary(
+        providerFilter: filter,
+        connection: .connected,
+        primary: primary,
+        details: details,
+        planLabel: "Max 20x",
+        footerLines: []
+    )
+}
+
+/// Claude's shape: a 5-hour window, the weekly window that is also `primary`,
+/// and the per-model weekly rows that must never be read as a short window.
+private func claudeQuota() -> QuotaSummary {
+    let weekly = window("Weekly", 0.21)
+    return quota(
+        [window("5-hour", 0.64), weekly, window("Weekly · Opus", 0.08)],
+        primary: weekly
+    )
+}
+
+@Suite("Capacity Dock glance window")
+struct CapacityDockGlanceWindowTests {
+    // MARK: - Which window a kind names
+
+    @Test("the billing horizon is the weekly window and the burst horizon is the 5-hour one")
+    func resolvesBothHorizons() {
+        let claude = claudeQuota()
+
+        #expect(CapacityDockGlanceWindow.window(.billing, quota: claude)?.label == "Weekly")
+        #expect(CapacityDockGlanceWindow.window(.burst, quota: claude)?.label == "5-hour")
+        #expect(CapacityDockGlanceWindow.isSwitchable(quota: claude))
+    }
+
+    @Test("the billing horizon stays the app-wide headline definition")
+    func billingMatchesHeadline() {
+        let claude = claudeQuota()
+
+        #expect(CapacityDockGlanceWindow.window(.billing, quota: claude) == claude.headlineWindow)
+    }
+
+    @Test("a per-model weekly row is never mistaken for a short window")
+    func perModelWeeklyIsNotBurst() {
+        // "Weekly · Opus" contains "Opus", not an hour or a session, but a
+        // naive "first window that is not the headline" rule would pick it.
+        let weekly = window("Weekly", 0.3)
+        let summary = quota([weekly, window("Weekly · Opus", 0.9)], primary: weekly)
+
+        #expect(CapacityDockGlanceWindow.window(.burst, quota: summary) == nil)
+        #expect(!CapacityDockGlanceWindow.isSwitchable(quota: summary))
+    }
+
+    @Test("session, hourly and daily labels all count as the burst horizon")
+    func burstLabelVariants() {
+        for label in ["5-hour", "Hourly", "Hour", "Daily", "Current session", "Today"] {
+            let monthly = window("Monthly", 0.4)
+            let summary = quota([window(label, 0.7), monthly], primary: monthly)
+            #expect(CapacityDockGlanceWindow.window(.burst, quota: summary)?.label == label)
+            #expect(CapacityDockGlanceWindow.window(.billing, quota: summary)?.label == "Monthly")
+        }
+    }
+
+    @Test("a window reported only as primary is still a candidate")
+    func primaryOnlyIsACandidate() {
+        let summary = quota([], primary: window("5-hour", 0.5))
+
+        #expect(CapacityDockGlanceWindow.window(.burst, quota: summary)?.label == "5-hour")
+    }
+
+    // MARK: - Fallbacks
+
+    @Test("a provider with one window shows it whichever horizon is stored")
+    func singleWindowFallsBack() {
+        // Cursor-shaped: one monthly window and nothing shorter.
+        let monthly = window("Monthly", 0.55)
+        let summary = quota([monthly], primary: monthly, filter: .cursor)
+
+        #expect(CapacityDockGlanceWindow.resolvedKind(preferred: .burst, quota: summary) == .billing)
+        #expect(
+            CapacityDockGlanceWindow.resolvedWindow(preferred: .burst, quota: summary) == monthly
+        )
+        #expect(
+            CapacityDockGlanceWindow.resolvedWindow(preferred: .billing, quota: summary) == monthly
+        )
+        #expect(!CapacityDockGlanceWindow.isSwitchable(quota: summary))
+    }
+
+    @Test("a provider that only reports a short window resolves to it from either preference")
+    func burstOnlyFallsBack() {
+        // With no weekly or monthly row the headline rule picks the busiest
+        // window, which here is the 5-hour one: both horizons agree, so there
+        // is nothing to switch.
+        let summary = quota([window("5-hour", 0.42)])
+
+        #expect(CapacityDockGlanceWindow.resolvedWindow(preferred: .billing, quota: summary)?.label == "5-hour")
+        #expect(CapacityDockGlanceWindow.resolvedWindow(preferred: .burst, quota: summary)?.label == "5-hour")
+        #expect(!CapacityDockGlanceWindow.isSwitchable(quota: summary))
+    }
+
+    @Test("no quota at all stays unknown instead of inventing a window")
+    func missingQuotaStaysUnknown() {
+        #expect(CapacityDockGlanceWindow.resolvedWindow(preferred: .billing, quota: nil) == nil)
+        #expect(CapacityDockGlanceWindow.resolvedWindow(preferred: .burst, quota: nil) == nil)
+        #expect(!CapacityDockGlanceWindow.isSwitchable(quota: nil))
+        // A disconnected provider has no windows yet; the click must not store
+        // a horizon the user cannot see the effect of.
+        let empty = QuotaSummary(
+            providerFilter: .claude,
+            connection: .disconnected,
+            primary: nil,
+            details: [],
+            planLabel: nil,
+            footerLines: []
+        )
+        #expect(CapacityDockGlanceWindow.next(after: .billing, quota: empty) == .billing)
+    }
+
+    // MARK: - Toggle policy
+
+    @Test("the click alternates the two horizons for a provider that has both")
+    func clickAlternates() {
+        let claude = claudeQuota()
+
+        let first = CapacityDockGlanceWindow.next(after: .billing, quota: claude)
+        #expect(first == .burst)
+        #expect(CapacityDockGlanceWindow.window(first, quota: claude)?.label == "5-hour")
+
+        let second = CapacityDockGlanceWindow.next(after: first, quota: claude)
+        #expect(second == .billing)
+        #expect(CapacityDockGlanceWindow.window(second, quota: claude)?.label == "Weekly")
+    }
+
+    @Test("the click is a no-op when the provider has a single window")
+    func clickIsNoOpWithOneWindow() {
+        let monthly = window("Monthly", 0.55)
+        let summary = quota([monthly], primary: monthly, filter: .cursor)
+
+        #expect(CapacityDockGlanceWindow.next(after: .billing, quota: summary) == .billing)
+        // A stored burst preference this provider cannot honour normalizes to
+        // what is actually drawn rather than flipping to a blank gauge.
+        #expect(CapacityDockGlanceWindow.next(after: .burst, quota: summary) == .billing)
+    }
+
+    @Test("a stored horizon the provider stopped reporting switches back to a real one")
+    func staleStoredHorizonRecovers() {
+        // The user chose the 5-hour window, then moved to a plan that reports
+        // only the weekly limit and a new 5-hour row later returns.
+        let weeklyOnly = quota([window("Weekly", 0.3)])
+        #expect(CapacityDockGlanceWindow.resolvedKind(preferred: .burst, quota: weeklyOnly) == .billing)
+        #expect(CapacityDockGlanceWindow.next(after: .burst, quota: weeklyOnly) == .billing)
+
+        let restored = claudeQuota()
+        #expect(CapacityDockGlanceWindow.resolvedKind(preferred: .burst, quota: restored) == .burst)
+    }
+
+    // MARK: - Persistence
+
+    private func defaults() -> UserDefaults {
+        let suiteName = "CodeBurnMenubarTests.CapacityDockGlance.\(UUID().uuidString)"
+        return UserDefaults(suiteName: suiteName)!
+    }
+
+    @Test("the glance window defaults to the billing horizon for every provider")
+    func defaultsToBilling() {
+        let defaults = defaults()
+
+        let snapshot = CapacityDockPreferences.load(defaults: defaults)
+        #expect(snapshot.glanceWindows.isEmpty)
+        #expect(snapshot.glanceWindow(for: .claude) == .billing)
+        #expect(snapshot.glanceWindow(for: .codex) == .billing)
+    }
+
+    @Test("the glance window round-trips per provider")
+    func roundTripsPerProvider() {
+        let defaults = defaults()
+
+        CapacityDockPreferences.setGlanceWindow(.burst, for: .claude, defaults: defaults)
+        var snapshot = CapacityDockPreferences.load(defaults: defaults)
+        #expect(snapshot.glanceWindow(for: .claude) == .burst)
+        // One provider's choice must not move another's.
+        #expect(snapshot.glanceWindow(for: .codex) == .billing)
+
+        CapacityDockPreferences.setGlanceWindow(.burst, for: .codex, defaults: defaults)
+        CapacityDockPreferences.setGlanceWindow(.billing, for: .claude, defaults: defaults)
+        snapshot = CapacityDockPreferences.load(defaults: defaults)
+        #expect(snapshot.glanceWindow(for: .claude) == .billing)
+        #expect(snapshot.glanceWindow(for: .codex) == .burst)
+    }
+
+    @Test("the glance window persists independently of the other dock preferences")
+    func persistsIndependently() {
+        let defaults = defaults()
+
+        CapacityDockPreferences.setGlanceWindow(.burst, for: .claude, defaults: defaults)
+        CapacityDockPreferences.setGaugeShape(.circle, defaults: defaults)
+        CapacityDockPreferences.setPreferredProvider(.claude, defaults: defaults)
+
+        let snapshot = CapacityDockPreferences.load(defaults: defaults)
+        #expect(snapshot.glanceWindow(for: .claude) == .burst)
+        #expect(snapshot.gaugeShape == .circle)
+        #expect(snapshot.theme == .graphite)
+    }
+
+    @Test("stored entries for unknown providers and unknown horizons are dropped")
+    func ignoresForeignStoredValues() {
+        let defaults = defaults()
+
+        let stored: [String: Any] = [
+            "claude": "burst",
+            "not-a-provider": "burst",
+            "codex": "fortnightly",
+            "gemini": 7,
+        ]
+        defaults.set(stored, forKey: CapacityDockPreferences.glanceWindowsKey)
+
+        let snapshot = CapacityDockPreferences.load(defaults: defaults)
+        #expect(snapshot.glanceWindows == ["claude": .burst])
+        #expect(snapshot.glanceWindow(for: .codex) == .billing)
+        #expect(snapshot.glanceWindow(for: .gemini) == .billing)
+    }
+}

--- a/mac/Tests/CodeBurnMenubarTests/CapacityDockPreferencesTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/CapacityDockPreferencesTests.swift
@@ -25,6 +25,8 @@ struct CapacityDockPreferencesTests {
         #expect(snapshot.scale == 0.6)
         #expect(snapshot.theme == .graphite)
         #expect(snapshot.gaugeShape == .squircle)
+        #expect(snapshot.glanceWindows.isEmpty)
+        #expect(snapshot.glanceWindow(for: .claude) == .billing)
     }
 
     @Test("dock material theme persists independently from placement")


### PR DESCRIPTION
## Summary

- The resting Capacity Dock gauge always reported the weekly (else monthly)
  billing window. Clicking the provider that already rests in the rail now
  switches that gauge to the provider's short rolling window — Claude's 5-hour
  limit, Codex's 5-hour or daily window, any `Hourly` / `Daily` / session row an
  adapter reports — and clicking again switches back. Closes #1243.
- The choice is stored per provider under `CodeBurnCapacityDockGlanceWindows`
  alongside the other dock preferences, so Claude can sit on its 5-hour window
  while Codex stays weekly, and it survives relaunch. It is deliberately not a
  Claude-only switch: the dock's collapsed row is provider-agnostic.
- A new pure `CapacityDockGlanceWindow` policy decides which window is drawn.
  `billing` reuses `QuotaSummary.headlineWindow` so the app keeps one definition
  of the weekly glance; `burst` matches short-horizon labels only after
  excluding weekly/monthly ones, so a per-model row like `Weekly · Opus` is
  never mistaken for a 5-hour window. A provider reporting one window keeps the
  existing click-to-pin behaviour, and a stored horizon the provider stops
  reporting falls back to the window it does report instead of blanking the
  gauge to `--`.
- The rail's geometry is untouched, the click can only pin and never collapses
  (so hover expansion, the drag suppression window and Escape / outside-click
  dismissal all behave as before), and keyboard and VoiceOver users get the same
  switch as a named action on the provider cell, whose accessibility value now
  names the window feeding the ring.

## Testing

- [ ] I have tested this locally against real data (not just unit tests)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds

`mac/` change only; no TypeScript touched.

- `cd mac && swift build` — passes.
- `cd mac && swift test --filter CapacityDock` — could not run on this machine:
  every test file, including ones this branch does not touch, fails with
  `error: no such module 'Testing'` on a CLT-only toolchain. Relying on CI for
  the suite.
- New coverage in `mac/Tests/CodeBurnMenubarTests/CapacityDockGlanceWindowTests.swift`:
  the per-provider preference round-trip (including defaults and rejection of
  foreign stored values) and the toggle policy — which window is shown for a
  given stored preference and set of published windows, that `Weekly · Opus` is
  not a short window, and the fallbacks when only one window exists or the
  stored horizon disappears.