### PR TITLE
ci: test on Node 24 and 26 as well as the 22 line

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Package floor, and the newest 22.x so paths gated on later node:zlib
-        # features (zstd, 22.15+) get exercised.
-        node-version: [22.13.0, 22]
+        # Package floor, the newest 22.x so paths gated on later node:zlib
+        # features (zstd, 22.15+) get exercised, and the current LTS plus
+        # current release so warnings newer Node prints reach the suite.
+        node-version: [22.13.0, 22, 24, 26]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
package.json supports Node >=22.13.0 but the test matrix ran only 22.13.0 and 22. Four tests that fail on any newer Node reached main unnoticed (#1298). Adds the current LTS and the current release to the matrix so a supported Node cannot break the suite silently.