### PR TITLE
fix(dsh): count every dropped session toward doctor

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -44,7 +44,8 @@ export type DoctorProviderReport = {
   parseVersion?: string
   /** Session sources discovered (candidate files/dbs). */
   candidatesFound: number
-  /** Sessions excluded by discovery because their highest format is unknown. */
+  /** Sessions discovery dropped for a format reason: an unknown generation,
+   *  an unreadable header, or a header disagreeing with its filename. */
   skippedVersionCount?: number
   /** How many discovered sources we attempted to parse (bounded sample). */
   sampled: number
@@ -319,7 +320,7 @@ async function collectOneProvider(
 
     if (skippedVersionCount > 0) {
       base.status = 'errors'
-      base.verdict = `ERRORS (${pluralSessions(skippedVersionCount)} skipped: unsupported format version; ${pluralSessions(base.candidatesFound)} readable; ${base.parseFailed} sampled parse failures)`
+      base.verdict = `ERRORS (${pluralSessions(skippedVersionCount)} skipped: unreadable or unsupported format; ${pluralSessions(base.candidatesFound)} readable; ${base.parseFailed} sampled parse failures)`
     } else if (base.parseFailed > 0) {
       base.status = 'errors'
       base.verdict = `ERRORS (${base.parseFailed}/${base.sampled} sampled file${base.sampled === 1 ? '' : 's'} failed to parse)`

--- a/src/providers/dsh.ts
+++ b/src/providers/dsh.ts
@@ -35,7 +35,7 @@ const ZSTD_MAGIC = 0xfd2fb528
 const MAX_FRAME_DECODED_BYTES = 64 * 1024 * 1024
 
 const SUPPORTED_SESSION_FORMAT_VERSIONS = new Set([0, 1, 2, 3])
-const SESSION_LOG_NAME = /^session(?:\.v([1-9][0-9]*))?\.jsonl(?:\.zstd)?$/u
+const SESSION_LOG_NAME = /^session(?:\.v(\d+))?\.jsonl(?:\.zstd)?$/u
 
 const MIN_REASONABLE_TIMESTAMP_MS = 1_000_000_000_000
 
@@ -47,6 +47,19 @@ function notice(message: string): void {
   if (noticed.has(message)) return
   noticed.add(message)
   process.stderr.write(message)
+}
+
+// A notice naming a file cannot dedup on its text: a systematic problem prints
+// one line per session and grows `noticed` without bound. Dedup on the kind
+// instead and show a few example paths.
+const PATH_NOTICE_EXAMPLES = 3
+const noticedPaths = new Map<string, number>()
+
+function noticePath(kind: string, detail: string): void {
+  const seen = (noticedPaths.get(kind) ?? 0) + 1
+  noticedPaths.set(kind, seen)
+  if (seen <= PATH_NOTICE_EXAMPLES) process.stderr.write(`codeburn: ${kind}: ${detail}\n`)
+  else if (seen === PATH_NOTICE_EXAMPLES + 1) process.stderr.write(`codeburn: ${kind}: further paths suppressed\n`)
 }
 
 type ZstdFrame = { start: number; end: number }
@@ -213,7 +226,7 @@ function generationFromPath(filePath: string): number | undefined {
 function headerMatchesPath(header: DshEvent, filePath: string): boolean {
   const generation = generationFromPath(filePath)
   if (generation === undefined || header.version !== generation) {
-    notice(`codeburn: skipping DSH session log whose filename and header versions disagree: ${filePath}\n`)
+    noticePath('skipping DSH session log whose filename and header versions disagree', filePath)
     return false
   }
   return isReadableVersion(header)
@@ -277,7 +290,7 @@ async function readEventLines(filePath: string): Promise<string[] | null> {
       // oversize guard readSessionFile applies to the uncompressed variant.
       const size = (await stat(filePath)).size
       if (size > MAX_SESSION_FILE_BYTES) {
-        notice(`codeburn: skipped oversize DSH session log ${filePath} (${size} bytes)\n`)
+        noticePath('skipped oversize DSH session log', `${filePath} (${size} bytes)`)
         return null
       }
       buffer = await readFile(filePath)
@@ -287,7 +300,7 @@ async function readEventLines(filePath: string): Promise<string[] | null> {
     try {
       return [...readZstdLines(buffer)]
     } catch (err) {
-      notice(`codeburn: skipped corrupt DSH session log ${filePath}: ${err instanceof Error ? err.message : err}\n`)
+      noticePath('skipped corrupt DSH session log', `${filePath}: ${err instanceof Error ? err.message : err}`)
       return null
     }
   }
@@ -386,6 +399,8 @@ async function discoverSessionsInDir(sessionsDir: string, onSkippedVersion?: (ve
       // never fall back to an older snapshot when that authoritative file is
       // unknown or corrupt, since that would silently report stale usage.
       const generationFiles: Array<{ path: string; version: number; compressed: boolean }> = []
+      const slots = new Set<string>()
+      let ambiguous: number | undefined
       const names = await readdir(sessionPath).catch(() => [])
       for (const name of names) {
         const match = SESSION_LOG_NAME.exec(name)
@@ -393,7 +408,25 @@ async function discoverSessionsInDir(sessionsDir: string, onSkippedVersion?: (ve
         const version = match[1] === undefined ? 0 : Number(match[1])
         const candidate = join(sessionPath, name)
         const fileStat = await stat(candidate).catch(() => null)
-        if (fileStat?.isFile()) generationFiles.push({ path: candidate, version, compressed: name.endsWith('.zstd') })
+        if (!fileStat?.isFile()) continue
+        const compressed = name.endsWith('.zstd')
+        // `session.v0.jsonl` names the unversioned generation and
+        // `session.v03.jsonl` names generation 3, so two files can claim one
+        // generation; past 2^53 a generation cannot be ordered at all. Either
+        // way no canonical log can be resolved, and dropping the session
+        // silently is the omission #1281 was about.
+        const slot = `${version}:${String(compressed)}`
+        if (!Number.isSafeInteger(version) || slots.has(slot)) {
+          ambiguous ??= version
+          continue
+        }
+        slots.add(slot)
+        generationFiles.push({ path: candidate, version, compressed })
+      }
+      if (ambiguous !== undefined) {
+        onSkippedVersion?.(ambiguous)
+        noticePath('skipping DSH session whose generation filenames are ambiguous', sessionPath)
+        continue
       }
       generationFiles.sort((a, b) => b.version - a.version || Number(b.compressed) - Number(a.compressed))
       const selected = generationFiles[0]
@@ -406,12 +439,24 @@ async function discoverSessionsInDir(sessionsDir: string, onSkippedVersion?: (ve
         continue
       }
 
-      const header = await readSessionHeader(filePath)
-      if (!header) {
-        notice(`codeburn: skipping unreadable DSH session header: ${filePath}\n`)
+      // Without zstd every compressed header reads as unreadable, so say why
+      // once rather than naming every session log.
+      if (selected.compressed && !zstdDecompress) {
+        onSkippedVersion?.(selected.version)
+        notice('codeburn: DSH sessions need Node >= 22.15 (zstd support); skipping DSH usage.\n')
         continue
       }
-      if (!headerMatchesPath(header, filePath)) continue
+
+      const header = await readSessionHeader(filePath)
+      if (!header) {
+        onSkippedVersion?.(selected.version)
+        noticePath('skipping unreadable DSH session header', filePath)
+        continue
+      }
+      if (!headerMatchesPath(header, filePath)) {
+        onSkippedVersion?.(selected.version)
+        continue
+      }
 
       const cwd = typeof header.cwd === 'string' && header.cwd.trim() ? header.cwd : dirName
       sources.push({ path: filePath, project: projectFromCwd(cwd, dirName), provider: 'dsh' })
@@ -473,7 +518,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
       if (header?.type !== 'session' || !headerMatchesPath(header, source.path)) return
       const formatVersion = header.version!
       if (formatVersion >= 2 && corruptInterior) {
-        notice(`codeburn: skipping corrupt DSH session with malformed interior rows: ${source.path}\n`)
+        noticePath('skipping corrupt DSH session with malformed interior rows', source.path)
         return
       }
 
@@ -495,11 +540,11 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           .filter(event => event.type === 'session/end-seed' && event.data?.inherited === true && typeof event.seq === 'number')
           .map(event => event.seq!)
         if (header.isSeeded === true && taggedCuts.length === 0) {
-          notice(`codeburn: skipping corrupt seeded DSH session without an inherited end-seed marker: ${source.path}\n`)
+          noticePath('skipping corrupt seeded DSH session without an inherited end-seed marker', source.path)
           return
         }
         if (header.isSeeded !== true && taggedCuts.length > 0) {
-          notice(`codeburn: skipping corrupt unseeded DSH session with an inherited end-seed marker: ${source.path}\n`)
+          noticePath('skipping corrupt unseeded DSH session with an inherited end-seed marker', source.path)
           return
         }
         inheritedCut = taggedCuts.at(-1) ?? -1
@@ -603,13 +648,13 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
         const turn = event.data?.turn ?? currentTurn
         const step = event.data?.step ?? 0
         if (![turn, step].every(value => typeof value === 'number' && Number.isSafeInteger(value) && value >= 0)) {
-          notice(`codeburn: skipping DSH usage with invalid attempt coordinates: ${source.path}\n`)
+          noticePath('skipping DSH usage with invalid attempt coordinates', source.path)
           continue
         }
         const key = `${turn}:${step}`
         if (!usage) {
           if (!activeAttempts.has(key)) {
-            notice(`codeburn: DSH session contains an attempt without usage; totals may be incomplete: ${source.path}\n`)
+            noticePath('DSH session contains an attempt without usage; totals may be incomplete', source.path)
           }
           continue
         }
@@ -649,7 +694,7 @@ function createParser(source: SessionSource, seenKeys: Set<string>): SessionPars
           const reasoning = Math.min(numberOrZero(observation.usage.reasoningTokens), output)
           const completeUsage = usageIsComplete(observation.usage)
           if (!completeUsage) {
-            notice(`codeburn: DSH session contains incomplete or invalid usage; retained counts are estimated: ${source.path}\n`)
+            noticePath('DSH session contains incomplete or invalid usage; retained counts are estimated', source.path)
           }
           if (input + output + cacheRead + cacheWrite === 0) continue
 

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -100,6 +100,27 @@ describe('collectDoctorReport - codex fixture dirs', () => {
       warnings.mockRestore()
     }
   })
+  it('reports DSH sessions dropped for an unreadable or mismatched header', async () => {
+    const warnings = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    try {
+      const unreadable = join(tmpDir, 'sessions', '--fixture--', 'unreadable')
+      const mismatch = join(tmpDir, 'sessions', '--fixture--', 'mismatch')
+      await mkdir(unreadable, { recursive: true })
+      await mkdir(mismatch, { recursive: true })
+      await writeFile(join(unreadable, 'session.v3.jsonl'), '{broken')
+      await writeFile(join(mismatch, 'session.v3.jsonl'), JSON.stringify({ type: 'session', version: 2 }))
+
+      const report = await collectDoctorReport('dsh', {
+        providers: [createDshProvider(tmpDir)], cache: emptyCache(), dailyCacheDays: [], launchers: [],
+      })
+
+      expect(only(report, 'dsh')).toMatchObject({ status: 'errors', skippedVersionCount: 2, candidatesFound: 0 })
+      expect(renderDoctorTable(report)).toContain('2 sessions skipped')
+    } finally {
+      warnings.mockRestore()
+    }
+  })
+
   it('found: a real session file yields an OK verdict and a parsed sample', async () => {
     await writeCodexSession(tmpDir)
     const provider = createCodexProvider(tmpDir)

--- a/tests/providers/dsh.test.ts
+++ b/tests/providers/dsh.test.ts
@@ -249,10 +249,85 @@ describe('dsh provider - session discovery', () => {
     expect(await createDshProvider(tmpDir).discoverSessions()).toEqual([])
   })
 
-  it('rejects a filename/header generation mismatch', async () => {
+  it('rejects a filename/header generation mismatch and counts it as skipped', async () => {
     await writeVersionedSession(3, '--home-u-proj--', 'session-mismatch', [versionedHeader(2)])
 
-    expect(await createDshProvider(tmpDir).discoverSessions()).toEqual([])
+    const skipped: number[] = []
+    expect(await createDshProvider(tmpDir).discoverSessions(v => { skipped.push(v) })).toEqual([])
+    expect(skipped).toEqual([3])
+  })
+
+  it('counts an unreadable header as skipped', async () => {
+    const dir = join(tmpDir, 'sessions', '--home-u-proj--', 'session-unreadable')
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, 'session.v3.jsonl'), '{broken\n')
+
+    const skipped: number[] = []
+    expect(await createDshProvider(tmpDir).discoverSessions(v => { skipped.push(v) })).toEqual([])
+    expect(skipped).toEqual([3])
+  })
+
+  it('orders generations numerically, not lexically', async () => {
+    const dir = join(tmpDir, 'sessions', '--home-u-proj--', 'session-v10')
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, 'session.v3.jsonl'), versionedHeader(3, { id: 'session-v10' }) + '\n')
+    await writeFile(join(dir, 'session.v10.jsonl'), JSON.stringify({ type: 'session', version: 10 }) + '\n')
+
+    const skipped: number[] = []
+    expect(await createDshProvider(tmpDir).discoverSessions(v => { skipped.push(v) })).toEqual([])
+    expect(skipped).toEqual([10])
+  })
+
+  it('reads session.v0 as the unversioned generation and session.v03 as generation 3', async () => {
+    const zero = join(tmpDir, 'sessions', '--home-u-proj--', 'session-v0')
+    const padded = join(tmpDir, 'sessions', '--home-u-proj--', 'session-v03')
+    await mkdir(zero, { recursive: true })
+    await mkdir(padded, { recursive: true })
+    await writeFile(join(zero, 'session.v0.jsonl'), sessionHeader({ id: 'session-v0', cwd: '/home/u/proj' }) + '\n')
+    await writeFile(join(padded, 'session.v03.jsonl'), versionedHeader(3, { id: 'session-v03' }) + '\n')
+
+    const sessions = await createDshProvider(tmpDir).discoverSessions()
+
+    expect(sessions.map(s => s.path).sort()).toEqual([join(padded, 'session.v03.jsonl'), join(zero, 'session.v0.jsonl')].sort())
+  })
+
+  it.each([
+    ['session.v03.jsonl', 3],
+    ['session.v99999999999999999999.jsonl', 1e20],
+  ])('skips and counts a session whose generation filename %s is ambiguous', async (name, expected) => {
+    const dir = join(tmpDir, 'sessions', '--home-u-proj--', 'session-ambiguous')
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, 'session.v3.jsonl'), versionedHeader(3, { id: 'session-ambiguous' }) + '\n')
+    await writeFile(join(dir, name), versionedHeader(3, { id: 'session-ambiguous' }) + '\n')
+
+    const skipped: number[] = []
+    expect(await createDshProvider(tmpDir).discoverSessions(v => { skipped.push(v) })).toEqual([])
+    expect(skipped).toEqual([expected])
+  })
+
+  it('explains missing zstd support once instead of naming every compressed log', async () => {
+    for (const id of ['one', 'two', 'three', 'four', 'five']) {
+      const dir = join(tmpDir, 'sessions', '--home-u-proj--', id)
+      await mkdir(dir, { recursive: true })
+      await writeFile(join(dir, 'session.v3.jsonl.zstd'), 'not zstd')
+    }
+    const zlibExports = zlib as unknown as Record<string, unknown>
+    const original = zlibExports['zstdDecompressSync']
+    delete zlibExports['zstdDecompressSync']
+    const warnings = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    try {
+      vi.resetModules()
+      const { createDshProvider: create } = await import('../../src/providers/dsh.js')
+      const skipped: number[] = []
+      expect(await create(tmpDir).discoverSessions(v => { skipped.push(v) })).toEqual([])
+      expect(skipped).toEqual([3, 3, 3, 3, 3])
+      expect(warnings.mock.calls.map(([m]) => String(m)))
+        .toEqual(['codeburn: DSH sessions need Node >= 22.15 (zstd support); skipping DSH usage.\n'])
+    } finally {
+      warnings.mockRestore()
+      if (original !== undefined) zlibExports['zstdDecompressSync'] = original
+      vi.resetModules()
+    }
   })
 
   it('returns empty for a non-existent home', async () => {


### PR DESCRIPTION
Follow-up to #1284. Discovery and diagnostics only, no accounting, cache-version, or retry changes.

- Every discovery path that drops a session for a format reason now calls `onSkippedVersion`: unreadable header, filename/header generation mismatch, ambiguous generation filename, and missing zstd support. Before this, doctor said OK while sessions were silently omitted, which is the bug #1281 was about. Doctor's verdict wording moves from "unsupported format version" to "unreadable or unsupported format" to match.
- On Node < 22.15 (no zstd in node:zlib), discovery now emits the "DSH sessions need Node >= 22.15" notice once and skips the compressed logs, instead of printing one `skipping unreadable DSH session header` line per session.
- Path-naming notices dedup on the message kind, print at most 3 example paths and then one suppression line. They used to dedup on the exact message text, so a systematic problem printed one line per file and grew the module-level set without bound. The unsupported-version notice stays keyed on the version, once per run.
- The filename regex now matches `v(\d+)` parsed with `Number` and guarded by `Number.isSafeInteger`. `session.v0.jsonl` is the unversioned generation 0 and `session.v03.jsonl` is generation 3; a duplicate-encoded generation (`session.v3` beside `session.v03`) or a generation past 2^53 skips the session and counts it, rather than being invisible.
- Tests: v10 ordering beats v3 numerically, v0/v03 semantics, mismatch and unreadable headers count toward doctor (provider level and via `collectDoctorReport`), ambiguous and non-safe generations count, and the single Node-version notice across 5 compressed logs (stubbed by deleting `zlib.zstdDecompressSync` under `vi.resetModules()`).
- Verified: `npx tsc --noEmit` clean; full `npm test` 3940 passed / 5 skipped across 288 files. No `PROVIDER_PARSE_VERSIONS.dsh` bump needed since per-file parse output is unchanged.