### PR TITLE
test(menubar): make ServeConnection cancellation tests deterministic under load

### DIFF
--- a/mac/Tests/CodeBurnMenubarTests/ServeConnectionTests.swift
+++ b/mac/Tests/CodeBurnMenubarTests/ServeConnectionTests.swift
@@ -54,6 +54,7 @@ private actor ManualTimeoutClock {
     private var nextToken = 0
     private var waiters: [Int: Waiter] = [:]
     private var recorded: [UInt64] = []
+    private var fired = 0
 
     func sleep(_ nanoseconds: UInt64) async throws {
         let token = nextToken
@@ -78,8 +79,12 @@ private actor ManualTimeoutClock {
 
     func history() -> [UInt64] { recorded }
 
+    /// How many timeouts this clock has let fire.
+    func firedCount() -> Int { fired }
+
     func fireOldest() {
         guard let token = waiters.keys.min(), let waiter = waiters.removeValue(forKey: token) else { return }
+        fired += 1
         waiter.continuation.resume()
     }
 
@@ -129,6 +134,43 @@ private final class ProcessQueue: @unchecked Sendable {
     }
 }
 
+/// Real-time bound on waiting for an event. It is a hang guard for a
+/// regression, never the assertion: every fixture that relies on it either
+/// blocks until the test releases it or never finishes on its own, so a runner
+/// starved by concurrently scheduled suites makes the wait longer without
+/// changing the outcome (#1333).
+private let hangGuardNanoseconds: UInt64 = 30 * 1_000_000_000
+
+/// Polls a condition the test can only observe from outside the process, such
+/// as a file a fixture child writes, until it holds or the hang guard expires.
+private func eventually(_ condition: () async throws -> Bool) async rethrows -> Bool {
+    let deadline = DispatchTime.now().uptimeNanoseconds + hangGuardNanoseconds
+    while DispatchTime.now().uptimeNanoseconds < deadline {
+        if try await condition() { return true }
+        try? await Task.sleep(nanoseconds: 10_000_000)
+    }
+    return try await condition()
+}
+
+/// Awaits `operation`. If it is still pending when the hang guard expires,
+/// `onExpiry` releases whatever it is blocked on, so a regression fails the
+/// assertions that follow instead of hanging the test run.
+private func withHangGuard<T>(
+    onExpiry: @escaping @Sendable () async -> Void,
+    _ operation: () async throws -> T
+) async rethrows -> T {
+    let expiry = Task {
+        do {
+            try await Task.sleep(nanoseconds: hangGuardNanoseconds)
+        } catch {
+            return
+        }
+        await onExpiry()
+    }
+    defer { expiry.cancel() }
+    return try await operation()
+}
+
 @Suite("ServeConnection", .serialized)
 struct ServeConnectionTests {
     @Test("the resident child starts at user-initiated QoS")
@@ -155,34 +197,51 @@ struct ServeConnectionTests {
         try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(atPath: dir) }
         let requestMarker = dir + "/request-read"
+        let clock = ManualTimeoutClock()
 
-        let connection = ServeConnection { _, qualityOfService in
-            let child = Process()
-            child.executableURL = URL(fileURLWithPath: "/bin/sh")
-            child.arguments = ["-c", "IFS= read -r line; : > \"$1\"; sleep 1", "serve-fixture", requestMarker]
-            child.qualityOfService = qualityOfService
-            return child
-        }
+        // The child reads the request, then neither answers nor exits until its
+        // stdin closes, and the request's timeout fires only when the test fires
+        // it. Cancellation is the only event left that can resume the caller, so
+        // "promptly" is asserted as "before the timeout", not as a wall-clock
+        // budget a starved runner cannot keep (#1333). A child that exited on
+        // its own would instead be retried on replacements until the death
+        // budget surfaced ServeUnavailable.
+        let connection = ServeConnection(
+            makeProcess: { _, qualityOfService in
+                let child = Process()
+                child.executableURL = URL(fileURLWithPath: "/bin/sh")
+                child.arguments = [
+                    "-c", "IFS= read -r line; : > \"$1\"; while IFS= read -r line; do :; done",
+                    "serve-fixture", requestMarker,
+                ]
+                child.qualityOfService = qualityOfService
+                return child
+            },
+            timeoutSleep: { nanoseconds in
+                try await clock.sleep(nanoseconds)
+            }
+        )
 
         let request = Task {
             try await connection.request(args: ["status", "--format", "menubar-json"])
         }
-        for _ in 0..<200 where !FileManager.default.fileExists(atPath: requestMarker) {
-            try await Task.sleep(nanoseconds: 10_000_000)
-        }
-        #expect(FileManager.default.fileExists(atPath: requestMarker))
+        let childReadRequest = await eventually { FileManager.default.fileExists(atPath: requestMarker) }
+        #expect(childReadRequest)
+        let timeoutArmed = await eventually { await clock.snapshot() == [coldTimeoutNanoseconds] }
+        #expect(timeoutArmed)
 
-        let clock = ContinuousClock()
-        let started = clock.now
         request.cancel()
         do {
-            _ = try await request.value
+            // Firing the timeout on expiry turns a connection that ignores
+            // cancellation into a failed assertion below rather than a hang.
+            _ = try await withHangGuard(onExpiry: { await clock.fireOldest() }) {
+                try await request.value
+            }
             #expect(Bool(false), "cancelled request unexpectedly succeeded")
         } catch {
             #expect(error is CancellationError)
         }
-        let elapsed = started.duration(to: clock.now)
-        #expect(elapsed < .milliseconds(500))
+        #expect(await clock.firedCount() == 0)
         await connection.shutdown()
     }
 
@@ -194,7 +253,7 @@ struct ServeConnectionTests {
         let pidsFile = dir + "/pids"
         let eventsFile = dir + "/events"
         let releaseMarker = dir + "/release-first"
-        let recorder = TimeoutRecorder()
+        let clock = ManualTimeoutClock()
 
         let connection = ServeConnection(
             makeProcess: { _, qualityOfService in
@@ -218,23 +277,31 @@ struct ServeConnectionTests {
                 return child
             },
             timeoutSleep: { nanoseconds in
-                try await recorder.recordAndWait(nanoseconds)
+                try await clock.sleep(nanoseconds)
             }
         )
 
         let first = Task {
             try await connection.request(args: ["status", "--request", "first"])
         }
-        for _ in 0..<200 {
-            let events = (try? String(contentsOfFile: eventsFile, encoding: .utf8)) ?? ""
-            if events.contains("first-read\n") { break }
-            try await Task.sleep(nanoseconds: 10_000_000)
+        let firstRead = await eventually {
+            ((try? String(contentsOfFile: eventsFile, encoding: .utf8)) ?? "").contains("first-read\n")
         }
+        #expect(firstRead)
         #expect(try String(contentsOfFile: eventsFile, encoding: .utf8) == "first-read\n")
+        // The timer is armed by a detached task, so it can register after the
+        // child has already read the line.
+        let coldTimeoutArmed = await eventually { await clock.history() == [coldTimeoutNanoseconds] }
+        #expect(coldTimeoutArmed)
 
         first.cancel()
         do {
-            _ = try await first.value
+            _ = try await withHangGuard(onExpiry: {
+                Issue.record("cancellation was not observed while the child was still hydrating")
+                _ = FileManager.default.createFile(atPath: releaseMarker, contents: Data())
+            }) {
+                try await first.value
+            }
             #expect(Bool(false), "cancelled request unexpectedly succeeded")
         } catch {
             #expect(error is CancellationError)
@@ -242,22 +309,37 @@ struct ServeConnectionTests {
 
         // Submit the next request while the child is still blocked hydrating
         // the cancelled first one. It stays client-side queued: neither its
-        // stdin line nor its own timeout may begin yet.
+        // stdin line nor its own timeout may begin yet. Nothing observable
+        // happens while it waits, so this settle can only miss a regression,
+        // never fail a correct run; the warm timeout asserted after the release
+        // is the deterministic proof that its line was written only after the
+        // late first reply.
         let second = Task {
             try await connection.request(args: ["status", "--request", "second"])
         }
         try await Task.sleep(nanoseconds: 100_000_000)
-        #expect(await recorder.snapshot() == [coldTimeoutNanoseconds])
+        #expect(await clock.history() == [coldTimeoutNanoseconds])
         #expect(try String(contentsOfFile: eventsFile, encoding: .utf8) == "first-read\n")
 
         _ = FileManager.default.createFile(atPath: releaseMarker, contents: Data())
-        let secondPayload = try await second.value
+        let secondPayload = try await withHangGuard(onExpiry: { await connection.shutdown() }) {
+            try await second.value
+        }
 
         #expect(String(decoding: secondPayload, as: UTF8.self) == "live-2")
-        #expect(await recorder.snapshot() == [coldTimeoutNanoseconds, warmTimeoutNanoseconds])
+        let warmTimeoutArmed = await eventually {
+            await clock.history() == [coldTimeoutNanoseconds, warmTimeoutNanoseconds]
+        }
+        #expect(warmTimeoutArmed)
         let pids = try String(contentsOfFile: pidsFile, encoding: .utf8)
             .split(separator: "\n")
         #expect(pids.count == 1)
+        // The child logs "second-replied" after writing the reply that resumed
+        // `second`, so wait for the log rather than racing the child to it.
+        let secondReplied = await eventually {
+            ((try? String(contentsOfFile: eventsFile, encoding: .utf8)) ?? "").contains("second-replied\n")
+        }
+        #expect(secondReplied)
         let events = try String(contentsOfFile: eventsFile, encoding: .utf8)
             .split(separator: "\n")
         #expect(events == ["first-read", "late-first", "second-read", "second-replied"])
@@ -522,53 +604,67 @@ struct ServeConnectionTests {
         let pidsFile = dir + "/pids"
         let requestsFile = dir + "/requests"
         let lateRepliesFile = dir + "/late-replies"
+        let clock = ManualTimeoutClock()
 
-        let connection = ServeConnection { _, qualityOfService in
-            let child = Process()
-            child.executableURL = URL(fileURLWithPath: "/bin/sh")
-            child.arguments = ["-c", """
-                printf '%s\n' "$$" >> "$1"
-                while IFS= read -r line; do
-                  printf r >> "$2"
-                  id=$(printf '%s' "$line" | sed -E 's/.*"id":([0-9]+).*/\\1/')
-                  if [ "$id" -le 3 ]; then
-                    sleep 0.05
-                    printf '{"id":%s,"ok":true,"output":"late-%s"}\n' "$id" "$id"
-                    printf l >> "$3"
-                  else
-                    printf '{"id":%s,"ok":true,"output":"live-%s"}\n' "$id" "$id"
-                  fi
-                done
-                """, "serve-fixture", pidsFile, requestsFile, lateRepliesFile]
-            child.qualityOfService = qualityOfService
-            return child
-        }
+        // Ids 1-3 are answered only once the test has created release-<id>, so
+        // the late reply cannot beat the cancellation it is meant to follow
+        // (#1333).
+        let connection = ServeConnection(
+            makeProcess: { _, qualityOfService in
+                let child = Process()
+                child.executableURL = URL(fileURLWithPath: "/bin/sh")
+                child.arguments = ["-c", """
+                    printf '%s\n' "$$" >> "$1"
+                    while IFS= read -r line; do
+                      printf r >> "$2"
+                      id=$(printf '%s' "$line" | sed -E 's/.*"id":([0-9]+).*/\\1/')
+                      if [ "$id" -le 3 ]; then
+                        while [ ! -f "$4/release-$id" ]; do sleep 0.01; done
+                        printf '{"id":%s,"ok":true,"output":"late-%s"}\n' "$id" "$id"
+                        printf l >> "$3"
+                      else
+                        printf '{"id":%s,"ok":true,"output":"live-%s"}\n' "$id" "$id"
+                      fi
+                    done
+                    """, "serve-fixture", pidsFile, requestsFile, lateRepliesFile, dir]
+                child.qualityOfService = qualityOfService
+                return child
+            },
+            timeoutSleep: { nanoseconds in
+                try await clock.sleep(nanoseconds)
+            }
+        )
 
         for attempt in 0..<3 {
             let request = Task {
                 try await connection.request(args: ["status", "--attempt", String(attempt)])
             }
-            for _ in 0..<200 {
-                let reads = (try? String(contentsOfFile: requestsFile, encoding: .utf8).count) ?? 0
-                if reads >= attempt + 1 { break }
-                try await Task.sleep(nanoseconds: 10_000_000)
+            let requestRead = await eventually {
+                ((try? String(contentsOfFile: requestsFile, encoding: .utf8))?.count ?? 0) >= attempt + 1
             }
+            #expect(requestRead)
+            let releaseMarker = dir + "/release-\(attempt + 1)"
             request.cancel()
             do {
-                _ = try await request.value
+                _ = try await withHangGuard(onExpiry: {
+                    Issue.record("cancellation of attempt \(attempt) was not observed before its reply was released")
+                    _ = FileManager.default.createFile(atPath: releaseMarker, contents: Data())
+                }) {
+                    try await request.value
+                }
                 #expect(Bool(false), "cancelled request unexpectedly succeeded")
             } catch {
                 #expect(error is CancellationError)
             }
 
-            // The fake child deliberately emits the now-orphaned response after
-            // cancellation. It must be ignored without double-resuming anything,
-            // and the same resident child must remain available for the next id.
-            for _ in 0..<200 {
-                let replies = (try? String(contentsOfFile: lateRepliesFile, encoding: .utf8).count) ?? 0
-                if replies >= attempt + 1 { break }
-                try await Task.sleep(nanoseconds: 10_000_000)
+            // Only now does the fake child emit the orphaned response. It must
+            // be ignored without double-resuming anything, and the same
+            // resident child must remain available for the next id.
+            _ = FileManager.default.createFile(atPath: releaseMarker, contents: Data())
+            let lateReplyWritten = await eventually {
+                ((try? String(contentsOfFile: lateRepliesFile, encoding: .utf8))?.count ?? 0) >= attempt + 1
             }
+            #expect(lateReplyWritten)
             let replies = (try? String(contentsOfFile: lateRepliesFile, encoding: .utf8).count) ?? 0
             #expect(replies == attempt + 1)
         }


### PR DESCRIPTION
## Summary

- Three `ServeConnectionTests` failed on about half of all macOS Menubar CI runs, including `main`, and passed on re-run. Each one raced real time against Swift-side work. swift-testing runs suites concurrently in one process, so CPU-heavy neighbours such as Localization coverage delay every actor hop and wake-up by seconds, while the `/bin/sh` fixture children keep real time.
- `cancelling a hung request returns promptly` no longer asserts a 500 ms wall-clock budget.
  - The fixture child now never answers or exits, and the timeout comes from the existing `ManualTimeoutClock`.
  - The test asserts that the caller gets `CancellationError` and that no timeout has fired. Cancellation is the only event left that can resume it.
  - The occasional `ServeUnavailable` in CI came from the old fixture, which exited after `sleep 1`. The connection retried the request on replacement children until the three-death budget answered, and a delayed cancel hop lost to that. The timeout path was never involved: the test used the real 10-minute budget.
- `a request queued during cancelled hydration completes on the same child`
  - The child logs `second-replied` only after writing the reply the test awaits, so the test now waits for that log line instead of racing the child to it.
  - `ManualTimeoutClock` replaces `TimeoutRecorder`, whose "never fires" timer actually fired after 5 s.
- `external cancellations keep one child and safely discard late replies`: the fixture used to reply 50 ms after reading. It now holds each late reply until the test has observed the cancellation.
- Polling now uses a 30 s hang guard instead of 2 s. When a guarded await expires, the guard releases the fixture, so a regression fails its assertions instead of hanging. All original assertions are kept.
- No production code changes. `ServeConnection` already injects its process factory, timeout sleep and grace sleep, and those seams were enough. `DataClient.runCLI` already turns a cancelled caller's resident failure into `CancellationError` before any fallback, so the `ServeUnavailable` shape is not a production bug.

Fixes #1333

## Testing

- [ ] I have tested this locally against real data (not just unit tests)
- [ ] `npm test` passes
- [ ] `npm run build` succeeds

- `swift build` (mac/) passes.
- The test file typechecks with `-swift-version 6 -strict-concurrency=complete` against a stub `Testing` module.
- `swift test` itself cannot run on this host (Command Line Tools only, no `Testing` module), so CI is the final gate.
- Stress: a standalone harness ran these three test bodies from the file against the real `ServeConnection.swift`, 200 iterations each. Original and new binaries ran side by side under identical load.

| profile | test | original | new |
|---|---|---|---|
| A: 16 CPU burners + 16 in-process tasks holding the Swift pool in bursts up to 800 ms | cancel | 200/200 failed (`:185` elapsed) | 0/200 |
| A | queued | 0/200 | 0/200 |
| A | reuse | 43/200 failed (`:559` cancelled request succeeded) | 0/200 |
| B: 32 CPU burners, Swift pool not held | cancel | 0/200 | 0/200 |
| B | queued | 3/200 failed (`:263` missing `second-replied`) | 0/200 |
| B | reuse | 0/200 | 0/200 |

- How the profiles map to CI:
  - Profile A starves the Swift scheduler the way concurrent CPU-heavy suites do. It reproduces the wall-clock budget and the late-reply race.
  - Profile B loads only the OS scheduler, so a child is descheduled between its reply and its log line while the Swift side reads the log immediately. It reproduces the queued-hydration ordering race that `main` hit.
  - Every CI failure shape reproduces on the original. The new version had 0 failures in 1,200 runs, with no hangs.
- Mutation checks, each applied to a harness copy of `ServeConnection` and checked against the new tests:
  - Cancellation never reaching the actor fails all three tests.
  - Cancel killing and replacing the child fails `queued` and `reuse`.
  - Cancel abandoning the active request, with or without handing the orphan reply to the waiting request, fails `queued`.
  - An orphan reply killing the resident fails `queued` and `reuse`.
  - The new `reuse` test also catches lost cancellation, which the original masked.